### PR TITLE
Dpi-aware process for Winforms

### DIFF
--- a/src/winforms/toga_winforms/app.py
+++ b/src/winforms/toga_winforms/app.py
@@ -2,7 +2,7 @@ import sys
 
 import toga
 
-from .libs import Threading, WinForms, add_handler
+from .libs import Threading, WinForms, add_handler, user32, win_version
 from .window import Window
 
 
@@ -20,6 +20,11 @@ class App:
 
     def create(self):
         self.native = WinForms.Application
+
+        if win_version >= 6:
+            user32.SetProcessDPIAware(True)
+        self.native.EnableVisualStyles()
+        self.native.SetCompatibleTextRenderingDefault(False)
 
         self.interface.commands.add(
             toga.Command(None, 'About ' + self.interface.name, group=toga.Group.HELP),

--- a/src/winforms/toga_winforms/libs.py
+++ b/src/winforms/toga_winforms/libs.py
@@ -1,3 +1,5 @@
+import ctypes
+
 import clr
 
 clr.AddReference("System.Windows.Forms")
@@ -9,6 +11,7 @@ from System import Convert  # noqa: E402, F401
 from System import DateTime as WinDateTime  # noqa: E402, F401
 from System import Threading  # noqa: E402, F401
 from System import Uri  # noqa: E402, F401
+from System import Environment  # noqa: E402, F401
 
 from System.Drawing import Icon as WinIcon  # noqa: E402, F401
 from System.Drawing import Image as WinImage  # noqa: E402, F401
@@ -26,6 +29,9 @@ from toga.fonts import (
     FANTASY,
     MONOSPACE,
 )  # noqa: E402
+
+user32 = ctypes.windll.user32
+win_version = Environment.OSVersion.Version.Major
 
 
 def TextAlignment(value):

--- a/src/winforms/toga_winforms/window.py
+++ b/src/winforms/toga_winforms/window.py
@@ -29,7 +29,7 @@ class Window:
 
     def create(self):
         self.native = WinForms.Form(self)
-        self.native.ClientSize = Size(self.interface._size[0], self.interface._size[1])
+        self.native.ClientSize = Size(*self.interface._size)
         self.native.interface = self.interface
         self.native.Resize += self.winforms_Resize
         self.toolbar_native = None
@@ -57,7 +57,7 @@ class Window:
         pass
 
     def set_size(self, size):
-        self.native.ClientSize = Size(self.interface._size[0], self.interface._size[1])
+        self.native.ClientSize = Size(*self.interface._size)
 
     def set_app(self, app):
         pass


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Currently toga Winforms apps are rendered with 96 dpi, and virtually scaled to higher dpi monitors which makes text and controls appear blurry on high dpi monitors.

This PR sets app process  to be dpi aware, which makes texts appear crisper, and makes window size smaller. It is only set so on Windows major versions higher than 6.0 (Windows Vista, apparently). 

The change can be seen on this screenshot, the dpi-aware window is on the left, and the previous dpi-non-aware window is on the right.
<img width="808" alt="win_dpi_changes" src="https://user-images.githubusercontent.com/15233243/58745831-1f18f680-845f-11e9-8ebd-af061517e89b.png">

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
