### PR TITLE
[win32] Getting win32 up to snuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,19 +1,11 @@
 *.pyc
 *~
 .*.sw[op]
-*.egg-info
-.eggs
 .coverage
-dist
-build
 _build
 distribute-*
 docs/env
 local
-venv
-.idea
-.tox
-node_modules
 README.md
 src/django/toga.js
 src/django/toga.min.js
@@ -25,7 +17,6 @@ src/gtk/cairo
 .DS_Store
 pip-selfcheck.json
 pyvenv.cfg
-.vscode
 bin/
 lib/
 
@@ -37,3 +28,26 @@ examples/*/android/
 examples/*/django/
 examples/*/windows/
 
+# Editor configs
+.vscode/
+.idea/
+
+# Compiled dependencies
+node_modules/
+
+# Lock files
+Pipfile.lock
+
+# Build/packaging files
+*.pyc
+*.egg-info/
+.eggs/
+dist/
+build/
+
+# Tests outputs
+.tox/
+
+# Virtual environments
+venv/
+.env/

--- a/src/core/toga/__init__.py
+++ b/src/core/toga/__init__.py
@@ -87,4 +87,3 @@ __all__ = [
 # __version__ = '1.2.3.post1' # Post Release 1
 
 __version__ = '0.3.0.dev12'
-

--- a/src/win32/toga_win32/__init__.py
+++ b/src/win32/toga_win32/__init__.py
@@ -9,10 +9,10 @@ from .widgets.button import Button
 # from .widgets.image import *
 # from .widgets.imageview import *
 from .widgets.label import Label
-from .widgets.multilinetextinput import *
+from .widgets.multilinetextinput import MultilineTextInput
 from .widgets.numberinput import NumberInput
 # from .widgets.optioncontainer import *
-from .widgets.passwordinput import *
+from .widgets.passwordinput import PasswordInput
 # from .widgets.progressbar import *
 # from .widgets.scrollcontainer import *
 # from .widgets.selection import Selection
@@ -25,7 +25,7 @@ from .widgets.textinput import TextInput
 # from .widgets.webview import *
 from .window import Window
 
-__all__ = [
+__all__ = (
     'App', 'MainWindow',
     # 'Command',
     # 'Font',
@@ -52,7 +52,7 @@ __all__ = [
     # 'Tree',
     # 'WebView',
     'Window',
-]
+)
 
 # Examples of valid version strings
 # __version__ = '1.2.3.dev1'  # Development release 1
@@ -62,4 +62,4 @@ __all__ = [
 # __version__ = '1.2.3'       # Final Release
 # __version__ = '1.2.3.post1' # Post Release 1
 
-__version__ = '0.2.3.dev1'
+__version__ = '0.3.0.dev12'

--- a/src/win32/toga_win32/__init__.py
+++ b/src/win32/toga_win32/__init__.py
@@ -1,8 +1,14 @@
+"""Toga win32 backend.
+
+Useful for importing important library functions for the win32 backend.
+"""
 from .app import App, MainWindow
+
 # from .command import Command
 # from .font import Font
-from .widgets.box import Box
+# from .widgets.box import Box
 from .widgets.button import Button
+
 # from .widgets.canvas import Canvas
 # from .widgets.detailedlist import DetailedList
 # from .widgets.icon import Icon
@@ -11,8 +17,10 @@ from .widgets.button import Button
 from .widgets.label import Label
 from .widgets.multilinetextinput import MultilineTextInput
 from .widgets.numberinput import NumberInput
+
 # from .widgets.optioncontainer import *
 from .widgets.passwordinput import PasswordInput
+
 # from .widgets.progressbar import *
 # from .widgets.scrollcontainer import *
 # from .widgets.selection import Selection
@@ -21,26 +29,28 @@ from .widgets.passwordinput import PasswordInput
 # from .widgets.switch import *
 # from .widgets.table import *
 from .widgets.textinput import TextInput
+
 # from .widgets.tree import *
 # from .widgets.webview import *
 from .window import Window
 
 __all__ = (
-    'App', 'MainWindow',
+    "App",
+    "MainWindow",
     # 'Command',
     # 'Font',
     # 'Box',
-    'Button',
+    "Button",
     # 'Canvas',
     # 'DetailedList',
     # 'Icon',
     # 'Image',
     # 'ImageView',
-    'Label',
-    'MultilineTextInput',
-    'NumberInput',
+    "Label",
+    "MultilineTextInput",
+    "NumberInput",
     # 'OptionContainer',
-    'PasswordInput',
+    "PasswordInput",
     # 'ProgressBar',
     # 'ScrollContainer',
     # 'Selection',
@@ -48,10 +58,10 @@ __all__ = (
     # 'SplitContainer',
     # 'Switch',
     # 'Table',
-    'TextInput',
+    "TextInput",
     # 'Tree',
     # 'WebView',
-    'Window',
+    "Window",
 )
 
 # Examples of valid version strings
@@ -62,4 +72,4 @@ __all__ = (
 # __version__ = '1.2.3'       # Final Release
 # __version__ = '1.2.3.post1' # Post Release 1
 
-__version__ = '0.3.0.dev12'
+__version__ = "0.3.0.dev12"

--- a/src/win32/toga_win32/constraints.py
+++ b/src/win32/toga_win32/constraints.py
@@ -1,0 +1,1 @@
+"""Toga win32 backend constraints."""

--- a/src/win32/toga_win32/widgets/base.py
+++ b/src/win32/toga_win32/widgets/base.py
@@ -3,7 +3,7 @@ from ctypes import c_wchar_p
 from toga_cassowary.widget import Widget as CassowaryWidget
 
 from ..libs import user32
-from ..libs.constants import *
+from ..libs.constants import WS_VISIBLE, WS_CHILD, WS_TABSTOP, HWND_TOP
 
 
 class Widget(CassowaryWidget):
@@ -11,10 +11,9 @@ class Widget(CassowaryWidget):
     default_style = WS_VISIBLE | WS_CHILD | WS_TABSTOP
     control_style = 0
 
-    def __init__(self, text=''):
+    def __init__(self, text=""):
         self.text = text
         super().__init__()
-
 
     @property
     def _width_hint(self):
@@ -24,7 +23,7 @@ class Widget(CassowaryWidget):
     def _height_hint(self):
         return (100, 100)
 
-    def create_win32_window(self, window_class=None, text="", style=0, identifier=None, ):
+    def create_win32_window(self, window_class=None, text="", style=0, identifier=None):
         window_class = window_class or self.window_class
         window_class = c_wchar_p(window_class)
         text = c_wchar_p(text)
@@ -32,9 +31,9 @@ class Widget(CassowaryWidget):
         style |= self.control_style
         x, y, width, height = self.geometry
         parent = self.window._impl
-        self._impl = user32.CreateWindowExW(0, window_class, text, style,
-            x, y, width, height,
-            parent, identifier, 0, 0)
+        self._impl = user32.CreateWindowExW(
+            0, window_class, text, style, x, y, width, height, parent, identifier, 0, 0
+        )
 
     def startup(self):
         identifier = self.window._allocate_id()
@@ -64,11 +63,10 @@ class Widget(CassowaryWidget):
 
     def _resize(self):
         x, y, width, height = self._geometry
-        print("RESIZE", self.text,x,y,width,height)
-        user32.SetWindowPos(self._impl, HWND_TOP,
-                  int(x), int(y), int(width), int(height),
-                  0)
-
+        print("RESIZE", self.text, x, y, width, height)
+        user32.SetWindowPos(
+            self._impl, HWND_TOP, int(x), int(y), int(width), int(height), 0
+        )
 
     def _on_wm_command(self, msg, wParam, lParam):
         "Called when a WM_COMMAND message is received referencing this widget."

--- a/src/win32/toga_win32/widgets/base.py
+++ b/src/win32/toga_win32/widgets/base.py
@@ -1,12 +1,10 @@
 from ctypes import c_wchar_p
 
-from toga_cassowary.widget import Widget as CassowaryWidget
-
 from ..libs import user32
 from ..libs.constants import WS_VISIBLE, WS_CHILD, WS_TABSTOP, HWND_TOP
 
 
-class Widget(CassowaryWidget):
+class Widget:
     window_class = None
     default_style = WS_VISIBLE | WS_CHILD | WS_TABSTOP
     control_style = 0

--- a/src/win32/toga_win32/widgets/container.py
+++ b/src/win32/toga_win32/widgets/container.py
@@ -1,12 +1,8 @@
-from toga_cassowary.widget import Container as CassowaryContainer
-
-
 class Win32Container(object):
     def add(self, widget):
         pass
 
-class Container(CassowaryContainer):
-
+class Container:
     def _create_container(self):
         # No impl is requried for a container, but we need a placeholder
         # to keep the cross-platform logic happy.

--- a/src/win32/toga_win32/widgets/container.py
+++ b/src/win32/toga_win32/widgets/container.py
@@ -2,6 +2,7 @@ class Win32Container(object):
     def add(self, widget):
         pass
 
+
 class Container:
     def _create_container(self):
         # No impl is requried for a container, but we need a placeholder

--- a/src/win32/toga_win32/widgets/textinput.py
+++ b/src/win32/toga_win32/widgets/textinput.py
@@ -1,16 +1,23 @@
 from ctypes import c_wchar_p
 
+from ..libs import (
+    EM_SETREADONLY,
+    ES_AUTOHSCROLL,
+    WS_CHILD,
+    WS_TABSTOP,
+    WS_VISIBLE,
+    user32,
+)
 from .base import Widget
-from ..libs import *
 
 
 class TextInput(Widget):
-    window_class = 'edit'
-    default_style = WS_VISIBLE | WS_CHILD | WS_TABSTOP| ES_AUTOHSCROLL
+    window_class = "edit"
+    default_style = WS_VISIBLE | WS_CHILD | WS_TABSTOP | ES_AUTOHSCROLL
 
     def __init__(self, initial=None, placeholder=None, readonly=False):
         super().__init__(text=initial)
-        self.placeholder = placeholder #not used on win32!
+        self.placeholder = placeholder  # not used on win32!
         self._readonly = readonly
 
     def startup(self):


### PR DESCRIPTION
## Changes
<!--- Describe your changes in detail -->
 - Updating the `win32` backend such that it is up-to-par with the major backends (i.e. `cocoa`)

## Problems to be resolved (non-exhaustive)
<!--- What problem does this change solve? -->
- [ ] Fix lack of maintenance on the `win32` backend
- [ ] Fix backend using old/unsupported dependencies (`toga_cassowary`)
    - [ ] Replace calls to phased out constants (`LEFT_ALIGNED`, `RIGHT_ALIGNED`, etc.). This issue is also present in the `android` backend.
- [ ] Add support for full widget selection that is available in other backends
- [ ] Remove left over debugging stuff (`print` statements) from backend
- [ ] Lay the ground work for making maintenance on this backend easier in the future

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
**Related issue:** https://github.com/beeware/toga/issues/662

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
