### PR TITLE
Make commands in Winforms possible to enable and disable

### DIFF
--- a/src/cocoa/toga_cocoa/app.py
+++ b/src/cocoa/toga_cocoa/app.py
@@ -158,7 +158,7 @@ class App:
                     if modifier is not None:
                         item.keyEquivalentModifierMask = modifier
 
-                    cmd._widgets.append(item)
+                    cmd._impl.native.append(item)
                     self._menu_items[item] = cmd
 
                     # This line may appear redundant, but it triggers the logic

--- a/src/cocoa/toga_cocoa/command.py
+++ b/src/cocoa/toga_cocoa/command.py
@@ -4,8 +4,13 @@ from toga.icons import Icon
 class Command:
     def __init__(self, interface):
         self.interface = interface
+        self.native = []
 
         if self.interface.icon_id:
             self.icon = Icon.load(self.interface.icon_id)
         else:
             self.icon = None
+
+    def set_enabled(self, value):
+        for widget in self.native:
+            widget.enabled = value

--- a/src/cocoa/toga_cocoa/window.py
+++ b/src/cocoa/toga_cocoa/window.py
@@ -71,25 +71,24 @@ class WindowDelegate(NSObject):
     @objc_method
     def toolbar_itemForItemIdentifier_willBeInsertedIntoToolbar_(self, toolbar, identifier, insert: bool):
         "Create the requested toolbar button"
-        _item = NSToolbarItem.alloc().initWithItemIdentifier_(identifier)
+        native = NSToolbarItem.alloc().initWithItemIdentifier_(identifier)
         try:
             item = self.interface._impl._toolbar_items[str(identifier)]
-            impl = item.bind(self.interface.factory)
             if item.label:
-                _item.setLabel(item.label)
-                _item.setPaletteLabel(item.label)
+                native.setLabel(item.label)
+                native.setPaletteLabel(item.label)
             if item.tooltip:
-                _item.setToolTip(item.tooltip)
-            if impl.icon:
-                _item.setImage(impl.icon.bind(self.interface.factory).native)
+                native.setToolTip(item.tooltip)
+            if item._impl.icon:
+                native.setImage(item._impl.icon.bind(self.interface.factory).native)
 
-            item._widgets.append(_item)
+            item._impl.native.append(native)
 
-            _item.setTarget_(self)
-            _item.setAction_(SEL('onToolbarButtonPress:'))
+            native.setTarget_(self)
+            native.setAction_(SEL('onToolbarButtonPress:'))
         except KeyError:
             pass
-        return _item
+        return native
 
     @objc_method
     def validateToolbarItem_(self, item) -> bool:

--- a/src/core/tests/test_command.py
+++ b/src/core/tests/test_command.py
@@ -1,12 +1,12 @@
 import unittest
-from unittest.mock import Mock
 
 import toga
 import toga_dummy
+from toga_dummy.utils import TestCase
 from toga.command import cmd_sort_key
 
 
-class TestCommand(unittest.TestCase):
+class TestCommand(TestCase):
     def test_group_init_no_order(self):
         grp = toga.Group('label')
         self.assertEqual(grp.label, 'label')
@@ -97,9 +97,9 @@ class TestCommand(unittest.TestCase):
         )
         cmd.bind(toga_dummy.factory)
         cmd.enabled = False
-        self.assertFalse(cmd._impl.enabled)
+        self.assertActionPerformedWith(cmd, 'set enabled', value=False)
         cmd.enabled = True
-        self.assertTrue(cmd._impl.enabled)
+        self.assertActionPerformedWith(cmd, 'set enabled', value=True)
 
     def test_cmd_sort_key(self):
         grp = toga.Group('Test group', order=10)

--- a/src/core/tests/test_command.py
+++ b/src/core/tests/test_command.py
@@ -39,7 +39,6 @@ class TestCommand(unittest.TestCase):
         self.assertEqual(cmd.section, 0)
         self.assertEqual(cmd.order, 0)
         self.assertTrue(cmd._enabled)
-        self.assertEqual(cmd._widgets, [])
 
     def test_command_init_kargs(self):
         grp = toga.Group('Test group', order=10)
@@ -62,7 +61,6 @@ class TestCommand(unittest.TestCase):
         self.assertEqual(cmd.section, 1)
         self.assertEqual(cmd.order, 1)
         self.assertTrue(cmd._enabled)
-        self.assertEqual(cmd._widgets, [])
         self.assertTrue(cmd.enabled)
         cmd.enabled = False
         self.assertFalse(cmd._enabled)
@@ -85,7 +83,6 @@ class TestCommand(unittest.TestCase):
         self.assertEqual(retur_val, cmd._impl)
 
     def test_command_enabler(self):
-        test_widget = toga.Widget(factory=toga_dummy.factory)
         grp = toga.Group('Test group', order=10)
         cmd = toga.Command(
             lambda x: print('Hello World'),
@@ -98,13 +95,11 @@ class TestCommand(unittest.TestCase):
             order=1,
             factory=toga_dummy.factory,
         )
-        cmd._widgets.append(test_widget)
-        cmd._widgets[0]._impl = Mock()
+        cmd.bind(toga_dummy.factory)
         cmd.enabled = False
-        self.assertEqual(cmd._enabled, False)
-
-        for widget in cmd._widgets:
-            self.assertEqual(widget.enabled, False)
+        self.assertFalse(cmd._impl.enabled)
+        cmd.enabled = True
+        self.assertTrue(cmd._impl.enabled)
 
     def test_cmd_sort_key(self):
         grp = toga.Group('Test group', order=10)

--- a/src/core/tests/test_command.py
+++ b/src/core/tests/test_command.py
@@ -126,14 +126,17 @@ class TestCommandSet(unittest.TestCase):
     def test_cmdset_init(self):
         test_widget = toga.Widget(factory=toga_dummy.factory)
         cs = toga.CommandSet(test_widget)
-        self.assertEqual(cs.widget, test_widget)
-        self.assertEqual(cs._values, set())
+        self.assertEqual(cs._commands, set())
         self.assertEqual(cs.on_change, None)
 
     def test_cmdset_add(self):
         self.changed = False
         test_widget = toga.Widget(factory=toga_dummy.factory)
-        cs = toga.CommandSet(test_widget, on_change=self._changed)
+        cs = toga.CommandSet(
+            factory=toga_dummy.factory,
+            widget=test_widget,
+            on_change=self._changed
+        )
         grp = toga.Group('Test group', order=10)
         cmd = toga.Command(
             lambda x: print('Hello World'),
@@ -147,11 +150,16 @@ class TestCommandSet(unittest.TestCase):
             factory=toga_dummy.factory
         )
         cs.add(cmd)
+
         self.assertTrue(self.changed)
+        self.assertIsNotNone(cmd._impl)
 
     def test_cmdset_iter(self):
         test_widget = toga.Widget(factory=toga_dummy.factory)
-        cs = toga.CommandSet(test_widget)
+        cs = toga.CommandSet(
+            factory=toga_dummy.factory,
+            widget=test_widget
+        )
         grp = toga.Group('Test group', order=10)
         cmd = toga.Command(
             lambda x: print('Hello World'),

--- a/src/core/toga/app.py
+++ b/src/core/toga/app.py
@@ -61,7 +61,7 @@ class App:
         self._app_id = app_id
         self._id = id if id else identifier(self)
 
-        self.commands = CommandSet(None)
+        self.commands = CommandSet(factory=self.factory)
 
         self._startup_method = startup
 

--- a/src/core/toga/command.py
+++ b/src/core/toga/command.py
@@ -59,7 +59,6 @@ class Command:
 
         self._enabled = self.action is not None
 
-        self._widgets = []
         self._impl = None
 
     def bind(self, factory):
@@ -74,8 +73,6 @@ class Command:
     @enabled.setter
     def enabled(self, value):
         self._enabled = value
-        for widget in self._widgets:
-            widget.enabled = value
         if self._impl is not None:
             self._impl.enabled = value
 

--- a/src/core/toga/command.py
+++ b/src/core/toga/command.py
@@ -89,28 +89,31 @@ class CommandSet:
     """
 
     Args:
+        factory:
         widget:
         on_change:
 
     Todo:
         * Add missing Docstrings.
     """
-    def __init__(self, widget, on_change=None):
-
+    def __init__(self, factory, widget=None, on_change=None):
+        self.factory = factory
         self.widget = widget
-        self._values = set()
+        self._commands = set()
         self.on_change = on_change
 
-    def add(self, *values):
-        if self.widget and self.widget.app != None:
-            self.widget.app.commands.add(*values)
-        self._values.update(values)
+    def add(self, *commands):
+        for cmd in commands:
+            cmd.bind(self.factory)
+        if self.widget and self.widget.app is not None:
+            self.widget.app.commands.add(*commands)
+        self._commands.update(commands)
         if self.on_change:
             self.on_change()
 
     def __iter__(self):
         prev_cmd = None
-        for cmd in sorted(self._values, key=cmd_sort_key):
+        for cmd in sorted(self._commands, key=cmd_sort_key):
             if prev_cmd:
                 if cmd.group != prev_cmd.group:
                     yield GROUP_BREAK

--- a/src/core/toga/command.py
+++ b/src/core/toga/command.py
@@ -74,7 +74,7 @@ class Command:
     def enabled(self, value):
         self._enabled = value
         if self._impl is not None:
-            self._impl.enabled = value
+            self._impl.set_enabled(value)
 
 
 GROUP_BREAK = object()

--- a/src/core/toga/window.py
+++ b/src/core/toga/window.py
@@ -41,7 +41,11 @@ class Window:
         self.factory = get_platform_factory(factory)
         self._impl = getattr(self.factory, self._WINDOW_CLASS)(interface=self)
 
-        self._toolbar = CommandSet(self, self._impl.create_toolbar)
+        self._toolbar = CommandSet(
+            factory=self.factory,
+            widget=self,
+            on_change=self._impl.create_toolbar
+        )
 
         self.position = position
         self.size = size

--- a/src/dummy/toga_dummy/command.py
+++ b/src/dummy/toga_dummy/command.py
@@ -4,4 +4,7 @@ from toga_dummy.utils import LoggedObject
 class Command(LoggedObject):
     def __init__(self, interface):
         super().__init__()
-        self.interface = interface        
+        self.interface = interface
+
+    def set_enabled(self, value):
+        self._action('set enabled', value=value)

--- a/src/gtk/toga_gtk/app.py
+++ b/src/gtk/toga_gtk/app.py
@@ -146,11 +146,11 @@ class App:
                         action = Gio.SimpleAction.new(cmd_id, None)
                         if cmd.action:
                             action.connect("activate", gtk_menu_item_activate(cmd))
-                        cmd._widgets.append(action)
+                        cmd_impl = cmd.bind(self.interface.factory)
+                        cmd_impl.native.append(action)
+                        cmd_impl.set_enabled(cmd.enabled)
                         self._actions[cmd] = action
                         self.native.add_action(action)
-
-                    # cmd.bind(self.interface.factory).set_enabled(cmd.enabled)
 
                     item = Gio.MenuItem.new(cmd.label, 'app.' + cmd_id)
                     if cmd.shortcut:

--- a/src/gtk/toga_gtk/app.py
+++ b/src/gtk/toga_gtk/app.py
@@ -146,9 +146,9 @@ class App:
                         action = Gio.SimpleAction.new(cmd_id, None)
                         if cmd.action:
                             action.connect("activate", gtk_menu_item_activate(cmd))
-                        cmd_impl = cmd.bind(self.interface.factory)
-                        cmd_impl.native.append(action)
-                        cmd_impl.set_enabled(cmd.enabled)
+
+                        cmd._impl.native.append(action)
+                        cmd._impl.set_enabled(cmd.enabled)
                         self._actions[cmd] = action
                         self.native.add_action(action)
 

--- a/src/gtk/toga_gtk/command.py
+++ b/src/gtk/toga_gtk/command.py
@@ -1,21 +1,24 @@
 from toga import Icon
 
 
-class Command():
+class Command:
+    """ Command `native` property is a list of native widgets associated with the command.
+    Native widgets can be both Gtk.ToolButton and Gio.SimpleAction.
+    """
     def __init__(self, interface):
         self.interface = interface
-
 
         if self.interface.icon_id:
             self.icon = Icon.load(self.interface.icon_id)
         else:
             self.icon = None
 
-        self._widgets = []
+        self.native = []
 
-    def _set_enabled(self, value):
-        for widget in self.interface._widgets:
+    def set_enabled(self, value):
+        enabled = self.interface.enabled
+        for widget in self.native:
             try:
-                widget.set_sensitive(value)
+                widget.set_sensitive(enabled)
             except AttributeError:
-                widget.set_enabled(value)
+                widget.set_enabled(enabled)

--- a/src/gtk/toga_gtk/window.py
+++ b/src/gtk/toga_gtk/window.py
@@ -55,7 +55,7 @@ class Window:
         else:
             for cmd, item_impl in self.toolbar_items.items():
                 self.toolbar_native.remove(item_impl)
-                cmd._impl._widgets.remove(item_impl)
+                cmd._impl.native.remove(item_impl)
 
         self.toolbar_native.set_style(Gtk.ToolbarStyle.BOTH)
         for cmd in self.interface.toolbar:
@@ -73,7 +73,7 @@ class Window:
                 item_impl.set_label(cmd.label)
                 item_impl.set_tooltip_text(cmd.tooltip)
                 item_impl.connect("clicked", wrapped_handler(cmd, cmd.action))
-                cmd._widgets.append(item_impl)
+                cmd_impl.native.append(item_impl)
             self.toolbar_items[cmd] = item_impl
             self.toolbar_native.insert(item_impl, -1)
 

--- a/src/gtk/toga_gtk/window.py
+++ b/src/gtk/toga_gtk/window.py
@@ -67,13 +67,12 @@ class Window:
                 item_impl.set_draw(False)
             else:
                 item_impl = Gtk.ToolButton()
-                cmd_impl = cmd.bind(self.interface.factory)
-                icon_impl = cmd_impl.icon.bind(self.interface.factory)
+                icon_impl = cmd._impl.icon.bind(self.interface.factory)
                 item_impl.set_icon_widget(icon_impl.native_32)
                 item_impl.set_label(cmd.label)
                 item_impl.set_tooltip_text(cmd.tooltip)
                 item_impl.connect("clicked", wrapped_handler(cmd, cmd.action))
-                cmd_impl.native.append(item_impl)
+                cmd._impl.native.append(item_impl)
             self.toolbar_items[cmd] = item_impl
             self.toolbar_native.insert(item_impl, -1)
 
@@ -116,7 +115,7 @@ class Window:
         pass
 
     def on_size_allocate(self, widget, allocation):
-        # print("ON WINDOW SIZE ALLOCATION", allocation.width, allocation.height)
+        #  ("ON WINDOW SIZE ALLOCATION", allocation.width, allocation.height)
         pass
 
     def close(self):

--- a/src/winforms/toga_winforms/app.py
+++ b/src/winforms/toga_winforms/app.py
@@ -72,6 +72,7 @@ class App:
                 elif cmd == toga.SECTION_BREAK:
                     submenu.DropDownItems.Add('-')
                 else:
+                    cmd_impl = cmd.bind(self.interface.factory)
                     if submenu is None:
                         submenu = WinForms.ToolStripMenuItem(cmd.group.label)
                     item = WinForms.ToolStripMenuItem(cmd.label)
@@ -79,7 +80,7 @@ class App:
                         item.Click += add_handler(cmd)
                     else:
                         item.Enabled = False
-                    cmd._widgets.append(item)
+                    cmd_impl.native.append(item)
                     self._menu_items[item] = cmd
                     submenu.DropDownItems.Add(item)
             if submenu:

--- a/src/winforms/toga_winforms/app.py
+++ b/src/winforms/toga_winforms/app.py
@@ -72,7 +72,6 @@ class App:
                 elif cmd == toga.SECTION_BREAK:
                     submenu.DropDownItems.Add('-')
                 else:
-                    cmd_impl = cmd.bind(self.interface.factory)
                     if submenu is None:
                         submenu = WinForms.ToolStripMenuItem(cmd.group.label)
                     item = WinForms.ToolStripMenuItem(cmd.label)
@@ -80,7 +79,7 @@ class App:
                         item.Click += add_handler(cmd)
                     else:
                         item.Enabled = False
-                    cmd_impl.native.append(item)
+                    cmd._impl.native.append(item)
                     self._menu_items[item] = cmd
                     submenu.DropDownItems.Add(item)
             if submenu:

--- a/src/winforms/toga_winforms/command.py
+++ b/src/winforms/toga_winforms/command.py
@@ -14,12 +14,7 @@ class Command:
         else:
             self.interface.icon = None
 
-    @property
-    def enabled(self):
-        return self.interface.enabled
-
-    @enabled.setter
-    def enabled(self, value):
+    def set_enabled(self, value):
         if self.native:
             for widget in self.native:
                 widget.Enabled = self.interface.enabled

--- a/src/winforms/toga_winforms/command.py
+++ b/src/winforms/toga_winforms/command.py
@@ -13,3 +13,12 @@ class Command:
                 self.interface.icon = CoreIcon(self.interface.icon_id)
         else:
             self.interface.icon = None
+
+    @property
+    def enabled(self):
+        return self.interface.enabled
+
+    @enabled.setter
+    def enabled(self, value):
+        for widget in self.interface._widgets:
+            widget.Enabled = self.interface.enabled

--- a/src/winforms/toga_winforms/command.py
+++ b/src/winforms/toga_winforms/command.py
@@ -4,7 +4,7 @@ from toga.icons import Icon as CoreIcon
 class Command:
     def __init__(self, interface):
         self.interface = interface
-        self.native = None
+        self.native = []
         if self.interface.icon_id:
             # If icon_id is an icon, not a filepath
             if type(self.interface.icon_id) is not str:
@@ -20,5 +20,6 @@ class Command:
 
     @enabled.setter
     def enabled(self, value):
-        for widget in self.interface._widgets:
-            widget.Enabled = self.interface.enabled
+        if self.native:
+            for widget in self.native:
+                widget.Enabled = self.interface.enabled

--- a/src/winforms/toga_winforms/window.py
+++ b/src/winforms/toga_winforms/window.py
@@ -43,14 +43,15 @@ class Window:
             elif cmd == SECTION_BREAK:
                 item = WinForms.ToolStripSeparator()
             else:
-                cmd.bind(self.interface.factory)
+                cmd_impl = cmd.bind(self.interface.factory)
+                print("Cmd impl is ", cmd_impl)
                 if cmd.icon is not None:
                     native_icon = cmd.icon.bind(self.interface.factory).native
                     item = WinForms.ToolStripMenuItem(cmd.label, native_icon.ToBitmap())
                 else:
                     item = WinForms.ToolStripMenuItem(cmd.label)
                 item.Click += add_handler(cmd)
-                cmd._widgets.append(item)
+                cmd_impl.native.append(item)
             self.toolbar_native.Items.Add(item)
 
     def set_position(self, position):

--- a/src/winforms/toga_winforms/window.py
+++ b/src/winforms/toga_winforms/window.py
@@ -43,14 +43,13 @@ class Window:
             elif cmd == SECTION_BREAK:
                 item = WinForms.ToolStripSeparator()
             else:
-                cmd_impl = cmd.bind(self.interface.factory)
                 if cmd.icon is not None:
                     native_icon = cmd.icon.bind(self.interface.factory).native
                     item = WinForms.ToolStripMenuItem(cmd.label, native_icon.ToBitmap())
                 else:
                     item = WinForms.ToolStripMenuItem(cmd.label)
                 item.Click += add_handler(cmd)
-                cmd_impl.native.append(item)
+                cmd._impl.native.append(item)
             self.toolbar_native.Items.Add(item)
 
     def set_position(self, position):

--- a/src/winforms/toga_winforms/window.py
+++ b/src/winforms/toga_winforms/window.py
@@ -44,7 +44,6 @@ class Window:
                 item = WinForms.ToolStripSeparator()
             else:
                 cmd_impl = cmd.bind(self.interface.factory)
-                print("Cmd impl is ", cmd_impl)
                 if cmd.icon is not None:
                     native_icon = cmd.icon.bind(self.interface.factory).native
                     item = WinForms.ToolStripMenuItem(cmd.label, native_icon.ToBitmap())

--- a/src/winforms/toga_winforms/window.py
+++ b/src/winforms/toga_winforms/window.py
@@ -49,8 +49,8 @@ class Window:
                     item = WinForms.ToolStripMenuItem(cmd.label, native_icon.ToBitmap())
                 else:
                     item = WinForms.ToolStripMenuItem(cmd.label)
-
                 item.Click += add_handler(cmd)
+                cmd._widgets.append(item)
             self.toolbar_native.Items.Add(item)
 
     def set_position(self, position):


### PR DESCRIPTION
Signed-off-by: obulat <obulat@gmail.com>

<!--- Describe your changes in detail -->
Commands in Winforms can now be enabled/disabled. 
<!--- What problem does this change solve? -->
It turns out that commands in toolbar were not added correctly. The `command._impl` was not added to `command._widgets`, which made it impossible to interact with it. Also, there was no handling of enabling/disabling commands in Winforms backend.
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
