### PR TITLE
Update documentation for Window API Reference. 

### DIFF
--- a/docs/reference/api/window.rst
+++ b/docs/reference/api/window.rst
@@ -22,8 +22,26 @@ instantiation and support displaying multiple widgets, toolbars and resizing.
 
     import toga
 
-    window = toga.Window('my window', title='This is a window!')
-    window.show()
+
+    class ExampleWindow(toga.App):
+        def startup(self):
+            self.label = toga.Label('Hello World')
+            outer_box = toga.Box(
+                children=[self.label]
+            )
+            self.window = toga.Window()
+            self.window.content = outer_box
+
+            self.window.show()
+
+
+    def main():
+        return ExampleWindow('Window', 'org.pybee.window')
+
+
+    if __name__ == '__main__':
+        app = main()
+        app.main_loop()
 
 Reference
 ---------


### PR DESCRIPTION
<!--- Describe your changes in detail -->

Update documentation snippet as first contribution.

NOTE:  `toga.App()` will error (but not crash) during runtime due to no attribute select_file() implemented in `toga-cocoa`. I ignored this in the documentation as it may complicate the example for beginners.

<!--- What problem does this change solve? -->

Documentation was originally misleading; I am a beginner to `toga` and thought it was an independent code snippet, and the snippet did not run. This code can be pasted into a file and run with python -m $FILENAME assuming correct dependencies install.

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

#668. This issue may remain open if the `select_file()` method is desired to be implemented and the runtime error not present in the example.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested; built documentation locally and opened in Google Chrome to make sure snippet rendered correctly.
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
