### PR TITLE
Progressbar crash on start

### DIFF
--- a/src/winforms/toga_winforms/widgets/progressbar.py
+++ b/src/winforms/toga_winforms/widgets/progressbar.py
@@ -8,6 +8,8 @@ from .base import Widget
 class ProgressBar(Widget):
     def create(self):
         self.native = WinForms.ProgressBar()
+        # Windows expects integers provide 3 decimal precision for % resolution
+        self.native.Maximum = 1000
 
     def start(self):
         '''Not supported for WinForms implementation'''
@@ -24,9 +26,19 @@ class ProgressBar(Widget):
         # self.native.Style = ProgressBarStyle.Continuous
 
     def set_max(self, value):
-        self.native.Maximum = value
+        self.interface.factory.not_implemented('ProgressBar.set_max()')
 
     def set_value(self, value):
+        if value is None:
+            value = self.native.Minimum
+        if not isinstance(value, float):
+            value = float(value)
+        # convert to integer that is % of max.
+        value = int(value * self.native.Maximum)
+        if value > self.native.Maximum:
+            value = self.native.Maximum
+        if value < self.native.Minimum:
+            value = self.native.Minimum
         self.native.Value = value
 
     def rehint(self):


### PR DESCRIPTION
<!--- Describe your changes in detail -->
windows expects int32 values for maximum and value.  core spec is working with floats.  
Adjusted the windows implementation to convert float to integer by setting a 3 decimal place precision for max value to cover edge cases.   Inserted not supported max for windows.   Now the value gets converted to a percentage of max (1000).  Will not allow you to go over max and under min will instead just set to max or min respectively.  Also added if None is passed in then the default is to use the min value as the value.
<!--- What problem does this change solve? -->
#504 
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x ] All new features have been tested
- [x ] All new features have been documented
- [x ] I have read the **CONTRIBUTING.md** file
- [x ] I will abide by the code of conduct
