### PR TITLE
Allow update of window content by assigning to the content attribute

### DIFF
--- a/src/gtk/toga_gtk/window.py
+++ b/src/gtk/toga_gtk/window.py
@@ -73,6 +73,12 @@ class Window:
             self.toolbar_native.insert(item_impl, -1)
 
     def set_content(self, widget):
+        is_content_update = False
+        # Remove any existing children (should be only one child)
+        for child in self.native.get_children():
+            self.native.remove(child)
+            is_content_update = True
+
         # Construct the top-level layout, and set the window's view to
         # the be the widget's native object.
         self.layout = Gtk.VBox()
@@ -82,7 +88,7 @@ class Window:
         self.layout.pack_start(widget.native, True, True, 0)
 
         self.native.add(self.layout)
-
+        
         # Make the window sensitive to size changes
         widget.native.connect('size-allocate', self.on_size_allocate)
 
@@ -92,6 +98,10 @@ class Window:
         # Add all children to the content widget.
         for child in widget.interface.children:
             child._impl.container = widget
+
+        if is_content_update:
+            # Make any changes visible
+            self.show()
 
     def show(self):
         self.native.show_all()


### PR DESCRIPTION
I've added code to the set_content method of the GTK native window wrapper that removes all current children from the window and refreshes the view at the end.

Updating the content of the application window  with a new toga.Box() did not work and instead produced this error:
```
Attempting to add a widget with type GtkVBox to a GtkApplicationWindow, but as a GtkBin subclass a GtkApplicationWindow can only contain one widget at a time; it already contains a widget of type GtkVBox
```
We can make this work by removing all children before adding the new layout. Additionally we have to 'refresh' the window by calling `self.show`. This is only done if we removed children before, to prevent the content from showing up during the creation of the window with a startup method.

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
