### PR TITLE
Fix the CAPSLOCK typo in toga_cocoa

### DIFF
--- a/src/cocoa/toga_cocoa/keys.py
+++ b/src/cocoa/toga_cocoa/keys.py
@@ -119,7 +119,7 @@ def toga_key(event):
     modifiers = set()
 
     if event.modifierFlags & NSEventModifierFlagCapsLock:
-        modifiers.add(Key.CAPS_LOCK)
+        modifiers.add(Key.CAPSLOCK)
     if event.modifierFlags & NSEventModifierFlagShift:
         modifiers.add(Key.SHIFT)
     if event.modifierFlags & NSEventModifierFlagControl:


### PR DESCRIPTION
There is a typo in `toga_cocoa/keys.py` which would break [podium](https://github.com/beeware/podium).
The problem is detailed in  [The arrows seem to be not working when capslock is on #27](https://github.com/beeware/podium/issues/27)

## PR Checklist:
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct