### PR TITLE
Set font for MultilineTextInput on Cocoa

### DIFF
--- a/src/cocoa/toga_cocoa/widgets/multilinetextinput.py
+++ b/src/cocoa/toga_cocoa/widgets/multilinetextinput.py
@@ -1,6 +1,6 @@
-from travertino.size import at_least
-
+from toga_cocoa.colors import native_color
 from toga_cocoa.libs import *
+from travertino.size import at_least
 
 from .base import Widget
 
@@ -51,6 +51,14 @@ class MultilineTextInput(Widget):
 
     def set_value(self, value):
         self.text.string = self.interface._value
+
+    def set_color(self, value):
+        if value:
+            self.text.textColor = native_color(value)
+
+    def set_font(self, value):
+        if value:
+            self.text.font = value._impl.native
 
     def rehint(self):
         self.interface.intrinsic.width = at_least(self.interface.MIN_WIDTH)

--- a/src/cocoa/toga_cocoa/widgets/multilinetextinput.py
+++ b/src/cocoa/toga_cocoa/widgets/multilinetextinput.py
@@ -1,5 +1,6 @@
 from toga_cocoa.colors import native_color
-from toga_cocoa.libs import *
+from toga_cocoa.libs import (NSBezelBorder, NSScrollView, NSTextView,
+                             NSViewWidthSizable, objc_method)
 from travertino.size import at_least
 
 from .base import Widget


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
MultilineTextInput on Cocoa didn't have options for setting font. Let's add that.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
