### PR TITLE
Fix Icon filename property

### DIFF
--- a/src/core/tests/test_icon.py
+++ b/src/core/tests/test_icon.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 from unittest.mock import MagicMock
 
@@ -12,9 +13,25 @@ class TestIcon(unittest.TestCase):
 
         self.test_path = "Example.bmp"
         self.icon = toga.Icon(self.test_path)
+        self.resource_icon = toga.Icon(self.test_path, system=True)
 
     def test_icon_bind(self):
         self.assertEqual(self.icon._impl, None)
         self.icon.bind(factory=toga_dummy.factory)
         self.assertEqual(self.icon._impl.interface, self.icon)
         self.assertEqual(self.icon.path, self.test_path)
+
+    def test_icon_file(self):
+        """
+        Validate filename property
+
+        :return: None
+        """
+        # Validate file name/path for non-system icon
+        self.assertEqual(self.icon.filename, self.test_path)
+
+        # Test file name/path for system icon
+        toga_dir = os.path.dirname(toga.__file__)
+        icon_path = os.path.join(toga_dir, "resources",  self.test_path)
+
+        self.assertEqual(self.resource_icon.filename, icon_path)

--- a/src/core/tests/test_icon.py
+++ b/src/core/tests/test_icon.py
@@ -22,11 +22,8 @@ class TestIcon(unittest.TestCase):
         self.assertEqual(self.icon.path, self.test_path)
 
     def test_icon_file(self):
-        """
-        Validate filename property
+        """Validate filename property."""
 
-        :return: None
-        """
         # Validate file name/path for non-system icon
         self.assertEqual(self.icon.filename, self.test_path)
 

--- a/src/core/toga/icons.py
+++ b/src/core/toga/icons.py
@@ -39,7 +39,7 @@ class Icon:
             return os.path.join(toga_dir, 'resources', self.path)
         else:
             # no resource dir so default to the file path
-            return os.path.join('', self.path)
+            return self.path
 
     def bind(self, factory):
         if self._impl is None:

--- a/src/core/toga/icons.py
+++ b/src/core/toga/icons.py
@@ -38,8 +38,8 @@ class Icon:
             toga_dir = os.path.dirname(__file__)
             return os.path.join(toga_dir, 'resources', self.path)
         else:
-            from toga.app import App
-            return os.path.join(App.app_dir, self.path)
+            # no resource dir so default to the file path
+            return os.path.join('', self.path)
 
     def bind(self, factory):
         if self._impl is None:


### PR DESCRIPTION
It looks like for non-system Icon resources, setting the file property did not work:
```
return os.path.join(App.app_dir, self.path)
```
Since app_dir is not defined on the App class, this was erroring out when I added a test cases for the filename property/method. 

I've made the change to basically default to the icon file path in cases where resource is specified as false.

I've added a test case for the file property/method as well. Prior to the change:
```
toga/icons.py                           31      8    74%   12, 37-42, 55, 72
```
after the change:
```
toga/icons.py                           30      3    90%   12, 53, 70
```

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
