### PR TITLE
fix: load module on win7; set DPIAware on win7

### DIFF
--- a/src/winforms/toga_winforms/app.py
+++ b/src/winforms/toga_winforms/app.py
@@ -2,7 +2,7 @@ import sys
 
 import toga
 
-from .libs import Threading, WinForms, add_handler, user32, win_version, ctypes
+from .libs import Threading, WinForms, add_handler, user32, win_version, shcore
 from .window import Window
 
 
@@ -30,7 +30,7 @@ class App:
             # SetProcessDpiAwareness(True)
             if ((win_version.Major == 6 and win_version.Minor == 3) or
                     (win_version.Major == 10 and win_version.Build < 15063)):
-                ctypes.windll.shcore.SetProcessDpiAwareness(True)
+                shcore.SetProcessDpiAwareness(True)
             # Represents Windows 10 Build 1703 and beyond which should use
             # SetProcessDpiAwarenessContext(-2)
             elif win_version.Major == 10 and win_version.Build >= 15063:

--- a/src/winforms/toga_winforms/app.py
+++ b/src/winforms/toga_winforms/app.py
@@ -2,7 +2,7 @@ import sys
 
 import toga
 
-from .libs import Threading, WinForms, add_handler, user32, win_version, shcore
+from .libs import Threading, WinForms, add_handler, user32, win_version, ctypes
 from .window import Window
 
 
@@ -30,14 +30,14 @@ class App:
             # SetProcessDpiAwareness(True)
             if ((win_version.Major == 6 and win_version.Minor == 3) or
                     (win_version.Major == 10 and win_version.Build < 15063)):
-                shcore.SetProcessDpiAwareness(True)
+                ctypes.windll.shcore.SetProcessDpiAwareness(True)
             # Represents Windows 10 Build 1703 and beyond which should use
             # SetProcessDpiAwarenessContext(-2)
             elif win_version.Major == 10 and win_version.Build >= 15063:
                 user32.SetProcessDpiAwarenessContext(-2)
-            # Any other version of windows should use SetProcessDPIAware(True)
+            # Any other version of windows should use SetProcessDPIAware()
             else:
-                user32.SetProcessDPIAware(True)
+                user32.SetProcessDPIAware()
 
         self.native.EnableVisualStyles()
         self.native.SetCompatibleTextRenderingDefault(False)

--- a/src/winforms/toga_winforms/libs.py
+++ b/src/winforms/toga_winforms/libs.py
@@ -31,7 +31,6 @@ from toga.fonts import (
 )  # noqa: E402
 
 user32 = ctypes.windll.user32
-shcore = ctypes.windll.shcore
 win_version = Environment.OSVersion.Version
 
 

--- a/src/winforms/toga_winforms/libs.py
+++ b/src/winforms/toga_winforms/libs.py
@@ -31,6 +31,12 @@ from toga.fonts import (
 )  # noqa: E402
 
 user32 = ctypes.windll.user32
+# shcore dll not exist on some Windows versions
+# win_version should be checked to ensure proper usage
+try:
+    shcore = ctypes.windll.shcore
+except OSError:
+    shcore = None
 win_version = Environment.OSVersion.Version
 
 


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

Example app crashes on Windows 7 due to:

Issue1:
shcore is loaded on win7 despite the fact that is not available there. It is from win8.1 (what is properly noticed in comment before shcore usage).  shcore was used only once in whole code.

Issue2:
`user32.SetProcessDPIAware()` shouldn't have an argument. Documentation: https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setprocessdpiaware

Tested on Windows 7 only.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [N/A] All new features have been tested
- [N/A] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
