### PR TITLE
Fix Makefile (in particular, make install)

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,17 +2,18 @@
 #
 
 # You can set these variables from the command line.
+SHELL         = /bin/bash
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build
-SOURCEDIR     = .
+SOURCEDIR    := .
 
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
 ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
-VENV = ../env/bin/activate
+VENV = $(VIRTUAL_ENV)/bin/activate
 PORT = 8001
 
 # the i18n builder cannot share the environment and doctrees with the others
@@ -165,9 +166,8 @@ spelling:
 		"build/spelling/output.txt."
 
 install:
-	@echo "... setting up virtualenv"
-	virtualenv env
-	. $(VENV); pip install -r requirements_docs.txt
+	@echo "installing dependencies"
+	pip install -r $(SOURCEDIR)/requirements.txt
 	@echo "\n" \
 	      "-------------------------------------------------------------------------------------------------- \n" \
 		    "* watch, build and serve the documentation: make run \n" \

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -23,7 +23,7 @@ I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
-	@echo "  instal     to create a virtualenv called 'env' in the docs directory"
+	@echo "  install     to create a virtualenv called 'env' in the docs directory"
 	@echo "  html       to make standalone HTML files"
 	@echo "  dirhtml    to make HTML files named index.html in directories"
 	@echo "  singlehtml to make a single large HTML file"


### PR DESCRIPTION
Signed-off-by: Rico Rodriguez <rico.l.rodriguez@gmail.com>

<!--- Describe your changes in detail -->
1) Force bash as shell (see http://www.gnu.org/software/make/manual/make.html#Setting, Variables defined with := in GNU make are expanded when they are defined rather than when they are used.)
2) Evaluate/expand source dir immediately to avoid dynamic evaluation resulting in path issues
3) Remove unused virtual environment reference in docs directory.
4) Correctly reference VENV using VIRTUAL_ENV environment variable.

<!--- What problem does this change solve? -->
Prior to these changes, make install did not actually work (even with bash) - it was creating a virtual environment that never got used. With alternate shells, nothing really worked.

These changes explicitly recognize the base virtual environment as the one where dependencies should be installed, and forces bash as the execution shell to enable compatibility with fish/zsh/etc.

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
