### PR TITLE
Added font support for WinForms backend

### DIFF
--- a/examples/tutorial1/tutorial/app.py
+++ b/examples/tutorial1/tutorial/app.py
@@ -10,8 +10,8 @@ def build(app):
     c_input = toga.TextInput(readonly=True)
     f_input = toga.TextInput()
 
-    c_label = toga.Label('Celsius', style=Pack(text_align=LEFT, font_family='wrong family'))
-    f_label = toga.Label('Fahrenheit', style=Pack(text_align=LEFT, font_weight=BOLD, font_style=OBLIQUE, font_size=16))
+    c_label = toga.Label('Celsius', style=Pack(text_align=LEFT))
+    f_label = toga.Label('Fahrenheit', style=Pack(text_align=LEFT))
     join_label = toga.Label('is equivalent to', style=Pack(text_align=RIGHT))
 
     def calculate(widget):

--- a/examples/tutorial1/tutorial/app.py
+++ b/examples/tutorial1/tutorial/app.py
@@ -10,8 +10,8 @@ def build(app):
     c_input = toga.TextInput(readonly=True)
     f_input = toga.TextInput()
 
-    c_label = toga.Label('Celsius', style=Pack(text_align=LEFT))
-    f_label = toga.Label('Fahrenheit', style=Pack(text_align=LEFT))
+    c_label = toga.Label('Celsius', style=Pack(text_align=LEFT, font_family='wrong family'))
+    f_label = toga.Label('Fahrenheit', style=Pack(text_align=LEFT, font_weight=BOLD, font_style=OBLIQUE, font_size=16))
     join_label = toga.Label('is equivalent to', style=Pack(text_align=RIGHT))
 
     def calculate(widget):

--- a/src/winforms/toga_winforms/factory.py
+++ b/src/winforms/toga_winforms/factory.py
@@ -1,7 +1,7 @@
 from .app import App, MainWindow
 from .command import Command
 
-# from .fonts import Font
+from .fonts import Font
 from .icons import Icon
 from .images import Image
 
@@ -40,7 +40,7 @@ __all__ = [
     'Command',
 
     # Resources
-    # 'Font',
+    'Font',
     'Icon',
     'Image',
 

--- a/src/winforms/toga_winforms/fonts.py
+++ b/src/winforms/toga_winforms/fonts.py
@@ -1,4 +1,4 @@
-from .libs import Font as WinFont
+from .libs import WinFont
 from .libs import FontFamily, FontStyle, Single, win_font_family
 
 _FONT_CACHE = {}

--- a/src/winforms/toga_winforms/fonts.py
+++ b/src/winforms/toga_winforms/fonts.py
@@ -1,0 +1,24 @@
+from .libs import Font as WinFont
+from .libs import FontFamily, FontStyle, Single, win_font_family
+
+_FONT_CACHE = {}
+
+
+class Font:
+    def __init__(self, interface):
+        self.interface = interface
+        try:
+            font = _FONT_CACHE[self.interface]
+        except KeyError:
+            font_family = win_font_family(self.interface.family)
+            font_style = FontStyle.Regular
+            if self.interface.weight.lower() == "bold" and font_family.IsStyleAvailable(FontStyle.Bold):
+                font_style += FontStyle.Bold
+            if self.interface.style.lower() == "italic" and font_family.IsStyleAvailable(FontStyle.Italic):
+                font_style += FontStyle.Italic
+            font = WinFont.Overloads[FontFamily, Single, FontStyle](
+                font_family, self.interface.size, font_style
+            )
+            _FONT_CACHE[self.interface] = font
+
+        self.native = font

--- a/src/winforms/toga_winforms/libs.py
+++ b/src/winforms/toga_winforms/libs.py
@@ -13,17 +13,9 @@ from System import Uri  # noqa: E402, F401
 from System.Drawing import Icon as WinIcon  # noqa: E402, F401
 from System.Drawing import Image as WinImage  # noqa: E402, F401
 from System.Drawing import Font as WinFont  # noqa: E402, F401
-from System.Drawing import (
-    ContentAlignment,
-    SystemFonts,
-    FontFamily,
-    FontStyle,
-    Text,
-    Size,
-    Point,
-    Color,
-    Bitmap,
-)  # noqa: E402, F401
+from System.Drawing import ContentAlignment, Size, Point  # noqa: E402, F401
+from System.Drawing import FontFamily, FontStyle, SystemFonts  # noqa: E402, F401
+from System.Drawing import Text, Color, Bitmap  # noqa: E402, F401
 from toga.constants import LEFT, RIGHT, CENTER, JUSTIFY  # noqa: E402
 from toga.fonts import (
     MESSAGE,

--- a/src/winforms/toga_winforms/libs.py
+++ b/src/winforms/toga_winforms/libs.py
@@ -3,11 +3,26 @@ import clr
 clr.AddReference("System.Windows.Forms")
 
 import System.Windows.Forms as WinForms  # noqa: E402
+from System import Decimal as ClrDecimal  # noqa: E402, F401
+from System import Single  # noqa: E402, F401
+from System import Convert  # noqa: E402, F401
+from System import DateTime as WinDateTime  # noqa: E402, F401
+from System import Threading  # noqa: E402, F401
+from System import Uri  # noqa: E402, F401
+
+from System.Drawing import Icon as WinIcon  # noqa: E402, F401
+from System.Drawing import Image as WinImage  # noqa: E402, F401
+from System.Drawing import Font as WinFont  # noqa: E402, F401
 from System.Drawing import (
     ContentAlignment,
     SystemFonts,
     FontFamily,
-    Text
+    FontStyle,
+    Text,
+    Size,
+    Point,
+    Color,
+    Bitmap
 )  # noqa: E402, F401
 from toga.constants import LEFT, RIGHT, CENTER, JUSTIFY  # noqa: E402
 from toga.fonts import (
@@ -66,7 +81,7 @@ def win_font_family(value):
         return FontFamily(value)
     else:
         print(
-            "Unable to load font-family {}, loading {}".format(
+            "Unable to load font-family '{}', loading {} instead".format(
                 value, SystemFonts.DefaultFont.FontFamily)
         )
         return SystemFonts.DefaultFont.FontFamily

--- a/src/winforms/toga_winforms/libs.py
+++ b/src/winforms/toga_winforms/libs.py
@@ -18,7 +18,7 @@ from toga.fonts import (
     CURSIVE,
     FANTASY,
     MONOSPACE,
-)
+)  # noqa: E402
 
 
 def TextAlignment(value):

--- a/src/winforms/toga_winforms/libs.py
+++ b/src/winforms/toga_winforms/libs.py
@@ -1,16 +1,24 @@
 import clr
+
 clr.AddReference("System.Windows.Forms")
 
 import System.Windows.Forms as WinForms  # noqa: E402
-from System import Decimal as ClrDecimal  # noqa: E402, F401
-from System import Convert  # noqa: E402, F401
-from System import DateTime as WinDateTime  # noqa: E402, F401
-from System import Threading  # noqa: E402, F401
-from System import Uri  # noqa: E402, F401
-from System.Drawing import Size, Point, Color, ContentAlignment, Bitmap  # noqa: E402, F401
-from System.Drawing import Icon as WinIcon  # noqa: E402, F401
-from System.Drawing import Image as WinImage  # noqa: E402, F401
+from System.Drawing import (
+    ContentAlignment,
+    SystemFonts,
+    FontFamily,
+    Text
+)  # noqa: E402, F401
 from toga.constants import LEFT, RIGHT, CENTER, JUSTIFY  # noqa: E402
+from toga.fonts import (
+    MESSAGE,
+    SYSTEM,
+    SERIF,
+    SANS_SERIF,
+    CURSIVE,
+    FANTASY,
+    MONOSPACE,
+)
 
 
 def TextAlignment(value):
@@ -39,3 +47,26 @@ def add_handler(cmd):
         return action(None)
 
     return handler
+
+
+def win_font_family(value):
+    win_families = {
+        SYSTEM: SystemFonts.DefaultFont.FontFamily,
+        MESSAGE: SystemFonts.MenuFont.FontFamily,
+        SERIF: FontFamily.GenericSerif,
+        SANS_SERIF: FontFamily.GenericSansSerif,
+        CURSIVE: FontFamily("Comic Sans MS"),
+        FANTASY: FontFamily("Impact"),
+        MONOSPACE: FontFamily.GenericMonospace,
+    }
+    for key in win_families:
+        if value in key:
+            return win_families[key]
+    if value in Text.InstalledFontCollection().Families:
+        return FontFamily(value)
+    else:
+        print(
+            "Unable to load font-family {}, loading {}".format(
+                value, SystemFonts.DefaultFont.FontFamily)
+        )
+        return SystemFonts.DefaultFont.FontFamily

--- a/src/winforms/toga_winforms/libs.py
+++ b/src/winforms/toga_winforms/libs.py
@@ -22,7 +22,7 @@ from System.Drawing import (
     Size,
     Point,
     Color,
-    Bitmap
+    Bitmap,
 )  # noqa: E402, F401
 from toga.constants import LEFT, RIGHT, CENTER, JUSTIFY  # noqa: E402
 from toga.fonts import (

--- a/src/winforms/toga_winforms/widgets/label.py
+++ b/src/winforms/toga_winforms/widgets/label.py
@@ -15,6 +15,10 @@ class Label(Widget):
     def set_text(self, value):
         self.native.Text = self.interface._text
 
+    def set_font(self, value):
+        if value:
+            self.native.Font = value._impl.native
+
     def rehint(self):
         # Width & height of a label is known and fixed.
         # self.native.Size = Size(0, 0)

--- a/src/winforms/toga_winforms/widgets/numberinput.py
+++ b/src/winforms/toga_winforms/widgets/numberinput.py
@@ -40,7 +40,8 @@ class NumberInput(Widget):
         self.native.TextAlign = HorizontalTextAlignment(value)
 
     def set_font(self, value):
-        self.interface.factory.not_implemented('NumberInput.set_font()')
+        if value:
+            self.native.Font = value._impl.native
 
     def rehint(self):
         self.interface.intrinsic.width = at_least(self.interface.MIN_WIDTH)

--- a/src/winforms/toga_winforms/widgets/textinput.py
+++ b/src/winforms/toga_winforms/widgets/textinput.py
@@ -25,7 +25,8 @@ class TextInput(Widget):
         self.native.TextAlign = HorizontalTextAlignment(value)
 
     def set_font(self, value):
-        self.interface.factory.not_implemented('TextInput.set_font()')
+        if value:
+            self.native.Font = value._impl.native
 
     def rehint(self):
         # Height of a text input is known and fixed.


### PR DESCRIPTION
<!--- Describe your changes in detail -->
I added font support for WinForms backend for the following widgets: `label`, `numberinput`, `textinput`. Winforms doesn't support `OBLIQUE` font style and `SMALL_CAPS` font variant, so they are ignored. 

There is a problem with label size: if label has a larger font, it does not become larger to fit the text, instead the text is cut off.

Also, there is a problem with dpi in WinForms: at the moment symbols look blurry. Pywebveiw project seems to have a solution.

<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
