### PR TITLE
fix #400 - Button seems to ignore enabled parameter on initialisation

### DIFF
--- a/src/core/toga/widgets/base.py
+++ b/src/core/toga/widgets/base.py
@@ -38,8 +38,6 @@ class Widget(Node):
         self._app = None
         self._impl = None
 
-        self._enabled = enabled
-
         self.factory = get_platform_factory(factory)
 
     def __repr__(self):

--- a/src/core/toga/widgets/button.py
+++ b/src/core/toga/widgets/button.py
@@ -27,6 +27,9 @@ class Button(Widget):
         self.label = label
         self.on_press = on_press
 
+        # enable or disable the button as the case may be
+        self.enabled = enabled
+
     @property
     def label(self):
         """

--- a/src/gtk/toga_gtk/widgets/button.py
+++ b/src/gtk/toga_gtk/widgets/button.py
@@ -16,10 +16,6 @@ class Button(Widget):
         self.native.set_label(self.interface.label)
         self.rehint()
 
-    def set_enabled(self, value):
-        # self._impl.set_sensitive(value)
-        self.interface.factory.not_implemented('Button.set_enabled()')
-
     def set_background_color(self, value):
         self.interface.factory.not_implemented('Button.set_background_color()')
 


### PR DESCRIPTION
Fixes #400. Fixed button enable/disable issue for Linux. Now the enabled parameter
works on Linux platform. Also enabled property can now be updated
properly using the enabled API which was previously not working.

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
