### PR TITLE
Canvas does not render in ScrollContainer in macOS

### DIFF
--- a/src/cocoa/toga_cocoa/widgets/scrollcontainer.py
+++ b/src/cocoa/toga_cocoa/widgets/scrollcontainer.py
@@ -22,7 +22,12 @@ class ScrollContainer(Widget):
 
     def set_content(self, widget):
         self.native.documentView = widget.native
-        widget.viewport = CocoaViewport(self.native.documentView)
+
+        if self.interface.content != None:
+            self.interface.content._impl.native.removeFromSuperview()
+        self.native.addSubview(widget.native)
+
+        widget.viewport = CocoaViewport(self.native)
 
         for child in widget.interface.children:
             child._impl.container = widget


### PR DESCRIPTION
On macOS, the canvas widget was not rendering in the scroll container. 

The widgets need to be added to the sub view for the drawRect function to be called on the canvas. The changes I have so far allow the canvas to be rendered, however if you have draw commands outside of the viewable window, no scroll bar appears.  

I believe this is the case since the canvas widget never reports its viewable bounds correctly to toga. It just reports the bounds of the viewable container, so the scroll container thinks it does not need a scroll bar. I am new to core graphics and have not found a way to get those bounds numbers. Any help would be appreciated

Fixes #579 

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct