### PR TITLE
Fix the toga object chain on fullscreen cocoa windows.

### DIFF
--- a/src/cocoa/toga_cocoa/app.py
+++ b/src/cocoa/toga_cocoa/app.py
@@ -198,6 +198,11 @@ class App:
 
         for window, screen in zip(windows, NSScreen.screens):
             window.content._impl.native.enterFullScreenMode(screen, withOptions=opts)
+            # Going full screen causes the window content to be re-homed
+            # in a NSFullScreenWindow; teach the new parent window
+            # about it's Toga representations.
+            window.content._impl.native.window._impl = window._impl
+            window.content._impl.native.window.interface = window
 
     def exit_full_screen(self, windows):
         opts = NSMutableDictionary.alloc().init()


### PR DESCRIPTION
When an app goes full screen, the windows involved are re-homed into an NSFulLScreenWindow. This is a new instance that doesn't have any Toga representation, so we need to fill in the gaps.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
