### PR TITLE
issue #646 Implement open file dialog for osx

### DIFF
--- a/examples/dialogs/dialogs/app.py
+++ b/examples/dialogs/dialogs/app.py
@@ -26,7 +26,10 @@ class ExampledialogsApp(toga.App):
                 title="Open file with Toga",
                 multiselect=False
             )
-            self.label.text = "File to open:" + fname
+            if fname is not None:
+                self.label.text = "File to open:" + fname
+            else:
+                self.label.text = "No file selected!"
         except ValueError:
             self.label.text = "Open file dialog was canceled"
 
@@ -36,7 +39,12 @@ class ExampledialogsApp(toga.App):
                 title="Open file with Toga",
                 multiselect=True
             )
-            self.label.text = "Files to open: {}".format(', '.join(filenames))
+            if filenames is not None:
+                msg = "Files to open: {}".format(', '.join(filenames))
+                self.label.text = msg
+            else:
+                self.label.text = "No files selected!"
+
         except ValueError:
             self.label.text = "Open file dialog was canceled"
 

--- a/examples/dialogs/dialogs/app.py
+++ b/examples/dialogs/dialogs/app.py
@@ -24,8 +24,19 @@ class ExampledialogsApp(toga.App):
         try:
             fname = self.main_window.open_file_dialog(
                 title="Open file with Toga",
+                multiselect=False
             )
             self.label.text = "File to open:" + fname
+        except ValueError:
+            self.label.text = "Open file dialog was canceled"
+
+    def action_open_file_dialog_multi(self, widget):
+        try:
+            filenames = self.main_window.open_file_dialog(
+                title="Open file with Toga",
+                multiselect=True
+            )
+            self.label.text = "Files to open: {}".format(', '.join(filenames))
         except ValueError:
             self.label.text = "Open file dialog was canceled"
 
@@ -63,6 +74,9 @@ class ExampledialogsApp(toga.App):
         btn_info = toga.Button('Info', on_press=self.action_info_dialog, style=btn_style)
         btn_question = toga.Button('Question', on_press=self.action_question_dialog, style=btn_style)
         btn_open = toga.Button('Open File', on_press=self.action_open_file_dialog, style=btn_style)
+        btn_open_multi = toga.Button('Open File (Multiple)',
+                                     on_press=self.action_open_file_dialog_multi,
+                                     style=btn_style)
         btn_save = toga.Button('Save File', on_press=self.action_save_file_dialog, style=btn_style)
         btn_select = toga.Button('Select Folder', on_press=self.action_select_folder_dialog, style=btn_style)
         dialog_btn_box = toga.Box(
@@ -81,8 +95,9 @@ class ExampledialogsApp(toga.App):
         btn_clear = toga.Button('Clear', on_press=self.do_clear, style=btn_style)
         btn_box = toga.Box(
             children=[
+                btn_open_multi,
                 btn_do_stuff,
-                btn_clear
+                btn_clear,
             ],
             style=Pack(direction=ROW)
         )

--- a/src/cocoa/toga_cocoa/dialogs.py
+++ b/src/cocoa/toga_cocoa/dialogs.py
@@ -99,3 +99,37 @@ def save_file(window, title, suggested_filename, file_types=None):
     if result == NSFileHandlingPanelOKButton:
         return panel.URL.path
     return None
+
+
+def open_file(window, title, file_types, multiselect):
+    """Cocoa open file dialog implementation.
+
+    We restrict the panel invocation to only choose files. We also allow
+    creating directories but not selecting directories.
+
+    Args:
+        window: The window this dialog belongs to.
+        title: Title of the modal.
+        file_types: Ignored for now.
+        multiselect: Flag to allow multiple file selection.
+    Returns: The file path on success, None otherwise
+
+    """
+
+    # Initialize and configure the panel.
+    panel = NSOpenPanel.alloc().init()
+    panel.title = title
+    panel.allowedFileTypes = file_types
+    panel.allowsMultipleSelection = multiselect
+    panel.canChooseDirectories = False
+    panel.canCreateDirectories = True
+    panel.canChooseFiles = True
+
+    # Show modal and return file path on success.
+    result = panel.runModal()
+    if NSFileHandlingPanelOKButton == result:
+        paths = [str(url.path) for url in panel.URLs]
+        filename_or_filenames = (paths if multiselect else
+                                 panel.URL.path)
+        return filename_or_filenames
+    return None

--- a/src/cocoa/toga_cocoa/dialogs.py
+++ b/src/cocoa/toga_cocoa/dialogs.py
@@ -127,7 +127,7 @@ def open_file(window, title, file_types, multiselect):
 
     # Show modal and return file path on success.
     result = panel.runModal()
-    if NSFileHandlingPanelOKButton == result:
+    if result == NSFileHandlingPanelOKButton:
         paths = [str(url.path) for url in panel.URLs]
         filename_or_filenames = (paths if multiselect else
                                  panel.URL.path)

--- a/src/cocoa/toga_cocoa/dialogs.py
+++ b/src/cocoa/toga_cocoa/dialogs.py
@@ -112,8 +112,8 @@ def open_file(window, title, file_types, multiselect):
         title: Title of the modal.
         file_types: Ignored for now.
         multiselect: Flag to allow multiple file selection.
-    Returns: The file path on success, None otherwise
-
+    Returns:
+        The file path on success, None otherwise.
     """
 
     # Initialize and configure the panel.

--- a/src/cocoa/toga_cocoa/dialogs.py
+++ b/src/cocoa/toga_cocoa/dialogs.py
@@ -122,7 +122,7 @@ def open_file(window, title, file_types, multiselect):
     panel.allowedFileTypes = file_types
     panel.allowsMultipleSelection = multiselect
     panel.canChooseDirectories = False
-    panel.canCreateDirectories = True
+    panel.canCreateDirectories = False
     panel.canChooseFiles = True
 
     # Show modal and return file path on success.

--- a/src/cocoa/toga_cocoa/window.py
+++ b/src/cocoa/toga_cocoa/window.py
@@ -242,3 +242,8 @@ class Window:
 
     def save_file_dialog(self, title, suggested_filename, file_types):
         return dialogs.save_file(self.interface, title, suggested_filename, file_types)
+
+    def open_file_dialog(self, title, initial_directory, file_types, multiselect):
+        # TODO: if the cocoa open file supports initial_directory,
+        #  we should pass it in
+        return dialogs.open_file(self.interface, title, file_types, multiselect)

--- a/src/cocoa/toga_cocoa/window.py
+++ b/src/cocoa/toga_cocoa/window.py
@@ -244,6 +244,4 @@ class Window:
         return dialogs.save_file(self.interface, title, suggested_filename, file_types)
 
     def open_file_dialog(self, title, initial_directory, file_types, multiselect):
-        # TODO: if the cocoa open file supports initial_directory,
-        #  we should pass it in
         return dialogs.open_file(self.interface, title, file_types, multiselect)


### PR DESCRIPTION
Added an open_file_dialog implementation the cocoa implementation. I've added a button to the dialog examples app as well.

Fixes #646 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
