### PR TITLE
[WIP] Switch WebView implementation for iOS & Cocoa from WebKit1(WebView/UIWebView) to WebKit2(WKWebView).

### DIFF
--- a/src/cocoa/toga_cocoa/libs/webkit.py
+++ b/src/cocoa/toga_cocoa/libs/webkit.py
@@ -17,4 +17,4 @@ WebView = ObjCClass('WebView')
 try:
     WKWebView = ObjCClass('WKWebView')
 except NameError:  # WKWebView is only available under macOS 10.10 or newer.
-    pass
+    WKWebView = None

--- a/src/cocoa/toga_cocoa/widgets/webview.py
+++ b/src/cocoa/toga_cocoa/widgets/webview.py
@@ -4,6 +4,8 @@ from toga_cocoa.libs import *
 
 from .base import Widget
 
+from concurrent.futures import Future
+
 
 class TogaWebView(WebView):
     @objc_method
@@ -27,7 +29,7 @@ class TogaWebView(WebView):
         return None
 
 
-class WebView(Widget):
+class WebKit1WebView(Widget):
     def create(self):
         self.native = TogaWebView.alloc().init()
         self.native.interface = self.interface
@@ -66,3 +68,78 @@ class WebView(Widget):
         :type  javascript: ``str``
         """
         return self.native.stringByEvaluatingJavaScriptFromString(javascript)
+
+
+if "WKWebView" in vars():
+    class TogaWKWebView(WKWebView):
+        @objc_method
+        def webView_didFinish_(self, navi):
+            if self.interface.on_webview_load:
+            self.interface.on_webview_load(self.interface)
+
+        @objc_method
+        def acceptsFirstResponder(self) -> bool:
+            return True
+
+        @objc_method
+        def keyDown_(self, event) -> None:
+            print('in keyDown', event.keyCode)
+            if self.interface.on_key_down:
+                self.interface.on_key_down(event.keyCode, event.modifierFlags)
+
+        @objc_method
+        def touchBar(self):
+            # Disable the touchbar.
+            return None
+
+    class WebKit2WebView(Widget):
+        def create(self):
+            self.native = TogaWKWebView.alloc().init()
+            self.native.interface = self.interface
+
+            self.native.uiDelegate = self.native
+            self.native.navigationDelegate = self.native
+
+            self.add_constraints()
+
+        def get_dom(self):
+            return self.evaluate(
+                'document.getElementsByTagName("html")[0].outerHTML')
+
+        def set_url(self, value):
+            if value:
+                self.interface.url = value
+
+            request = NSURLRequest.requestWithURL(NSURL.URLWithString(
+                self.interface.url))
+            self.native.load(request)
+
+        def set_content(self, root_url, content):
+            self.native.loadHTMLString_baseURL_(
+                content, NSURL.URLWithString(root_url))
+
+        def set_user_agent(self, value):
+            self.native.customUserAgent = value
+
+        def evaluate(self, js_str):
+            fur = Future()  # type: concurrent.futures.Future
+
+            def when_finish(result, err):
+                if fur.done():
+                    return
+
+                if err:
+                    fur.set_exception(err)
+
+                else:
+                    fur.set_result(result)
+
+            self.native.evaluateJavaScript_completionHandler_(
+                js_str, when_finish)
+
+            return fur
+
+    WebView = WebKit2WebView
+
+else:
+    WebView = WebKit1WebView

--- a/src/cocoa/toga_cocoa/widgets/webview.py
+++ b/src/cocoa/toga_cocoa/widgets/webview.py
@@ -4,7 +4,7 @@ from toga_cocoa.libs import *
 
 from .base import Widget
 
-from concurrent.futures import Future
+import asyncio
 
 
 class TogaWebView(WebView):
@@ -70,7 +70,7 @@ class WebKit1WebView(Widget):
         return self.native.stringByEvaluatingJavaScriptFromString(javascript)
 
 
-if "WKWebView" in vars():
+if WKWebView is not None:  # WKWebView is only available under macOS 10.10 or newer.
     class TogaWKWebView(WKWebView):
         @objc_method
         def webView_didFinish_(self, navi):
@@ -122,14 +122,15 @@ if "WKWebView" in vars():
             self.native.customUserAgent = value
 
         def evaluate(self, js_str):
-            fur = Future()  # type: concurrent.futures.Future
+            fur = asyncio.Future()
 
             def when_finish(result, err):
                 if fur.done():
                     return
 
                 if err:
-                    fur.set_exception(err)
+                    # Is NSError a subclass of BaseException?
+                    fur.set_exception(RuntimeError(err))
 
                 else:
                     fur.set_result(result)

--- a/src/iOS/toga_iOS/libs/__init__.py
+++ b/src/iOS/toga_iOS/libs/__init__.py
@@ -1,8 +1,4 @@
 from .core_graphics import *
 from .foundation import *
 from .uikit import *
-
-try:
-    from .webkit import *
-except ImportError:
-    pass
+from .webkit import *

--- a/src/iOS/toga_iOS/libs/__init__.py
+++ b/src/iOS/toga_iOS/libs/__init__.py
@@ -1,3 +1,8 @@
 from .core_graphics import *
 from .foundation import *
 from .uikit import *
+
+try:
+    from .webkit import *
+except ImportError:
+    pass

--- a/src/iOS/toga_iOS/libs/webkit.py
+++ b/src/iOS/toga_iOS/libs/webkit.py
@@ -7,14 +7,14 @@ from ctypes import util
 from rubicon.objc import *
 
 ######################################################################
-webkit = cdll.LoadLibrary(util.find_library('WebKit'))
+
+webkit_path = util.find_library('WebKit')
+
+if not webkit_path:  # WKWebView is only available under iOS 8.0 or newer.
+    raise ImportError("WebKit is not available.")
+
+webkit = cdll.LoadLibrary(webkit_path)
 ######################################################################
 
 ######################################################################
-# WebView.h
-WebView = ObjCClass('WebView')
-
-try:
-    WKWebView = ObjCClass('WKWebView')
-except NameError:  # WKWebView is only available under macOS 10.10 or newer.
-    pass
+WKWebView = ObjCClass('WKWebView')

--- a/src/iOS/toga_iOS/libs/webkit.py
+++ b/src/iOS/toga_iOS/libs/webkit.py
@@ -8,13 +8,11 @@ from rubicon.objc import *
 
 ######################################################################
 
-webkit_path = util.find_library('WebKit')
+_webkit_path = util.find_library('WebKit')
 
-if not webkit_path:  # WKWebView is only available under iOS 8.0 or newer.
-    raise ImportError("WebKit is not available.")
+if not _webkit_path:  # WebKit framework is only available under iOS 8.0 or newer.
+    WKWebView = None
+else:
+    webkit = cdll.LoadLibrary(_webkit_path)
 
-webkit = cdll.LoadLibrary(webkit_path)
-######################################################################
-
-######################################################################
-WKWebView = ObjCClass('WKWebView')
+    WKWebView = ObjCClass('WKWebView')

--- a/src/iOS/toga_iOS/widgets/webview.py
+++ b/src/iOS/toga_iOS/widgets/webview.py
@@ -4,7 +4,7 @@ from toga_iOS.libs import *
 
 from .base import Widget
 
-from concurrent.futures import Future
+import asyncio
 
 
 class TogaUIWebView(UIWebView):
@@ -52,7 +52,7 @@ class WebKit1WebView(Widget):
         return self.native.stringByEvaluatingJavaScriptFromString_(javascript)
 
 
-if "WKWebView" in vars():
+if WKWebView is not None:  # WKWebView is only available under iOS 8.0 or newer.
     class TogaWKWebView(WKWebView):
         @objc_method
         def webView_didFinish_(self, navi):
@@ -104,14 +104,15 @@ if "WKWebView" in vars():
             self.native.customUserAgent = value
 
         def evaluate(self, js_str):
-            fur = Future()  # type: concurrent.futures.Future
+            fur = asyncio.Future()
 
             def when_finish(result, err):
                 if fur.done():
                     return
 
                 if err:
-                    fur.set_exception(err)
+                    # Is NSError a subclass of BaseException?
+                    fur.set_exception(RuntimeError(err))
 
                 else:
                     fur.set_result(result)

--- a/src/iOS/toga_iOS/widgets/webview.py
+++ b/src/iOS/toga_iOS/widgets/webview.py
@@ -4,8 +4,10 @@ from toga_iOS.libs import *
 
 from .base import Widget
 
+from concurrent.futures import Future
 
-class TogaWebView(UIWebView):
+
+class TogaUIWebView(UIWebView):
     @objc_method
     def webView_didFinishLoadForFrame_(self, sender, frame) -> None:
         if self.interface.on_webview_load:
@@ -21,9 +23,9 @@ class TogaWebView(UIWebView):
             self.interface.on_key_down(event.keyCode, event.modifierFlags)
 
 
-class WebView(Widget):
+class WebKit1WebView(Widget):
     def create(self):
-        self.native = TogaWebView.alloc().init()
+        self.native = TogaUIWebView.alloc().init()
         self.native.interface = self.interface
         self.native.delegate = self.native
 
@@ -49,3 +51,77 @@ class WebView(Widget):
     def evaluate(self, javascript):
         return self.native.stringByEvaluatingJavaScriptFromString_(javascript)
 
+
+if "WKWebView" in vars():
+    class TogaWKWebView(WKWebView):
+        @objc_method
+        def webView_didFinish_(self, navi):
+            if self.interface.on_webview_load:
+            self.interface.on_webview_load(self.interface)
+
+        @objc_method
+        def acceptsFirstResponder(self) -> bool:
+            return True
+
+        @objc_method
+        def keyDown_(self, event) -> None:
+            print('in keyDown', event.keyCode)
+            if self.interface.on_key_down:
+                self.interface.on_key_down(event.keyCode, event.modifierFlags)
+
+        @objc_method
+        def touchBar(self):
+            # Disable the touchbar.
+            return None
+
+    class WebKit2WebView(Widget):
+        def create(self):
+            self.native = TogaWKWebView.alloc().init()
+            self.native.interface = self.interface
+
+            self.native.uiDelegate = self.native
+            self.native.navigationDelegate = self.native
+
+            self.add_constraints()
+
+        def get_dom(self):
+            return self.evaluate(
+                'document.getElementsByTagName("html")[0].outerHTML')
+
+        def set_url(self, value):
+            if value:
+                self.interface.url = value
+
+            request = NSURLRequest.requestWithURL(NSURL.URLWithString(
+                self.interface.url))
+            self.native.load(request)
+
+        def set_content(self, root_url, content):
+            self.native.loadHTMLString_baseURL_(
+                content, NSURL.URLWithString(root_url))
+
+        def set_user_agent(self, value):
+            self.native.customUserAgent = value
+
+        def evaluate(self, js_str):
+            fur = Future()  # type: concurrent.futures.Future
+
+            def when_finish(result, err):
+                if fur.done():
+                    return
+
+                if err:
+                    fur.set_exception(err)
+
+                else:
+                    fur.set_result(result)
+
+            self.native.evaluateJavaScript_completionHandler_(
+                js_str, when_finish)
+
+            return fur
+
+    WebView = WebKit2WebView
+
+else:
+    WebView = WebKit1WebView


### PR DESCRIPTION
The new WKWebView is a new and unified API across macOS and iOS based on WebKit2 aiming to replace the existing WebView and UIWebView which both are based on WebKit1.

The main advantage is that it splits UI process and web processes and isolates different web pages into different processes, which makes it more stable and will not affect the UI process and the other web pages when one web process crashes.

However, UI process and web processes communicate via IPC, which means `evaluate` and `get_dom` will not return instantly and result in breaking API changes.

In addition, I haven't tested it yet as I am stilling working on it.

See: https://trac.webkit.org/wiki/WebKit2