### PR TITLE
Fix broken 'fork the code' link

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@ $ ln -si /usr/lib/python2.7/dist-packages/gi
 <h2>
 <a name="contributing" class="anchor" href="#contributing"><span class="octicon octicon-link"></span></a>Contributing</h2>
 
-<p>If you experience problems with Toga, you can <a href="https://github.com/pybee/toga/issues">log them on GitHub</a>. If you want to contribute code, please <a href="https://github.com/freakboy3742/toga">fork the code</a> and <a href="https://github.com/pybee/toga/pulls">submit a pull request</a>.</p>
+<p>If you experience problems with Toga, you can <a href="https://github.com/pybee/toga/issues">log them on GitHub</a>. If you want to contribute code, please <a href="https://github.com/pybee/toga">fork the code</a> and <a href="https://github.com/pybee/toga/pulls">submit a pull request</a>.</p>
 
       </section>
       <footer>


### PR DESCRIPTION
Fix a broken link on the toga web page
