### PR TITLE
Added test code for togo.icon.TIBERIUS_ICON method.

### DIFF
--- a/src/core/tests/test_icon.py
+++ b/src/core/tests/test_icon.py
@@ -32,7 +32,7 @@ class TestIcon(unittest.TestCase):
         icon_path = os.path.join(toga_dir, "resources",  self.test_path)
 
         self.assertEqual(self.resource_icon.filename, icon_path)
-    
+
     def test_TIBERIUS_ICON(self):
         """Validate TIBERIUS_ICON"""
         # Get Tiberius object

--- a/src/core/tests/test_icon.py
+++ b/src/core/tests/test_icon.py
@@ -32,3 +32,14 @@ class TestIcon(unittest.TestCase):
         icon_path = os.path.join(toga_dir, "resources",  self.test_path)
 
         self.assertEqual(self.resource_icon.filename, icon_path)
+    
+    def test_TIBERIUS_ICON(self):
+        """Validate TIBERIUS_ICON"""
+        # Get Tiberius object
+        self.tiberius = toga.Icon.TIBERIUS_ICON
+        
+        # Test file name/path for tiberius icon
+        tiberius_dir = os.path.dirname(toga.__file__)
+        icon_tiberius = os.path.join(tiberius_dir, "resources", "tiberius")
+        
+        self.assertEqual(self.tiberius.filename, icon_tiberius)

--- a/src/core/tests/test_icon.py
+++ b/src/core/tests/test_icon.py
@@ -35,7 +35,7 @@ class TestIcon(unittest.TestCase):
 
     def test_TIBERIUS_ICON(self):
         """Validate TIBERIUS_ICON"""
-        # Get Tiberius object
+        # Get Tiberius object 
         self.tiberius = toga.Icon.TIBERIUS_ICON
 
         # Test file name/path for tiberius icon

--- a/src/core/tests/test_icon.py
+++ b/src/core/tests/test_icon.py
@@ -35,7 +35,7 @@ class TestIcon(unittest.TestCase):
 
     def test_TIBERIUS_ICON(self):
         """Validate TIBERIUS_ICON"""
-        # Get Tiberius object 
+        # Get Tiberius object
         self.tiberius = toga.Icon.TIBERIUS_ICON
 
         # Test file name/path for tiberius icon

--- a/src/core/tests/test_icon.py
+++ b/src/core/tests/test_icon.py
@@ -37,9 +37,9 @@ class TestIcon(unittest.TestCase):
         """Validate TIBERIUS_ICON"""
         # Get Tiberius object
         self.tiberius = toga.Icon.TIBERIUS_ICON
-        
+
         # Test file name/path for tiberius icon
         tiberius_dir = os.path.dirname(toga.__file__)
         icon_tiberius = os.path.join(tiberius_dir, "resources", "tiberius")
-        
+
         self.assertEqual(self.tiberius.filename, icon_tiberius)


### PR DESCRIPTION
Looking at the coverage tests attempted to expand coverage to the icon.py file in core.
These changes attempt to expand coverage to the TIBERIUS_ICON method of toga.icon

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
