### PR TITLE
Updated legacy pybee references and setup docs for toga-demo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,13 +15,13 @@ Toga
     :target: https://pypi.python.org/pypi/toga
 
 .. image:: https://img.shields.io/pypi/l/toga.svg
-    :target: https://github.com/pybee/toga/blob/master/LICENSE
+    :target: https://github.com/beeware/toga/blob/master/LICENSE
 
 .. image:: https://beekeeper.beeware.org/projects/beeware/batavia/shield
     :target: https://beekeeper.beeware.org/projects/beeware/batavia
 
-.. image:: https://badges.gitter.im/pybee/general.svg
-    :target: https://gitter.im/pybee/general
+.. image:: https://badges.gitter.im/beeware/general.svg
+    :target: https://gitter.im/beeware/general
 
 
 A Python native, OS native GUI toolkit.
@@ -88,7 +88,7 @@ Toga is part of the `BeeWare suite`_. You can talk to the community through:
 
 * `@pybeeware on Twitter`_
 
-* The `pybee/general`_ channel on Gitter.
+* The `beeware/general`_ channel on Gitter.
 
 Contributing
 ~~~~~~~~~~~~
@@ -102,9 +102,9 @@ contribute code, please `fork the code`_ and `submit a pull request`_.
 .. _BeeWare suite: https://beeware.org/
 .. _Read The Docs: https://toga.readthedocs.io
 .. _@pybeeware on Twitter: https://twitter.com/pybeeware
-.. _pybee/general: https://gitter.im/pybee/general
+.. _beeware/general: https://gitter.im/beeware/general
 .. _guide for first time contributors: https://toga.readthedocs.io/en/latest/how-to/contribute.html 
-.. _log them on Github: https://github.com/pybee/toga/issues
-.. _fork the code: https://github.com/pybee/toga
-.. _submit a pull request: https://github.com/pybee/toga/pulls
+.. _log them on Github: https://github.com/beeware/toga/issues
+.. _fork the code: https://github.com/beeware/toga
+.. _submit a pull request: https://github.com/beeware/toga/pulls
 .. _Virtual Environment: https://www.virtualenv.org

--- a/beekeeper.yml
+++ b/beekeeper.yml
@@ -40,7 +40,7 @@ pull_request:
             - winforms:
                 name: Winforms implementation compliance check
                 environment:
-                    EXTRA_REQUIRES: https://github.com/pybee/legless-lizard/archive/master.zip
+                    EXTRA_REQUIRES: https://github.com/beeware/legless-lizard/archive/master.zip
                     TEST_DIR: src/winforms
                     SRC_DEPENDANTS: src/core src/dummy
             - cocoa:

--- a/demo/CONTRIBUTING.md
+++ b/demo/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # Contributing
 
-PyBee <3's contributions! 
+BeeWare <3's contributions! 
 
-Please be aware, PyBee operates under a Code of Conduct. 
+Please be aware, BeeWare operates under a Code of Conduct. 
 
-See [CONTRIBUTING to PyBee](http://pybee.org/contributing) for details.
+See [CONTRIBUTING to BeeWare](http://beeware.org/contributing) for details.
 

--- a/demo/README.rst
+++ b/demo/README.rst
@@ -30,7 +30,7 @@ Toga Demo is part of the `BeeWare suite`_. You can talk to the community through
 
 * `@pybeeware on Twitter`_
 
-* The `pybee/general`_ channel on Gitter.
+* The `beeware/general`_ channel on Gitter.
 
 Contributing
 ------------
@@ -38,12 +38,12 @@ Contributing
 If you experience problems with Toga Demo, `log them on GitHub`_. If you
 want to contribute code, please `fork the code`_ and `submit a pull request`_.
 
-.. _BeeWare suite: http://pybee.org
+.. _BeeWare suite: http://beeware.org
 .. _Read The Docs: http://toga-demo.readthedocs.org
-.. _Toga widget toolkit: http://pybee.org/toga
-.. _toga repository on GitHub: https://github.com/pybee/toga
+.. _Toga widget toolkit: http://beeware.org/toga
+.. _toga repository on GitHub: https://github.com/beeware/toga
 .. _@pybeeware on Twitter: https://twitter.com/pybeeware
-.. _pybee/general: https://gitter.im/pybee/general
-.. _log them on Github: https://github.com/pybee/toga-demo/issues
-.. _fork the code: https://github.com/pybee/toga-demo
-.. _submit a pull request: https://github.com/pybee/toga-demo/pulls
+.. _beeware/general: https://gitter.im/beeware/general
+.. _log them on Github: https://github.com/beeware/toga-demo/issues
+.. _fork the code: https://github.com/beeware/toga-demo
+.. _submit a pull request: https://github.com/beeware/toga-demo/pulls

--- a/demo/setup.py
+++ b/demo/setup.py
@@ -23,7 +23,7 @@ setup(
     long_description=long_description,
     author='Russell Keith-Magee',
     author_email='russell@keith-magee.com',
-    url='http://pybee.org/toga-demo',
+    url='http://beeware.org/toga-demo',
     include_package_data=True,
     packages=find_packages(),
     python_requires='>=3.5',
@@ -55,7 +55,7 @@ setup(
     options={
         'app': {
             'formal_name': 'Toga Demo',
-            'bundle': 'org.pybee',
+            'bundle': 'org.beeware',
         },
         'ios': {
             'app_requires': [

--- a/demo/toga_demo/app.py
+++ b/demo/toga_demo/app.py
@@ -89,4 +89,4 @@ class TogaDemo(toga.App):
 
 
 def main():
-    return TogaDemo('Toga Demo', 'org.pybee.toga-demo')
+    return TogaDemo('Toga Demo', 'org.beeware.toga-demo')

--- a/docs/background/faq.rst
+++ b/docs/background/faq.rst
@@ -40,4 +40,4 @@ with various widget toolkits for over 20 years, so the metaphor seemed
 appropriate.
 
 .. _yak shaving: http://en.wiktionary.org/wiki/yak_shaving
-.. _BeeWare: http://pybee.org
+.. _BeeWare: http://beeware.org

--- a/docs/how-to/contribute.rst
+++ b/docs/how-to/contribute.rst
@@ -6,9 +6,9 @@ How to contribute to Toga
 
 If you experience problems with Toga, `log them on GitHub`_. If you want to contribute code, please `fork the code`_ and `submit a pull request`_.
 
-.. _log them on Github: https://github.com/pybee/toga/issues
-.. _fork the code: https://github.com/pybee/toga
-.. _submit a pull request: https://github.com/pybee/toga/pulls
+.. _log them on Github: https://github.com/beeware/toga/issues
+.. _fork the code: https://github.com/beeware/toga
+.. _submit a pull request: https://github.com/beeware/toga/pulls
 
 
 Set up your development environment
@@ -87,7 +87,7 @@ start coding. To set up a virtual environment, run:
 
 Your prompt should now have a ``(venv)`` prefix in front of it.
 
-Next, go to `the Toga page on Github <https://github.com/pybee/toga>`__, and
+Next, go to `the Toga page on Github <https://github.com/beeware/toga>`__, and
 fork the repository into your own account, and then clone a copy of that
 repository onto your computer by clicking on "Clone or Download". If you
 have the Github desktop application installed on your computer, you can
@@ -463,7 +463,7 @@ raising a ticket. Or, if you're confident that you know what needs to be done,
 create a pull request that fixes the problem you've found.
 
 One example of the type of consistency we're looking for is described in
-`this ticket <https://github.com/pybee/toga/issues/299>`__.
+`this ticket <https://github.com/beeware/toga/issues/299>`__.
 
 What next?
 ==========

--- a/docs/how-to/get-started.rst
+++ b/docs/how-to/get-started.rst
@@ -21,4 +21,9 @@ Create a new virtualenv. In your virtualenv, install Toga, and then run it::
 This will pop up a GUI window showing the full range of widgets available
 to an application using Toga.
 
+There is a known issue with the current build on some Mac OS distributions. If you are
+running Mac OS Sierra or higher, use the following installation command instead:
+
+    $ pip install toga-demo --pre
+
 Have fun, and see the :ref:`reference` to learn more about what's going on.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -89,12 +89,12 @@ Toga is part of the `BeeWare suite`_. You can talk to the community through:
 
  * `@pybeeware on Twitter`_
 
- * `pybee/general on Gitter`_
+ * `beeware/general on Gitter`_
 
-.. _BeeWare suite: http://pybee.org
+.. _BeeWare suite: http://beeware.org
 .. _Read The Docs: https://toga.readthedocs.io
 .. _@pybeeware on Twitter: https://twitter.com/pybeeware
-.. _pybee/general on Gitter: https://gitter.im/pybee/general
+.. _beeware/general on Gitter: https://gitter.im/beeware/general
 
 
 .. toctree::

--- a/docs/reference/api/app.rst
+++ b/docs/reference/api/app.rst
@@ -30,7 +30,7 @@ To start a UI loop, call `app.main_loop()`
 
 
     if __name__ == '__main__':
-        app = toga.App('First App', 'org.pybee.helloworld', startup=build)
+        app = toga.App('First App', 'org.beeware.helloworld', startup=build)
         app.main_loop()
 
 Alternatively, you can subclass App and implement the startup method
@@ -47,7 +47,7 @@ Alternatively, you can subclass App and implement the startup method
 
 
     if __name__ == '__main__':
-        app = MyApp('First App', 'org.pybee.helloworld')
+        app = MyApp('First App', 'org.beeware.helloworld')
         app.main_loop()
 
 Reference

--- a/docs/reference/api/window.rst
+++ b/docs/reference/api/window.rst
@@ -36,7 +36,7 @@ instantiation and support displaying multiple widgets, toolbars and resizing.
 
 
     def main():
-        return ExampleWindow('Window', 'org.pybee.window')
+        return ExampleWindow('Window', 'org.beeware.window')
 
 
     if __name__ == '__main__':

--- a/docs/reference/platforms.rst
+++ b/docs/reference/platforms.rst
@@ -22,8 +22,8 @@ report ``sys.platform == 'darwin'``), or can be manually installed by invoking::
 The macOS backend has seen the most development to date. It uses `Rubicon`_ to
 provide a bridge to native macOS libraries.
 
-.. _toga-cocoa: https://github.com/pybee/toga/tree/master/src/cocoa
-.. _Rubicon: https://github.com/pybee/rubicon-objc
+.. _toga-cocoa: https://github.com/beeware/toga/tree/master/src/cocoa
+.. _Rubicon: https://github.com/beeware/rubicon-objc
 
 Linux
 ~~~~~
@@ -40,7 +40,7 @@ invoking::
 The GTK+ backend is reasonably well developed, but currently has some known issues
 with widget layout. It uses the native GObject Python bindings.
 
-.. _toga-gtk: https://github.com/pybee/toga/tree/master/src/gtk
+.. _toga-gtk: https://github.com/beeware/toga/tree/master/src/gtk
 
 Winforms
 ~~~~~~~~
@@ -55,7 +55,7 @@ installed by invoking::
 The Windows backend is currently proof-of-concept only. Most widgets have not been
 implemented. It uses `Python.net`_
 
-.. _toga-winforms: https://github.com/pybee/toga/tree/master/src/winforms
+.. _toga-winforms: https://github.com/beeware/toga/tree/master/src/winforms
 .. _Python.net: https://pythonnet.github.io
 
 Mobile platforms
@@ -74,8 +74,8 @@ manually installed by invoking::
 The iOS backend is currently proof-of-concept only. Most widgets have not been
 implemented. It uses `Rubicon`_ to provide a bridge to native macOS libraries.
 
-.. _Python-iOS-template cookiecutter: http://github.com/pybee/Python-iOS-template
-.. _toga-iOS: http://github.com/pybee/toga/tree/master/src/iOS
+.. _Python-iOS-template cookiecutter: http://github.com/beeware/Python-iOS-template
+.. _toga-iOS: http://github.com/beeware/toga/tree/master/src/iOS
 
 Android
 ~~~~~~~
@@ -89,8 +89,8 @@ The android backend is currently proof-of-concept only. Most widgets have not
 been implemented. It uses `VOC`_ to compile Python code to Java class files
 for execution on Android devices.
 
-.. _toga-android: http://github.com/pybee/toga/tree/master/src/android
-.. _VOC: http://github.com/pybee/voc
+.. _toga-android: http://github.com/beeware/toga/tree/master/src/android
+.. _VOC: http://github.com/beeware/voc
 
 Web platforms
 -------------
@@ -106,8 +106,8 @@ by invoking::
 The Django backend is currently proof-of-concept only. Most widgets have not been
 implemented. It uses `Batavia`_ to run Python code in the browser.
 
-.. _toga-django: http://github.com/pybee/toga/tree/master/src/django
-.. _Batavia: https://github.com/pybee/batavia
+.. _toga-django: http://github.com/beeware/toga/tree/master/src/django
+.. _Batavia: https://github.com/beeware/batavia
 
 The Dummy platform
 ------------------
@@ -133,7 +133,7 @@ If you are interested in these platforms and would like to contribute, please
 get in touch on Twitter_ or Gitter_.
 
 .. _Twitter: https://twitter.com/pybeeware
-.. _Gitter: https://gitter.im/pybee/general
+.. _Gitter: https://gitter.im/beeware/general
 
 Unofficial platform support
 ===========================

--- a/docs/requirements_rtd.txt
+++ b/docs/requirements_rtd.txt
@@ -1,3 +1,3 @@
 -r requirements.txt
-git+https://github.com/pybee/toga#egg=toga-core&subdirectory=src/core
-git+https://github.com/pybee/toga#egg=toga-gtk&subdirectory=docs/mock_gtk
+git+https://github.com/beeware/toga#egg=toga-core&subdirectory=src/core
+git+https://github.com/beeware/toga#egg=toga-gtk&subdirectory=docs/mock_gtk

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -2,6 +2,7 @@
 App
 apps
 backends
+beeware
 ButtonsType
 checkbox
 CheckButton
@@ -35,7 +36,6 @@ pre
 prepurposed
 ProgressBar
 Progressbar
-pybee
 Quickstart
 Refactored
 Ren

--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -12,7 +12,7 @@ Set up your development environment
 ===================================
 
 Open a command prompt on your computer and make sure that you can successfully run the :code:`python3` command. Create a working directory for your code and change to it.
-If Python 3 is *not* installed, you can do so via `the official installer <https://www.python.org/downloads>`_, or via `pyenv <https://github.com/pyenv/pyenv#simple-python-version-management-pyenv>`_, as described in the `environment page <https://pybee.org/contributing/how/first-time/setup>`_.
+If Python 3 is *not* installed, you can do so via `the official installer <https://www.python.org/downloads>`_, or via `pyenv <https://github.com/pyenv/pyenv#simple-python-version-management-pyenv>`_, as described in the `environment page <https://beeware.org/contributing/how/first-time/setup>`_.
 
 The recommended way of setting up your development environment for Toga
 is to install a virtual environment, install the required dependencies and
@@ -164,7 +164,7 @@ our callable defining the main window contents. We wrap this creation process
 into a method called `main`, which returns a new instance of our application::
 
     def main():
-        return toga.App('First App', 'org.pybee.helloworld', startup=build)
+        return toga.App('First App', 'org.beeware.helloworld', startup=build)
 
 The entry point for the project then needs to instantiate this entry point,
 and start the main app loop. The call to `main_loop()` is a blocking call;

--- a/docs/tutorial/tutorial-issues-note.rst
+++ b/docs/tutorial/tutorial-issues-note.rst
@@ -1,3 +1,3 @@
 .. note:: Toga is a work in progress, and may not be consistent across all platforms.
 
-    Please check the `Tutorial Issues <https://github.com/pybee/toga/issues?q=is%3Aopen+is%3Aissue+label%3Atutorial-bugs>`_ label on Github to see what's currently broken.
+    Please check the `Tutorial Issues <https://github.com/beeware/toga/issues?q=is%3Aopen+is%3Aissue+label%3Atutorial-bugs>`_ label on Github to see what's currently broken.

--- a/examples/.template/{{ cookiecutter.name }}/setup.py
+++ b/examples/.template/{{ cookiecutter.name }}/setup.py
@@ -22,7 +22,7 @@ setup(
     description='Test app for the {{ cookiecutter.formal_name }} widget.',
     long_description=long_description,
     author='BeeWare Project',
-    author_email='contact@pybee.org',
+    author_email='contact@beeware.org',
     license='BSD license',
     packages=find_packages(
         exclude=[
@@ -46,7 +46,7 @@ setup(
     options={
         'app': {
             'formal_name': '{{ cookiecutter.formal_name }}',
-            'bundle': 'org.pybee.widgets'
+            'bundle': 'org.beeware.widgets'
         },
 
         # Desktop/laptop deployments

--- a/examples/.template/{{ cookiecutter.name }}/{{ cookiecutter.name }}/app.py
+++ b/examples/.template/{{ cookiecutter.name }}/{{ cookiecutter.name }}/app.py
@@ -52,7 +52,7 @@ class Example{{ cookiecutter.widget_name }}App(toga.App):
 
 
 def main():
-    return Example{{ cookiecutter.widget_name }}App('{{ cookiecutter.formal_name }}', 'org.pybee.widgets.{{ cookiecutter.name }}')
+    return Example{{ cookiecutter.widget_name }}App('{{ cookiecutter.formal_name }}', 'org.beeware.widgets.{{ cookiecutter.name }}')
 
 
 if __name__ == '__main__':

--- a/examples/beeliza/beeliza/app.py
+++ b/examples/beeliza/beeliza/app.py
@@ -81,7 +81,7 @@ class BeelizaApp(toga.App):
 
 
 def main():
-    return BeelizaApp('Beeliza', 'org.pybee.beeliza')
+    return BeelizaApp('Beeliza', 'org.beeware.beeliza')
 
 
 if __name__ == '__main__':

--- a/examples/beeliza/setup.py
+++ b/examples/beeliza/setup.py
@@ -22,7 +22,7 @@ setup(
     description='A Bee-themed Eliza chat-bot.',
     long_description=long_description,
     author='BeeWare Project',
-    author_email='contact@pybee.org',
+    author_email='contact@beeware.org',
     license='BSD license',
     packages=find_packages(
         exclude=[
@@ -46,7 +46,7 @@ setup(
     options={
         'app': {
             'formal_name': 'Beeliza',
-            'bundle': 'org.pybee'
+            'bundle': 'org.beeware'
         },
 
         # Desktop/laptop deployments

--- a/examples/button/button/app.py
+++ b/examples/button/button/app.py
@@ -86,5 +86,5 @@ class ExampleButtonApp(toga.App):
 def main():
     # Application class
     #   App name and namespace
-    app = ExampleButtonApp('Button', 'org.pybee.widgets.buttons')
+    app = ExampleButtonApp('Button', 'org.beeware.widgets.buttons')
     return app

--- a/examples/button/setup.py
+++ b/examples/button/setup.py
@@ -43,7 +43,7 @@ setup(
     options={
         'app': {
             'formal_name': 'Button',
-            'bundle': 'org.pybee'
+            'bundle': 'org.beeware'
         },
         'macos': {
             'app_requires': [

--- a/examples/canvas/canvas/app.py
+++ b/examples/canvas/canvas/app.py
@@ -22,7 +22,7 @@ class ExampleCanvasApp(toga.App):
 
 
 def main():
-    return ExampleCanvasApp('Canvas', 'org.pybee.widgets.canvas')
+    return ExampleCanvasApp('Canvas', 'org.beeware.widgets.canvas')
 
 
 if __name__ == '__main__':

--- a/examples/canvas/setup.py
+++ b/examples/canvas/setup.py
@@ -22,7 +22,7 @@ setup(
     description='Test app for the Canvas widget.',
     long_description=long_description,
     author='BeeWare Project',
-    author_email='contact@pybee.org',
+    author_email='contact@beeware.org',
     license='BSD license',
     packages=find_packages(
         exclude=[
@@ -46,7 +46,7 @@ setup(
     options={
         'app': {
             'formal_name': 'Canvas',
-            'bundle': 'org.pybee.widgets'
+            'bundle': 'org.beeware.widgets'
         },
 
         # Desktop/laptop deployments

--- a/examples/detailedlist/detailedlist/app.py
+++ b/examples/detailedlist/detailedlist/app.py
@@ -62,7 +62,7 @@ class ExampleDetailedListApp(toga.App):
         self.main_window.show()
 
 def main():
-    return ExampleDetailedListApp('Detailed List', 'org.pybee.widgets.detailedlist')
+    return ExampleDetailedListApp('Detailed List', 'org.beeware.widgets.detailedlist')
 
 
 if __name__ == '__main__':

--- a/examples/detailedlist/detailedlist/app.py
+++ b/examples/detailedlist/detailedlist/app.py
@@ -61,6 +61,7 @@ class ExampleDetailedListApp(toga.App):
         # Show the main window
         self.main_window.show()
 
+
 def main():
     return ExampleDetailedListApp('Detailed List', 'org.beeware.widgets.detailedlist')
 

--- a/examples/detailedlist/setup.py
+++ b/examples/detailedlist/setup.py
@@ -22,7 +22,7 @@ setup(
     description='Test app for the Detailed List widget.',
     long_description=long_description,
     author='BeeWare Project',
-    author_email='contact@pybee.org',
+    author_email='contact@beeware.org',
     license='BSD license',
     packages=find_packages(
         exclude=[
@@ -46,7 +46,7 @@ setup(
     options={
         'app': {
             'formal_name': 'Detailed List',
-            'bundle': 'org.pybee.widgets'
+            'bundle': 'org.beeware.widgets'
         },
 
         # Desktop/laptop deployments

--- a/examples/dialogs/dialogs/app.py
+++ b/examples/dialogs/dialogs/app.py
@@ -144,7 +144,7 @@ class ExampledialogsApp(toga.App):
 
 
 def main():
-    return ExampledialogsApp('Dialogs', 'org.pybee.widgets.dialogs')
+    return ExampledialogsApp('Dialogs', 'org.beeware.widgets.dialogs')
 
 
 if __name__ == '__main__':

--- a/examples/dialogs/setup.py
+++ b/examples/dialogs/setup.py
@@ -20,7 +20,7 @@ setup(
     description='Test app for the Dialogs widget.',
     long_description=long_description,
     author='BeeWare Project',
-    author_email='contact@pybee.org',
+    author_email='contact@beeware.org',
     license='BSD license',
     packages=find_packages(
         exclude=[
@@ -44,7 +44,7 @@ setup(
     options={
         'app': {
             'formal_name': 'Dialogs',
-            'bundle': 'org.pybee.widgets'
+            'bundle': 'org.beeware.widgets'
         },
 
         # Desktop/laptop deployments

--- a/examples/imageview/imageview/app.py
+++ b/examples/imageview/imageview/app.py
@@ -2,15 +2,16 @@ import os
 import toga
 from toga.style.pack import *
 
+
 class ImageViewApp(toga.App):
     def startup(self):
         self.main_window = toga.MainWindow(title=self.name)
-        
+
         box = toga.Box()
         box.style.padding = 40
         box.style.update(alignment=CENTER)
         box.style.update(direction=COLUMN)
-        
+
         # image from local path
         # load brutus.png from the package
         # We set the style width/height parameters for this one
@@ -26,7 +27,7 @@ class ImageViewApp(toga.App):
         image_from_url = toga.Image('https://beeware.org/project/projects/libraries/toga/toga.png')
         imageview_from_url = toga.ImageView(image_from_url)
         box.add(imageview_from_url)
-        
+
         self.main_window.content = box
         self.main_window.show()
 

--- a/examples/imageview/imageview/app.py
+++ b/examples/imageview/imageview/app.py
@@ -1,6 +1,6 @@
 import os
 import toga
-from toga.style.pack import *
+from toga.style.pack import CENTER, COLUMN
 
 
 class ImageViewApp(toga.App):

--- a/examples/imageview/imageview/app.py
+++ b/examples/imageview/imageview/app.py
@@ -1,4 +1,3 @@
-import os
 import toga
 from toga.style.pack import CENTER, COLUMN
 

--- a/examples/imageview/imageview/app.py
+++ b/examples/imageview/imageview/app.py
@@ -31,6 +31,7 @@ class ImageViewApp(toga.App):
         self.main_window.content = box
         self.main_window.show()
 
+
 def main():
     return ImageViewApp('ImageView', 'org.beeware.widgets.imageview')
 

--- a/examples/imageview/imageview/app.py
+++ b/examples/imageview/imageview/app.py
@@ -23,7 +23,7 @@ class ImageViewApp(toga.App):
         # image from remote URL
         # no style parameters - we let Pack determine how to allocate
         # the space
-        image_from_url = toga.Image('https://pybee.org/project/projects/libraries/toga/toga.png')
+        image_from_url = toga.Image('https://beeware.org/project/projects/libraries/toga/toga.png')
         imageview_from_url = toga.ImageView(image_from_url)
         box.add(imageview_from_url)
         
@@ -31,7 +31,7 @@ class ImageViewApp(toga.App):
         self.main_window.show()
 
 def main():
-    return ImageViewApp('ImageView', 'org.pybee.widgets.imageview')
+    return ImageViewApp('ImageView', 'org.beeware.widgets.imageview')
 
 
 if __name__ == '__main__':

--- a/examples/imageview/setup.py
+++ b/examples/imageview/setup.py
@@ -22,7 +22,7 @@ setup(
     description='Test app for the ImageView widget.',
     long_description=long_description,
     author='BeeWare Project',
-    author_email='contact@pybee.org',
+    author_email='contact@beeware.org',
     license='BSD license',
     packages=find_packages(
         exclude=[
@@ -46,7 +46,7 @@ setup(
     options={
         'app': {
             'formal_name': 'ImageView',
-            'bundle': 'org.pybee.widgets'
+            'bundle': 'org.beeware.widgets'
         },
 
         # Desktop/laptop deployments

--- a/examples/multilinetextinput/multilinetextinput/app.py
+++ b/examples/multilinetextinput/multilinetextinput/app.py
@@ -63,7 +63,7 @@ class ExampleMultilineTextInputApp(toga.App):
 
 
 def main():
-    return ExampleMultilineTextInputApp('Multiline Text Input', 'org.pybee.widgets.multilinetextinput')
+    return ExampleMultilineTextInputApp('Multiline Text Input', 'org.beeware.widgets.multilinetextinput')
 
 
 if __name__ == '__main__':

--- a/examples/multilinetextinput/setup.py
+++ b/examples/multilinetextinput/setup.py
@@ -22,7 +22,7 @@ setup(
     description='Test app for the Multiline Text Input widget.',
     long_description=long_description,
     author='BeeWare Project',
-    author_email='contact@pybee.org',
+    author_email='contact@beeware.org',
     license='BSD license',
     packages=find_packages(
         exclude=[
@@ -46,7 +46,7 @@ setup(
     options={
         'app': {
             'formal_name': 'Multiline Text Input',
-            'bundle': 'org.pybee.widgets'
+            'bundle': 'org.beeware.widgets'
         },
 
         # Desktop/laptop deployments

--- a/examples/progressbar/progressbar/app.py
+++ b/examples/progressbar/progressbar/app.py
@@ -85,4 +85,4 @@ class ProgressBarApp(toga.App):
 
 def main():
     # App name and namespace
-    return ProgressBarApp('ProgressBar', 'org.pybee.examples.progressbar')
+    return ProgressBarApp('ProgressBar', 'org.beeware.examples.progressbar')

--- a/examples/progressbar/setup.py
+++ b/examples/progressbar/setup.py
@@ -21,7 +21,7 @@ setup(
     description='Test app for the ProgressBar widget.',
     long_description=long_description,
     author='BeeWare Project',
-    author_email='contact@pybee.org',
+    author_email='contact@beeware.org',
     license='BSD license',
     packages=find_packages(
         exclude=[
@@ -41,7 +41,7 @@ setup(
     options={
         'app': {
             'formal_name': 'ProgressBar',
-            'bundle': 'org.pybee.widgets'
+            'bundle': 'org.beeware.widgets'
         },
 
         # Desktop/laptop deployments

--- a/examples/scrollcontainer/scrollcontainer/app.py
+++ b/examples/scrollcontainer/scrollcontainer/app.py
@@ -4,7 +4,7 @@ from toga.style.pack import *
 
 class ScrollContainerApp(toga.App):
     def startup(self):
-        self.main_window = toga.MainWindow(self.name)        
+        self.main_window = toga.MainWindow(self.name)
         box = toga.Box()
         box.style.direction = COLUMN
 
@@ -14,9 +14,10 @@ class ScrollContainerApp(toga.App):
 
         scroller = toga.ScrollContainer()
         scroller.content = box
-        
+
         self.main_window.content = scroller
         self.main_window.show()
+
 
 def main():
     return ScrollContainerApp('ScrollContainer', 'org.beeware.widgets.scrollcontainer')

--- a/examples/scrollcontainer/scrollcontainer/app.py
+++ b/examples/scrollcontainer/scrollcontainer/app.py
@@ -19,7 +19,7 @@ class ScrollContainerApp(toga.App):
         self.main_window.show()
 
 def main():
-    return ScrollContainerApp('ScrollContainer', 'org.pybee.widgets.scrollcontainer')
+    return ScrollContainerApp('ScrollContainer', 'org.beeware.widgets.scrollcontainer')
 
 
 if __name__ == '__main__':

--- a/examples/scrollcontainer/scrollcontainer/app.py
+++ b/examples/scrollcontainer/scrollcontainer/app.py
@@ -1,6 +1,6 @@
 import os
 import toga
-from toga.style.pack import *
+from toga.style.pack import COLUMN, LEFT
 
 class ScrollContainerApp(toga.App):
     def startup(self):

--- a/examples/scrollcontainer/scrollcontainer/app.py
+++ b/examples/scrollcontainer/scrollcontainer/app.py
@@ -1,6 +1,6 @@
-import os
 import toga
 from toga.style.pack import COLUMN, LEFT
+
 
 class ScrollContainerApp(toga.App):
     def startup(self):

--- a/examples/scrollcontainer/setup.py
+++ b/examples/scrollcontainer/setup.py
@@ -22,7 +22,7 @@ setup(
     description='Test app for the Scroll Container widget.',
     long_description=long_description,
     author='BeeWare Project',
-    author_email='contact@pybee.org',
+    author_email='contact@beeware.org',
     license='BSD license',
     packages=find_packages(
         exclude=[
@@ -46,7 +46,7 @@ setup(
     options={
         'app': {
             'formal_name': 'Scroll Container',
-            'bundle': 'org.pybee.widgets'
+            'bundle': 'org.beeware.widgets'
         },
 
         # Desktop/laptop deployments

--- a/examples/selection/selection/app.py
+++ b/examples/selection/selection/app.py
@@ -70,4 +70,4 @@ class SelectionApp(toga.App):
 
 def main():
     # App name and namespace
-    return SelectionApp('Selection', 'org.pybee.selection')
+    return SelectionApp('Selection', 'org.beeware.selection')

--- a/examples/selection/setup.py
+++ b/examples/selection/setup.py
@@ -22,7 +22,7 @@ setup(
     description='A demonstration of all features of a toga.Selection example for the native GUI toolkit, Toga.',
     long_description=long_description,
     author='BeeWare',
-    author_email='contact@pybee.org',
+    author_email='contact@beeware.org',
     license='New BSD',
     packages=find_packages(exclude=['docs', 'tests']),
     python_requires='>=3.5',
@@ -43,7 +43,7 @@ setup(
     options={
         'app': {
             'formal_name': 'Selection',
-            'bundle': 'org.pybee'
+            'bundle': 'org.beeware'
         },
         'macos': {
             'app_requires': [

--- a/examples/slider/setup.py
+++ b/examples/slider/setup.py
@@ -22,7 +22,7 @@ setup(
     description='A demonstration of all features of a toga.Slider example for the native GUI toolkit, Toga.',
     long_description=long_description,
     author='BeeWare Project',
-    author_email='contact@pybee.org',
+    author_email='contact@beeware.org',
     license='New BSD',
     packages=find_packages(exclude=['docs', 'tests']),
     python_requires='>=3.5',
@@ -43,7 +43,7 @@ setup(
     options={
         'app': {
             'formal_name': 'Slider',
-            'bundle': 'org.pybee'
+            'bundle': 'org.beeware'
         },
         'macos': {
             'app_requires': [

--- a/examples/slider/slider/app.py
+++ b/examples/slider/slider/app.py
@@ -62,4 +62,4 @@ class SliderApp(toga.App):
 
 def main():
     # App name and namespace
-    return SliderApp('Slider', 'org.pybee.examples.slider')
+    return SliderApp('Slider', 'org.beeware.examples.slider')

--- a/examples/slider/slider/app.py
+++ b/examples/slider/slider/app.py
@@ -60,6 +60,7 @@ class SliderApp(toga.App):
         # get the current value of the slider with `slider.value`
         self.sliderValueLabel.text = "The slider value changed to {0}".format(int(slider.value))
 
+
 def main():
     # App name and namespace
     return SliderApp('Slider', 'org.beeware.examples.slider')

--- a/examples/switch/setup.py
+++ b/examples/switch/setup.py
@@ -22,7 +22,7 @@ setup(
     description='A demonstration of all features of a toga.Switch example for the native GUI toolkit, Toga.',
     long_description=long_description,
     author='BeeWare',
-    author_email='contact@pybee.org',
+    author_email='contact@beeware.org',
     license='New BSD',
     packages=find_packages(exclude=['docs', 'tests']),
     python_requires='>=3.5',
@@ -43,7 +43,7 @@ setup(
     options={
         'app': {
             'formal_name': 'Switch',
-            'bundle': 'org.pybee'
+            'bundle': 'org.beeware'
         },
         'macos': {
             'app_requires': [

--- a/examples/switch/switch/app.py
+++ b/examples/switch/switch/app.py
@@ -38,5 +38,5 @@ class SwitchApp(toga.App):
 def main():
     # Application class
     #   App name and namespace
-    app = SwitchApp('Switches', 'org.pybee.helloworld')
+    app = SwitchApp('Switches', 'org.beeware.helloworld')
     return app

--- a/examples/table/setup.py
+++ b/examples/table/setup.py
@@ -22,7 +22,7 @@ setup(
     description='Test app for the Table widget.',
     long_description=long_description,
     author='BeeWare Project',
-    author_email='contact@pybee.org',
+    author_email='contact@beeware.org',
     license='BSD license',
     packages=find_packages(
         exclude=[
@@ -42,7 +42,7 @@ setup(
     options={
         'app': {
             'formal_name': 'Table',
-            'bundle': 'org.pybee.widgets'
+            'bundle': 'org.beeware.widgets'
         },
 
         # Desktop/laptop deployments

--- a/examples/table/table/app.py
+++ b/examples/table/table/app.py
@@ -86,7 +86,7 @@ class ExampleTableApp(toga.App):
 
 
 def main():
-    return ExampleTableApp('Table', 'org.pybee.widgets.table')
+    return ExampleTableApp('Table', 'org.beeware.widgets.table')
 
 
 if __name__ == '__main__':

--- a/examples/table_source/setup.py
+++ b/examples/table_source/setup.py
@@ -22,7 +22,7 @@ setup(
     description='Test app for the Table Source widget.',
     long_description=long_description,
     author='BeeWare Project',
-    author_email='contact@pybee.org',
+    author_email='contact@beeware.org',
     license='BSD license',
     packages=find_packages(
         exclude=[
@@ -42,7 +42,7 @@ setup(
     options={
         'app': {
             'formal_name': 'Table Source',
-            'bundle': 'org.pybee.widgets'
+            'bundle': 'org.beeware.widgets'
         },
 
         # Desktop/laptop deployments

--- a/examples/table_source/table_source/app.py
+++ b/examples/table_source/table_source/app.py
@@ -154,7 +154,7 @@ class ExampleTableSourceApp(toga.App):
 
 
 def main():
-    return ExampleTableSourceApp('Table Source', 'org.pybee.widgets.table_source')
+    return ExampleTableSourceApp('Table Source', 'org.beeware.widgets.table_source')
 
 
 if __name__ == '__main__':

--- a/examples/tree/setup.py
+++ b/examples/tree/setup.py
@@ -22,7 +22,7 @@ setup(
     description='Test app for the Tree widget.',
     long_description=long_description,
     author='BeeWare Project',
-    author_email='contact@pybee.org',
+    author_email='contact@beeware.org',
     license='BSD license',
     packages=find_packages(
         exclude=[
@@ -42,7 +42,7 @@ setup(
     options={
         'app': {
             'formal_name': 'Tree',
-            'bundle': 'org.pybee.widgets'
+            'bundle': 'org.beeware.widgets'
         },
 
         # Desktop/laptop deployments

--- a/examples/tree/tree/app.py
+++ b/examples/tree/tree/app.py
@@ -87,7 +87,7 @@ class ExampleTreeApp(toga.App):
 
 
 def main():
-    return ExampleTreeApp('Tree', 'org.pybee.widgets.tree')
+    return ExampleTreeApp('Tree', 'org.beeware.widgets.tree')
 
 
 if __name__ == '__main__':

--- a/examples/tree_source/setup.py
+++ b/examples/tree_source/setup.py
@@ -22,7 +22,7 @@ setup(
     description='Test app for the Tree Source widget.',
     long_description=long_description,
     author='BeeWare Project',
-    author_email='contact@pybee.org',
+    author_email='contact@beeware.org',
     license='BSD license',
     packages=find_packages(
         exclude=[
@@ -42,7 +42,7 @@ setup(
     options={
         'app': {
             'formal_name': 'Tree Source',
-            'bundle': 'org.pybee.widgets'
+            'bundle': 'org.beeware.widgets'
         },
 
         # Desktop/laptop deployments

--- a/examples/tree_source/tree_source/app.py
+++ b/examples/tree_source/tree_source/app.py
@@ -124,7 +124,7 @@ class ExampleTreeSourceApp(toga.App):
 
 
 def main():
-    return ExampleTreeSourceApp('Tree Source', 'org.pybee.widgets.tree_source')
+    return ExampleTreeSourceApp('Tree Source', 'org.beeware.widgets.tree_source')
 
 
 if __name__ == '__main__':

--- a/examples/tutorial0/setup.py
+++ b/examples/tutorial0/setup.py
@@ -43,7 +43,7 @@ setup(
     options={
         'app': {
             'formal_name': 'Tutorial 0',
-            'bundle': 'org.pybee'
+            'bundle': 'org.beeware'
         },
 
         # Desktop/laptop deployments

--- a/examples/tutorial0/tutorial/app.py
+++ b/examples/tutorial0/tutorial/app.py
@@ -17,7 +17,7 @@ def build(app):
 
 
 def main():
-    return toga.App('First App', 'org.pybee.helloworld', startup=build)
+    return toga.App('First App', 'org.beeware.helloworld', startup=build)
 
 
 if __name__ == '__main__':

--- a/examples/tutorial1/setup.py
+++ b/examples/tutorial1/setup.py
@@ -43,7 +43,7 @@ setup(
     options={
         'app': {
             'formal_name': 'Tutorial 1',
-            'bundle': 'org.pybee'
+            'bundle': 'org.beeware'
         },
 
         # Desktop/laptop deployments

--- a/examples/tutorial1/tutorial/app.py
+++ b/examples/tutorial1/tutorial/app.py
@@ -49,7 +49,7 @@ def build(app):
 
 
 def main():
-    return toga.App('Temperature Converter', 'org.pybee.f_to_c', startup=build)
+    return toga.App('Temperature Converter', 'org.beeware.f_to_c', startup=build)
 
 
 if __name__ == '__main__':

--- a/examples/tutorial2/setup.py
+++ b/examples/tutorial2/setup.py
@@ -47,7 +47,7 @@ setup(
     options={
         'app': {
             'formal_name': 'Tutorial 2',
-            'bundle': 'org.pybee'
+            'bundle': 'org.beeware'
         },
 
         # Desktop/laptop deployments

--- a/examples/tutorial2/tutorial/app.py
+++ b/examples/tutorial2/tutorial/app.py
@@ -110,7 +110,7 @@ def build(app):
 
 
 def main():
-    return toga.App('First App', 'org.pybee.helloworld', startup=build)
+    return toga.App('First App', 'org.beeware.helloworld', startup=build)
 
 
 if __name__ == '__main__':

--- a/examples/tutorial3/setup.py
+++ b/examples/tutorial3/setup.py
@@ -43,7 +43,7 @@ setup(
     options={
         'app': {
             'formal_name': 'Tutorial 3',
-            'bundle': 'org.pybee'
+            'bundle': 'org.beeware'
         },
 
         # Desktop/laptop deployments

--- a/examples/tutorial3/tutorial/app.py
+++ b/examples/tutorial3/tutorial/app.py
@@ -43,7 +43,7 @@ class Graze(toga.App):
 
 
 def main():
-    return Graze('Graze', 'org.pybee.graze')
+    return Graze('Graze', 'org.beeware.graze')
 
 
 if __name__ == '__main__':

--- a/examples/tutorial4/setup.py
+++ b/examples/tutorial4/setup.py
@@ -43,7 +43,7 @@ setup(
     options={
         'app': {
             'formal_name': 'Tutorial 4',
-            'bundle': 'org.pybee'
+            'bundle': 'org.beeware'
         },
 
         # Desktop/laptop deployments

--- a/examples/tutorial4/tutorial/app.py
+++ b/examples/tutorial4/tutorial/app.py
@@ -103,7 +103,7 @@ class StartApp(toga.App):
 
 
 def main():
-    return StartApp('Tutorial 4', 'org.pybee.helloworld')
+    return StartApp('Tutorial 4', 'org.beeware.helloworld')
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     package_urls={
         'Funding': 'https://beeware.org/contributing/membership/',
         'Documentation': 'https://toga.readthedocs.io/',
-        'Tracker': 'https://github.com/pybee/toga/issues',
-        'Source': 'https://github.com/pybee/toga',
+        'Tracker': 'https://github.com/beeware/toga/issues',
+        'Source': 'https://github.com/beeware/toga',
     },
 )

--- a/src/android/README.rst
+++ b/src/android/README.rst
@@ -16,7 +16,7 @@ Toga is part of the `BeeWare suite`_. You can talk to the community through:
 
 * `@pybeeware on Twitter`_
 
-* The `pybee/general`_ channel on Gitter.
+* The `beeware/general`_ channel on Gitter.
 
 Contributing
 ------------
@@ -24,12 +24,12 @@ Contributing
 If you experience problems with this backend, `log them on GitHub`_. If you
 want to contribute code, please `fork the code`_ and `submit a pull request`_.
 
-.. _Toga widget toolkit: http://pybee.org/toga
+.. _Toga widget toolkit: http://beeware.org/toga
 .. _the core Toga library: https://pypi.python.org/pypi/toga-core
-.. _Toga project on Github: https://github.com/pybee/toga
-.. _BeeWare suite: http://pybee.org
+.. _Toga project on Github: https://github.com/beeware/toga
+.. _BeeWare suite: http://beeware.org
 .. _@pybeeware on Twitter: https://twitter.com/pybeeware
-.. _pybee/general: https://gitter.im/pybee/general
-.. _log them on Github: https://github.com/pybee/toga/issues
-.. _fork the code: https://github.com/pybee/toga
-.. _submit a pull request: https://github.com/pybee/toga/pulls
+.. _beeware/general: https://gitter.im/beeware/general
+.. _log them on Github: https://github.com/beeware/toga/issues
+.. _fork the code: https://github.com/beeware/toga
+.. _submit a pull request: https://github.com/beeware/toga/pulls

--- a/src/android/setup.py
+++ b/src/android/setup.py
@@ -23,7 +23,7 @@ setup(
     long_description=long_description,
     author='Russell Keith-Magee',
     author_email='russell@keith-magee.com',
-    url='http://pybee.org/toga',
+    url='http://beeware.org/toga',
     packages=find_packages(exclude='tests'),
     python_requires='>=3.5',
     install_requires=[

--- a/src/cocoa/README.rst
+++ b/src/cocoa/README.rst
@@ -21,7 +21,7 @@ Toga is part of the `BeeWare suite`_. You can talk to the community through:
 
 * `@pybeeware on Twitter`_
 
-* The `pybee/general`_ channel on Gitter.
+* The `beeware/general`_ channel on Gitter.
 
 Contributing
 ------------
@@ -29,12 +29,12 @@ Contributing
 If you experience problems with this backend, `log them on GitHub`_. If you
 want to contribute code, please `fork the code`_ and `submit a pull request`_.
 
-.. _Toga widget toolkit: http://pybee.org/toga
+.. _Toga widget toolkit: http://beeware.org/toga
 .. _the core Toga library: https://pypi.python.org/pypi/toga-core
-.. _Toga project on Github: https://github.com/pybee/toga
-.. _BeeWare suite: http://pybee.org
+.. _Toga project on Github: https://github.com/beeware/toga
+.. _BeeWare suite: http://beeware.org
 .. _@pybeeware on Twitter: https://twitter.com/pybeeware
-.. _pybee/general: https://gitter.im/pybee/general
-.. _log them on Github: https://github.com/pybee/toga/issues
-.. _fork the code: https://github.com/pybee/toga
-.. _submit a pull request: https://github.com/pybee/toga/pulls
+.. _beeware/general: https://gitter.im/beeware/general
+.. _log them on Github: https://github.com/beeware/toga/issues
+.. _fork the code: https://github.com/beeware/toga
+.. _submit a pull request: https://github.com/beeware/toga/pulls

--- a/src/cocoa/setup.py
+++ b/src/cocoa/setup.py
@@ -23,7 +23,7 @@ setup(
     long_description=long_description,
     author='Russell Keith-Magee',
     author_email='russell@keith-magee.com',
-    url='http://pybee.org/toga',
+    url='http://beeware.org/toga',
     packages=find_packages(exclude='tests'),
     python_requires='>=3.5',
     install_requires=[

--- a/src/core/README.rst
+++ b/src/core/README.rst
@@ -104,7 +104,7 @@ Toga is part of the `BeeWare suite`_. You can talk to the community through:
 Contributing
 ------------
 
-If you experience problems with this backend, `log them on GitHub`_. If you
+If you experience problems with Toga, `log them on GitHub`_. If you
 want to contribute code, please `fork the code`_ and `submit a pull request`_.
 
 .. _Toga widget toolkit: http://beeware.org/toga

--- a/src/core/README.rst
+++ b/src/core/README.rst
@@ -99,25 +99,20 @@ Toga is part of the `BeeWare suite`_. You can talk to the community through:
 
 * `@pybeeware on Twitter`_
 
-* The `pybee/general`_ channel on Gitter.
+* The `beeware/general`_ channel on Gitter.
 
 Contributing
 ------------
 
-If you experience problems with Toga, `log them on GitHub`_. If you
+If you experience problems with this backend, `log them on GitHub`_. If you
 want to contribute code, please `fork the code`_ and `submit a pull request`_.
 
-.. _BeeWare suite: http://pybee.org
-.. _Read The Docs: https://toga.readthedocs.io
-.. _toga-cocoa: https://pypi.python.org/pypi/toga-cocoa
-.. _toga-gtk: https://pypi.python.org/pypi/toga-gtk
-.. _toga-win32: https://pypi.python.org/pypi/toga-win32
-.. _toga-iOS: https://pypi.python.org/pypi/toga-iOS
-.. _toga-android: https://pypi.python.org/pypi/toga-android
-.. _toga-winforms: https://pypi.python.org/pypi/toga-winforms
-.. _toga-uwp: https://pypi.python.org/pypi/toga-uwp
+.. _Toga widget toolkit: http://beeware.org/toga
+.. _the core Toga library: https://pypi.python.org/pypi/toga-core
+.. _Toga project on Github: https://github.com/beeware/toga
+.. _BeeWare suite: http://beeware.org
 .. _@pybeeware on Twitter: https://twitter.com/pybeeware
-.. _pybee/general: https://gitter.im/pybee/general
-.. _log them on Github: https://github.com/pybee/toga/issues
-.. _fork the code: https://github.com/pybee/toga
-.. _submit a pull request: https://github.com/pybee/toga/pulls
+.. _beeware/general: https://gitter.im/beeware/general
+.. _log them on Github: https://github.com/beeware/toga/issues
+.. _fork the code: https://github.com/beeware/toga
+.. _submit a pull request: https://github.com/beeware/toga/pulls

--- a/src/core/setup.py
+++ b/src/core/setup.py
@@ -23,7 +23,7 @@ setup(
     long_description=long_description,
     author='Russell Keith-Magee',
     author_email='russell@keith-magee.com',
-    url='http://pybee.org/toga',
+    url='http://beeware.org/toga',
     packages=find_packages(exclude='tests'),
     python_requires='>=3.5',
     package_data={

--- a/src/core/tests/widgets/test_webview.py
+++ b/src/core/tests/widgets/test_webview.py
@@ -7,7 +7,7 @@ class WebViewTests(TestCase):
     def setUp(self):
         super().setUp()
 
-        self.url = 'https://pybee.org/'
+        self.url = 'https://beeware.org/'
 
         def callback(widget):
             pass

--- a/src/core/toga/app.py
+++ b/src/core/toga/app.py
@@ -33,7 +33,7 @@ class App:
 
     Args:
         name (str): Is the name of the application.
-        app_id (str): The unique application identifier, the reversed domain name, e.g. 'org.pybee.me'
+        app_id (str): The unique application identifier, the reversed domain name, e.g. 'org.beeware.me'
         icon (str): Path to the icon for the application.
         id (str): The DOM identifier for the app (optional)
         startup(``callable``): The callback method before starting the app, typically to add the components.
@@ -43,7 +43,7 @@ class App:
 
     Examples:
         >>> # Here is the absolute minimum App::
-        >>> app = toga.App('Empty App', 'org.pybee.empty')
+        >>> app = toga.App('Empty App', 'org.beeware.empty')
         >>> app.main_loop()
     """
     app = None

--- a/src/curses/README.rst
+++ b/src/curses/README.rst
@@ -28,10 +28,10 @@ Contributing
 If you experience problems with this backend, `log them on GitHub`_. If you
 want to contribute code, please `fork the code`_ and `submit a pull request`_.
 
-.. _Toga widget toolkit: http://pybee.org/toga
+.. _Toga widget toolkit: http://beeware.org/toga
 .. _the core Toga library: https://pypi.python.org/pypi/toga-core
 .. _Toga project on Github: https://github.com/pybee/toga
-.. _BeeWare suite: http://pybee.org
+.. _BeeWare suite: http://beeware.org
 .. _@pybeeware on Twitter: https://twitter.com/pybeeware
 .. _pybee/general: https://gitter.im/pybee/general
 .. _log them on Github: https://github.com/pybee/toga/issues

--- a/src/curses/setup.py
+++ b/src/curses/setup.py
@@ -23,7 +23,7 @@ setup(
     long_description=long_description,
     author='Russell Keith-Magee',
     author_email='russell@keith-magee.com',
-    url='http://pybee.org/toga',
+    url='http://beeware.org/toga',
     packages=find_packages(exclude='tests'),
     python_requires='>=3.5',
     install_requires=[

--- a/src/django/README.rst
+++ b/src/django/README.rst
@@ -21,7 +21,7 @@ Toga is part of the `BeeWare suite`_. You can talk to the community through:
 
 * `@pybeeware on Twitter`_
 
-* The `pybee/general`_ channel on Gitter.
+* The `beeware/general`_ channel on Gitter.
 
 Contributing
 ------------
@@ -29,12 +29,12 @@ Contributing
 If you experience problems with this backend, `log them on GitHub`_. If you
 want to contribute code, please `fork the code`_ and `submit a pull request`_.
 
-.. _Toga widget toolkit: http://pybee.org/toga
+.. _Toga widget toolkit: http://beeware.org/toga
 .. _the core Toga library: https://pypi.python.org/pypi/toga-core
-.. _Toga project on Github: https://github.com/pybee/toga
-.. _BeeWare suite: http://pybee.org
+.. _Toga project on Github: https://github.com/beeware/toga
+.. _BeeWare suite: http://beeware.org
 .. _@pybeeware on Twitter: https://twitter.com/pybeeware
-.. _pybee/general: https://gitter.im/pybee/general
-.. _log them on Github: https://github.com/pybee/toga/issues
-.. _fork the code: https://github.com/pybee/toga
-.. _submit a pull request: https://github.com/pybee/toga/pulls
+.. _beeware/general: https://gitter.im/beeware/general
+.. _log them on Github: https://github.com/beeware/toga/issues
+.. _fork the code: https://github.com/beeware/toga
+.. _submit a pull request: https://github.com/beeware/toga/pulls

--- a/src/django/package.json
+++ b/src/django/package.json
@@ -6,7 +6,7 @@
   "main": "toga/toga.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/pybee/toga.git"
+    "url": "git+https://github.com/beeware/toga.git"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
@@ -22,9 +22,9 @@
   ],
   "license": "BSD-3-Clause",
   "bugs": {
-    "url": "https://github.com/pybee/toga/issues"
+    "url": "https://github.com/beeware/toga/issues"
   },
-  "homepage": "https://github.com/pybee/toga#readme",
+  "homepage": "https://github.com/beeware/toga#readme",
   "devDependencies": {
     "babel-core": "6.18.2",
     "babel-loader": "6.2.8",

--- a/src/django/setup.py
+++ b/src/django/setup.py
@@ -23,7 +23,7 @@ setup(
     long_description=long_description,
     author='Russell Keith-Magee',
     author_email='russell@keith-magee.com',
-    url='http://pybee.org/toga',
+    url='http://beeware.org/toga',
     packages=find_packages(exclude='tests'),
     python_requires='>=3.5',
     include_package_data=True,

--- a/src/dummy/README.rst
+++ b/src/dummy/README.rst
@@ -17,7 +17,7 @@ Toga is part of the `BeeWare suite`_. You can talk to the community through:
 
 * `@pybeeware on Twitter`_
 
-* The `pybee/general`_ channel on Gitter.
+* The `beeware/general`_ channel on Gitter.
 
 Contributing
 ------------
@@ -25,12 +25,12 @@ Contributing
 If you experience problems with this backend, `log them on GitHub`_. If you
 want to contribute code, please `fork the code`_ and `submit a pull request`_.
 
-.. _Toga widget toolkit: http://pybee.org/toga
+.. _Toga widget toolkit: http://beeware.org/toga
 .. _the core Toga library: https://pypi.python.org/pypi/toga-core
-.. _Toga project on Github: https://github.com/pybee/toga
-.. _BeeWare suite: http://pybee.org
+.. _Toga project on Github: https://github.com/beeware/toga
+.. _BeeWare suite: http://beeware.org
 .. _@pybeeware on Twitter: https://twitter.com/pybeeware
-.. _pybee/general: https://gitter.im/pybee/general
-.. _log them on Github: https://github.com/pybee/toga/issues
-.. _fork the code: https://github.com/pybee/toga
-.. _submit a pull request: https://github.com/pybee/toga/pulls
+.. _beeware/general: https://gitter.im/beeware/general
+.. _log them on Github: https://github.com/beeware/toga/issues
+.. _fork the code: https://github.com/beeware/toga
+.. _submit a pull request: https://github.com/beeware/toga/pulls

--- a/src/dummy/setup.py
+++ b/src/dummy/setup.py
@@ -23,7 +23,7 @@ setup(
     long_description=long_description,
     author='Russell Keith-Magee',
     author_email='russell@keith-magee.com',
-    url='http://pybee.org/toga',
+    url='http://beeware.org/toga',
     packages=find_packages(),
     python_requires='>=3.5',
     install_requires=[

--- a/src/flask/README.rst
+++ b/src/flask/README.rst
@@ -20,7 +20,7 @@ Toga is part of the `BeeWare suite`_. You can talk to the community through:
 
 * `@pybeeware on Twitter`_
 
-* The `pybee/general`_ channel on Gitter.
+* The `beeware/general`_ channel on Gitter.
 
 Contributing
 ------------
@@ -28,12 +28,12 @@ Contributing
 If you experience problems with this backend, `log them on GitHub`_. If you
 want to contribute code, please `fork the code`_ and `submit a pull request`_.
 
-.. _Toga widget toolkit: http://pybee.org/toga
+.. _Toga widget toolkit: http://beeware.org/toga
 .. _the core Toga library: https://pypi.python.org/pypi/toga-core
-.. _Toga project on Github: https://github.com/pybee/toga
-.. _BeeWare suite: http://pybee.org
+.. _Toga project on Github: https://github.com/beeware/toga
+.. _BeeWare suite: http://beeware.org
 .. _@pybeeware on Twitter: https://twitter.com/pybeeware
-.. _pybee/general: https://gitter.im/pybee/general
-.. _log them on Github: https://github.com/pybee/toga/issues
-.. _fork the code: https://github.com/pybee/toga
-.. _submit a pull request: https://github.com/pybee/toga/pulls
+.. _beeware/general: https://gitter.im/beeware/general
+.. _log them on Github: https://github.com/beeware/toga/issues
+.. _fork the code: https://github.com/beeware/toga
+.. _submit a pull request: https://github.com/beeware/toga/pulls

--- a/src/flask/setup.py
+++ b/src/flask/setup.py
@@ -23,7 +23,7 @@ setup(
     long_description=long_description,
     author='Russell Keith-Magee',
     author_email='russell@keith-magee.com',
-    url='http://pybee.org/toga',
+    url='http://beeware.org/toga',
     packages=find_packages(exclude='tests'),
     python_requires='>=3.5',
     install_requires=[

--- a/src/gtk/README.rst
+++ b/src/gtk/README.rst
@@ -35,7 +35,7 @@ Toga is part of the `BeeWare suite`_. You can talk to the community through:
 
 * `@pybeeware on Twitter`_
 
-* The `pybee/general`_ channel on Gitter.
+* The `beeware/general`_ channel on Gitter.
 
 Contributing
 ------------
@@ -43,12 +43,12 @@ Contributing
 If you experience problems with this backend, `log them on GitHub`_. If you
 want to contribute code, please `fork the code`_ and `submit a pull request`_.
 
-.. _Toga widget toolkit: http://pybee.org/toga
+.. _Toga widget toolkit: http://beeware.org/toga
 .. _the core Toga library: https://pypi.python.org/pypi/toga-core
-.. _Toga project on Github: https://github.com/pybee/toga
-.. _BeeWare suite: http://pybee.org
+.. _Toga project on Github: https://github.com/beeware/toga
+.. _BeeWare suite: http://beeware.org
 .. _@pybeeware on Twitter: https://twitter.com/pybeeware
-.. _pybee/general: https://gitter.im/pybee/general
-.. _log them on Github: https://github.com/pybee/toga/issues
-.. _fork the code: https://github.com/pybee/toga
-.. _submit a pull request: https://github.com/pybee/toga/pulls
+.. _beeware/general: https://gitter.im/beeware/general
+.. _log them on Github: https://github.com/beeware/toga/issues
+.. _fork the code: https://github.com/beeware/toga
+.. _submit a pull request: https://github.com/beeware/toga/pulls

--- a/src/gtk/setup.py
+++ b/src/gtk/setup.py
@@ -24,7 +24,7 @@ setup(
     long_description=long_description,
     author='Russell Keith-Magee',
     author_email='russell@keith-magee.com',
-    url='http://pybee.org/toga',
+    url='http://beeware.org/toga',
     packages=find_packages(exclude='tests'),
     python_requires='>=3.5',
     install_requires=[

--- a/src/gtk/toga_gtk/widgets/webview.py
+++ b/src/gtk/toga_gtk/widgets/webview.py
@@ -4,7 +4,7 @@ from gi.repository import Gtk
 
 # The following import will fail if WebKit or it's API wrappers aren't
 # installed; handle failure gracefully
-# (see https://github.com/pybee/toga/issues/26)
+# (see https://github.com/beeware/toga/issues/26)
 # Accept any API version greater than 3.0
 WebKit2 = None
 for version in ['4.0', '3.0']:

--- a/src/iOS/README.rst
+++ b/src/iOS/README.rst
@@ -24,12 +24,13 @@ Contributing
 If you experience problems with this backend, `log them on GitHub`_. If you
 want to contribute code, please `fork the code`_ and `submit a pull request`_.
 
-.. _Toga widget toolkit: http://pybee.org/toga
+.. _Toga widget toolkit: http://beeware.org/toga
 .. _the core Toga library: https://pypi.python.org/pypi/toga-core
-.. _Toga project on Github: https://github.com/pybee/toga
-.. _BeeWare suite: http://pybee.org
+.. _Toga project on Github: https://github.com/beeware/toga
+.. _BeeWare suite: http://beeware.org
 .. _@pybeeware on Twitter: https://twitter.com/pybeeware
-.. _pybee/general: https://gitter.im/pybee/general
-.. _log them on Github: https://github.com/pybee/toga/issues
-.. _fork the code: https://github.com/pybee/toga
-.. _submit a pull request: https://github.com/pybee/toga/pulls
+.. _beeware/general: https://gitter.im/beeware/general
+.. _log them on Github: https://github.com/beeware/toga/issues
+.. _fork the code: https://github.com/beeware/toga
+.. _submit a pull request: https://github.com/beeware/toga/pulls
+

--- a/src/iOS/setup.py
+++ b/src/iOS/setup.py
@@ -23,7 +23,7 @@ setup(
     long_description=long_description,
     author='Russell Keith-Magee',
     author_email='russell@keith-magee.com',
-    url='http://pybee.org/toga',
+    url='http://beeware.org/toga',
     packages=find_packages(exclude='tests'),
     python_requires='>=3.5',
     install_requires=[

--- a/src/pyramid/README.rst
+++ b/src/pyramid/README.rst
@@ -20,7 +20,7 @@ Toga is part of the `BeeWare suite`_. You can talk to the community through:
 
 * `@pybeeware on Twitter`_
 
-* The `pybee/general`_ channel on Gitter.
+* The `beeware/general`_ channel on Gitter.
 
 Contributing
 ------------
@@ -28,12 +28,12 @@ Contributing
 If you experience problems with this backend, `log them on GitHub`_. If you
 want to contribute code, please `fork the code`_ and `submit a pull request`_.
 
-.. _Toga widget toolkit: http://pybee.org/toga
+.. _Toga widget toolkit: http://beeware.org/toga
 .. _the core Toga library: https://pypi.python.org/pypi/toga-core
-.. _Toga project on Github: https://github.com/pybee/toga
-.. _BeeWare suite: http://pybee.org
+.. _Toga project on Github: https://github.com/beeware/toga
+.. _BeeWare suite: http://beeware.org
 .. _@pybeeware on Twitter: https://twitter.com/pybeeware
-.. _pybee/general: https://gitter.im/pybee/general
-.. _log them on Github: https://github.com/pybee/toga/issues
-.. _fork the code: https://github.com/pybee/toga
-.. _submit a pull request: https://github.com/pybee/toga/pulls
+.. _beeware/general: https://gitter.im/beeware/general
+.. _log them on Github: https://github.com/beeware/toga/issues
+.. _fork the code: https://github.com/beeware/toga
+.. _submit a pull request: https://github.com/beeware/toga/pulls

--- a/src/pyramid/setup.py
+++ b/src/pyramid/setup.py
@@ -23,7 +23,7 @@ setup(
     long_description=long_description,
     author='Russell Keith-Magee',
     author_email='russell@keith-magee.com',
-    url='http://pybee.org/toga',
+    url='http://beeware.org/toga',
     packages=find_packages(exclude='tests'),
     python_requires='>=3.5',
     install_requires=[

--- a/src/qt/README.rst
+++ b/src/qt/README.rst
@@ -20,7 +20,7 @@ Toga is part of the `BeeWare suite`_. You can talk to the community through:
 
 * `@pybeeware on Twitter`_
 
-* The `pybee/general`_ channel on Gitter.
+* The `beeware/general`_ channel on Gitter.
 
 Contributing
 ------------
@@ -28,12 +28,12 @@ Contributing
 If you experience problems with this backend, `log them on GitHub`_. If you
 want to contribute code, please `fork the code`_ and `submit a pull request`_.
 
-.. _Toga widget toolkit: http://pybee.org/toga
+.. _Toga widget toolkit: http://beeware.org/toga
 .. _the core Toga library: https://pypi.python.org/pypi/toga-core
-.. _Toga project on Github: https://github.com/pybee/toga
-.. _BeeWare suite: http://pybee.org
+.. _Toga project on Github: https://github.com/beeware/toga
+.. _BeeWare suite: http://beeware.org
 .. _@pybeeware on Twitter: https://twitter.com/pybeeware
-.. _pybee/general: https://gitter.im/pybee/general
-.. _log them on Github: https://github.com/pybee/toga/issues
-.. _fork the code: https://github.com/pybee/toga
-.. _submit a pull request: https://github.com/pybee/toga/pulls
+.. _beeware/general: https://gitter.im/beeware/general
+.. _log them on Github: https://github.com/beeware/toga/issues
+.. _fork the code: https://github.com/beeware/toga
+.. _submit a pull request: https://github.com/beeware/toga/pulls

--- a/src/qt/setup.py
+++ b/src/qt/setup.py
@@ -23,7 +23,7 @@ setup(
     long_description=long_description,
     author='Russell Keith-Magee',
     author_email='russell@keith-magee.com',
-    url='http://pybee.org/toga',
+    url='http://beeware.org/toga',
     packages=find_packages(exclude='tests'),
     python_requires='>=3.5',
     install_requires=[

--- a/src/tvOS/README.rst
+++ b/src/tvOS/README.rst
@@ -20,7 +20,7 @@ Toga is part of the `BeeWare suite`_. You can talk to the community through:
 
 * `@pybeeware on Twitter`_
 
-* The `pybee/general`_ channel on Gitter.
+* The `beeware/general`_ channel on Gitter.
 
 Contributing
 ------------
@@ -28,12 +28,12 @@ Contributing
 If you experience problems with this backend, `log them on GitHub`_. If you
 want to contribute code, please `fork the code`_ and `submit a pull request`_.
 
-.. _Toga widget toolkit: http://pybee.org/toga
+.. _Toga widget toolkit: http://beeware.org/toga
 .. _the core Toga library: https://pypi.python.org/pypi/toga-core
-.. _Toga project on Github: https://github.com/pybee/toga
-.. _BeeWare suite: http://pybee.org
+.. _Toga project on Github: https://github.com/beeware/toga
+.. _BeeWare suite: http://beeware.org
 .. _@pybeeware on Twitter: https://twitter.com/pybeeware
-.. _pybee/general: https://gitter.im/pybee/general
-.. _log them on Github: https://github.com/pybee/toga/issues
-.. _fork the code: https://github.com/pybee/toga
-.. _submit a pull request: https://github.com/pybee/toga/pulls
+.. _beeware/general: https://gitter.im/beeware/general
+.. _log them on Github: https://github.com/beeware/toga/issues
+.. _fork the code: https://github.com/beeware/toga
+.. _submit a pull request: https://github.com/beeware/toga/pulls

--- a/src/tvOS/setup.py
+++ b/src/tvOS/setup.py
@@ -23,7 +23,7 @@ setup(
     long_description=long_description,
     author='Russell Keith-Magee',
     author_email='russell@keith-magee.com',
-    url='http://pybee.org/toga',
+    url='http://beeware.org/toga',
     packages=find_packages(exclude='tests'),
     python_requires='>=3.5',
     install_requires=[

--- a/src/uwp/README.rst
+++ b/src/uwp/README.rst
@@ -20,7 +20,7 @@ Toga is part of the `BeeWare suite`_. You can talk to the community through:
 
 * `@pybeeware on Twitter`_
 
-* The `pybee/general`_ channel on Gitter.
+* The `beeware/general`_ channel on Gitter.
 
 Contributing
 ------------
@@ -28,12 +28,12 @@ Contributing
 If you experience problems with this backend, `log them on GitHub`_. If you
 want to contribute code, please `fork the code`_ and `submit a pull request`_.
 
-.. _Toga widget toolkit: http://pybee.org/toga
+.. _Toga widget toolkit: http://beeware.org/toga
 .. _the core Toga library: https://pypi.python.org/pypi/toga-core
-.. _Toga project on Github: https://github.com/pybee/toga
-.. _BeeWare suite: http://pybee.org
+.. _Toga project on Github: https://github.com/beeware/toga
+.. _BeeWare suite: http://beeware.org
 .. _@pybeeware on Twitter: https://twitter.com/pybeeware
-.. _pybee/general: https://gitter.im/pybee/general
-.. _log them on Github: https://github.com/pybee/toga/issues
-.. _fork the code: https://github.com/pybee/toga
-.. _submit a pull request: https://github.com/pybee/toga/pulls
+.. _beeware/general: https://gitter.im/beeware/general
+.. _log them on Github: https://github.com/beeware/toga/issues
+.. _fork the code: https://github.com/beeware/toga
+.. _submit a pull request: https://github.com/beeware/toga/pulls

--- a/src/uwp/setup.py
+++ b/src/uwp/setup.py
@@ -23,7 +23,7 @@ setup(
     long_description=long_description,
     author='Russell Keith-Magee',
     author_email='russell@keith-magee.com',
-    url='http://pybee.org/toga',
+    url='http://beeware.org/toga',
     packages=find_packages(exclude='tests'),
     python_requires='>=3.5',
     install_requires=[

--- a/src/watchOS/README.rst
+++ b/src/watchOS/README.rst
@@ -20,7 +20,7 @@ Toga is part of the `BeeWare suite`_. You can talk to the community through:
 
 * `@pybeeware on Twitter`_
 
-* The `pybee/general`_ channel on Gitter.
+* The `beeware/general`_ channel on Gitter.
 
 Contributing
 ------------
@@ -28,12 +28,12 @@ Contributing
 If you experience problems with this backend, `log them on GitHub`_. If you
 want to contribute code, please `fork the code`_ and `submit a pull request`_.
 
-.. _Toga widget toolkit: http://pybee.org/toga
+.. _Toga widget toolkit: http://beeware.org/toga
 .. _the core Toga library: https://pypi.python.org/pypi/toga-core
-.. _Toga project on Github: https://github.com/pybee/toga
-.. _BeeWare suite: http://pybee.org
+.. _Toga project on Github: https://github.com/beeware/toga
+.. _BeeWare suite: http://beeware.org
 .. _@pybeeware on Twitter: https://twitter.com/pybeeware
-.. _pybee/general: https://gitter.im/pybee/general
-.. _log them on Github: https://github.com/pybee/toga/issues
-.. _fork the code: https://github.com/pybee/toga
-.. _submit a pull request: https://github.com/pybee/toga/pulls
+.. _beeware/general: https://gitter.im/beeware/general
+.. _log them on Github: https://github.com/beeware/toga/issues
+.. _fork the code: https://github.com/beeware/toga
+.. _submit a pull request: https://github.com/beeware/toga/pulls

--- a/src/watchOS/setup.py
+++ b/src/watchOS/setup.py
@@ -23,7 +23,7 @@ setup(
     long_description=long_description,
     author='Russell Keith-Magee',
     author_email='russell@keith-magee.com',
-    url='http://pybee.org/toga',
+    url='http://beeware.org/toga',
     packages=find_packages(exclude='tests'),
     python_requires='>=3.5',
     install_requires=[

--- a/src/web/README.rst
+++ b/src/web/README.rst
@@ -20,7 +20,7 @@ Toga is part of the `BeeWare suite`_. You can talk to the community through:
 
 * `@pybeeware on Twitter`_
 
-* The `pybee/general`_ channel on Gitter.
+* The `beeware/general`_ channel on Gitter.
 
 Contributing
 ------------
@@ -28,12 +28,12 @@ Contributing
 If you experience problems with this backend, `log them on GitHub`_. If you
 want to contribute code, please `fork the code`_ and `submit a pull request`_.
 
-.. _Toga widget toolkit: http://pybee.org/toga
+.. _Toga widget toolkit: http://beeware.org/toga
 .. _the core Toga library: https://pypi.python.org/pypi/toga-core
-.. _Toga project on Github: https://github.com/pybee/toga
-.. _BeeWare suite: http://pybee.org
+.. _Toga project on Github: https://github.com/beeware/toga
+.. _BeeWare suite: http://beeware.org
 .. _@pybeeware on Twitter: https://twitter.com/pybeeware
-.. _pybee/general: https://gitter.im/pybee/general
-.. _log them on Github: https://github.com/pybee/toga/issues
-.. _fork the code: https://github.com/pybee/toga
-.. _submit a pull request: https://github.com/pybee/toga/pulls
+.. _beeware/general: https://gitter.im/beeware/general
+.. _log them on Github: https://github.com/beeware/toga/issues
+.. _fork the code: https://github.com/beeware/toga
+.. _submit a pull request: https://github.com/beeware/toga/pulls

--- a/src/web/setup.py
+++ b/src/web/setup.py
@@ -23,7 +23,7 @@ setup(
     long_description=long_description,
     author='Russell Keith-Magee',
     author_email='russell@keith-magee.com',
-    url='http://pybee.org/toga',
+    url='http://beeware.org/toga',
     packages=find_packages(exclude='tests'),
     python_requires='>=3.5',
     install_requires=[

--- a/src/win32/README.rst
+++ b/src/win32/README.rst
@@ -19,7 +19,7 @@ Toga is part of the `BeeWare suite`_. You can talk to the community through:
 
 * `@pybeeware on Twitter`_
 
-* The `pybee/general`_ channel on Gitter.
+* The `beeware/general`_ channel on Gitter.
 
 Contributing
 ------------
@@ -27,12 +27,12 @@ Contributing
 If you experience problems with this backend, `log them on GitHub`_. If you
 want to contribute code, please `fork the code`_ and `submit a pull request`_.
 
-.. _Toga widget toolkit: http://pybee.org/toga
+.. _Toga widget toolkit: http://beeware.org/toga
 .. _the core Toga library: https://pypi.python.org/pypi/toga-core
-.. _Toga project on Github: https://github.com/pybee/toga
-.. _BeeWare suite: http://pybee.org
+.. _Toga project on Github: https://github.com/beeware/toga
+.. _BeeWare suite: http://beeware.org
 .. _@pybeeware on Twitter: https://twitter.com/pybeeware
-.. _pybee/general: https://gitter.im/pybee/general
-.. _log them on Github: https://github.com/pybee/toga/issues
-.. _fork the code: https://github.com/pybee/toga
-.. _submit a pull request: https://github.com/pybee/toga/pulls
+.. _beeware/general: https://gitter.im/beeware/general
+.. _log them on Github: https://github.com/beeware/toga/issues
+.. _fork the code: https://github.com/beeware/toga
+.. _submit a pull request: https://github.com/beeware/toga/pulls

--- a/src/win32/setup.py
+++ b/src/win32/setup.py
@@ -23,7 +23,7 @@ setup(
     long_description=long_description,
     author='Russell Keith-Magee',
     author_email='russell@keith-magee.com',
-    url='http://pybee.org/toga',
+    url='http://beeware.org/toga',
     packages=find_packages(exclude='tests'),
     python_requires='>=3.5',
     install_requires=[

--- a/src/winforms/README.rst
+++ b/src/winforms/README.rst
@@ -16,7 +16,7 @@ Toga is part of the `BeeWare suite`_. You can talk to the community through:
 
 * `@pybeeware on Twitter`_
 
-* The `pybee/general`_ channel on Gitter.
+* The `beeware/general`_ channel on Gitter.
 
 Contributing
 ------------
@@ -24,12 +24,12 @@ Contributing
 If you experience problems with this backend, `log them on GitHub`_. If you
 want to contribute code, please `fork the code`_ and `submit a pull request`_.
 
-.. _Toga widget toolkit: http://pybee.org/toga
+.. _Toga widget toolkit: http://beeware.org/toga
 .. _the core Toga library: https://pypi.python.org/pypi/toga-core
-.. _Toga project on Github: https://github.com/pybee/toga
-.. _BeeWare suite: http://pybee.org
+.. _Toga project on Github: https://github.com/beeware/toga
+.. _BeeWare suite: http://beeware.org
 .. _@pybeeware on Twitter: https://twitter.com/pybeeware
-.. _pybee/general: https://gitter.im/pybee/general
-.. _log them on Github: https://github.com/pybee/toga/issues
-.. _fork the code: https://github.com/pybee/toga
-.. _submit a pull request: https://github.com/pybee/toga/pulls
+.. _beeware/general: https://gitter.im/beeware/general
+.. _log them on Github: https://github.com/beeware/toga/issues
+.. _fork the code: https://github.com/beeware/toga
+.. _submit a pull request: https://github.com/beeware/toga/pulls

--- a/src/winforms/setup.py
+++ b/src/winforms/setup.py
@@ -23,7 +23,7 @@ setup(
     long_description=long_description,
     author='Russell Keith-Magee',
     author_email='russell@keith-magee.com',
-    url='http://pybee.org/toga',
+    url='http://beeware.org/toga',
     packages=find_packages(exclude='tests'),
     python_requires='>=3.5',
     install_requires=[


### PR DESCRIPTION
Minor updates for documentation as follows:
1. Replaced legacy references to 'pybee' with 'beeware'
2. Updated the documentation for toga-demo installation to provide additional instruction on the main page for people with Mac OS Sierra+ distributions (captured in comments on issue 602).

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested - N/A doc update
- [ ] All new features have been documented - N/A doc update
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
