### PR TITLE
Decode the name argument

### DIFF
--- a/toga/platform/cocoa/libs/objc.py
+++ b/toga/platform/cocoa/libs/objc.py
@@ -840,6 +840,7 @@ class ObjCClass(object):
         try:
             return self.properties[name]
         except KeyError:
+            name = name.decode('utf-8')
             selector = get_selector('set' + name[0].upper() + name[1:] + ':')
             responds = objc.class_respondsToSelector(self.ptr, selector)
             self.properties[name] = responds


### PR DESCRIPTION
The name ends up being a bytes in Python 3.
