### PR TITLE
Test SplitContainer setting container tuple weights

### DIFF
--- a/src/core/tests/widgets/test_splitcontainer.py
+++ b/src/core/tests/widgets/test_splitcontainer.py
@@ -51,7 +51,7 @@ class SplitContainerTests(TestCase):
         self.assertValueSet(self.split, 'direction', new_value)
 
     def test_setting_content_valid_input_with_tuple(self):
-        
+
         new_content = [
             (toga.Box(style=TestStyle(), factory=toga_dummy.factory), 1.2),
             (toga.Box(style=TestStyle(), factory=toga_dummy.factory), 2.5)

--- a/src/core/tests/widgets/test_splitcontainer.py
+++ b/src/core/tests/widgets/test_splitcontainer.py
@@ -49,3 +49,14 @@ class SplitContainerTests(TestCase):
         new_value = False
         self.split.direction = new_value
         self.assertValueSet(self.split, 'direction', new_value)
+
+    def test_setting_content_valid_input_with_tuple(self):
+        
+        new_content = [
+            (toga.Box(style=TestStyle(), factory=toga_dummy.factory), 1.2),
+            (toga.Box(style=TestStyle(), factory=toga_dummy.factory), 2.5)
+        ]
+
+        self.split.content = new_content
+        self.assertEqual(self.split._weight[0], 1.2)
+        self.assertEqual(self.split._weight[1], 2.5)


### PR DESCRIPTION
Adding test coverage for line 58 of SplitContainer widget whereby the
boxes passed to the SplitContainer can have their weights preset in a
tuple.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
