### PR TITLE
Fix links pointing to pybee.org

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,5 +4,5 @@ BeeWare <3's contributions!
 
 Please be aware, BeeWare operates under a Code of Conduct.
 
-See [CONTRIBUTING to BeeWare](http://pybee.org/contributing) for details.
+See [CONTRIBUTING to BeeWare](https://beeware.org/contributing/) for details.
 

--- a/README.rst
+++ b/README.rst
@@ -99,7 +99,7 @@ contributors`_ will help you get started.
 If you experience problems with Toga, `log them on GitHub`_. If you want to
 contribute code, please `fork the code`_ and `submit a pull request`_.
 
-.. _BeeWare suite: http://pybee.org
+.. _BeeWare suite: https://beeware.org/
 .. _Read The Docs: https://toga.readthedocs.io
 .. _@pybeeware on Twitter: https://twitter.com/pybeeware
 .. _pybee/general: https://gitter.im/pybee/general

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     long_description=long_description,
     author='Russell Keith-Magee',
     author_email='russell@keith-magee.com',
-    url='http://pybee.org/toga',
+    url='https://beeware.org/project/projects/libraries/toga/',
     extras_require={
         # Automatically installed platform backends
         ':sys_platform=="win32"': ['toga-winforms==%s' % version],
@@ -46,7 +46,7 @@ setup(
         'Topic :: Software Development :: Widget Sets',
     ],
     package_urls={
-        'Funding': 'https://pybee.org/contributing/membership/',
+        'Funding': 'https://beeware.org/contributing/membership/',
         'Documentation': 'https://toga.readthedocs.io/',
         'Tracker': 'https://github.com/pybee/toga/issues',
         'Source': 'https://github.com/pybee/toga',


### PR DESCRIPTION
BeeWare no longer uses the https://pybee.org/ domain. I have replaced what few links I have found with the updated domain https://beeware.org/

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
