### PR TITLE
TOGA-GTK password input can be used

### DIFF
--- a/docs/reference/supported_platforms/PasswordInput.rst
+++ b/docs/reference/supported_platforms/PasswordInput.rst
@@ -3,7 +3,7 @@
     +-------------+----+-----+----+------+-----+----+-------+
     |  Component  |iOS |win32|web |django|cocoa|gtk |android|
     +=============+====+=====+====+======+=====+====+=======+
-    |PasswordInput||no|||yes|||no|||no|  ||yes|||no|||no|   |
+    |PasswordInput||no|||yes|||no|||no|  ||yes|||yes|||no|   |
     +-------------+----+-----+----+------+-----+----+-------+
 
 .. |yes| image:: /_static/yes.png


### PR DESCRIPTION
Sir,

I think that this is a working widget. I DID NOT CREATE THIS WIDGET.

When I was doing tests on the the widgets and comparing them to the documentation to see if everything is up to date I found that I can import the widget and use it...

