### PR TITLE
Fix a Python 3 issue

### DIFF
--- a/toga/platform/cocoa/libs/objc.py
+++ b/toga/platform/cocoa/libs/objc.py
@@ -731,9 +731,9 @@ class ObjCMethod(object):
             return result
         except ArgumentError as error:
             # Add more useful info to argument error exceptions, then reraise.
-            error.args += ('selector = ' + self.name,
-                           'argtypes =' + str(self.argtypes),
-                           'encoding = ' + self.encoding)
+            error.args += (b'selector = ' + self.name,
+                           b'argtypes =' + str(self.argtypes).encode(),
+                           b'encoding = ' + self.encoding)
             raise
 
 ######################################################################


### PR DESCRIPTION
Here is the script I was using (it now gives a ctypes error)

``` py
import toga

def button_handler(widget):
    print("hello")

if __name__ == '__main__':

    app = toga.App('First App', 'org.pybee.helloworld')

    container = toga.Container()

    button = toga.Button('Hello world', on_press=button_handler)

    progress = toga.ProgressBar(10)

    container.add(button)
    container.add(progress)

    container.constrain(button.TOP == container.TOP + 50)
    container.constrain(button.LEADING == container.LEADING + 50)
    container.constrain(button.TRAILING + 50 == container.TRAILING)
    container.constrain(button.BOTTOM + 50 < container.BOTTOM)
    container.constrain(progress.BOTTOM == (container.BOTTOM - button.BOTTOM)/2)

    app.main_window.content = container

    app.main_loop()

```
