### PR TITLE
Fix the open command in DocumentApp

### DIFF
--- a/src/cocoa/toga_cocoa/app.py
+++ b/src/cocoa/toga_cocoa/app.py
@@ -208,7 +208,7 @@ class DocumentApp(App):
     def _create_app_commands(self):
         self.interface.commands.add(
             toga.Command(
-                lambda w: self.open_file,
+                lambda _: self.select_file(),
                 label='Open...',
                 shortcut='o',
                 group=toga.Group.FILE,


### PR DESCRIPTION
## Problem
In [podium](https://github.com/beeware/podium), the `File > Open...` button does not work. The action bound to the open command seems to be wrong.

## Changes
It's due to an error in `toga_cocoa/app.py::DocumentApp::_create_app_commands`. The action bound to the open command should be `select_file` instead of `open_file` 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct