### PR TITLE
Covering test case for Canvas's clear method

### DIFF
--- a/src/core/tests/widgets/test_canvas.py
+++ b/src/core/tests/widgets/test_canvas.py
@@ -216,6 +216,15 @@ class CanvasTests(TestCase):
         self.testing_canvas.remove(new_path)
         self.assertNotIn(new_path, self.testing_canvas.drawing_objects)
 
+    def test_canvas_context_clear(self):
+        # Create canvas objects 
+        new_path = self.testing_canvas.new_path()
+        rect = self.testing_canvas.rect(x=1000.2, y=2000, width=3000, height=-4000.0)
+
+        self.testing_canvas.clear()
+        self.assertNotIn(new_path, self.testing_canvas.drawing_objects)
+        self.assertNotIn(rect, self.testing_canvas.drawing_objects)
+
     def test_new_path_repr(self):
         new_path = self.testing_canvas.new_path()
         self.assertEqual(repr(new_path), "NewPath()")

--- a/src/core/tests/widgets/test_canvas.py
+++ b/src/core/tests/widgets/test_canvas.py
@@ -217,7 +217,7 @@ class CanvasTests(TestCase):
         self.assertNotIn(new_path, self.testing_canvas.drawing_objects)
 
     def test_canvas_context_clear(self):
-        # Create canvas objects 
+        # Create canvas objects
         new_path = self.testing_canvas.new_path()
         rect = self.testing_canvas.rect(x=1000.2, y=2000, width=3000, height=-4000.0)
 


### PR DESCRIPTION
Added code in Canvas's Test to to cover it's clear method. 
The clear method clears all drawn objects.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
