### PR TITLE
Fix open file not working when using open command and double click files

### DIFF
--- a/src/cocoa/toga_cocoa/app.py
+++ b/src/cocoa/toga_cocoa/app.py
@@ -241,6 +241,7 @@ class DocumentApp(App):
             fileURL (str): The URL/path to the file to add as a document.
         """
         # Convert a cocoa fileURL to a file path.
+        fileURL = fileURL.strip('/')
         path = unquote(urlparse(fileURL).path)
         extension = os.path.splitext(path)[1][1:]
 


### PR DESCRIPTION
## Problem
Open file does not work when using open command and double click files on macOS

## Change
* When using open command or double click on macOS would send a file
  URL with trailing slash. It's the cause of failing to open a file.
  By removing it, the problem would be solved.

## Related Issue
Podium: [Cannot open using `open <deck>.podium` #17](https://github.com/beeware/podium/issues/17)

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct