### PR TITLE
Add windows TimePicker Widget 

### DIFF
--- a/src/core/tests/widgets/test_timepicker.py
+++ b/src/core/tests/widgets/test_timepicker.py
@@ -1,0 +1,51 @@
+import toga
+import toga_dummy
+from toga_dummy.utils import TestCase
+import datetime
+
+
+class TimePickerTests(TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.time_picker = toga.TimePicker(factory=toga_dummy.factory)
+
+    def test_widget_created(self):
+        self.assertEqual(self.time_picker._impl.interface, self.time_picker)
+        self.assertActionPerformed(self.time_picker, 'create TimePicker')
+
+    def test_getting_value_invokes_impl_method(self):
+        # Exercise the value attribute getter for testing only. Actual value not needed.
+        self.time_picker.value
+        self.assertValueGet(self.time_picker, 'value')
+
+    def test_set_value_with_None(self):
+        self.time_picker.value = None
+        self.assertValueSet(self.time_picker, 'value', datetime.datetime.today().strftime('%-I:%M:%S %p'))
+
+    def test_set_value_with_an_hour_ago(self):
+        hour_ago = datetime.date.today() - datetime.timedelta(hours=1)
+        self.time_picker.value = hour_ago
+        self.assertValueSet(self.time_picker, 'value', hour_ago.strftime('%-I:%M:%S %p'))
+
+    def test_setting_value_invokes_impl_method(self):
+        new_value = 'New Value'
+        self.time_picker.value = new_value
+        self.assertValueSet(self.time_picker, 'value', new_value)
+
+    def test_min_max_dates(self):
+        self.assertEqual(self.time_picker.min_time, None)
+        self.assertEqual(self.time_picker.max_time, None)
+
+        hour_ago = datetime.date.today() - datetime.timedelta(hours=1)
+        self.time_picker.min_date = hour_ago
+        self.time_picker.max_date = hour_ago
+        self.assertEqual(self.time_picker.min_date, hour_ago.strftime('%-I:%M:%S %p'))
+        self.assertEqual(self.time_picker.max_date, hour_ago.strftime('%-I:%M:%S %p'))
+
+    def test_on_change_callback_set(self):
+        def dummy_function():
+            pass
+
+        self.time_picker.on_change = dummy_function
+        self.assertIsNotNone(self.time_picker.on_change)

--- a/src/core/tests/widgets/test_timepicker.py
+++ b/src/core/tests/widgets/test_timepicker.py
@@ -21,7 +21,7 @@ class TimePickerTests(TestCase):
 
     def test_set_value_with_None(self):
         self.time_picker.value = None
-        none_default = datetime.datetime.today().time()
+        none_default = datetime.datetime.today().time().replace(microsecond=0)
         self.assertValueSet(self.time_picker, 'value', none_default.strftime('%H:%M:%S'))
 
     def test_set_value_with_an_hour_ago(self):

--- a/src/core/tests/widgets/test_timepicker.py
+++ b/src/core/tests/widgets/test_timepicker.py
@@ -22,7 +22,7 @@ class TimePickerTests(TestCase):
     def test_set_value_with_None(self):
         self.time_picker.value = None
         none_default = datetime.datetime.today().time()
-        self.assertValueSet(self.time_picker, 'value', none_default.strftime('%H:%M:%S.%f'))
+        self.assertValueSet(self.time_picker, 'value', none_default.strftime('%H:%M:%S'))
 
     def test_set_value_with_an_hour_ago(self):
         hour_ago = datetime.datetime.today() - datetime.timedelta(hours=1)
@@ -34,7 +34,7 @@ class TimePickerTests(TestCase):
         self.time_picker.value = new_value
         self.assertValueSet(self.time_picker, 'value', new_value)
 
-    def test_min_max_dates(self):
+    def test_min_max_time(self):
         self.assertEqual(self.time_picker.min_time, None)
         self.assertEqual(self.time_picker.max_time, None)
 

--- a/src/core/tests/widgets/test_timepicker.py
+++ b/src/core/tests/widgets/test_timepicker.py
@@ -21,12 +21,13 @@ class TimePickerTests(TestCase):
 
     def test_set_value_with_None(self):
         self.time_picker.value = None
-        self.assertValueSet(self.time_picker, 'value', datetime.datetime.today().strftime('%-I:%M:%S %p'))
+        none_default = datetime.datetime.today().time()
+        self.assertValueSet(self.time_picker, 'value', none_default.strftime('%H:%M:%S.%f'))
 
     def test_set_value_with_an_hour_ago(self):
-        hour_ago = datetime.date.today() - datetime.timedelta(hours=1)
-        self.time_picker.value = hour_ago
-        self.assertValueSet(self.time_picker, 'value', hour_ago.strftime('%-I:%M:%S %p'))
+        hour_ago = datetime.datetime.today() - datetime.timedelta(hours=1)
+        self.time_picker.value = hour_ago.time()
+        self.assertValueSet(self.time_picker, 'value', hour_ago.strftime('%H:%M:%S.%f'))
 
     def test_setting_value_invokes_impl_method(self):
         new_value = 'New Value'
@@ -37,11 +38,11 @@ class TimePickerTests(TestCase):
         self.assertEqual(self.time_picker.min_time, None)
         self.assertEqual(self.time_picker.max_time, None)
 
-        hour_ago = datetime.date.today() - datetime.timedelta(hours=1)
-        self.time_picker.min_date = hour_ago
-        self.time_picker.max_date = hour_ago
-        self.assertEqual(self.time_picker.min_date, hour_ago.strftime('%-I:%M:%S %p'))
-        self.assertEqual(self.time_picker.max_date, hour_ago.strftime('%-I:%M:%S %p'))
+        hour_ago = datetime.datetime.today() - datetime.timedelta(hours=1)
+        self.time_picker.min_time = hour_ago.time()
+        self.time_picker.max_time = hour_ago.time()
+        self.assertEqual(self.time_picker.min_time, hour_ago.strftime('%H:%M:%S.%f'))
+        self.assertEqual(self.time_picker.max_time, hour_ago.strftime('%H:%M:%S.%f'))
 
     def test_on_change_callback_set(self):
         def dummy_function():

--- a/src/core/toga/__init__.py
+++ b/src/core/toga/__init__.py
@@ -18,6 +18,7 @@ from .widgets.canvas import Canvas
 from .widgets.detailedlist import DetailedList
 from .widgets.imageview import ImageView
 from .widgets.datepicker import DatePicker
+from .widgets.timepicker import TimePicker
 from .widgets.label import Label
 from .widgets.multilinetextinput import MultilineTextInput
 from .widgets.numberinput import NumberInput
@@ -62,6 +63,7 @@ __all__ = [
     'ImageView',
     'Label',
     'DatePicker',
+    'TimePicker',
     'MultilineTextInput',
     'NumberInput',
     'OptionContainer',

--- a/src/core/toga/widgets/timepicker.py
+++ b/src/core/toga/widgets/timepicker.py
@@ -13,6 +13,10 @@ class TimePicker(Widget):
             a new one will be created for the widget.
         factory (:obj:`module`): A python module that is capable to return a
             implementation of this class with the same name. (optional & normally not needed)
+        initial (str): The initial value to set the widget to. (Defaults to time of program execution)
+        min_time (str): The minimum allowable time for the widget.
+        max_time (str): The maximum allowable time for the widget.
+        on_change (``callable``): Function that is invoked on time value change.
     """
     MIN_WIDTH = 100
 
@@ -28,16 +32,16 @@ class TimePicker(Widget):
     @property
     def value(self):
         """
-        The value of the currently selected date.
+        The value of the currently selected time.
 
-        :return: Selected date as Date object
+        :return: Selected time as time object
         """
         return self._impl.get_value()
 
     @value.setter
     def value(self, value):
         if value is None:
-            v = str(datetime.datetime.today())
+            v = str(datetime.datetime.today().time())
         else:
             v = str(value)
         self._impl.set_value(v)
@@ -45,9 +49,10 @@ class TimePicker(Widget):
     @property
     def min_time(self):
         """
-        The minimum allowable date for the widget. All dates prior to the minimum date will be blanked out.
+        The minimum allowable time for the widget. The widget will not allow the user to enter at time less than the
+        min time. If initial time set is less than the minimum time, the minimum time will be used as the initial value.
 
-        :return: The minimum date specified. Returns None if min_date not specified
+        :return: The minimum time specified. Returns None if min_time not specified
         """
         return self._min_time
 
@@ -61,9 +66,11 @@ class TimePicker(Widget):
     @property
     def max_time(self):
         """
-        The maximum allowable date for the widget. All dates prior to the minimum date will be blanked out.
+        The maximum allowable time for the widget. The widget will not allow the user to enter at time greater than the
+        max time. If initial time set is greater than the maximum time, the maximum time will be used as
+        the initial value.
 
-        :return: The maximum date specified. Returns None if max_date not specified
+        :return: The maximum time specified. Returns None if max_time not specified
         """
         return self._max_time
 

--- a/src/core/toga/widgets/timepicker.py
+++ b/src/core/toga/widgets/timepicker.py
@@ -1,0 +1,94 @@
+from .base import Widget
+from toga.handlers import wrapped_handler
+import datetime
+
+
+class TimePicker(Widget):
+    """
+    A widget to get user selected datetime object
+
+    Args:
+        id (str): An identifier for this widget.
+        style (:obj:`Style`): An optional style object. If no style is provided then
+            a new one will be created for the widget.
+        factory (:obj:`module`): A python module that is capable to return a
+            implementation of this class with the same name. (optional & normally not needed)
+    """
+    MIN_WIDTH = 100
+
+    def __init__(self, id=None, style=None, factory=None, initial=None, min_time=None, max_time=None, on_change=None):
+        super().__init__(id=id, style=style, factory=factory)
+        # Create a platform specific implementation of a TimePicker
+        self._impl = self.factory.TimePicker(interface=self)
+        self.value = initial
+        self.min_time = min_time
+        self.max_time = max_time
+        self.on_change = on_change
+
+    @property
+    def value(self):
+        """
+        The value of the currently selected date.
+
+        :return: Selected date as Date object
+        """
+        return self._impl.get_value()
+
+    @value.setter
+    def value(self, value):
+        if value is None:
+            v = str(datetime.datetime.today())
+        else:
+            v = str(value)
+        self._impl.set_value(v)
+
+    @property
+    def min_time(self):
+        """
+        The minimum allowable date for the widget. All dates prior to the minimum date will be blanked out.
+
+        :return: The minimum date specified. Returns None if min_date not specified
+        """
+        return self._min_time
+
+    @min_time.setter
+    def min_time(self, value):
+        self._min_time = None
+        if value is not None:
+            self._min_time = str(value)
+            self._impl.set_min_time(self._min_time)
+
+    @property
+    def max_time(self):
+        """
+        The maximum allowable date for the widget. All dates prior to the minimum date will be blanked out.
+
+        :return: The maximum date specified. Returns None if max_date not specified
+        """
+        return self._max_time
+
+    @max_time.setter
+    def max_time(self, value):
+        self._max_time = None
+        if value is not None:
+            self._max_time = str(value)
+            self._impl.set_max_time(self._max_time)
+
+    @property
+    def on_change(self):
+        """The handler to invoke when the value changes
+
+        Returns:
+            The function ``callable`` that is called on a content change.
+        """
+        return self._on_change
+
+    @on_change.setter
+    def on_change(self, handler):
+        """Set the handler to invoke when the date is changed.
+
+        Args:
+            handler (:obj:`callable`): The handler to invoke when the date is changed.
+        """
+        self._on_change = wrapped_handler(self, handler)
+        self._impl.set_on_change(self._on_change)

--- a/src/core/toga/widgets/timepicker.py
+++ b/src/core/toga/widgets/timepicker.py
@@ -50,7 +50,8 @@ class TimePicker(Widget):
     def min_time(self):
         """
         The minimum allowable time for the widget. The widget will not allow the user to enter at time less than the
-        min time. If initial time set is less than the minimum time, the minimum time will be used as the initial value.
+        min time. If initial time set is less than the minimum time, the minimum time will be used as
+        the initial value.
 
         :return: The minimum time specified. Returns None if min_time not specified
         """

--- a/src/core/toga/widgets/timepicker.py
+++ b/src/core/toga/widgets/timepicker.py
@@ -41,7 +41,7 @@ class TimePicker(Widget):
     @value.setter
     def value(self, value):
         if value is None:
-            v = str(datetime.datetime.today().time())
+            v = str(datetime.datetime.today().time().replace(microsecond=0))
         else:
             v = str(value)
         self._impl.set_value(v)

--- a/src/dummy/toga_dummy/factory.py
+++ b/src/dummy/toga_dummy/factory.py
@@ -12,6 +12,7 @@ from .widgets.canvas import Canvas
 from .widgets.detailedlist import DetailedList
 from .widgets.imageview import ImageView
 from .widgets.datepicker import DatePicker
+from .widgets.timepicker import TimePicker
 from .widgets.label import Label
 from .widgets.multilinetextinput import MultilineTextInput
 from .widgets.navigationview import NavigationView
@@ -52,6 +53,7 @@ __all__ = [
     'DetailedList',
     'ImageView',
     'DatePicker',
+    'TimePicker',
     'Label',
     'MultilineTextInput',
     'NavigationView',

--- a/src/dummy/toga_dummy/widgets/timepicker.py
+++ b/src/dummy/toga_dummy/widgets/timepicker.py
@@ -1,0 +1,24 @@
+from .base import Widget
+
+
+class TimePicker(Widget):
+    def create(self):
+        self._action('create TimePicker')
+
+    def get_value(self):
+        return self._get_value('value')
+
+    def set_value(self, value):
+        return self._set_value('value', value)
+
+    def set_min_time(self, value):
+        return self._set_value('min time', value)
+
+    def set_max_time(self, value):
+        return self._set_value('max time', value)
+
+    def rehint(self):
+        self._action('rehint TimePicker')
+
+    def set_on_change(self, handler):
+        self._set_value('on_change', handler)

--- a/src/winforms/toga_winforms/factory.py
+++ b/src/winforms/toga_winforms/factory.py
@@ -11,6 +11,7 @@ from .widgets.button import Button
 # from .widgets.detailedlist import DetailedList
 from .widgets.imageview import ImageView
 from .widgets.datepicker import DatePicker
+from .widgets.timepicker import TimePicker
 from .widgets.label import Label
 from .widgets.multilinetextinput import MultilineTextInput
 from .widgets.numberinput import NumberInput
@@ -51,6 +52,7 @@ __all__ = [
     # 'DetailedList',
     'ImageView',
     'DatePicker',
+    'TimePicker',
     'Label',
     'MultilineTextInput',
     'NumberInput',

--- a/src/winforms/toga_winforms/widgets/timepicker.py
+++ b/src/winforms/toga_winforms/widgets/timepicker.py
@@ -1,0 +1,50 @@
+from toga_winforms.libs import WinForms, WinDateTime
+from travertino.size import at_least
+import datetime
+
+from .base import Widget
+
+
+class TimePicker(Widget):
+    def create(self):
+        self.native = WinForms.DateTimePicker()
+        self.native.Format = WinForms.DateTimePickerFormat.Time
+        self.native.ShowUpDown = True
+
+    def get_value(self):
+        time = datetime.datetime.strptime(self.native.Text, '%I:%M:%S %p').time()
+        return time
+
+    def set_value(self, value):
+        value = WinDateTime.Parse(value)
+        self.native.Value = value
+
+    def set_min_time(self, value):
+        if value is None:
+            value = str(self.native.MinDateTime)
+        value = WinDateTime.Parse(value)
+        if self.native.Value < value:
+            self.native.Value = value
+
+    def set_max_time(self, value):
+        if value is None:
+            value = str(self.native.MaxDateTime)
+        value = WinDateTime.Parse(value)
+        if self.native.Value > value:
+            self.native.Value = value
+
+    def rehint(self):
+        # Height of a date input is known and fixed.
+        # Width must be > 100
+        self.interface.intrinsic.width = at_least(self.interface.MIN_WIDTH)
+        self.interface.intrinsic.height = self.native.PreferredSize.Height
+
+    def set_on_change(self, handler):
+        self.native.ValueChanged += self.on_date_change
+
+    def on_date_change(self, sender, event):
+        # Since there is no native option to set a min or max time, calling min/max to validate on each change.
+        self.set_max_time(self.interface.max_time)
+        self.set_min_time(self.interface.min_time)
+        if self.interface._on_change:
+            self.interface.on_change(self.interface)


### PR DESCRIPTION
This PR implements a time picking widget on Windows and related tests. 

Below is the TimePicker widget in action with 11:15 AM set as the **max_time** and 11:00 AM set as the **min_time**. Also in action is the **on_change** automatically updated the toga label. 
![timepicker](https://user-images.githubusercontent.com/44148347/47340205-58c88a00-d652-11e8-8fd9-bc597fb4de96.gif)

Overall, pretty similar in concept to the DatePicker widget with the exception of the min_time and max_time implementation not being strictly native, but it works!

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
