### PR TITLE
Add Winforms-compatible asyncio Proactor.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,7 @@ exclude=\
     src/*/build,\
     src/gtk/toga_gtk/libs/gtk.py
     src/gtk/toga_gtk/libs/__init__.py
+    src/winforms/toga_winforms/libs/__init__.py
     examples/.template,\
     examples/*/android,\
     examples/*/linux,\

--- a/src/android/toga_android/app.py
+++ b/src/android/toga_android/app.py
@@ -57,6 +57,9 @@ class App:
         # main Android event loop.
         pass
 
+    def set_main_window(self, window):
+        pass
+
     def exit(self):
         pass
 

--- a/src/cocoa/toga_cocoa/app.py
+++ b/src/cocoa/toga_cocoa/app.py
@@ -186,6 +186,9 @@ class App:
 
         self.loop.run_forever(lifecycle=CocoaLifecycle(self.native))
 
+    def set_main_window(self, window):
+        pass
+
     def exit(self):
         self.native.terminate(None)
 

--- a/src/core/toga/app.py
+++ b/src/core/toga/app.py
@@ -123,6 +123,7 @@ class App:
     def main_window(self, window):
         self._main_window = window
         window.app = self
+        self._impl.set_main_window(window)
 
     @property
     def current_window(self):

--- a/src/django/toga_django/app.py
+++ b/src/django/toga_django/app.py
@@ -40,6 +40,9 @@ class App(AppInterface):
     def create_menus(self):
         self.interface.factory.not_implemented('App.create_menus()')
 
+    def set_main_window(self, window):
+        pass
+
     def exit(self):
         pass
 

--- a/src/dummy/toga_dummy/app.py
+++ b/src/dummy/toga_dummy/app.py
@@ -23,6 +23,9 @@ class App(LoggedObject):
     def main_loop(self):
         self._action('main loop')
 
+    def set_main_window(self, window):
+        self._set_value('main_window', window)
+
     def exit(self):
         self._action('exit')
 

--- a/src/gtk/toga_gtk/app.py
+++ b/src/gtk/toga_gtk/app.py
@@ -175,6 +175,9 @@ class App:
 
         self.loop.run_forever(application=self.native)
 
+    def set_main_window(self, window):
+        pass
+
     def exit(self):
         self.native.quit()
 

--- a/src/iOS/toga_iOS/app.py
+++ b/src/iOS/toga_iOS/app.py
@@ -110,6 +110,9 @@ class App:
 
         self.loop.run_forever(lifecycle=iOSLifecycle())
 
+    def set_main_window(self, window):
+        pass
+
     def exit(self):
         pass
 

--- a/src/winforms/setup.py
+++ b/src/winforms/setup.py
@@ -1,4 +1,4 @@
-#/usr/bin/env python
+#!/usr/bin/env python
 import io
 import re
 

--- a/src/winforms/toga_winforms/app.py
+++ b/src/winforms/toga_winforms/app.py
@@ -5,7 +5,7 @@ import traceback
 import toga
 from toga.handlers import wrapped_handler
 
-from .libs import WinForms, add_handler, user32, win_version, shcore
+from .libs import WinForms, user32, win_version, shcore
 from .libs.proactor import WinformsProactorEventLoop
 from .window import Window
 
@@ -83,7 +83,7 @@ class App:
                         submenu = WinForms.ToolStripMenuItem(cmd.group.label)
                     item = WinForms.ToolStripMenuItem(cmd.label)
                     if cmd.action:
-                        item.Click += add_handler(cmd)
+                        item.Click += cmd._impl.as_handler()
                     else:
                         item.Enabled = False
                     cmd._impl.native.append(item)
@@ -137,7 +137,7 @@ class App:
             traceback.print_exc()
 
     def app_exit_handler(self, sender, *args, **kwargs):
-        print("APP EXIT")
+        pass
 
     def exit(self):
         self.native.Exit()

--- a/src/winforms/toga_winforms/app.py
+++ b/src/winforms/toga_winforms/app.py
@@ -15,7 +15,6 @@ class MainWindow(Window):
         pass
 
 
-
 class App:
     _MAIN_WINDOW_CLASS = MainWindow
 

--- a/src/winforms/toga_winforms/app.py
+++ b/src/winforms/toga_winforms/app.py
@@ -15,17 +15,6 @@ class MainWindow(Window):
         pass
 
 
-class MessageFilter(WinForms.IMessageFilter):
-    __namespace__ = 'System.Windows.Forms'
-
-    # def __init__(self, app):
-    #     self.app = app
-
-    def PreFilterMessage(self, message):
-        print('ping', message)
-        # print(self.app, "Filter message", message)
-        return False
-
 
 class App:
     _MAIN_WINDOW_CLASS = MainWindow
@@ -142,14 +131,7 @@ class App:
             self.native.ThreadException += self.app_exception_handler
             self.native.ApplicationExit += self.app_exit_handler
 
-            # self.filter = MessageFilter()
-            # self.native.AddMessageFilter(self.filter)
-
-            # self.filter.PreFilterMessage('MSG IS DUMMY')
-
-            self.loop.setup_run_forever(self.app_context)
-
-            self.native.Run(self.app_context)
+            self.loop.run_forever(self.app_context)
         except:  # NOQA
             traceback.print_exc()
 

--- a/src/winforms/toga_winforms/command.py
+++ b/src/winforms/toga_winforms/command.py
@@ -18,3 +18,9 @@ class Command:
         if self.native:
             for widget in self.native:
                 widget.Enabled = self.interface.enabled
+
+    def as_handler(self):
+        def handler(sender, event):
+            return self.interface.action(None)
+
+        return handler

--- a/src/winforms/toga_winforms/icons.py
+++ b/src/winforms/toga_winforms/icons.py
@@ -34,9 +34,12 @@ class Icon:
             self.native = create_icon_from_file(file_path + '.bmp')
 
         else:
-            print("[Winforms] No valid icon format available for {}; "
-                  "fall back on Tiberius instead".format(
-                self.interface.filename))
+            print(
+                "[Winforms] No valid icon format available for {}; "
+                "fall back on Tiberius instead".format(
+                    self.interface.filename
+                )
+            )
             tiberius_file = toga_Icon.TIBERIUS_ICON.filename + '.ico'
             self.interface.icon = toga_Icon.TIBERIUS_ICON
             self.native = WinIcon(tiberius_file)

--- a/src/winforms/toga_winforms/images.py
+++ b/src/winforms/toga_winforms/images.py
@@ -1,6 +1,7 @@
 from toga_winforms.libs import WinImage
 import os
 
+
 class Image(object):
     def __init__(self, interface):
         self.interface = interface

--- a/src/winforms/toga_winforms/libs/__init__.py
+++ b/src/winforms/toga_winforms/libs/__init__.py
@@ -7,6 +7,7 @@ from .winforms import (  # noqa: F401
     Point,
     Single,
     Size,
+    Threading,
     Uri,
     WinDateTime,
     WinFont,

--- a/src/winforms/toga_winforms/libs/__init__.py
+++ b/src/winforms/toga_winforms/libs/__init__.py
@@ -1,0 +1,10 @@
+from .winforms import (   # noqa: E401
+    WinForms, Single,
+    Convert, WinDateTime, Uri,
+    WinIcon, WinImage, WinFont,
+    ContentAlignment, Size, Point,
+    TextAlignment, HorizontalTextAlignment,
+    FontFamily, FontStyle, win_font_family,
+    Text, Color, Bitmap,
+    add_handler, user32, win_version, shcore
+)

--- a/src/winforms/toga_winforms/libs/__init__.py
+++ b/src/winforms/toga_winforms/libs/__init__.py
@@ -1,4 +1,4 @@
-from .winforms import (   # noqa: E401
+from .winforms import (  # noqa: F401
     WinForms, Single,
     Convert, WinDateTime, Uri,
     WinIcon, WinImage, WinFont,

--- a/src/winforms/toga_winforms/libs/__init__.py
+++ b/src/winforms/toga_winforms/libs/__init__.py
@@ -1,10 +1,24 @@
 from .winforms import (  # noqa: F401
-    WinForms, Single,
-    Convert, WinDateTime, Uri,
-    WinIcon, WinImage, WinFont,
-    ContentAlignment, Size, Point,
-    TextAlignment, HorizontalTextAlignment,
-    FontFamily, FontStyle, win_font_family,
-    Text, Color, Bitmap,
-    add_handler, user32, win_version, shcore
+    Bitmap,
+    Color,
+    Convert,
+    FontFamily,
+    FontStyle,
+    Point,
+    Single,
+    Size,
+    Uri,
+    WinDateTime,
+    WinFont,
+    WinForms,
+    WinIcon,
+    WinImage,
+    shcore,
+    user32,
+    win_version
+)
+from .fonts import (
+    HorizontalTextAlignment,
+    TextAlignment,
+    win_font_family
 )

--- a/src/winforms/toga_winforms/libs/fonts.py
+++ b/src/winforms/toga_winforms/libs/fonts.py
@@ -1,0 +1,54 @@
+from .winforms import ContentAlignment, FontFamily, WinForms, SystemFonts, Text
+
+from toga.constants import LEFT, RIGHT, CENTER, JUSTIFY
+from toga.fonts import (
+    MESSAGE,
+    SYSTEM,
+    SERIF,
+    SANS_SERIF,
+    CURSIVE,
+    FANTASY,
+    MONOSPACE,
+)
+
+
+def TextAlignment(value):
+    return {
+        LEFT: ContentAlignment.MiddleLeft,
+        RIGHT: ContentAlignment.MiddleRight,
+        CENTER: ContentAlignment.MiddleCenter,
+        JUSTIFY: ContentAlignment.MiddleLeft,
+    }[value]
+
+
+# Justify simply sets Left alignment. Is this the best option?
+def HorizontalTextAlignment(value):
+    return {
+        LEFT: WinForms.HorizontalAlignment.Left,
+        RIGHT: WinForms.HorizontalAlignment.Right,
+        CENTER: WinForms.HorizontalAlignment.Center,
+        JUSTIFY: WinForms.HorizontalAlignment.Left,
+    }[value]
+
+
+def win_font_family(value):
+    win_families = {
+        SYSTEM: SystemFonts.DefaultFont.FontFamily,
+        MESSAGE: SystemFonts.MenuFont.FontFamily,
+        SERIF: FontFamily.GenericSerif,
+        SANS_SERIF: FontFamily.GenericSansSerif,
+        CURSIVE: FontFamily("Comic Sans MS"),
+        FANTASY: FontFamily("Impact"),
+        MONOSPACE: FontFamily.GenericMonospace,
+    }
+    for key in win_families:
+        if value in key:
+            return win_families[key]
+    if value in Text.InstalledFontCollection().Families:
+        return FontFamily(value)
+    else:
+        print(
+            "Unable to load font-family '{}', loading {} instead".format(
+                value, SystemFonts.DefaultFont.FontFamily)
+        )
+        return SystemFonts.DefaultFont.FontFamily

--- a/src/winforms/toga_winforms/libs/proactor.py
+++ b/src/winforms/toga_winforms/libs/proactor.py
@@ -3,18 +3,57 @@ import sys
 import threading
 from asyncio import events
 
-from .winforms import Action, Task
+from .winforms import Action, Task, WinForms, user32
+
+
+class AsyncIOTickMessageFilter(WinForms.IMessageFilter):
+    """
+    A Winforms message filter that will catch the request to tick the Asyncio
+    event loop.
+    """
+    __namespace__ = 'System.Windows.Forms'
+
+    def __init__(self, loop, msg_id):
+        self.loop = loop
+        self.msg_id = msg_id
+
+    def PreFilterMessage(self, message):
+        print('ping', message)
+        if message.Msg == self.msg_id:
+            print("asyncio tick message!!")
+            self.loop.run_once_recurring()
+            return True
+        # print("Filter message", message)
+        return False
 
 
 class WinformsProactorEventLoop(asyncio.ProactorEventLoop):
-    def setup_run_forever(self, app_context):
-        """Set up the asyncio event loop.
+    def run_forever(self, app_context):
+        """Set up the asyncio event loop, integrate it with the Winforms
+        event loop, and start the application.
 
         This largely duplicates the setup behavior of the default Proactor
         run_forever implementation.
+
+        :param app_context: The WinForms.ApplicationContext instance
+            controlling the lifecycle of the app.
         """
+        # Remember the application context.
         self.app_context = app_context
 
+        # Register a custom user window message.
+        self.msg_id = user32.RegisterWindowMessageA("Python asyncio tick")
+        # Add a message filter to listen for the asyncio tick message
+        msg_filter = AsyncIOTickMessageFilter(self, self.msg_id)
+        # FIXME: Actually install the message filter.
+        # WinForms.Application.AddMessageFilter(msg_filter)
+
+        # Setup the Proactor.
+        # The code between the following markers should be exactly the same as
+        # the official CPython implementation, up to the start of the
+        # `while True:` part of run_forever() (see BaseEventLoop.run_forever()
+        # in Lib/ascynio/base_events.py)
+        # === START BaseEventLoop.run_forever() setup ===
         self._check_closed()
         if self.is_running():
             raise RuntimeError('This event loop is already running')
@@ -35,26 +74,64 @@ class WinformsProactorEventLoop(asyncio.ProactorEventLoop):
             pass
 
         events._set_running_loop(self)
-        # Queue the first asyncio tick.
-        self.queue_tick()
+        # === END BaseEventLoop.run_forever() setup ===
 
-    def queue_tick(self):
-        Task.Delay(500).ContinueWith(Action[Task](self.tick))
+        # Rather than going into a `while True:` loop, we're going to use the
+        # Winforms event loop to queue a tick() message that will cause a
+        # single iteration of the asyncio event loop to be executed. Each time
+        # we do this, we queue *another* tick() message in 5ms time. In this
+        # way, we'll get a continuous stream of tick() calls, without blocking
+        # the Winforms event loop.
+
+        # Queue the first asyncio tick.
+        self.enqueue_tick()
+
+        # Start the Winforms event loop.
+        WinForms.Application.Run(self.app_context)
+
+    def enqueue_tick(self):
+        # Queue a call to tick in 5ms.
+        Task.Delay(5).ContinueWith(Action[Task](self.tick))
 
     def tick(self, *args, **kwargs):
         """
-        Run a single iteration of the event loop on the main GUI thread,
-        and enqueue the next iteration (if we're not stopping).
+        Cause a single iteration of the event loop to run on the main GUI thread.
+        """
+        # Post a userspace message that will trigger running an iteration
+        # of the asyncio event loop. This can't be done directly, because the
+        # tick() will be executing in a threadpool, and we need the asyncio
+        # handling to occur in the main GUI thread. However, by positing a
+        # message, it will be caught by the MessageFilter we installed on the
+        # Application thread.
+
+        # The message is sent with:
+        # * HWND 0xfff (all windows),
+        # * MSG self.msg_id (a message ID in the WM_USER range)
+        # * LPARAM and WPARAM empty (no extra details needed; just tick!)
+        user32.PostMessageA(0xffff, self.msg_id, None, None)
+
+        # FIXME: Once we have a working message filter, this invoke call
+        # can be removed.
+        # If the app context has a main form, invoke run_once_recurring()
+        # on the thread associated with that form.
+        if self.app_context.MainForm:
+            self.app_context.MainForm.Invoke(Action(self.run_once_recurring))
+
+    def run_once_recurring(self):
+        """
+        Run one iteration of the event loop, and enqueue the next iteration
+        (if we're not stopping).
 
         This largely duplicates the "finally" behavior of the default Proactor
         run_forever implementation.
         """
-        # Run one iteration of the event loop on the main GUI thread
-        if self.app_context.MainForm:
-            self.app_context.MainForm.Invoke(Action(self._run_once))
+        # Perform one tick of the event loop.
+        self._run_once()
 
         if self._stopping:
-            # If we're stopping, close down the event loop
+            # If we're stopping, we can do the "finally" handling from
+            # the BaseEventLoop run_forever().
+            # === START BaseEventLoop.run_forever() finally handling ===
             self._stopping = False
             self._thread_id = None
             events._set_running_loop(None)
@@ -65,11 +142,14 @@ class WinformsProactorEventLoop(asyncio.ProactorEventLoop):
                 # Python < 3.6 didn't have set_asyncgen_hooks.
                 # No action required for those versions.
                 pass
+            # === END BaseEventLoop.run_forever() finally handling ===
         else:
-            # Live to tick another day. Enqueue the next tick,
+            # Otherwise, live to tick another day. Enqueue the next tick,
             # and make sure there will be *something* to be processed.
-            self.queue_tick()
-            self.call_soon_threadsafe(lambda: True)
+            # If you don't ensure there is at least one message on the
+            # queue, the select() call will block, locking the app.
+            self.enqueue_tick()
+            self.call_soon_threadsafe(lambda: 0)
 
 
 # Python 3.7 changed the name of an internal wrapper function.

--- a/src/winforms/toga_winforms/libs/proactor.py
+++ b/src/winforms/toga_winforms/libs/proactor.py
@@ -44,8 +44,8 @@ class WinformsProactorEventLoop(asyncio.ProactorEventLoop):
         # Register a custom user window message.
         self.msg_id = user32.RegisterWindowMessageA("Python asyncio tick")
         # Add a message filter to listen for the asyncio tick message
-        msg_filter = AsyncIOTickMessageFilter(self, self.msg_id)
         # FIXME: Actually install the message filter.
+        # msg_filter = AsyncIOTickMessageFilter(self, self.msg_id)
         # WinForms.Application.AddMessageFilter(msg_filter)
 
         # Setup the Proactor.

--- a/src/winforms/toga_winforms/libs/proactor.py
+++ b/src/winforms/toga_winforms/libs/proactor.py
@@ -1,0 +1,75 @@
+import asyncio
+import sys
+import threading
+from asyncio import events
+
+from .winforms import Action, Task
+
+
+class WinformsProactorEventLoop(asyncio.ProactorEventLoop):
+    def setup_run_forever(self):
+        """Set up the asyncio event loop.
+
+        This largely duplicates the setup behavior of the default Proactor
+        run_forever implementation.
+        """
+        self._check_closed()
+        if self.is_running():
+            raise RuntimeError('This event loop is already running')
+        if events._get_running_loop() is not None:
+            raise RuntimeError(
+                'Cannot run the event loop while another loop is running')
+        self._set_coroutine_origin_tracking(self._debug)
+        self._thread_id = threading.get_ident()
+        try:
+            self._old_agen_hooks = sys.get_asyncgen_hooks()
+            sys.set_asyncgen_hooks(
+                firstiter=self._asyncgen_firstiter_hook,
+                finalizer=self._asyncgen_finalizer_hook
+            )
+        except AttributeError:
+            # Python < 3.6 didn't have sys.get_asyncgen_hooks();
+            # No action required for those versions.
+            pass
+
+        events._set_running_loop(self)
+        # Queue the first asyncio tick.
+        self.queue_tick()
+
+    def queue_tick(self):
+        Task.Delay(5).ContinueWith(Action[Task](self.tick))
+
+    def tick(self, *args, **kwargs):
+        """
+        Run a single iteration of the event loop on the main GUI thread,
+        and enqueue the next iteration (if we're not stopping).
+
+        This largely duplicates the "finally" behavior of the default Proactor
+        run_forever implementation.
+        """
+        # Run one iteration of the event loop on the main GUI thread
+        self._form.Invoke(Action(self._run_once))
+
+        if self._stopping:
+            # If we're stopping, close down the event loop
+            self._stopping = False
+            self._thread_id = None
+            events._set_running_loop(None)
+            self._set_coroutine_origin_tracking(False)
+            try:
+                sys.set_asyncgen_hooks(*self._old_agen_hooks)
+            except AttributeError:
+                # Python < 3.6 didn't have set_asyncgen_hooks.
+                # No action required for those versions.
+                pass
+        else:
+            # Live to tick another day. Enqueue the next tick,
+            # and make sure there will be *something* to be processed.
+            self.queue_tick()
+            self.call_soon_threadsafe(lambda: True)
+
+
+# Python 3.7 changed the name of an internal wrapper function.
+# Install an alias for the old name at the new name if
+if sys.version_info < (3, 7):
+    WinformsProactorEventLoop._set_coroutine_origin_tracking = WinformsProactorEventLoop._set_coroutine_wrapper

--- a/src/winforms/toga_winforms/libs/winforms.py
+++ b/src/winforms/toga_winforms/libs/winforms.py
@@ -4,7 +4,7 @@ import clr
 
 clr.AddReference("System.Windows.Forms")
 
-import System.Windows.Forms as WinForms  # noqa: E402
+import System.Windows.Forms as WinForms  # noqa: E402, F401
 from System import Action  # noqa: E402, F401
 from System import Single  # noqa: E402, F401
 from System import Convert  # noqa: E402, F401
@@ -20,16 +20,6 @@ from System.Drawing import FontFamily, FontStyle, SystemFonts  # noqa: E402, F40
 from System.Drawing import Text, Color, Bitmap  # noqa: E402, F401
 from System.Threading.Tasks import Task  # noqa: E402, F401
 
-from toga.constants import LEFT, RIGHT, CENTER, JUSTIFY  # noqa: E402
-from toga.fonts import (
-    MESSAGE,
-    SYSTEM,
-    SERIF,
-    SANS_SERIF,
-    CURSIVE,
-    FANTASY,
-    MONOSPACE,
-)  # noqa: E402
 
 user32 = ctypes.windll.user32
 # shcore dll not exist on some Windows versions
@@ -39,54 +29,3 @@ try:
 except OSError:
     shcore = None
 win_version = Environment.OSVersion.Version
-
-
-def TextAlignment(value):
-    return {
-        LEFT: ContentAlignment.MiddleLeft,
-        RIGHT: ContentAlignment.MiddleRight,
-        CENTER: ContentAlignment.MiddleCenter,
-        JUSTIFY: ContentAlignment.MiddleLeft,
-    }[value]
-
-
-# Justify simply sets Left alignment. Is this the best option?
-def HorizontalTextAlignment(value):
-    return {
-        LEFT: WinForms.HorizontalAlignment.Left,
-        RIGHT: WinForms.HorizontalAlignment.Right,
-        CENTER: WinForms.HorizontalAlignment.Center,
-        JUSTIFY: WinForms.HorizontalAlignment.Left,
-    }[value]
-
-
-def add_handler(cmd):
-    action = cmd.action
-
-    def handler(sender, event):
-        return action(None)
-
-    return handler
-
-
-def win_font_family(value):
-    win_families = {
-        SYSTEM: SystemFonts.DefaultFont.FontFamily,
-        MESSAGE: SystemFonts.MenuFont.FontFamily,
-        SERIF: FontFamily.GenericSerif,
-        SANS_SERIF: FontFamily.GenericSansSerif,
-        CURSIVE: FontFamily("Comic Sans MS"),
-        FANTASY: FontFamily("Impact"),
-        MONOSPACE: FontFamily.GenericMonospace,
-    }
-    for key in win_families:
-        if value in key:
-            return win_families[key]
-    if value in Text.InstalledFontCollection().Families:
-        return FontFamily(value)
-    else:
-        print(
-            "Unable to load font-family '{}', loading {} instead".format(
-                value, SystemFonts.DefaultFont.FontFamily)
-        )
-        return SystemFonts.DefaultFont.FontFamily

--- a/src/winforms/toga_winforms/libs/winforms.py
+++ b/src/winforms/toga_winforms/libs/winforms.py
@@ -5,11 +5,10 @@ import clr
 clr.AddReference("System.Windows.Forms")
 
 import System.Windows.Forms as WinForms  # noqa: E402
-from System import Decimal as ClrDecimal  # noqa: E402, F401
+from System import Action  # noqa: E402, F401
 from System import Single  # noqa: E402, F401
 from System import Convert  # noqa: E402, F401
 from System import DateTime as WinDateTime  # noqa: E402, F401
-from System import Threading  # noqa: E402, F401
 from System import Uri  # noqa: E402, F401
 from System import Environment  # noqa: E402, F401
 
@@ -19,6 +18,8 @@ from System.Drawing import Font as WinFont  # noqa: E402, F401
 from System.Drawing import ContentAlignment, Size, Point  # noqa: E402, F401
 from System.Drawing import FontFamily, FontStyle, SystemFonts  # noqa: E402, F401
 from System.Drawing import Text, Color, Bitmap  # noqa: E402, F401
+from System.Threading.Tasks import Task  # noqa: E402, F401
+
 from toga.constants import LEFT, RIGHT, CENTER, JUSTIFY  # noqa: E402
 from toga.fonts import (
     MESSAGE,

--- a/src/winforms/toga_winforms/libs/winforms.py
+++ b/src/winforms/toga_winforms/libs/winforms.py
@@ -6,15 +6,16 @@ clr.AddReference("System.Windows.Forms")
 
 import System.Windows.Forms as WinForms  # noqa: E402, F401
 from System import Action  # noqa: E402, F401
-from System import Single  # noqa: E402, F401
 from System import Convert  # noqa: E402, F401
 from System import DateTime as WinDateTime  # noqa: E402, F401
-from System import Uri  # noqa: E402, F401
 from System import Environment  # noqa: E402, F401
+from System import Single  # noqa: E402, F401
+from System import Threading  # noqa: E402, F401
+from System import Uri  # noqa: E402, F401
 
+from System.Drawing import Font as WinFont  # noqa: E402, F401
 from System.Drawing import Icon as WinIcon  # noqa: E402, F401
 from System.Drawing import Image as WinImage  # noqa: E402, F401
-from System.Drawing import Font as WinFont  # noqa: E402, F401
 from System.Drawing import ContentAlignment, Size, Point  # noqa: E402, F401
 from System.Drawing import FontFamily, FontStyle, SystemFonts  # noqa: E402, F401
 from System.Drawing import Text, Color, Bitmap  # noqa: E402, F401

--- a/src/winforms/toga_winforms/widgets/base.py
+++ b/src/winforms/toga_winforms/widgets/base.py
@@ -37,7 +37,7 @@ class Widget:
         if self.native:
             self.native.Enabled = self.interface.enabled
 
-    ### APPLICATOR
+    # APPLICATOR
 
     @property
     def vertical_shift(self):
@@ -75,7 +75,7 @@ class Widget:
         # By default, background color can't be changed.
         pass
 
-    ### INTERFACE
+    # INTERFACE
 
     def add_child(self, child):
         if self.container:

--- a/src/winforms/toga_winforms/widgets/box.py
+++ b/src/winforms/toga_winforms/widgets/box.py
@@ -1,4 +1,4 @@
-from toga_winforms.libs import WinForms, Color, Size, Point
+from toga_winforms.libs import WinForms, Size, Point
 
 from .base import Widget
 

--- a/src/winforms/toga_winforms/widgets/numberinput.py
+++ b/src/winforms/toga_winforms/widgets/numberinput.py
@@ -1,6 +1,5 @@
 import sys
 
-from toga.constants import LEFT, RIGHT, CENTER
 from travertino.size import at_least
 
 from toga_winforms.libs import WinForms, Convert, HorizontalTextAlignment
@@ -33,7 +32,7 @@ class NumberInput(Widget):
             self.native.Maximum = Convert.ToDecimal(self.interface.max_value)
 
     def set_value(self, value):
-        if value is None or value is '':
+        if value is None or value == '':
             self.native.Value = Convert.ToDecimal(0.0)
         else:
             self.native.Value = Convert.ToDecimal(float(self.interface.value))

--- a/src/winforms/toga_winforms/widgets/numberinput.py
+++ b/src/winforms/toga_winforms/widgets/numberinput.py
@@ -1,7 +1,9 @@
 import sys
-from toga_winforms.libs import LEFT, RIGHT, CENTER
-from toga_winforms.libs import WinForms, Convert, HorizontalTextAlignment
+
+from toga.constants import LEFT, RIGHT, CENTER
 from travertino.size import at_least
+
+from toga_winforms.libs import WinForms, Convert, HorizontalTextAlignment
 
 from .base import Widget
 

--- a/src/winforms/toga_winforms/widgets/scrollcontainer.py
+++ b/src/winforms/toga_winforms/widgets/scrollcontainer.py
@@ -1,6 +1,4 @@
-from travertino.size import at_least
-
-from toga_winforms.libs import WinForms, Size, Point
+from toga_winforms.libs import WinForms
 from toga_winforms.window import WinFormsViewport
 
 from .base import Widget

--- a/src/winforms/toga_winforms/widgets/splitcontainer.py
+++ b/src/winforms/toga_winforms/widgets/splitcontainer.py
@@ -1,4 +1,4 @@
-from toga_winforms.libs import WinForms, Size, Point
+from toga_winforms.libs import WinForms
 from toga_winforms.window import WinFormsViewport
 
 from .base import Widget

--- a/src/winforms/toga_winforms/window.py
+++ b/src/winforms/toga_winforms/window.py
@@ -1,7 +1,7 @@
 from toga import GROUP_BREAK, SECTION_BREAK
 from travertino.layout import Viewport
 
-from .libs import WinForms, Size, add_handler
+from .libs import WinForms, Size
 
 
 class WinFormsViewport:
@@ -48,7 +48,7 @@ class Window:
                     item = WinForms.ToolStripMenuItem(cmd.label, native_icon.ToBitmap())
                 else:
                     item = WinForms.ToolStripMenuItem(cmd.label)
-                item.Click += add_handler(cmd)
+                item.Click += cmd._impl.as_handler()
                 cmd._impl.native.append(item)
             self.toolbar_native.Items.Add(item)
 

--- a/src/winforms/toga_winforms/window.py
+++ b/src/winforms/toga_winforms/window.py
@@ -107,8 +107,6 @@ class Window:
             int(self.interface.content.layout.height) + TITLEBAR_HEIGHT
         )
         self.interface.content.refresh()
-        if self.interface is self.interface.app._main_window:
-            self.native.FormClosing += self.winforms_FormClosing
 
         self.native.Show()
 

--- a/src/winforms/toga_winforms/window.py
+++ b/src/winforms/toga_winforms/window.py
@@ -110,8 +110,7 @@ class Window:
         if self.interface is self.interface.app._main_window:
             self.native.FormClosing += self.winforms_FormClosing
 
-        if self.interface is not self.interface.app._main_window:
-            self.native.Show()
+        self.native.Show()
 
     def winforms_FormClosing(self, event, handler):
         if self.interface.app.on_exit:


### PR DESCRIPTION
Integrates the Winforms event handling lifecycle with the asyncio event loop.

This is done by instantiating a Proactor, but customizing the Proactor so that `run_forever()` is split into two parts; `setup_run_forever()` and `tick()`. The `tick()` component is what historically would have been run as a tight "while True" loop; in this version, the call to tick is scheduled to run every 5ms using the winforms event infrastructure.

It also involves some refactoring of the winforms libs - they were starting to get unwieldly, and introducing the Proactor was a good opportunity to modularize that code.

Huge thanks for @hawkowl for the many, many pointers on getting this going.
