### PR TITLE
add close() to Window

### DIFF
--- a/examples/extrawindows/README.rst
+++ b/examples/extrawindows/README.rst
@@ -1,7 +1,7 @@
 extrawindows example
 ===============
 
-An example for opening and closing extar windows.
+An example for opening and closing extra windows.
 
 Quickstart
 ~~~~~~~~~~
@@ -9,5 +9,5 @@ Quickstart
 To run this example:
 
     > pip install toga
-    > python -m slider
+    > python -m extrawindows
 

--- a/examples/extrawindows/README.rst
+++ b/examples/extrawindows/README.rst
@@ -1,0 +1,13 @@
+extrawindows example
+===============
+
+An example for opening and closing extar windows.
+
+Quickstart
+~~~~~~~~~~
+
+To run this example:
+
+    > pip install toga
+    > python -m slider
+

--- a/examples/extrawindows/extrawindows/__init__.py
+++ b/examples/extrawindows/extrawindows/__init__.py
@@ -1,0 +1,9 @@
+# Examples of valid version strings
+# __version__ = '1.2.3.dev1'  # Development release 1
+# __version__ = '1.2.3a1'     # Alpha Release 1
+# __version__ = '1.2.3b1'     # Beta Release 1
+# __version__ = '1.2.3rc1'    # RC Release 1
+# __version__ = '1.2.3'       # Final Release
+# __version__ = '1.2.3.post1' # Post Release 1
+
+__version__ = '0.0.1'

--- a/examples/extrawindows/extrawindows/__main__.py
+++ b/examples/extrawindows/extrawindows/__main__.py
@@ -1,0 +1,4 @@
+from extrawindows.app import main
+
+if __name__ == '__main__':
+    main().main_loop()

--- a/examples/extrawindows/extrawindows/app.py
+++ b/examples/extrawindows/extrawindows/app.py
@@ -1,6 +1,7 @@
 import toga
 from toga.style import Pack
-from toga.constants import COLUMN, ROW
+from toga.constants import COLUMN
+
 
 class ExampleExtraWindowsApp(toga.App):
     # Button callback functions
@@ -16,14 +17,11 @@ class ExampleExtraWindowsApp(toga.App):
     def do_close(self, widget, **kwargs):
         '''Close a window, but only if a window is selected in the table.'''
         selection = self.table_open_windows.selection
-        if selection == None:
+        if selection is None:
             return
         window_name = selection.open_windows
         w = self.window(window_name)
         w.close()
-
-
-
 
     def update(self):
         '''Update what is displayed in the tables, and enable/disable some
@@ -43,7 +41,6 @@ class ExampleExtraWindowsApp(toga.App):
             self.btn_close.enabled = False
         else:
             self.btn_close.enabled = True
-
 
     def startup(self):
         # Set up main window
@@ -69,8 +66,6 @@ class ExampleExtraWindowsApp(toga.App):
         # Add the content on the main window
         self.main_window.content = box
 
-
-
         # Show the main window
         self.main_window.show()
 
@@ -79,22 +74,22 @@ class ExampleExtraWindowsApp(toga.App):
 
         self.update()
 
+
 class ExtraWindow(toga.Window):
     def startup(self, name, parent_app):
         self.parent = parent_app
         self.name = name
-        window_index = int(name.split()[1])
 
         box = toga.Box()
-        self.title=name
-        l = toga.Label(name)
-        box.add(l)
+        self.title = name
+        label = toga.Label(name)
+        box.add(label)
         self.content = box
-
 
     def on_close(self):
         super().on_close()
         self.parent.update()
+
 
 def main():
     return ExampleExtraWindowsApp('Extra Windows', 'org.pybee.widgets.extrawindows')

--- a/examples/extrawindows/extrawindows/app.py
+++ b/examples/extrawindows/extrawindows/app.py
@@ -10,7 +10,7 @@ class ExampleExtraWindowsApp(toga.App):
         self.window_count += 1
         w = ExtraWindow()
         w.startup(window_name, self)
-        self.add_window(window_name, w)
+        self.windows.add(w)
         w.show()
         self.update()
 
@@ -20,24 +20,22 @@ class ExampleExtraWindowsApp(toga.App):
         if selection is None:
             return
         window_name = selection.open_windows
-        w = self.window(window_name)
-        w.close()
+        for w in list(self.windows):
+            if w.name != window_name:
+                continue
+            w.close()
 
     def update(self):
         '''Update what is displayed in the tables, and enable/disable some
         buttons as appropriate'''
         self.table_open_windows.data.clear()
 
-        for window_id in self.windows:
-            if window_id == 'main':
-                continue
+        for window in self.windows:
 
-            self.table_open_windows.data.append(window_id)
+            self.table_open_windows.data.append(window.name)
 
         # enable/disable the top box buttons, for open windows
-        if len(self.windows) == 1:
-            # If just one window, the main window, there are no child
-            # windows.
+        if len(self.windows) == 0:
             self.btn_close.enabled = False
         else:
             self.btn_close.enabled = True

--- a/examples/extrawindows/extrawindows/app.py
+++ b/examples/extrawindows/extrawindows/app.py
@@ -1,0 +1,105 @@
+import toga
+from toga.style import Pack
+from toga.constants import COLUMN, ROW
+
+class ExampleExtraWindowsApp(toga.App):
+    # Button callback functions
+    def do_new(self, widget, **kwargs):
+        window_name = 'Window ' + str(self.window_count)
+        self.window_count += 1
+        w = ExtraWindow()
+        w.startup(window_name, self)
+        self.add_window(window_name, w)
+        w.show()
+        self.update()
+
+    def do_close(self, widget, **kwargs):
+        '''Close a window, but only if a window is selected in the table.'''
+        selection = self.table_open_windows.selection
+        if selection == None:
+            return
+        window_name = selection.open_windows
+        w = self.window(window_name)
+        w.close()
+
+
+
+
+    def update(self):
+        '''Update what is displayed in the tables, and enable/disable some
+        buttons as appropriate'''
+        self.table_open_windows.data.clear()
+
+        for window_id in self.windows:
+            if window_id == 'main':
+                continue
+
+            self.table_open_windows.data.append(window_id)
+
+        # enable/disable the top box buttons, for open windows
+        if len(self.windows) == 1:
+            # If just one window, the main window, there are no child
+            # windows.
+            self.btn_close.enabled = False
+        else:
+            self.btn_close.enabled = True
+
+
+    def startup(self):
+        # Set up main window
+        self.main_window = toga.MainWindow(self.name)
+
+        # Buttons next to the open windows table
+        btn_style = Pack(flex=1)
+        self.btn_new = toga.Button('New Window', on_press=self.do_new, style=btn_style)
+        self.btn_close = toga.Button('Close Window', on_press=self.do_close, style=btn_style)
+
+        self.table_open_windows = toga.Table(['Open Windows'])
+
+        # Outermost box
+        box = toga.Box(
+            children=[self.btn_new, self.btn_close, self.table_open_windows],
+            style=Pack(
+                flex=1,
+                direction=COLUMN,
+                padding=10,
+            )
+        )
+
+        # Add the content on the main window
+        self.main_window.content = box
+
+
+
+        # Show the main window
+        self.main_window.show()
+
+        # A counter of how many child windows we've made.
+        self.window_count = 1
+
+        self.update()
+
+class ExtraWindow(toga.Window):
+    def startup(self, name, parent_app):
+        self.parent = parent_app
+        self.name = name
+        window_index = int(name.split()[1])
+
+        box = toga.Box()
+        self.title=name
+        l = toga.Label(name)
+        box.add(l)
+        self.content = box
+
+
+    def on_close(self):
+        super().on_close()
+        self.parent.update()
+
+def main():
+    return ExampleExtraWindowsApp('Extra Windows', 'org.pybee.widgets.extrawindows')
+
+
+if __name__ == '__main__':
+    app = main()
+    app.main_loop()

--- a/examples/extrawindows/extrawindows/resources/README
+++ b/examples/extrawindows/extrawindows/resources/README
@@ -1,0 +1,1 @@
+Put any icons or images in this directory.

--- a/examples/extrawindows/setup.py
+++ b/examples/extrawindows/setup.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+import io
+import re
+
+from setuptools import setup, find_packages
+
+with io.open('./extrawindows/__init__.py', encoding='utf8') as version_file:
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
+    if version_match:
+        version = version_match.group(1)
+    else:
+        raise RuntimeError("Unable to find version string.")
+
+
+with io.open('README.rst', encoding='utf8') as readme:
+    long_description = readme.read()
+
+
+setup(
+    name='extrawindows',
+    version=version,
+    description='A demonstration of open and closing extra windows, in the Toga GUI toolkit.',
+    long_description=long_description,
+    author='BeeWare Project',
+    author_email='contact@pybee.org',
+    license='New BSD',
+    packages=find_packages(exclude=['docs', 'tests']),
+    python_requires='>=3.5',
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: BSD License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3 :: Only',
+        'Topic :: Software Development',
+        'Topic :: Software Development :: User Interfaces',
+        'Topic :: Software Development :: Widget Sets',
+    ],
+    options={
+        'app': {
+            'formal_name': 'extrawindows',
+            'bundle': 'org.pybee'
+        },
+        'macos': {
+            'app_requires': [
+                'toga-cocoa',
+            ]
+        },
+    }
+)

--- a/src/core/tests/test_app.py
+++ b/src/core/tests/test_app.py
@@ -70,7 +70,17 @@ class AppTests(TestCase):
         self.assertEqual(self.app.main_window.app, self.app)
         self.assertActionPerformed(self.app.main_window, 'show')
 
+        self.assertEqual(self.app.window('main').content, self.content)
+        self.assertEqual(self.app.windows['main'].content, self.content)
+
     def test_app_exit(self):
         self.app.exit()
 
         self.assertActionPerformed(self.app, 'exit')
+
+    def test_add_window(self):
+        window = MagicMock()
+        self.app.add_window('new', window)
+        self.assertEqual(self.app.window('new'), window)
+        self.assertEqual(self.app.windows, {'main': None, 'new': window})
+        

--- a/src/core/tests/test_app.py
+++ b/src/core/tests/test_app.py
@@ -75,8 +75,34 @@ class AppTests(TestCase):
 
         self.assertActionPerformed(self.app, 'exit')
 
-    def test_add_window(self):
-        window = MagicMock()
-        self.app.windows.add(window)
-        self.assertIn(window, self.app.windows)
-        self.assertEqual(window.app, self.app)
+class TestWindowSet(TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.app = toga.App('test_name', 'id.app', factory=toga_dummy.factory)
+        self.window = MagicMock()
+
+    def test_add(self):
+        self.app.windows.add(self.window)
+        self.assertIn(self.window, self.app.windows)
+        self.assertEqual(self.window.app, self.app)
+        self.assertEqual(1, len(self.app.windows))
+
+    def test_discard(self):
+        self.app.windows.add(self.window)
+        self.app.windows.discard(self.window)
+        self.assertNotIn(self.window, self.app.windows)
+
+    def test_remove(self):
+        self.app.windows.add(self.window)
+        self.app.windows.remove(self.window)
+        self.assertNotIn(self.window, self.app.windows)
+
+        with self.assertRaises(KeyError):
+            self.app.windows.remove(self.window)
+
+    def test_iter(self):
+        self.app.windows.add(self.window)
+
+        for w in self.app.windows:
+            self.assertEqual(w, self.window)

--- a/src/core/tests/test_app.py
+++ b/src/core/tests/test_app.py
@@ -74,3 +74,9 @@ class AppTests(TestCase):
         self.app.exit()
 
         self.assertActionPerformed(self.app, 'exit')
+
+    def test_add_window(self):
+        window = MagicMock()
+        self.app.windows.add(window)
+        self.assertIn(window, self.app.windows)
+        self.assertEqual(window.app, self.app)

--- a/src/core/tests/test_app.py
+++ b/src/core/tests/test_app.py
@@ -70,17 +70,7 @@ class AppTests(TestCase):
         self.assertEqual(self.app.main_window.app, self.app)
         self.assertActionPerformed(self.app.main_window, 'show')
 
-        self.assertEqual(self.app.window('main').content, self.content)
-        self.assertEqual(self.app.windows['main'].content, self.content)
-
     def test_app_exit(self):
         self.app.exit()
 
         self.assertActionPerformed(self.app, 'exit')
-
-    def test_add_window(self):
-        window = MagicMock()
-        self.app.add_window('new', window)
-        self.assertEqual(self.app.window('new'), window)
-        self.assertEqual(self.app.windows, {'main': None, 'new': window})
-        

--- a/src/core/tests/test_window.py
+++ b/src/core/tests/test_window.py
@@ -61,11 +61,20 @@ class TestWindow(TestCase):
             self.window._impl.set_full_screen.assert_called_once_with(True)
 
     def test_on_close(self):
+        app = toga.App('test_name', 'id.app', factory=toga_dummy.factory)
+        app.windows.add(self.window)
         with patch.object(self.window, '_impl'):
             self.window.on_close()
             self.window._impl.on_close.assert_called_once_with()
+            self.assertNotIn(self.window, app.windows)
 
     def test_close(self):
         with patch.object(self.window, '_impl'):
             self.window.close()
             self.window._impl.close.assert_called_once_with()
+
+    def test_windows_registry(self):
+        app = toga.App('test_name', 'id.app', factory=toga_dummy.factory)
+        app.windows.add(self.window)
+        self.assertIn(self.window, app.windows)
+

--- a/src/core/tests/test_window.py
+++ b/src/core/tests/test_window.py
@@ -64,3 +64,8 @@ class TestWindow(TestCase):
         with patch.object(self.window, '_impl'):
             self.window.on_close()
             self.window._impl.on_close.assert_called_once_with()
+
+    def test_close(self):
+        with patch.object(self.window, '_impl'):
+            self.window.close()
+            self.window._impl.close.assert_called_once_with()

--- a/src/core/toga/app.py
+++ b/src/core/toga/app.py
@@ -16,6 +16,14 @@ class MainWindow(Window):
     def __init__(self, id=None, title=None, position=(100, 100), size=(640, 480), factory=None):
         super().__init__(id=id, title=title, position=position, size=size, factory=factory)
 
+class WindowsRegistry(set):
+
+    def __init__(self, app):
+        self.app = app
+
+    def add(self, window):
+        super().add(window)
+        window.app = self.app
 
 class App:
     """ The App is the top level of any GUI program. It is the manager of all
@@ -72,6 +80,7 @@ class App:
         self.default_icon = Icon('tiberius', system=True)
         self.icon = icon
         self._main_window = None
+        self.windows = WindowsRegistry(self)
         self._on_exit = None
 
         self._impl = self.factory.App(interface=self)

--- a/src/core/toga/app.py
+++ b/src/core/toga/app.py
@@ -132,7 +132,11 @@ class App:
 
     def add_window(self, window_id, window):
         self._windows[window_id] = window
+        window._app_id = window_id
         window.app = self
+
+    def del_window(self, window_id):
+        del self._windows[window_id]
 
     @property
     def documents(self):

--- a/src/core/toga/app.py
+++ b/src/core/toga/app.py
@@ -71,7 +71,7 @@ class App:
 
         self.default_icon = Icon('tiberius', system=True)
         self.icon = icon
-        self._windows = {'main': None}
+        self._main_window = None
         self._on_exit = None
 
         self._impl = self.factory.App(interface=self)
@@ -116,23 +116,11 @@ class App:
         Returns:
             The main Window of the app.
         """
-        return self._windows['main']
+        return self._main_window
 
     @main_window.setter
     def main_window(self, window):
-        self._windows['main'] = window
-        window.app = self
-
-    @property
-    def windows(self):
-        return self._windows
-
-    def window(self, window_id):
-        return self._windows[window_id]
-
-    def add_window(self, window_id, window):
-        self._windows[window_id] = window
-        window._app_id = window_id
+        self._main_window = window
         window.app = self
 
     def del_window(self, window_id):

--- a/src/core/toga/app.py
+++ b/src/core/toga/app.py
@@ -16,14 +16,31 @@ class MainWindow(Window):
     def __init__(self, id=None, title=None, position=(100, 100), size=(640, 480), factory=None):
         super().__init__(id=id, title=title, position=position, size=size, factory=factory)
 
-class WindowsRegistry(set):
+class WindowSet:
+    '''The set of windows. Provides a set like API'''
 
     def __init__(self, app):
+        self._set = set()
         self.app = app
 
+    def __iter__(self):
+        return self._set.__iter__()
+
     def add(self, window):
-        super().add(window)
+        self._set.add(window)
         window.app = self.app
+
+    def remove(self, item):
+        return self._set.remove(item)
+
+    def discard(self, item):
+        self._set.discard(item)
+
+    def __contains__(self, item):
+        return self._set.__contains__(item)
+
+    def __len__(self):
+        return len(self._set)
 
 class App:
     """ The App is the top level of any GUI program. It is the manager of all
@@ -80,7 +97,7 @@ class App:
         self.default_icon = Icon('tiberius', system=True)
         self.icon = icon
         self._main_window = None
-        self.windows = WindowsRegistry(self)
+        self.windows = WindowSet(self)
         self._on_exit = None
 
         self._impl = self.factory.App(interface=self)
@@ -131,9 +148,6 @@ class App:
     def main_window(self, window):
         self._main_window = window
         window.app = self
-
-    def del_window(self, window_id):
-        del self._windows[window_id]
 
     @property
     def documents(self):

--- a/src/core/toga/app.py
+++ b/src/core/toga/app.py
@@ -71,7 +71,7 @@ class App:
 
         self.default_icon = Icon('tiberius', system=True)
         self.icon = icon
-        self._main_window = None
+        self._windows = {'main': None}
         self._on_exit = None
 
         self._impl = self.factory.App(interface=self)
@@ -116,11 +116,22 @@ class App:
         Returns:
             The main Window of the app.
         """
-        return self._main_window
+        return self._windows['main']
 
     @main_window.setter
     def main_window(self, window):
-        self._main_window = window
+        self._windows['main'] = window
+        window.app = self
+
+    @property
+    def windows(self):
+        return self._windows
+
+    def window(self, window_id):
+        return self._windows[window_id]
+
+    def add_window(self, window_id, window):
+        self._windows[window_id] = window
         window.app = self
 
     @property

--- a/src/core/toga/window.py
+++ b/src/core/toga/window.py
@@ -165,6 +165,10 @@ class Window:
         """ Show window, if hidden """
         self._impl.show()
 
+    def close(self):
+        """ Close window"""
+        self._impl.close()
+
     @property
     def full_screen(self):
         return self._is_full_screen

--- a/src/core/toga/window.py
+++ b/src/core/toga/window.py
@@ -34,6 +34,11 @@ class Window:
         self._size = size
         self._is_full_screen = False
 
+        self._closed = False
+        # The identifier used when calling an App.add_window. Set by that
+        # method.
+        self._app_id = None
+
         self.resizeable = resizeable
         self.closeable = closeable
         self.minimizable = minimizable
@@ -163,10 +168,13 @@ class Window:
 
     def show(self):
         """ Show window, if hidden """
-        self._impl.show()
+        if not self._closed:
+            self._impl.show()
 
     def close(self):
         """ Close window"""
+
+        self._closed = True
         self._impl.close()
 
     @property
@@ -179,6 +187,10 @@ class Window:
         self._impl.set_full_screen(is_full_screen)
 
     def on_close(self):
+        # If we registered this window with the app, make sure we remove
+        # that registration.
+        if self.app and self._app_id:
+            self.app.del_window(self._app_id)
         self._impl.on_close()
 
     ############################################################

--- a/src/core/toga/window.py
+++ b/src/core/toga/window.py
@@ -189,8 +189,8 @@ class Window:
     def on_close(self):
         # If we registered this window with the app, make sure we remove
         # that registration.
-        if self.app and self._app_id:
-            self.app.del_window(self._app_id)
+        if self.app:
+            self.app.windows.discard(self)
         self._impl.on_close()
 
     ############################################################


### PR DESCRIPTION
<!--- Describe your changes in detail -->
In this change I'm adding some toga.Window and toga.App changes to handle closing windows. I'm speculating that it's good for a App to keep track of it's windows, and for this registry to be updated when windows are closed.

I'm assuming that once windows are closed, they may not be re-opened.

<!--- What problem does this change solve? -->
I didn't find any practices on opening windows to be documented in the project, and indeed this PR doesn't (yet) change any documentation. But it should be possible to create short term windows, much like the existing Window.*_dialog controls, but with more options for controlling the content of the dialogs. Hence this change adds an example of an app that gives users buttons to open and close new windows.

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
