### PR TITLE
Add `index` to remove listeners for ListSource

### DIFF
--- a/src/cocoa/toga_cocoa/widgets/detailedlist.py
+++ b/src/cocoa/toga_cocoa/widgets/detailedlist.py
@@ -131,7 +131,7 @@ class DetailedList(Widget):
     def change(self, item):
         self.detailedlist.reloadData()
 
-    def remove(self, item):
+    def remove(self, item, index):
         self.detailedlist.reloadData()
 
     def clear(self):

--- a/src/cocoa/toga_cocoa/widgets/table.py
+++ b/src/cocoa/toga_cocoa/widgets/table.py
@@ -128,7 +128,7 @@ class Table(Widget):
     def change(self, item):
         self.table.reloadData()
 
-    def remove(self, item):
+    def remove(self, item, index):
         self.table.reloadData()
 
     def clear(self):

--- a/src/core/tests/sources/test_list_source.py
+++ b/src/core/tests/sources/test_list_source.py
@@ -402,7 +402,7 @@ class ListSourceTests(TestCase):
         self.assertEqual(source[1].val1, 'third')
         self.assertEqual(source[1].val2, 333)
 
-        listener.remove.assert_called_once_with(item=row)
+        listener.remove.assert_called_once_with(item=row, index=1)
 
     def test_get_row_index(self):
         "You can get the index of any row within a list source"

--- a/src/core/toga/sources/list_source.py
+++ b/src/core/toga/sources/list_source.py
@@ -98,8 +98,9 @@ class ListSource(Source):
         return self.insert(len(self), *values, **named)
 
     def remove(self, row):
-        self._data.remove(row)
-        self._notify('remove', item=row)
+        index = self._data.index(row)
+        self._data.pop(index)
+        self._notify('remove', item=row, index=index)
         return row
 
     def index(self, row):

--- a/src/dummy/toga_dummy/widgets/detailedlist.py
+++ b/src/dummy/toga_dummy/widgets/detailedlist.py
@@ -14,8 +14,8 @@ class DetailedList(Widget):
     def change(self, item):
         self._action('change', item=item)
 
-    def remove(self, item):
-        self._action('remove', item=item)
+    def remove(self, item, index):
+        self._action('remove', item=item, index=index)
 
     def clear(self):
         self._action('clear')

--- a/src/dummy/toga_dummy/widgets/table.py
+++ b/src/dummy/toga_dummy/widgets/table.py
@@ -14,8 +14,8 @@ class Table(Widget):
     def change(self, item):
         self._action('change row', item=item)
 
-    def remove(self, item):
-        self._action('remove row', item=item)
+    def remove(self, item, index):
+        self._action('remove row', item=item, index=index)
 
     def clear(self):
         self._action('clear')

--- a/src/gtk/tests/widgets/test_table.py
+++ b/src/gtk/tests/widgets/test_table.py
@@ -104,7 +104,7 @@ class TestGtkTable(unittest.TestCase):
         self.assertIsNotNone(row._impl[self.gtk_table])
 
         # Then remove it
-        self.gtk_table.remove(row)
+        self.gtk_table.remove(row, 0)
 
         # Make sure its gone
         self.assertIsNone(row._impl.get(self.gtk_table, None))

--- a/src/gtk/toga_gtk/widgets/detailedlist.py
+++ b/src/gtk/toga_gtk/widgets/detailedlist.py
@@ -25,7 +25,7 @@ class DetailedList(Widget):
         # TODO
         self.interface.factory.not_implemented('DetailedList.change()')
 
-    def remove(self, item):
+    def remove(self, item, index):
         # TODO
         self.interface.factory.not_implemented('DetailedList.remove()')
 

--- a/src/gtk/toga_gtk/widgets/table.py
+++ b/src/gtk/toga_gtk/widgets/table.py
@@ -43,7 +43,9 @@ class Table(Tree):
     def change(self, item):
         super().change(item)
 
-    def remove(self, item):
+    def remove(self, item, index):
+        # TODO: fix this confusing super call; the remove function signature is
+        # different here
         super().remove(item)
 
     def clear(self):

--- a/src/iOS/toga_iOS/widgets/detailedlist.py
+++ b/src/iOS/toga_iOS/widgets/detailedlist.py
@@ -112,7 +112,7 @@ class DetailedList(Widget):
     def change(self, item):
         self.native.reloadData()
 
-    def remove(self, item):
+    def remove(self, item, index):
         self.native.reloadData()
 
     def clear(self):

--- a/src/winforms/toga_winforms/widgets/table.py
+++ b/src/winforms/toga_winforms/widgets/table.py
@@ -45,7 +45,7 @@ class Table(Widget):
     def change(self, item):
         self.interface.factory.not_implemented('Table.change()')
 
-    def remove(self, item):
+    def remove(self, item, index):
         self.update_data()
 
     def clear(self):


### PR DESCRIPTION
This PR changes the remove API used when a platform-specific widget is subscribed to a `ListSource`. The `remove` method for `ListSource` now also expects the `index` to be passed in.

The main problem this solves is an issue where the index of the deleted item is needed when responding to a `remove` event, and since the item in the `ListSource` is deleted prior to the the call of the listener method itself, the API needs to change.

Will help with `remove` implementation in https://github.com/pybee/toga/pull/548 and later https://github.com/pybee/toga/pull/536

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
