### PR TITLE
Add placeholder implementation to textinput in Winforms

### DIFF
--- a/src/winforms/toga_winforms/widgets/textinput.py
+++ b/src/winforms/toga_winforms/widgets/textinput.py
@@ -32,8 +32,7 @@ class TextInput(Widget):
         return self.native.Text
 
     def set_value(self, value):
-        if value:
-            self.native.Text = value
+        self.native.Text = value
 
     def set_alignment(self, value):
         self.native.TextAlign = HorizontalTextAlignment(value)

--- a/src/winforms/toga_winforms/widgets/textinput.py
+++ b/src/winforms/toga_winforms/widgets/textinput.py
@@ -1,4 +1,4 @@
-from toga_winforms.libs import WinForms, HorizontalTextAlignment
+from toga_winforms.libs import WinForms, HorizontalTextAlignment, Color
 from travertino.size import at_least
 
 from .base import Widget
@@ -8,18 +8,25 @@ class TextInput(Widget):
     def create(self):
         self.native = WinForms.TextBox()
         self.native.Multiline = False
+        self.native.TextChanged += self.winforms_onTextChanged
+        self.native.Leave += self.winforms_onFocusLost
 
     def set_readonly(self, value):
         self.native.ReadOnly = value
 
     def set_placeholder(self, value):
-        self.native.Text = self.interface.placeholder
+        if self.interface.placeholder and not self.interface.value:
+            self.native.Click += self.winforms_Click
+            self.native.Text = self.interface.placeholder
+            self.native.ForeColor = Color.FromName('GRAY')
 
     def get_value(self):
         return self.native.Text
 
     def set_value(self, value):
-        self.native.Text = value
+        if value:
+            self.native.ForeColor = Color.FromName('BLACK')
+            self.native.Text = value
 
     def set_alignment(self, value):
         self.native.TextAlign = HorizontalTextAlignment(value)
@@ -36,8 +43,18 @@ class TextInput(Widget):
         self.interface.intrinsic.height = self.native.PreferredSize.Height
 
     def set_on_change(self, handler):
-        self.native.TextChanged += self.on_text_change
+        pass
 
-    def on_text_change(self, sender, event):
+    def winforms_onTextChanged(self, sender, event):
         if self.interface._on_change:
             self.interface.on_change(self.interface)
+
+    def winforms_Click(self, sender, event):
+        self.native.SelectAll()
+        if self.interface.placeholder and self.get_value() == self.interface.placeholder:
+            self.native.Clear()
+            self.native.ForeColor = Color.FromName('BLACK')
+
+    def winforms_onFocusLost(self, sender, event):
+        if not self.native.Text and self.interface.placeholder:
+            self.set_placeholder(None)


### PR DESCRIPTION
Signed-off-by: obulat <obulat@gmail.com>

<!--- Describe your changes in detail -->
Added placeholder implementation to TextInput in Winforms backend. 
Winforms TextInput (TextBox) doesn't have native implementation of placeholder, so I added it myself: 
- `set_placeholder` sets text for `TextInput` and changes color to gray.
- clicking on the `TextInput` selects its text. If the current `TextInput` value is the same as the `self.interface.placeholder` value, the text is deleted and text color is set to black.
- when the `TextInput` loses focus, if the user didn't type anything in and there is a placeholder value, the `TextInput` text is again set back to grayed out placeholder text.

One question I have is this: should placeholder text be returned as value of the `TextInput`? If not, I need to add one more change to the code: returning '' as value if the text of `TextInput` is gray, else returning current text.
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
