### PR TITLE
Sphinx was failing to build the docs because of invalid tab code.

### DIFF
--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -45,11 +45,9 @@ Your prompt should now have a ``(venv)`` prefix in front of it.
 
 If you are using Python 3.7 on Windows, you might get an error in the next step. Before proceeding, download unofficial pythonnet wheel file from `<https://www.lfd.uci.edu/~gohlke/pythonlibs/#pythonnet>` to your current directory, rename it to ``pythonnet.whl`` and run:
 
-  .. group-tab:: Windows
-    
-    .. code-block:: doscon
-    
-      C:\..> pip install pythonnet.whl
+.. code-block:: doscon
+
+  C:\..> pip install pythonnet.whl
 
 Next, install Toga into your virtual environment:
 


### PR DESCRIPTION
<!--- Describe your changes in detail -->
In Tutorial 0, code line for installing pythonnet.whl for Windows was in an incomplete tab specification, leading to a build failure.

<!--- What problem does this change solve? -->
Fixes build failure and properly displays the command.

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x ] All new features have been tested
- [x ] All new features have been documented
- [x ] I have read the **CONTRIBUTING.md** file
- [x ] I will abide by the code of conduct