### PR TITLE
#646 Add in open directory functionality in toga-cocoa.

### DIFF
--- a/examples/dialogs/dialogs/app.py
+++ b/examples/dialogs/dialogs/app.py
@@ -51,11 +51,21 @@ class ExampledialogsApp(toga.App):
     def action_select_folder_dialog(self, widget):
         try:
             path_names = self.main_window.select_folder_dialog(
-                title="Select folder with Toga",
+                title="Select folder with Toga"
             )
             self.label.text = "Folder selected:" + ','.join([path for path in path_names])
         except ValueError:
             self.label.text = "Folder select dialog was canceled"
+
+    def action_select_folder_dialog_multi(self, widget):
+        try:
+            path_names = self.main_window.select_folder_dialog(
+                title="Select multiple folders with Toga",
+                multiselect=True
+            )
+            self.label.text = "Folders selected:" + ','.join([path for path in path_names])
+        except ValueError:
+            self.label.text = "Folders select dialog was canceled"
 
     def action_save_file_dialog(self, widget):
         fname = 'Toga_file.txt'
@@ -87,13 +97,15 @@ class ExampledialogsApp(toga.App):
                                      style=btn_style)
         btn_save = toga.Button('Save File', on_press=self.action_save_file_dialog, style=btn_style)
         btn_select = toga.Button('Select Folder', on_press=self.action_select_folder_dialog, style=btn_style)
+        btn_select_multi = toga.Button('Select Folders', on_press=self.action_select_folder_dialog_multi, style=btn_style)
         dialog_btn_box = toga.Box(
             children=[
                 btn_info,
                 btn_question,
                 btn_open,
                 btn_save,
-                btn_select
+                btn_select,
+                btn_select_multi
             ],
             style=Pack(direction=ROW)
         )

--- a/examples/dialogs/dialogs/app.py
+++ b/examples/dialogs/dialogs/app.py
@@ -97,7 +97,11 @@ class ExampledialogsApp(toga.App):
                                      style=btn_style)
         btn_save = toga.Button('Save File', on_press=self.action_save_file_dialog, style=btn_style)
         btn_select = toga.Button('Select Folder', on_press=self.action_select_folder_dialog, style=btn_style)
-        btn_select_multi = toga.Button('Select Folders', on_press=self.action_select_folder_dialog_multi, style=btn_style)
+        btn_select_multi = toga.Button(
+            'Select Folders',
+            on_press=self.action_select_folder_dialog_multi,
+            style=btn_style
+        )
         dialog_btn_box = toga.Box(
             children=[
                 btn_info,

--- a/examples/dialogs/dialogs/app.py
+++ b/examples/dialogs/dialogs/app.py
@@ -50,10 +50,10 @@ class ExampledialogsApp(toga.App):
 
     def action_select_folder_dialog(self, widget):
         try:
-            path_name = self.main_window.select_folder_dialog(
+            path_names = self.main_window.select_folder_dialog(
                 title="Select folder with Toga",
             )
-            self.label.text = "Folder selected:" + path_name
+            self.label.text = "Folder selected:" + ','.join([path for path in path_names])
         except ValueError:
             self.label.text = "Folder select dialog was canceled"
 

--- a/src/cocoa/toga_cocoa/dialogs.py
+++ b/src/cocoa/toga_cocoa/dialogs.py
@@ -99,3 +99,21 @@ def save_file(window, title, suggested_filename, file_types=None):
     if result == NSFileHandlingPanelOKButton:
         return panel.URL.path
     return None
+
+
+def select_folder(window, title):
+    filename = None
+
+    dialog = NSOpenPanel.alloc().init()
+    dialog.title = title
+
+    dialog.canChooseFiles = False
+    dialog.canChooseDirectories = True
+    dialog.resolvesAliases = True
+    dialog.allowsMultipleSelection = True
+
+    result = dialog.runModal()
+
+    if result == NSFileHandlingPanelOKButton:
+        return dialog.URL.path
+    return None

--- a/src/cocoa/toga_cocoa/dialogs.py
+++ b/src/cocoa/toga_cocoa/dialogs.py
@@ -134,17 +134,31 @@ def open_file(window, title, file_types, multiselect):
         return filename_or_filenames
 
 
-def select_folder(window, title):
+def select_folder(window, title, multiselect):
+    """Cocoa select folder dialog implementation.
+
+    Args:
+        window: Window dialog belongs to.
+        title: Title of the dialog.
+        multiselect: Flag to allow multiple folder selection.
+    Returns:
+        (list) Paths of folders
+    """
     dialog = NSOpenPanel.alloc().init()
     dialog.title = title
 
     dialog.canChooseFiles = False
     dialog.canChooseDirectories = True
     dialog.resolvesAliases = True
-    dialog.allowsMultipleSelection = True
+    dialog.allowsMultipleSelection = multiselect
 
     result = dialog.runModal()
 
+    # Ensure regardless of the result, return types remain the same so as to not
+    # require type checking logic in user code.
     if result == NSFileHandlingPanelOKButton:
-        return dialog.URL.path
-    return None
+        if multiselect:
+            return [dialog.URL.path]
+        else:
+            return [str(url.path) for url in dialog.URLs]
+    return []

--- a/src/cocoa/toga_cocoa/dialogs.py
+++ b/src/cocoa/toga_cocoa/dialogs.py
@@ -1,4 +1,18 @@
-from .libs import *
+from .libs import (
+    NSAlert,
+    NSInformationalAlertStyle,
+    NSAlertFirstButtonReturn,
+    NSWarningAlertStyle,
+    NSCriticalAlertStyle,
+    NSScrollView,
+    NSMakeRect,
+    NSBezelBorder,
+    NSTextView,
+    NSSavePanel,
+    NSArray,
+    NSFileHandlingPanelOKButton,
+    NSOpenPanel
+)
 
 
 def info(window, title, message):

--- a/src/cocoa/toga_cocoa/dialogs.py
+++ b/src/cocoa/toga_cocoa/dialogs.py
@@ -142,7 +142,7 @@ def select_folder(window, title, multiselect):
         title: Title of the dialog.
         multiselect: Flag to allow multiple folder selection.
     Returns:
-        (list) Paths of folders
+        (list) A list of folder paths.
     """
     dialog = NSOpenPanel.alloc().init()
     dialog.title = title

--- a/src/cocoa/toga_cocoa/dialogs.py
+++ b/src/cocoa/toga_cocoa/dialogs.py
@@ -135,8 +135,6 @@ def open_file(window, title, file_types, multiselect):
 
 
 def select_folder(window, title):
-    filename = None
-
     dialog = NSOpenPanel.alloc().init()
     dialog.title = title
 

--- a/src/cocoa/toga_cocoa/dialogs.py
+++ b/src/cocoa/toga_cocoa/dialogs.py
@@ -156,9 +156,10 @@ def select_folder(window, title, multiselect):
 
     # Ensure regardless of the result, return types remain the same so as to not
     # require type checking logic in user code.
+    # Convert types from 'ObjCStrInstance' to 'str'.
     if result == NSFileHandlingPanelOKButton:
         if multiselect:
-            return [dialog.URL.path]
-        else:
             return [str(url.path) for url in dialog.URLs]
+        else:
+            return [str(dialog.URL.path)]
     return []

--- a/src/cocoa/toga_cocoa/window.py
+++ b/src/cocoa/toga_cocoa/window.py
@@ -246,5 +246,5 @@ class Window:
     def open_file_dialog(self, title, initial_directory, file_types, multiselect):
         return dialogs.open_file(self.interface, title, file_types, multiselect)
 
-    def select_folder_dialog(self, title, initial_directory):
-        return dialogs.select_folder(self.interface, title)
+    def select_folder_dialog(self, title, initial_directory, multiselect):
+        return dialogs.select_folder(self.interface, title, multiselect)

--- a/src/cocoa/toga_cocoa/window.py
+++ b/src/cocoa/toga_cocoa/window.py
@@ -242,3 +242,6 @@ class Window:
 
     def save_file_dialog(self, title, suggested_filename, file_types):
         return dialogs.save_file(self.interface, title, suggested_filename, file_types)
+
+    def select_folder_dialog(self, title, initial_directory):
+        return dialogs.select_folder(self.interface, title)

--- a/src/core/toga/window.py
+++ b/src/core/toga/window.py
@@ -284,6 +284,6 @@ class Window:
             multiselect (bool): Value showing whether a user can select multiple files.
 
         Returns:
-            The absolute path(str) to the selected file or None
+            The absolute path(str) to the selected file or None.
         """
         return self._impl.select_folder_dialog(title, initial_directory, multiselect)

--- a/src/core/toga/window.py
+++ b/src/core/toga/window.py
@@ -274,15 +274,16 @@ class Window:
         """
         return self._impl.open_file_dialog(title, initial_directory, file_types, multiselect)
 
-    def select_folder_dialog(self, title, initial_directory=None):
+    def select_folder_dialog(self, title, initial_directory=None, multiselect=False):
         """ This opens a native dialog where the user can select a folder.
         It is possible to set the initial folder.
         If no path is returned (eg. dialog is canceled), a ValueError is raised.
         Args:
             title (str): The title of the dialog window.
             initial_directory(str): Initial folder displayed in the dialog.
+            multiselect (bool): Value showing whether a user can select multiple files.
 
         Returns:
             The absolute path(str) to the selected file or None
         """
-        return self._impl.select_folder_dialog(title, initial_directory)
+        return self._impl.select_folder_dialog(title, initial_directory, multiselect)

--- a/src/gtk/toga_gtk/dialogs.py
+++ b/src/gtk/toga_gtk/dialogs.py
@@ -105,7 +105,7 @@ def open_file(window, title, file_types, multiselect):
     return filename_or_filenames
 
 
-def select_folder(window, title):
+def select_folder(window, title, multiselect):
     '''This function is very similar to the open_file function but more limited
     in scope. If broadening scope here, or aligning features with the other
     dialogs, consider refactoring around a common base function or set of
@@ -122,4 +122,4 @@ def select_folder(window, title):
     dialog.destroy()
     if filename is None:
         raise ValueError("No folder provided in the select folder dialog")
-    return filename
+    return [filename]

--- a/src/gtk/toga_gtk/window.py
+++ b/src/gtk/toga_gtk/window.py
@@ -150,7 +150,7 @@ class Window:
         '''
         return dialogs.open_file(self.interface, title, file_types, multiselect)
 
-    def select_folder_dialog(self, title, initial_directory):
+    def select_folder_dialog(self, title, initial_directory, multiselect):
         '''Note that at this time, GTK does not recommend setting the initial
         directory. This function explicitly chooses not to pass it along:
         https://developer.gnome.org/gtk3/stable/GtkFileChooser.html#gtk-file-chooser-set-current-folder

--- a/src/winforms/toga_winforms/window.py
+++ b/src/winforms/toga_winforms/window.py
@@ -114,7 +114,6 @@ class Window:
         if self.interface is not self.interface.app._main_window:
             self.native.Show()
 
-
     def winforms_FormClosing(self, event, handler):
         if self.interface.app.on_exit:
             self.interface.app.on_exit(self.interface.app)

--- a/src/winforms/toga_winforms/window.py
+++ b/src/winforms/toga_winforms/window.py
@@ -114,14 +114,14 @@ class Window:
         if self.interface is not self.interface.app._main_window:
             self.native.Show()
 
-            
+
     def winforms_FormClosing(self, event, handler):
         if self.interface.app.on_exit:
             self.interface.app.on_exit(self.interface.app)
-          
+
     def set_full_screen(self, is_full_screen):
         self.interface.factory.not_implemented('Window.set_full_screen()')
-        
+
     def on_close(self):
         pass
 
@@ -179,13 +179,13 @@ class Window:
         else:
             raise ValueError("No filename provided in the open file dialog")
 
-    def select_folder_dialog(self, title, initial_directory):
+    def select_folder_dialog(self, title, initial_directory, multiselect):
         dialog = WinForms.FolderBrowserDialog()
         dialog.Title = title
         if initial_directory is not None:
             dialog.InitialDirectory = initial_directory
 
         if dialog.ShowDialog() == WinForms.DialogResult.OK:
-            return dialog.SelectedPath
+            return [dialog.SelectedPath]
         else:
             raise ValueError("No folder provided in the select folder dialog")


### PR DESCRIPTION
<!--- Describe your changes in detail -->

Adds in open directory functionality in toga-cocoa, kind of copying functionality in toga-gtk. This pull request is in progress and composes PR #674 by @nehararora; will be updated and merged in after 674 is merged in.

<!--- What problem does this change solve? -->

Previously, ExampledialogsApp had an `action_select_folder_dialog` that hooked to nothing when running on macOS. This feature has been implemented as methods `select_folder()` and `select_folder_dialog()` in toga-cocoa using NSOpenPanel.

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

Partially resolves issue #646.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested: Manual testing has directory path listed, and file selection disabled.
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
