### PR TITLE
ComboBox implementation for GTK

### DIFF
--- a/docs/reference/api/index.rst
+++ b/docs/reference/api/index.rst
@@ -23,6 +23,7 @@ General widgets
 ======================================================================= ====================================
  :doc:`Button </reference/api/widgets/button>`                           Basic clickable Button
  :doc:`Canvas </reference/api/widgets/canvas>`                           Area you can draw on
+ :doc:`ComboBox </reference/api/widgets/combobox>`                       A text input with options
  :doc:`DetailedList </reference/api/widgets/detailedlist>`               A list of complex content
  :doc:`ImageView </reference/api/widgets/imageview>`                     Image Viewer
  :doc:`Label </reference/api/widgets/label>`                             Text label

--- a/docs/reference/api/widgets/combobox.rst
+++ b/docs/reference/api/widgets/combobox.rst
@@ -1,0 +1,30 @@
+ComboBox
+========
+
+======= ====== ========= ===== ========= ========
+ macOS   GTK+   Windows   iOS   Android   Django
+======= ====== ========= ===== ========= ========
+         |y|
+======= ====== ========= ===== ========= ========
+
+.. |y| image:: /_static/yes.png
+    :width: 16
+
+The ComboBox widget is a free entry input field that provides options to the user.
+
+Usage
+-----
+
+.. code-block:: Python
+
+    import toga
+
+    container = toga.ComboBox(initial='toga', items=['batavia', 'voc', 'beekeeper'])
+
+Reference
+---------
+
+.. autoclass:: toga.widgets.combobox.ComboBox
+   :members:
+   :undoc-members:
+   :inherited-members:

--- a/docs/reference/api/widgets/index.rst
+++ b/docs/reference/api/widgets/index.rst
@@ -5,6 +5,7 @@ Widgets
 
    button
    canvas
+   combobox
    detailedlist
    imageview
    label

--- a/examples/combobox/README.rst
+++ b/examples/combobox/README.rst
@@ -1,0 +1,14 @@
+ComboBox example
+===============
+
+ComboBox example for the `Toga widget toolkit`_
+
+
+Quickstart
+~~~~~~~~~~
+
+To run this example:
+
+    > pip install toga
+    > python -m combobox
+

--- a/examples/combobox/combobox/__init__.py
+++ b/examples/combobox/combobox/__init__.py
@@ -1,0 +1,9 @@
+# Examples of valid version strings
+# __version__ = '1.2.3.dev1'  # Development release 1
+# __version__ = '1.2.3a1'     # Alpha Release 1
+# __version__ = '1.2.3b1'     # Beta Release 1
+# __version__ = '1.2.3rc1'    # RC Release 1
+# __version__ = '1.2.3'       # Final Release
+# __version__ = '1.2.3.post1' # Post Release 1
+
+__version__ = '0.0.1'

--- a/examples/combobox/combobox/__main__.py
+++ b/examples/combobox/combobox/__main__.py
@@ -1,0 +1,4 @@
+from combobox.app import main
+
+if __name__ == '__main__':
+    main().main_loop()

--- a/examples/combobox/combobox/app.py
+++ b/examples/combobox/combobox/app.py
@@ -16,39 +16,63 @@ class ComboBoxApp(toga.App):
         # Add the content on the main window
         self.main_window.content = toga.Box(
             children=[
-                toga.Box(style=box_style, children=[
-                    toga.Label("Select an element",
-                        style=label_style),
+                toga.Box(
+                    style=box_style,
+                    children=[
+                        toga.Label(
+                            "Select an element",
+                            style=label_style
+                        ),
+                        toga.ComboBox(
+                            initial='toga',
+                            placeholder='shoutout',
+                            items=['batavia', 'voc', 'beekeeper'],
+                        ),
+                    ]
+                ),
 
-                    toga.ComboBox(items=["Carbon", "Ytterbium", "Thulium"])
-                ]),
+                toga.Box(
+                    style=box_style,
+                    children=[
+                        toga.Label(
+                            "use the 'on_change' callback to respond to changes",
+                            style=label_style
+                        ),
+                        toga.ComboBox(
+                            on_change=self.my_on_change,
+                            placeholder='!!!',
+                            items=["Dubnium", "Holmium", "Zirconium"],
+                        )
 
-                toga.Box(style=box_style, children=[
-                    toga.Label("use the 'on_change' callback to respond to changes",
-                        style=label_style),
+                    ]),
 
-                    toga.ComboBox(
-                      on_change=self.my_on_change,
-                      items=["Dubnium", "Holmium", "Zirconium"])
+                toga.Box(
+                    style=box_style,
+                    children=[
+                        toga.Label(
+                            "Long lists of items should scroll",
+                            style=label_style
+                        ),
+                        toga.ComboBox(
+                            placeholder='dir(toga)',
+                            items=dir(toga)
+                        ),
+                    ]),
 
-                ]),
+                toga.Box(
+                    style=box_style, children=[
+                        toga.Label(
+                            "use some style!",
+                            style=label_style,
+                        ),
 
-                toga.Box(style=box_style, children=[
-                    toga.Label("Long lists of items should scroll",
-                        style=label_style),
-
-                    toga.ComboBox(items=dir(toga)),
-                ]),
-
-                toga.Box(style=box_style, children=[
-                    toga.Label("use some style!", style=label_style),
-
-                    toga.ComboBox(
-                        style=Pack(width=200, padding=24),
-                        items=["Curium", "Titanium", "Copernicium"])
-                ]),
+                        toga.ComboBox(
+                            style=Pack(width=200, padding=24),
+                            items=["Curium", "Titanium", "Copernicium"]
+                        )
+                    ]),
             ],
-            style=Pack(direction=COLUMN, padding=24)
+        style=Pack(direction=COLUMN, padding=24)
         )
 
         self.main_window.show()

--- a/examples/combobox/combobox/app.py
+++ b/examples/combobox/combobox/app.py
@@ -1,0 +1,62 @@
+import toga
+from toga.style import Pack
+from toga.constants import COLUMN, ROW
+
+class ComboBoxApp(toga.App):
+
+    def startup(self):
+        # Main window of the application with title and size
+        self.main_window = toga.MainWindow(title=self.name, size=(640, 400))
+
+        # set up common styles
+        label_style = Pack(flex=1, padding_right=24)
+        box_style = Pack(direction=ROW, padding=10)
+
+        # Add the content on the main window
+        self.main_window.content = toga.Box(
+            children=[
+                toga.Box(style=box_style, children=[
+                    toga.Label("Select an element",
+                        style=label_style),
+
+                    toga.ComboBox(items=["Carbon", "Ytterbium", "Thulium"])
+                ]),
+
+                toga.Box(style=box_style, children=[
+                    toga.Label("use the 'on_change' callback to respond to changes",
+                        style=label_style),
+
+                    toga.ComboBox(
+                      on_change=self.my_on_change,
+                      items=["Dubnium", "Holmium", "Zirconium"])
+
+                ]),
+
+                toga.Box(style=box_style, children=[
+                    toga.Label("Long lists of items should scroll",
+                        style=label_style),
+
+                    toga.ComboBox(items=dir(toga)),
+                ]),
+
+                toga.Box(style=box_style, children=[
+                    toga.Label("use some style!", style=label_style),
+
+                    toga.ComboBox(
+                        style=Pack(width=200, padding=24),
+                        items=["Curium", "Titanium", "Copernicium"])
+                ]),
+            ],
+            style=Pack(direction=COLUMN, padding=24)
+        )
+
+        self.main_window.show()
+
+    def my_on_change(self, combobox):
+        # get the current value of the slider with `combobox.value`
+        print("The combobox widget changed to {0}".format(combobox.value))
+
+
+def main():
+    # App name and namespace
+    return ComboBoxApp('ComboBox', 'org.pybee.combobox')

--- a/examples/combobox/combobox/app.py
+++ b/examples/combobox/combobox/app.py
@@ -15,70 +15,68 @@ class ComboBoxApp(toga.App):
 
         # Add the content on the main window
         self.main_window.content = toga.Box(
-            children=[
+            style=Pack(direction=COLUMN, padding=24),
+            children=(
                 toga.Box(
                     style=box_style,
                     children=[
                         toga.Label(
                             "Select an element",
-                            style=label_style
+                            style=label_style,
                         ),
                         toga.ComboBox(
                             initial='toga',
                             placeholder='shoutout',
                             items=['batavia', 'voc', 'beekeeper'],
                         ),
-                    ]
+                    ],
                 ),
-
                 toga.Box(
                     style=box_style,
                     children=[
                         toga.Label(
-                            "use the 'on_change' callback to respond to changes",
-                            style=label_style
+                            "use 'on_change' callback to respond to changes",
+                            style=label_style,
                         ),
                         toga.ComboBox(
                             on_change=self.my_on_change,
                             placeholder='!!!',
                             items=["Dubnium", "Holmium", "Zirconium"],
-                        )
-
-                    ]),
-
+                        ),
+                    ],
+                ),
                 toga.Box(
                     style=box_style,
                     children=[
                         toga.Label(
                             "Long lists of items should scroll",
-                            style=label_style
+                            style=label_style,
                         ),
                         toga.ComboBox(
                             placeholder='dir(toga)',
                             items=dir(toga)
                         ),
-                    ]),
-
+                    ],
+                ),
                 toga.Box(
-                    style=box_style, children=[
+                    style=box_style,
+                    children=[
                         toga.Label(
                             "use some style!",
                             style=label_style,
                         ),
-
                         toga.ComboBox(
                             style=Pack(width=200, padding=24),
-                            items=["Curium", "Titanium", "Copernicium"]
-                        )
-                    ]),
-            ],
-        style=Pack(direction=COLUMN, padding=24)
+                            items=["Curium", "Titanium", "Copernicium"],
+                        ),
+                    ],
+                ),
+            ),
         )
-
         self.main_window.show()
 
     def my_on_change(self, combobox):
-        # get the current value of the slider with `combobox.value`
+        # get the current value of the combobox with `combobox.value`
         print("The combobox widget changed to {0}".format(combobox.value))
 
 

--- a/examples/combobox/combobox/app.py
+++ b/examples/combobox/combobox/app.py
@@ -27,7 +27,7 @@ class ComboBoxApp(toga.App):
                         toga.ComboBox(
                             initial='toga',
                             placeholder='shoutout',
-                            data=['batavia', 'voc', 'beekeeper'],
+                            items=['batavia', 'voc', 'beekeeper'],
                         ),
                     ],
                 ),
@@ -41,7 +41,7 @@ class ComboBoxApp(toga.App):
                         toga.ComboBox(
                             on_change=self.my_on_change,
                             placeholder='!!!',
-                            data=["Dubnium", "Holmium", "Zirconium"],
+                            items=["Dubnium", "Holmium", "Zirconium"],
                         ),
                     ],
                 ),
@@ -49,12 +49,12 @@ class ComboBoxApp(toga.App):
                     style=box_style,
                     children=[
                         toga.Label(
-                            "Long lists of data should scroll",
+                            "Long lists of items should scroll",
                             style=label_style,
                         ),
                         toga.ComboBox(
                             placeholder='dir(toga)',
-                            data=dir(toga)
+                            items=dir(toga)
                         ),
                     ],
                 ),
@@ -67,7 +67,7 @@ class ComboBoxApp(toga.App):
                         ),
                         toga.ComboBox(
                             style=Pack(width=200, padding=24),
-                            data=["Curium", "Titanium", "Copernicium"],
+                            items=["Curium", "Titanium", "Copernicium"],
                         ),
                     ],
                 ),

--- a/examples/combobox/combobox/app.py
+++ b/examples/combobox/combobox/app.py
@@ -27,7 +27,7 @@ class ComboBoxApp(toga.App):
                         toga.ComboBox(
                             initial='toga',
                             placeholder='shoutout',
-                            items=['batavia', 'voc', 'beekeeper'],
+                            data=['batavia', 'voc', 'beekeeper'],
                         ),
                     ],
                 ),
@@ -41,7 +41,7 @@ class ComboBoxApp(toga.App):
                         toga.ComboBox(
                             on_change=self.my_on_change,
                             placeholder='!!!',
-                            items=["Dubnium", "Holmium", "Zirconium"],
+                            data=["Dubnium", "Holmium", "Zirconium"],
                         ),
                     ],
                 ),
@@ -49,12 +49,12 @@ class ComboBoxApp(toga.App):
                     style=box_style,
                     children=[
                         toga.Label(
-                            "Long lists of items should scroll",
+                            "Long lists of data should scroll",
                             style=label_style,
                         ),
                         toga.ComboBox(
                             placeholder='dir(toga)',
-                            items=dir(toga)
+                            data=dir(toga)
                         ),
                     ],
                 ),
@@ -67,7 +67,7 @@ class ComboBoxApp(toga.App):
                         ),
                         toga.ComboBox(
                             style=Pack(width=200, padding=24),
-                            items=["Curium", "Titanium", "Copernicium"],
+                            data=["Curium", "Titanium", "Copernicium"],
                         ),
                     ],
                 ),

--- a/examples/combobox/combobox/app.py
+++ b/examples/combobox/combobox/app.py
@@ -2,6 +2,7 @@ import toga
 from toga.style import Pack
 from toga.constants import COLUMN, ROW
 
+
 class ComboBoxApp(toga.App):
 
     def startup(self):

--- a/examples/combobox/setup.py
+++ b/examples/combobox/setup.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+import io
+import re
+
+from setuptools import setup, find_packages
+
+with io.open('./combobox/__init__.py', encoding='utf8') as version_file:
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
+    if version_match:
+        version = version_match.group(1)
+    else:
+        raise RuntimeError("Unable to find version string.")
+
+
+with io.open('README.rst', encoding='utf8') as readme:
+    long_description = readme.read()
+
+
+setup(
+    name='combobox',
+    version=version,
+    description='A demonstration of all features of a toga.Selection example for the native GUI toolkit, Toga.',
+    long_description=long_description,
+    author='BeeWare',
+    author_email='contact@pybee.org',
+    license='New BSD',
+    packages=find_packages(exclude=['docs', 'tests']),
+    python_requires='>=3.5',
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: BSD License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3 :: Only',
+        'Topic :: Software Development',
+        'Topic :: Software Development :: User Interfaces',
+        'Topic :: Software Development :: Widget Sets',
+    ],
+    options={
+        'app': {
+            'formal_name': 'Selection',
+            'bundle': 'org.pybee'
+        },
+        'macos': {
+            'app_requires': [
+                'toga-gtk',
+            ]
+        },
+    }
+)

--- a/examples/combobox/setup.py
+++ b/examples/combobox/setup.py
@@ -19,7 +19,7 @@ with io.open('README.rst', encoding='utf8') as readme:
 setup(
     name='combobox',
     version=version,
-    description='A demonstration of all features of a toga.Selection example for the native GUI toolkit, Toga.',
+    description='A demonstration of all features of a toga.ComboBox example for the native GUI toolkit, Toga.',
     long_description=long_description,
     author='BeeWare',
     author_email='contact@pybee.org',
@@ -42,7 +42,7 @@ setup(
     ],
     options={
         'app': {
-            'formal_name': 'Selection',
+            'formal_name': 'ComboBox',
             'bundle': 'org.pybee'
         },
         'macos': {

--- a/src/core/tests/widgets/test_combobox.py
+++ b/src/core/tests/widgets/test_combobox.py
@@ -1,0 +1,44 @@
+import toga
+import toga_dummy
+from toga_dummy.utils import TestCase
+
+
+class SelectionTests(TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.items = ['item_{}'.format(x) for x in range(0, 3)]
+        self.combobox = toga.ComboBox(factory=toga_dummy.factory)
+        self.combobox = toga.ComboBox(items=self.items, factory=toga_dummy.factory)
+
+    def test_widget_created(self):
+        self.assertEqual(self.combobox._impl.interface, self.combobox)
+        self.assertActionPerformed(self.combobox, 'create ComboBox')
+
+    def test_items_were_set(self):
+        self.assertEqual(self.combobox.items, self.items)
+        self.assertActionPerformedWith(self.combobox, 'add item', item=self.items[0])
+        self.assertActionPerformedWith(self.combobox, 'add item', item=self.items[1])
+        self.assertActionPerformedWith(self.combobox, 'add item', item=self.items[2])
+
+    def test_set_items(self):
+        new_items = ['new_item_{}'.format(x) for x in range(0, 3)]
+        self.combobox.items = new_items
+        self.assertActionPerformed(self.combobox, 'remove all items')
+        for item in new_items:
+            self.assertActionPerformedWith(self.combobox, 'add item', item=item)
+        self.assertEqual(self.combobox.items, new_items)
+        self.assertEqual(self.combobox._items, new_items)
+
+    def test_get_selected_item_invokes_impl_method(self):
+        value = self.combobox.value
+        self.assertValueGet(self.combobox, 'value')
+
+    def test_value_set_invokes_impl_methods(self):
+        self.combobox.value = self.items[0]
+        self.assertValueSet(self.combobox, 'value', self.items[0])
+        self.combobox.value = 'not in items'
+        self.assertValueSet(self.combobox, 'value', 'not in items')
+
+    def test_on_change(self):
+        self.assertIsNone(self.combobox.on_change)

--- a/src/core/tests/widgets/test_combobox.py
+++ b/src/core/tests/widgets/test_combobox.py
@@ -7,27 +7,27 @@ from toga_dummy.utils import TestCase
 class ComboBoxTests(TestCase):
     def setUp(self):
         super().setUp()
-        self.data = ['item_{}'.format(x) for x in range(0, 3)]
+        self.items = ['item_{}'.format(x) for x in range(0, 3)]
         self.combobox = toga.ComboBox(factory=toga_dummy.factory)
-        self.combobox = toga.ComboBox(data=self.data, factory=toga_dummy.factory)
+        self.combobox = toga.ComboBox(items=self.items, factory=toga_dummy.factory)
 
     def test_widget_created(self):
         self.assertEqual(self.combobox._impl.interface, self.combobox)
         self.assertActionPerformed(self.combobox, 'create ComboBox')
 
-    def test_data_were_set(self):
-        actual_fields = [i.field for i in self.combobox.data]
-        self.assertEqual(self.data, actual_fields)
+    def test_items_were_set(self):
+        actual_fields = [i.field for i in self.combobox.items]
+        self.assertEqual(self.items, actual_fields)
         self.assertValueSet(
             self.combobox,
             'source',
-            self.combobox.data
+            self.combobox.items
         )
 
-    def test_set_data(self):
+    def test_set_items(self):
         expected_fields = ['new_item_{}'.format(x) for x in range(0, 3)]
-        self.combobox.data = expected_fields
-        actual_fields = [i.field for i in self.combobox.data]
+        self.combobox.items = expected_fields
+        actual_fields = [i.field for i in self.combobox.items]
         self.assertEqual(expected_fields, actual_fields)
 
     def test_get_selected_item_invokes_impl_method(self):
@@ -35,10 +35,10 @@ class ComboBoxTests(TestCase):
         self.assertValueGet(self.combobox, 'value')
 
     def test_value_set_invokes_impl_methods(self):
-        self.combobox.value = self.data[0]
-        self.assertValueSet(self.combobox, 'value', self.data[0])
-        self.combobox.value = 'not in data'
-        self.assertValueSet(self.combobox, 'value', 'not in data')
+        self.combobox.value = self.items[0]
+        self.assertValueSet(self.combobox, 'value', self.items[0])
+        self.combobox.value = 'not in items'
+        self.assertValueSet(self.combobox, 'value', 'not in items')
 
     def test_on_change(self):
         self.assertIsNone(self.combobox.on_change)

--- a/src/core/tests/widgets/test_combobox.py
+++ b/src/core/tests/widgets/test_combobox.py
@@ -1,4 +1,5 @@
 import toga
+from toga.sources import ListSource
 import toga_dummy
 from toga_dummy.utils import TestCase
 
@@ -6,39 +7,38 @@ from toga_dummy.utils import TestCase
 class ComboBoxTests(TestCase):
     def setUp(self):
         super().setUp()
-
-        self.items = ['item_{}'.format(x) for x in range(0, 3)]
+        self.data = ['item_{}'.format(x) for x in range(0, 3)]
         self.combobox = toga.ComboBox(factory=toga_dummy.factory)
-        self.combobox = toga.ComboBox(items=self.items, factory=toga_dummy.factory)
+        self.combobox = toga.ComboBox(data=self.data, factory=toga_dummy.factory)
 
     def test_widget_created(self):
         self.assertEqual(self.combobox._impl.interface, self.combobox)
         self.assertActionPerformed(self.combobox, 'create ComboBox')
 
-    def test_items_were_set(self):
-        self.assertEqual(self.combobox.items, self.items)
-        self.assertActionPerformedWith(self.combobox, 'add item', item=self.items[0])
-        self.assertActionPerformedWith(self.combobox, 'add item', item=self.items[1])
-        self.assertActionPerformedWith(self.combobox, 'add item', item=self.items[2])
+    def test_data_were_set(self):
+        actual_fields = [i.field for i in self.combobox.data]
+        self.assertEqual(self.data, actual_fields)
+        self.assertValueSet(
+            self.combobox,
+            'source',
+            self.combobox.data
+        )
 
-    def test_set_items(self):
-        new_items = ['new_item_{}'.format(x) for x in range(0, 3)]
-        self.combobox.items = new_items
-        self.assertActionPerformed(self.combobox, 'remove all items')
-        for item in new_items:
-            self.assertActionPerformedWith(self.combobox, 'add item', item=item)
-        self.assertEqual(self.combobox.items, new_items)
-        self.assertEqual(self.combobox._items, new_items)
+    def test_set_data(self):
+        expected_fields = ['new_item_{}'.format(x) for x in range(0, 3)]
+        self.combobox.data = expected_fields
+        actual_fields = [i.field for i in self.combobox.data]
+        self.assertEqual(expected_fields, actual_fields)
 
     def test_get_selected_item_invokes_impl_method(self):
         value = self.combobox.value
         self.assertValueGet(self.combobox, 'value')
 
     def test_value_set_invokes_impl_methods(self):
-        self.combobox.value = self.items[0]
-        self.assertValueSet(self.combobox, 'value', self.items[0])
-        self.combobox.value = 'not in items'
-        self.assertValueSet(self.combobox, 'value', 'not in items')
+        self.combobox.value = self.data[0]
+        self.assertValueSet(self.combobox, 'value', self.data[0])
+        self.combobox.value = 'not in data'
+        self.assertValueSet(self.combobox, 'value', 'not in data')
 
     def test_on_change(self):
         self.assertIsNone(self.combobox.on_change)

--- a/src/core/tests/widgets/test_combobox.py
+++ b/src/core/tests/widgets/test_combobox.py
@@ -3,7 +3,7 @@ import toga_dummy
 from toga_dummy.utils import TestCase
 
 
-class SelectionTests(TestCase):
+class ComboBoxTests(TestCase):
     def setUp(self):
         super().setUp()
 

--- a/src/core/toga/__init__.py
+++ b/src/core/toga/__init__.py
@@ -11,6 +11,7 @@ from .widgets.base import Widget
 from .widgets.box import Box
 from .widgets.button import Button
 from .widgets.canvas import Canvas
+from .widgets.combobox import ComboBox
 from .widgets.detailedlist import DetailedList
 from .widgets.image import *
 from .widgets.imageview import *
@@ -51,6 +52,7 @@ __all__ = [
     'Box',
     'Button',
     'Canvas',
+    'ComboBox',
     'Icon',
     'Image',
     'ImageView',

--- a/src/core/toga/widgets/combobox.py
+++ b/src/core/toga/widgets/combobox.py
@@ -14,14 +14,14 @@ class ComboBox(Widget):
         factory (:obj:`module`): A python module that is capable to return a
             implementation of this class with the same name. (optional & normally not needed)
         initial (str): The initial text for the combobox.
-        data (list[str]): The dropdown list of data
+        items (list[str]): The dropdown list of items
         placeholder (str): If no input is present this text is shown.
         on_change (callable[[], None]): Handle input/selection change
     '''
     MIN_WIDTH = 100
 
     def __init__(
-            self, id=None, style=None, factory=None, data=None,
+            self, id=None, style=None, factory=None, items=None,
             initial=None, placeholder=None, on_change=None):
         super().__init__(id=id, style=style, factory=factory)
 
@@ -33,30 +33,30 @@ class ComboBox(Widget):
 
         # Use public setters
         self.placeholder = placeholder
-        self.data = data if data else []
+        self.items = items if items else []
         self.value = initial
         self.on_change = on_change
 
     @property
-    def data(self):
-        ''' The data to display. It accepts data in the form of ``list``,
+    def items(self):
+        ''' The items to display. It accepts items in the form of ``list``,
         ``tuple``, or :obj:`ListSource`
 
         Returns:
             Returns a (:obj:`ListSource`).
         '''
-        return self._data
+        return self._items
 
-    @data.setter
-    def data(self, data):
-        if data is None:
-            self._data = ListSource(data=[], accessors=['field'])
-        if isinstance(data, (list, tuple)):
-            self._data = ListSource(data=data, accessors=['field'])
+    @items.setter
+    def items(self, items):
+        if items is None:
+            self._items = ListSource(data=[], accessors=['field'])
+        if isinstance(items, (list, tuple)):
+            self._items = ListSource(data=items, accessors=['field'])
         else:
-            self._data = data
-        self._data.add_listener(self._impl)
-        self._impl.change_source(source=self._data)
+            self._items = items
+        self._items.add_listener(self._impl)
+        self._impl.change_source(source=self._items)
 
     @property
     def placeholder(self):

--- a/src/core/toga/widgets/combobox.py
+++ b/src/core/toga/widgets/combobox.py
@@ -1,4 +1,5 @@
 from toga.handlers import wrapped_handler
+from toga.sources import ListSource
 
 from .base import Widget
 
@@ -13,14 +14,14 @@ class ComboBox(Widget):
         factory (:obj:`module`): A python module that is capable to return a
             implementation of this class with the same name. (optional & normally not needed)
         initial (str): The initial text for the combobox.
-        items (list[str]): The dropdown list of items
+        data (list[str]): The dropdown list of data
         placeholder (str): If no input is present this text is shown.
         on_change (callable[[], None]): Handle input/selection change
     '''
     MIN_WIDTH = 100
 
     def __init__(
-            self, id=None, style=None, factory=None, items=None,
+            self, id=None, style=None, factory=None, data=None,
             initial=None, placeholder=None, on_change=None):
         super().__init__(id=id, style=style, factory=factory)
 
@@ -32,27 +33,30 @@ class ComboBox(Widget):
 
         # Use public setters
         self.placeholder = placeholder
-        self.items = items if items else []
+        self.data = data if data else []
         self.value = initial
         self.on_change = on_change
 
     @property
-    def items(self):
-        ''' The list of items.
+    def data(self):
+        ''' The data to display. It accepts data in the form of ``list``,
+        ``tuple``, or :obj:`ListSource`
 
         Returns:
-             The ``list`` of ``str`` of all selectable items.
+            Returns a (:obj:`ListSource`).
         '''
-        return self._items
+        return self._data
 
-    @items.setter
-    def items(self, items):
-        self._impl.remove_all_items()
-
-        for i in items:
-            self._impl.add_item(i)
-
-        self._items = items
+    @data.setter
+    def data(self, data):
+        if data is None:
+            self._data = ListSource(data=[], accessors=['field'])
+        if isinstance(data, (list, tuple)):
+            self._data = ListSource(data=data, accessors=['field'])
+        else:
+            self._data = data
+        self._data.add_listener(self._impl)
+        self._impl.change_source(source=self._data)
 
     @property
     def placeholder(self):

--- a/src/core/toga/widgets/combobox.py
+++ b/src/core/toga/widgets/combobox.py
@@ -1,0 +1,88 @@
+from toga.handlers import wrapped_handler
+
+from .base import Widget
+
+
+class ComboBox(Widget):
+    """ A widget similar to textinput that provides a predefined set of choices
+
+    Args:
+        id (str): An identifier for this widget.
+        style (:obj:`Style`): An optional style object. If no style is provided then
+            a new one will be created for the widget.
+        factory (:obj:`module`): A python module that is capable to return a
+            implementation of this class with the same name. (optional & normally not needed)
+        initial (str): The initial text for the combobox.
+        placeholder (str): If no input is present this text is shown.
+        on_change (callable[[], None]): Handle input change
+    """
+    MIN_WIDTH = 100
+
+    def __init__(
+            self, id=None, style=None, factory=None,
+            initial=None, placeholder=None, on_change=None):
+        super().__init__(id=id, style=style, factory=factory)
+
+        # Create a platform specific implementation of a ComboBox
+        self._impl = self.factory.ComboBox(interface=self)
+
+        self.value = initial
+        self.placeholder = placeholder
+        self.on_change = on_change
+
+    @property
+    def placeholder(self):
+        """ The placeholder text.
+
+        Returns:
+            The placeholder text as a ``str``.
+        """
+        return self._placeholder
+
+    @placeholder.setter
+    def placeholder(self, value):
+        if value is None:
+            self._placeholder = ''
+        else:
+            self._placeholder = str(value)
+        self._impl.set_placeholder(value)
+
+    @property
+    def value(self):
+        """ The value of the text input field
+
+        Returns:
+            The current text of the widget as a ``str``.
+        """
+        return self._impl.get_value()
+
+    @value.setter
+    def value(self, value):
+        if value is None:
+            v = ''
+        else:
+            v = str(value)
+        self._impl.set_value(v)
+
+    def clear(self):
+        """ Clears the text of the widget """
+        self.value = ''
+
+    @property
+    def on_change(self):
+        """The handler to invoke when the value changes
+
+        Returns:
+            The function ``callable`` that is called on a content change.
+        """
+        return self._on_change
+
+    @on_change.setter
+    def on_change(self, handler):
+        """Set the handler to invoke when the value is changeed.
+
+        Args:
+            handler (:obj:`callable`): The handler to invoke when the value is changeed.
+        """
+        self._on_change = wrapped_handler(self, handler)
+        self._impl.set_on_change(self._on_change)

--- a/src/core/toga/widgets/combobox.py
+++ b/src/core/toga/widgets/combobox.py
@@ -31,9 +31,9 @@ class ComboBox(Widget):
         self._on_change = None
 
         # Use public setters
+        self.placeholder = placeholder
         self.items = items if items else []
         self.value = initial
-        self.placeholder = placeholder
         self.on_change = on_change
 
     @property

--- a/src/core/toga/widgets/combobox.py
+++ b/src/core/toga/widgets/combobox.py
@@ -27,7 +27,7 @@ class ComboBox(Widget):
         # Create a platform specific implementation of a ComboBox
         self._impl = self.factory.ComboBox(interface=self)
 
-        # # Initialize private values
+        # Initialize private values
         self._on_change = None
 
         # Use public setters

--- a/src/core/toga/widgets/combobox.py
+++ b/src/core/toga/widgets/combobox.py
@@ -4,7 +4,7 @@ from .base import Widget
 
 
 class ComboBox(Widget):
-    """ A widget similar to textinput that provides a predefined set of choices
+    ''' A widget similar to textinput that provides a predefined set of choices
 
     Args:
         id (str): An identifier for this widget.
@@ -13,30 +13,54 @@ class ComboBox(Widget):
         factory (:obj:`module`): A python module that is capable to return a
             implementation of this class with the same name. (optional & normally not needed)
         initial (str): The initial text for the combobox.
+        items (list[str]): The dropdown list of items
         placeholder (str): If no input is present this text is shown.
-        on_change (callable[[], None]): Handle input change
-    """
+        on_change (callable[[], None]): Handle input/selection change
+    '''
     MIN_WIDTH = 100
 
     def __init__(
-            self, id=None, style=None, factory=None,
+            self, id=None, style=None, factory=None, items=None,
             initial=None, placeholder=None, on_change=None):
         super().__init__(id=id, style=style, factory=factory)
 
         # Create a platform specific implementation of a ComboBox
         self._impl = self.factory.ComboBox(interface=self)
 
+        # # Initialize private values
+        self._on_change = None
+
+        # Use public setters
+        self.items = items if items else []
         self.value = initial
         self.placeholder = placeholder
         self.on_change = on_change
 
     @property
+    def items(self):
+        ''' The list of items.
+
+        Returns:
+             The ``list`` of ``str`` of all selectable items.
+        '''
+        return self._items
+
+    @items.setter
+    def items(self, items):
+        self._impl.remove_all_items()
+
+        for i in items:
+            self._impl.add_item(i)
+
+        self._items = items
+
+    @property
     def placeholder(self):
-        """ The placeholder text.
+        ''' The placeholder text.
 
         Returns:
             The placeholder text as a ``str``.
-        """
+        '''
         return self._placeholder
 
     @placeholder.setter
@@ -49,11 +73,11 @@ class ComboBox(Widget):
 
     @property
     def value(self):
-        """ The value of the text input field
+        ''' The value of the text input field
 
         Returns:
             The current text of the widget as a ``str``.
-        """
+        '''
         return self._impl.get_value()
 
     @value.setter
@@ -65,24 +89,24 @@ class ComboBox(Widget):
         self._impl.set_value(v)
 
     def clear(self):
-        """ Clears the text of the widget """
+        ''' Clears the text of the widget '''
         self.value = ''
 
     @property
     def on_change(self):
-        """The handler to invoke when the value changes
+        '''The handler to invoke when the value changes
 
         Returns:
             The function ``callable`` that is called on a content change.
-        """
+        '''
         return self._on_change
 
     @on_change.setter
     def on_change(self, handler):
-        """Set the handler to invoke when the value is changeed.
+        '''Set the handler to invoke when the value is changeed.
 
         Args:
             handler (:obj:`callable`): The handler to invoke when the value is changeed.
-        """
+        '''
         self._on_change = wrapped_handler(self, handler)
         self._impl.set_on_change(self._on_change)

--- a/src/dummy/toga_dummy/factory.py
+++ b/src/dummy/toga_dummy/factory.py
@@ -6,6 +6,7 @@ from .font import Font
 from .widgets.box import Box
 from .widgets.button import Button
 from .widgets.canvas import Canvas
+from .widgets.combobox import ComboBox
 from .widgets.detailedlist import DetailedList
 from .widgets.icon import Icon
 from .widgets.image import *
@@ -45,6 +46,7 @@ __all__ = [
     'Box',
     'Button',
     'Canvas',
+    'ComboBox',
     'DetailedList',
     'Icon',
     'Image',

--- a/src/dummy/toga_dummy/widgets/combobox.py
+++ b/src/dummy/toga_dummy/widgets/combobox.py
@@ -4,8 +4,20 @@ class ComboBox(Widget):
     def create(self):
         self._action('create ComboBox')
 
+    def remove_all_items(self):
+        self._action('remove all items')
+
+    def add_item(self, item):
+        self._action('add item', item)
+
+    def select_item(self, item):
+        self._action('select item', item)
+
     def get_value(self):
         return self._get_value('value')
+
+    def set_placeholder(self, value):
+        self._set_value('placeholder', value)
 
     def set_value(self, value):
         self._set_value('value', value)

--- a/src/dummy/toga_dummy/widgets/combobox.py
+++ b/src/dummy/toga_dummy/widgets/combobox.py
@@ -9,10 +9,10 @@ class ComboBox(Widget):
         self._action('remove all items')
 
     def add_item(self, item):
-        self._action('add item', item)
+        self._action('add item', item=item)
 
     def select_item(self, item):
-        self._action('select item', item)
+        self._action('select item', item=item)
 
     def get_value(self):
         return self._get_value('value')

--- a/src/dummy/toga_dummy/widgets/combobox.py
+++ b/src/dummy/toga_dummy/widgets/combobox.py
@@ -5,11 +5,8 @@ class ComboBox(Widget):
     def create(self):
         self._action('create ComboBox')
 
-    def remove_all_items(self):
-        self._action('remove all items')
-
-    def add_item(self, item):
-        self._action('add item', item=item)
+    def change_source(self, source):
+        self._set_value('source', source)
 
     def get_value(self):
         return self._get_value('value')

--- a/src/dummy/toga_dummy/widgets/combobox.py
+++ b/src/dummy/toga_dummy/widgets/combobox.py
@@ -1,0 +1,23 @@
+from .base import Widget
+
+class ComboBox(Widget):
+    def create(self):
+        self._action('create ComboBox')
+
+    def get_value(self):
+        return self._get_value('value')
+
+    def set_value(self, value):
+        self._set_value('value', value)
+
+    def set_font(self, value):
+        self._set_value('font', value)
+
+    def set_alignment(self, value):
+        self._set_value('alignment', value)
+
+    def rehint(self):
+        self._action('rehint ComboBox')
+
+    def set_on_change(self, handler):
+        self._set_value('on_change', handler)

--- a/src/dummy/toga_dummy/widgets/combobox.py
+++ b/src/dummy/toga_dummy/widgets/combobox.py
@@ -11,9 +11,6 @@ class ComboBox(Widget):
     def add_item(self, item):
         self._action('add item', item=item)
 
-    def select_item(self, item):
-        self._action('select item', item=item)
-
     def get_value(self):
         return self._get_value('value')
 

--- a/src/dummy/toga_dummy/widgets/combobox.py
+++ b/src/dummy/toga_dummy/widgets/combobox.py
@@ -1,5 +1,6 @@
 from .base import Widget
 
+
 class ComboBox(Widget):
     def create(self):
         self._action('create ComboBox')

--- a/src/gtk/toga_gtk/factory.py
+++ b/src/gtk/toga_gtk/factory.py
@@ -6,6 +6,7 @@ from .font import Font
 from .widgets.box import Box
 from .widgets.button import Button
 from .widgets.canvas import Canvas
+from .widgets.combobox import ComboBox
 from .widgets.detailedlist import DetailedList
 from .widgets.icon import Icon
 from .widgets.image import Image
@@ -43,6 +44,7 @@ __all__ = [
     'Box',
     'Button',
     'Canvas',
+    'ComboBox',
     'DetailedList',
     'Icon',
     'Image',

--- a/src/gtk/toga_gtk/widgets/combobox.py
+++ b/src/gtk/toga_gtk/widgets/combobox.py
@@ -26,9 +26,6 @@ class ComboBox(Widget):
         self.interface.factory.not_implemented('ComboBox.set_placeholder()')
 
     def get_value(self):
-        # TODO: Confirm this does not leak memory (not sure if the ctypes/cffi
-        # wrapper is handling). See:
-        # https://lazka.github.io/pgi-docs/#Gtk-3.0/classes/ComboBoxText.html#Gtk.ComboBoxText.get_active_text
         return self.native.get_active_text()
 
     def set_value(self, value):

--- a/src/gtk/toga_gtk/widgets/combobox.py
+++ b/src/gtk/toga_gtk/widgets/combobox.py
@@ -23,22 +23,15 @@ class ComboBox(Widget):
         self.native.append_text(item)
 
     def set_placeholder(self, value):
-        self.interface.factory.not_implemented('ComboBox.set_placeholder()')
+        entry = self.native.get_child()
+        entry.set_placeholder_text(value)
 
     def get_value(self):
         return self.native.get_active_text()
 
     def set_value(self, value):
-        # Set the active item to the entry
-        entry_id = self.native.get_entry_text_column()
-        self.native.set_active(entry_id)
-
-        # Pull out the ListStore
-        model = self.native.get_model()
-
-        # Get the TreeIter object for setting values in a TreeModel
-        tree_iter = model.get_iter_first()
-        model.set_value(tree_iter, entry_id, value)
+        entry = self.native.get_child()
+        entry.set_text(value)
 
     def set_font(self, value):
         self.interface.factory.not_implemented('ComboBox.set_font()')

--- a/src/gtk/toga_gtk/widgets/combobox.py
+++ b/src/gtk/toga_gtk/widgets/combobox.py
@@ -9,10 +9,9 @@ class ComboBox(Widget):
     def create(self):
         self.native = Gtk.ComboBoxText.new_with_entry()
         self.native.interface = self.interface
-        self.native.connect('changed', self._on_change)
-        self.native.connect('show', lambda event: self.rehint())
+        self.native.connect('changed', self.gtk_on_change)
 
-    def _on_change(self, widget):
+    def gtk_on_change(self, widget):
         if self.interface.on_change:
             self.interface.on_change(self.interface)
 

--- a/src/gtk/toga_gtk/widgets/combobox.py
+++ b/src/gtk/toga_gtk/widgets/combobox.py
@@ -1,0 +1,56 @@
+from gi.repository import Gtk
+from travertino.size import at_least
+
+from .base import Widget
+
+
+class ComboBox(Widget):
+
+    def create(self):
+        self.native = Gtk.ComboBoxText.new_with_entry()
+        self.native.interface = self.interface
+        self.native.connect('changed', self._on_select)
+        self.native.connect('show', lambda event: self.rehint())
+
+
+    # v- add to dummy
+    def _on_select(self, widget):
+        if self.interface.on_select:
+            self.interface.on_select(widget)
+
+    def remove_all_items(self):
+        self.native.remove_all()
+
+    def add_item(self, item):
+        self.native.append_text(item)
+
+        # Gtk.ComboBox does not select the first item, so it's done here.
+        if not self.get_selected_item():
+            self.select_item(item)
+
+    def select_item(self, item):
+        self.native.set_active(self.interface.items.index(item))
+    # ^- add to dummy
+
+    def get_value(self):
+        pass
+
+    def set_value(self, value):
+        pass
+
+    def set_font(self, value):
+        self.interface.factory.not_implemented('ComboBox.set_font()')
+
+    def set_alignment(self, value):
+        self.interface.factory.not_implemented('ComboBox.set_alignment()')
+
+    def rehint(self):
+        width = self.native.get_preferred_width()
+        height = self.native.get_preferred_height()
+
+        self.interface.intrinsic.width = at_least(self.interface.MIN_WIDTH)
+        self.interface.intrinsic.height = height[1]
+
+    def set_on_change(self, handler):
+        # No special handling required
+        pass

--- a/src/gtk/toga_gtk/widgets/combobox.py
+++ b/src/gtk/toga_gtk/widgets/combobox.py
@@ -15,11 +15,10 @@ class ComboBox(Widget):
         if self.interface.on_change:
             self.interface.on_change(self.interface)
 
-    def remove_all_items(self):
+    def change_source(self, source):
         self.native.remove_all()
-
-    def add_item(self, item):
-        self.native.append_text(item)
+        for row in source:
+            self.native.append_text(row.field)
 
     def set_placeholder(self, value):
         entry = self.native.get_child()

--- a/src/gtk/toga_gtk/widgets/combobox.py
+++ b/src/gtk/toga_gtk/widgets/combobox.py
@@ -1,4 +1,4 @@
-from gi.repository import Gtk, GLib
+from gi.repository import Gtk
 from travertino.size import at_least
 
 from .base import Widget

--- a/src/gtk/toga_gtk/widgets/combobox.py
+++ b/src/gtk/toga_gtk/widgets/combobox.py
@@ -22,10 +22,6 @@ class ComboBox(Widget):
     def add_item(self, item):
         self.native.append_text(item)
 
-    def select_item(self, item):
-        # here we rely on the fact that the first item is the entry
-        self.native.set_active(self.interface.items.index(item) + 1)
-
     def set_placeholder(self, value):
         self.interface.factory.not_implemented('ComboBox.set_placeholder()')
 

--- a/src/gtk/toga_gtk/widgets/combobox.py
+++ b/src/gtk/toga_gtk/widgets/combobox.py
@@ -31,7 +31,7 @@ class ComboBox(Widget):
 
     def get_value(self):
         # TODO: Confirm this does not leak memory (not sure if the ctypes/cffi
-        # wrapper is handling; see:
+        # wrapper is handling). See:
         # https://lazka.github.io/pgi-docs/#Gtk-3.0/classes/ComboBoxText.html#Gtk.ComboBoxText.get_active_text
         return self.native.get_active_text()
 

--- a/src/gtk/toga_gtk/widgets/multilinetextinput.py
+++ b/src/gtk/toga_gtk/widgets/multilinetextinput.py
@@ -1,4 +1,5 @@
 from gi.repository import Gtk
+from travertino.size import at_least
 
 from .base import Widget
 


### PR DESCRIPTION
This PR implements the ComboBox widget for GTK and defines the dummy interface to be expected on native implementations. The example works locally for me, let me know if there are any preferences about behavior/implementation details.

I've added docstrings to the best of my ability, let me know if any style changes are desired there.

~~Finally, while I was reading through pygobject docuentation, I saw a [note about memory allocation](https://lazka.github.io/pgi-docs/#Gtk-3.0/classes/ComboBoxText.html#Gtk.ComboBoxText.get_active_text), which expects a call to `GLib.free`. Not sure if this is something to worry about, but I figured I'd point it out (`get_active_text` is also used in the GTK selection widget). When I attempted to use `GLib.free`, I got the following error:~~

~~self.native.connect('destroy', lambda widget: GLib.free(output))~~
~~ValueError: Pointer arguments are restricted to integers, capsules, and None. See: https://bugzilla.gnome.org/show_bug.cgi?id=683599~~

EDIT: Switched the implementation to use the Gtk.Entry itself; missed that in the docs
> To allow the user to enter values not in the model, the “has-entry” property allows the Gtk.ComboBox to contain a Gtk.Entry. This entry can be accessed by calling Gtk.Bin.get_child() on the combo box.

[Reference](https://lazka.github.io/pgi-docs/#Gtk-3.0/classes/ComboBox.html#Gtk.ComboBox)

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct