### PR TITLE
Implemented DPI process bug fix

### DIFF
--- a/src/winforms/toga_winforms/app.py
+++ b/src/winforms/toga_winforms/app.py
@@ -25,11 +25,11 @@ class App:
         # with the most up to date API
         # Windows Versioning Check Sources : https://www.lifewire.com/windows-version-numbers-2625171
         # and https://docs.microsoft.com/en-us/windows/release-information/
-        if win_version.Major >= 6: # Checks for Windows Vista or later
+        if win_version.Major >= 6:  # Checks for Windows Vista or later
             # Represents Windows 8.1 up to Windows 10 before Build 1703 which should use
             # SetProcessDpiAwareness(True)
-            if ((win_version.Major == 6 and win_version.Minor == 3) or 
-            (win_version.Major == 10 and win_version.Build < 15063)):
+            if ((win_version.Major == 6 and win_version.Minor == 3) or
+                    (win_version.Major == 10 and win_version.Build < 15063)):
                 shcore.SetProcessDpiAwareness(True)
             # Represents Windows 10 Build 1703 and beyond which should use
             # SetProcessDpiAwarenessContext(-2)

--- a/src/winforms/toga_winforms/app.py
+++ b/src/winforms/toga_winforms/app.py
@@ -2,7 +2,7 @@ import sys
 
 import toga
 
-from .libs import Threading, WinForms, add_handler, user32, win_version
+from .libs import Threading, WinForms, add_handler, user32, win_version, shcore, win_build
 from .window import Window
 
 
@@ -21,8 +21,13 @@ class App:
     def create(self):
         self.native = WinForms.Application
 
-        if win_version >= 6:
+        if win_version >= 6 and win_version < 8:
             user32.SetProcessDPIAware(True)
+        elif win_version >= 8 and win_build < 15063:
+            shcore.SetProcessDpiAwareness(True)
+        elif win_version >= 10 and win_build >= 15063:
+            user32.SetProcessDpiAwarenessContext(True)
+            
         self.native.EnableVisualStyles()
         self.native.SetCompatibleTextRenderingDefault(False)
 

--- a/src/winforms/toga_winforms/app.py
+++ b/src/winforms/toga_winforms/app.py
@@ -25,11 +25,11 @@ class App:
         # with the most up to date API
         # Windows Versioning Check Sources : https://www.lifewire.com/windows-version-numbers-2625171
         # and https://docs.microsoft.com/en-us/windows/release-information/
-        if win_version.Major >= 6:  # Checks for Windows Vista or later
+        if win_version.Major >= 6: # Checks for Windows Vista or later
             # Represents Windows 8.1 up to Windows 10 before Build 1703 which should use
             # SetProcessDpiAwareness(True)
             if ((win_version.Major == 6 and win_version.Minor == 3) or 
-                (win_version.Major == 10 and win_version.Build < 15063)): 
+            (win_version.Major == 10 and win_version.Build < 15063)):
                 shcore.SetProcessDpiAwareness(True)
             # Represents Windows 10 Build 1703 and beyond which should use
             # SetProcessDpiAwarenessContext(-2)

--- a/src/winforms/toga_winforms/app.py
+++ b/src/winforms/toga_winforms/app.py
@@ -27,7 +27,7 @@ class App:
             shcore.SetProcessDpiAwareness(True)
         elif win_version >= 10 and win_build >= 15063:
             user32.SetProcessDpiAwarenessContext(True)
-            
+
         self.native.EnableVisualStyles()
         self.native.SetCompatibleTextRenderingDefault(False)
 

--- a/src/winforms/toga_winforms/app.py
+++ b/src/winforms/toga_winforms/app.py
@@ -2,7 +2,7 @@ import sys
 
 import toga
 
-from .libs import Threading, WinForms, add_handler, user32, win_version, shcore, win_build
+from .libs import Threading, WinForms, add_handler, user32, win_version, shcore
 from .window import Window
 
 
@@ -21,12 +21,22 @@ class App:
     def create(self):
         self.native = WinForms.Application
 
-        if win_version >= 6 and win_version < 8:
-            user32.SetProcessDPIAware(True)
-        elif win_version >= 8 and win_build < 15063:
-            shcore.SetProcessDpiAwareness(True)
-        elif win_version >= 10 and win_build >= 15063:
-            user32.SetProcessDpiAwarenessContext(True)
+        # Check the version of windows and make sure we are setting the DPI mode 
+        # with the most up to date API
+        # Windows Versioning Check Sources : https://www.lifewire.com/windows-version-numbers-2625171
+        # and https://docs.microsoft.com/en-us/windows/release-information/
+        if win_version.Major >= 6:  # Checks for Windows Vista or later
+            # Represents Windows 8.1 up to Windows 10 before Build 1703 which should use 
+            # SetProcessDpiAwareness(True)
+            if (win_version.Major == 6 and win_version.Minor == 3) or (win_version.Major == 10 and win_version.Build < 15063): 
+                shcore.SetProcessDpiAwareness(True)
+            # Represents Windows 10 Build 1703 and beyond which should use 
+            # SetProcessDpiAwarenessContext(-2)
+            elif win_version.Major == 10 and win_version.Build >= 15063:
+                user32.SetProcessDpiAwarenessContext(-2)
+            # Any other version of windows should use SetProcessDPIAware(True)
+            else:
+                user32.SetProcessDPIAware(True)
 
         self.native.EnableVisualStyles()
         self.native.SetCompatibleTextRenderingDefault(False)

--- a/src/winforms/toga_winforms/app.py
+++ b/src/winforms/toga_winforms/app.py
@@ -21,16 +21,17 @@ class App:
     def create(self):
         self.native = WinForms.Application
 
-        # Check the version of windows and make sure we are setting the DPI mode 
+        # Check the version of windows and make sure we are setting the DPI mode
         # with the most up to date API
         # Windows Versioning Check Sources : https://www.lifewire.com/windows-version-numbers-2625171
         # and https://docs.microsoft.com/en-us/windows/release-information/
         if win_version.Major >= 6:  # Checks for Windows Vista or later
-            # Represents Windows 8.1 up to Windows 10 before Build 1703 which should use 
+            # Represents Windows 8.1 up to Windows 10 before Build 1703 which should use
             # SetProcessDpiAwareness(True)
-            if (win_version.Major == 6 and win_version.Minor == 3) or (win_version.Major == 10 and win_version.Build < 15063): 
+            if ((win_version.Major == 6 and win_version.Minor == 3) or 
+                (win_version.Major == 10 and win_version.Build < 15063)): 
                 shcore.SetProcessDpiAwareness(True)
-            # Represents Windows 10 Build 1703 and beyond which should use 
+            # Represents Windows 10 Build 1703 and beyond which should use
             # SetProcessDpiAwarenessContext(-2)
             elif win_version.Major == 10 and win_version.Build >= 15063:
                 user32.SetProcessDpiAwarenessContext(-2)

--- a/src/winforms/toga_winforms/libs.py
+++ b/src/winforms/toga_winforms/libs.py
@@ -32,8 +32,7 @@ from toga.fonts import (
 
 user32 = ctypes.windll.user32
 shcore = ctypes.windll.shcore
-win_version = Environment.OSVersion.Version.Major
-win_build = Environment.OSVersion.Version.Build
+win_version = Environment.OSVersion.Version
 
 
 def TextAlignment(value):

--- a/src/winforms/toga_winforms/libs.py
+++ b/src/winforms/toga_winforms/libs.py
@@ -31,7 +31,9 @@ from toga.fonts import (
 )  # noqa: E402
 
 user32 = ctypes.windll.user32
+shcore = ctypes.windll.shcore
 win_version = Environment.OSVersion.Version.Major
+win_build = Environment.OSVersion.Version.Build
 
 
 def TextAlignment(value):


### PR DESCRIPTION
Changed the app.py create method for toga_winforms to check the current OS Version and build number to make sure we are using the most up to date DPI setting API for the user. Came across this issue when updating windows to the 1903 update (Build #: 18362)

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
