### PR TITLE
Platform support matrix for widgets

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,14 @@
+div.body table.widget-descriptions td p
+{
+    text-align: center;
+}
+div.body table.widget-support th p,
+div.body table.widget-support td p {
+    text-align: center;
+}
+
+div.body table.widget-descriptions td:first-of-type p,
+div.body table.widget-descriptions th:first-of-type p
+{
+    text-align: left;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,8 +25,7 @@ sys.path.insert(0, os.path.abspath('../src/core/'))
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.napoleon', 'sphinx.ext.todo', 'sphinx_tabs.tabs']
-
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.napoleon', 'sphinx.ext.todo', 'sphinx_tabs.tabs', 'crate.sphinx.csv']
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
@@ -193,6 +192,10 @@ try:
 except ImportError:
     # The sphinx-rtd-theme package is not installed, so to the default
     pass
+
+html_css_files = [
+    'custom.css',
+]
 
 # -- Options for LaTeX output --------------------------------------------------
 

--- a/docs/reference/api/app.rst
+++ b/docs/reference/api/app.rst
@@ -1,11 +1,12 @@
 Application
 ===========
 
-======= ====== ========= ===== ========= ========
- macOS   GTK+   Windows   iOS   Android   Django
-======= ====== ========= ===== ========= ========
- |y|     |y|    |y|       |y|   |y|       |y|
-======= ====== ========= ===== ========= ========
+.. rst-class:: widget-support
+.. csv-filter::
+   :header-rows: 1
+   :file: ../data/widgets_by_platform.csv
+   :included_cols: 4,5,6,7,8,9
+   :exclude: {0: '(?!(App|Component))'}
 
 .. |y| image:: /_static/yes.png
     :width: 16

--- a/docs/reference/api/containers/box.rst
+++ b/docs/reference/api/containers/box.rst
@@ -1,11 +1,12 @@
 Box
 ===
 
-======= ====== ========= ===== ========= ========
- macOS   GTK+   Windows   iOS   Android   Django
-======= ====== ========= ===== ========= ========
- |y|     |y|    |y|       |y|   |y|       |y|
-======= ====== ========= ===== ========= ========
+.. rst-class:: widget-support
+.. csv-filter::
+   :header-rows: 1
+   :file: ../../data/widgets_by_platform.csv
+   :included_cols: 4,5,6,7,8,9
+   :exclude: {0: '(?!(Box|Component))'}
 
 .. |y| image:: /_static/yes.png
     :width: 16

--- a/docs/reference/api/containers/optioncontainer.rst
+++ b/docs/reference/api/containers/optioncontainer.rst
@@ -1,11 +1,12 @@
 Option Container
 ================
 
-======= ====== ========= ===== ========= ========
- macOS   GTK+   Windows   iOS   Android   Django
-======= ====== ========= ===== ========= ========
- |y|     |y|    |y|
-======= ====== ========= ===== ========= ========
+.. rst-class:: widget-support
+.. csv-filter::
+   :header-rows: 1
+   :file: ../../data/widgets_by_platform.csv
+   :included_cols: 4,5,6,7,8,9
+   :exclude: {0: '(?!(OptionContainer|Component))'}
 
 .. |y| image:: /_static/yes.png
     :width: 16

--- a/docs/reference/api/containers/scrollcontainer.rst
+++ b/docs/reference/api/containers/scrollcontainer.rst
@@ -1,11 +1,12 @@
 Scroll Container
 ================
 
-======= ====== ========= ===== ========= ========
- macOS   GTK+   Windows   iOS   Android   Django
-======= ====== ========= ===== ========= ========
- |y|     |y|    |y|      |y|
-======= ====== ========= ===== ========= ========
+.. rst-class:: widget-support
+.. csv-filter::
+   :header-rows: 1
+   :file: ../../data/widgets_by_platform.csv
+   :included_cols: 4,5,6,7,8,9
+   :exclude: {0: '(?!(ScrollContainer|Component))'}
 
 .. |y| image:: /_static/yes.png
     :width: 16

--- a/docs/reference/api/containers/splitcontainer.rst
+++ b/docs/reference/api/containers/splitcontainer.rst
@@ -1,11 +1,12 @@
 Split Container
 ===============
 
-======= ====== ========= ===== ========= ========
- macOS   GTK+   Windows   iOS   Android   Django
-======= ====== ========= ===== ========= ========
- |y|     |y|    |y|
-======= ====== ========= ===== ========= ========
+.. rst-class:: widget-support
+.. csv-filter::
+   :header-rows: 1
+   :file: ../../data/widgets_by_platform.csv
+   :included_cols: 4,5,6,7,8,9
+   :exclude: {0: '(?!(SplitContainer|Component))'}
 
 .. |y| image:: /_static/yes.png
     :width: 16

--- a/docs/reference/api/mainwindow.rst
+++ b/docs/reference/api/mainwindow.rst
@@ -1,11 +1,12 @@
 MainWindow
 ==========
 
-======= ====== ========= ===== ========= ========
- macOS   GTK+   Windows   iOS   Android   Django
-======= ====== ========= ===== ========= ========
- |y|     |y|    |y|       |y|   |y|       |y|
-======= ====== ========= ===== ========= ========
+.. rst-class:: widget-support
+.. csv-filter::
+   :header-rows: 1
+   :file: ../data/widgets_by_platform.csv
+   :included_cols: 4,5,6,7,8,9
+   :exclude: {0: '(?!(MainWindow|Component))'}
 
 .. |y| image:: /_static/yes.png
     :width: 16

--- a/docs/reference/api/resources/command.rst
+++ b/docs/reference/api/resources/command.rst
@@ -1,11 +1,12 @@
 Command
 =======
 
-======= ====== ========= ===== ========= ========
- macOS   GTK+   Windows   iOS   Android   Django
-======= ====== ========= ===== ========= ========
- |y|     |y|
-======= ====== ========= ===== ========= ========
+.. rst-class:: widget-support
+.. csv-filter::
+   :header-rows: 1
+   :file: ../../data/widgets_by_platform.csv
+   :included_cols: 4,5,6,7,8,9
+   :exclude: {0: '(?!(Command|Component))'}
 
 .. |y| image:: /_static/yes.png
     :width: 16

--- a/docs/reference/api/resources/fonts.rst
+++ b/docs/reference/api/resources/fonts.rst
@@ -1,11 +1,12 @@
 Font
 ====
 
-======= ====== ========= ===== ========= ========
- macOS   GTK+   Windows   iOS   Android   Django
-======= ====== ========= ===== ========= ========
- |y|     |y|              |y|
-======= ====== ========= ===== ========= ========
+.. rst-class:: widget-support
+.. csv-filter::
+   :header-rows: 1
+   :file: ../../data/widgets_by_platform.csv
+   :included_cols: 4,5,6,7,8,9
+   :exclude: {0: '(?!(Font|Component))'}
 
 .. |y| image:: /_static/yes.png
     :width: 16

--- a/docs/reference/api/resources/group.rst
+++ b/docs/reference/api/resources/group.rst
@@ -1,11 +1,12 @@
 Group
 =====
 
-======= ====== ========= ===== ========= ========
- macOS   GTK+   Windows   iOS   Android   Django
-======= ====== ========= ===== ========= ========
- |y|     |y|    |y|       |y|   |y|       |y|
-======= ====== ========= ===== ========= ========
+.. rst-class:: widget-support
+.. csv-filter::
+   :header-rows: 1
+   :file: ../../data/widgets_by_platform.csv
+   :included_cols: 4,5,6,7,8,9
+   :exclude: {0: '(?!(Group|Component))'}
 
 .. |y| image:: /_static/yes.png
     :width: 16

--- a/docs/reference/api/resources/icons.rst
+++ b/docs/reference/api/resources/icons.rst
@@ -1,11 +1,12 @@
 Icon
 ====
 
-======= ====== ========= ===== ========= ========
- macOS   GTK+   Windows   iOS   Android   Django
-======= ====== ========= ===== ========= ========
- |y|     |y|       |y|
-======= ====== ========= ===== ========= ========
+.. rst-class:: widget-support
+.. csv-filter::
+   :header-rows: 1
+   :file: ../../data/widgets_by_platform.csv
+   :included_cols: 4,5,6,7,8,9
+   :exclude: {0: '(?!(Icon|Component))'}
 
 .. |y| image:: /_static/yes.png
     :width: 16

--- a/docs/reference/api/resources/images.rst
+++ b/docs/reference/api/resources/images.rst
@@ -1,11 +1,12 @@
 Image
 =====
 
-======= ====== ========= ===== ========= ========
- macOS   GTK+   Windows   iOS   Android   Django
-======= ====== ========= ===== ========= ========
- |y|     |y|    |y|       |y|
-======= ====== ========= ===== ========= ========
+.. rst-class:: widget-support
+.. csv-filter::
+   :header-rows: 1
+   :file: ../../data/widgets_by_platform.csv
+   :included_cols: 4,5,6,7,8,9
+   :exclude: {0: '(?!(Image|Component)$)'}
 
 .. |y| image:: /_static/yes.png
     :width: 16

--- a/docs/reference/api/widgets/button.rst
+++ b/docs/reference/api/widgets/button.rst
@@ -1,11 +1,12 @@
 Button
 ======
 
-======= ====== ========= ===== ========= ========
- macOS   GTK+   Windows   iOS   Android   Django
-======= ====== ========= ===== ========= ========
- |y|     |y|    |y|       |y|   |y|       |y|
-======= ====== ========= ===== ========= ========
+.. rst-class:: widget-support
+.. csv-filter::
+   :header-rows: 1
+   :file: ../../data/widgets_by_platform.csv
+   :included_cols: 4,5,6,7,8,9
+   :exclude: {0: '(?!(Button|Component))'}
 
 .. |y| image:: /_static/yes.png
     :width: 16

--- a/docs/reference/api/widgets/canvas.rst
+++ b/docs/reference/api/widgets/canvas.rst
@@ -1,11 +1,12 @@
 Canvas
 ======
 
-======= ====== ========= ===== ========= ========
- macOS   GTK+   Windows   iOS   Android   Django
-======= ====== ========= ===== ========= ========
- |y|     |y|              |y|
-======= ====== ========= ===== ========= ========
+.. rst-class:: widget-support
+.. csv-filter::
+   :header-rows: 1
+   :file: ../../data/widgets_by_platform.csv
+   :included_cols: 4,5,6,7,8,9
+   :exclude: {0: '(?!(Canvas|Component))'}
 
 .. |y| image:: /_static/yes.png
     :width: 16

--- a/docs/reference/api/widgets/detailedlist.rst
+++ b/docs/reference/api/widgets/detailedlist.rst
@@ -1,11 +1,12 @@
 DetailedList
 ============
 
-======= ====== ========= ===== ========= ========
- macOS   GTK+   Windows   iOS   Android   Django
-======= ====== ========= ===== ========= ========
- |y|                      |y|
-======= ====== ========= ===== ========= ========
+.. rst-class:: widget-support
+.. csv-filter::
+   :header-rows: 1
+   :file: ../../data/widgets_by_platform.csv
+   :included_cols: 4,5,6,7,8,9
+   :exclude: {0: '(?!(DetailedList|Component))'}
 
 .. |y| image:: /_static/yes.png
     :width: 16

--- a/docs/reference/api/widgets/imageview.rst
+++ b/docs/reference/api/widgets/imageview.rst
@@ -1,11 +1,12 @@
 Image View
 ==========
 
-======= ====== ========= ===== ========= ========
- macOS   GTK+   Windows   iOS   Android   Django
-======= ====== ========= ===== ========= ========
- |y|     |y|     |y|      |y|
-======= ====== ========= ===== ========= ========
+.. rst-class:: widget-support
+.. csv-filter::
+   :header-rows: 1
+   :file: ../../data/widgets_by_platform.csv
+   :included_cols: 4,5,6,7,8,9
+   :exclude: {0: '(?!^(ImageView|Component)$)'}
 
 .. |y| image:: /_static/yes.png
     :width: 16

--- a/docs/reference/api/widgets/label.rst
+++ b/docs/reference/api/widgets/label.rst
@@ -1,11 +1,12 @@
 Label
 =====
 
-======= ====== ========= ===== ========= ========
- macOS   GTK+   Windows   iOS   Android   Django
-======= ====== ========= ===== ========= ========
- |y|     |y|    |y|       |y|   |y|
-======= ====== ========= ===== ========= ========
+.. rst-class:: widget-support
+.. csv-filter::
+   :header-rows: 1
+   :file: ../../data/widgets_by_platform.csv
+   :included_cols: 4,5,6,7,8,9
+   :exclude: {0: '(?!^(Label|Component)$)'}
 
 .. |y| image:: /_static/yes.png
     :width: 16

--- a/docs/reference/api/widgets/multilinetextinput.rst
+++ b/docs/reference/api/widgets/multilinetextinput.rst
@@ -1,11 +1,12 @@
 Multi-line text input
 =====================
 
-======= ====== ========= ===== ========= ========
- macOS   GTK+   Windows   iOS   Android   Django
-======= ====== ========= ===== ========= ========
- |y|     |y|    |y|       |y|
-======= ====== ========= ===== ========= ========
+.. rst-class:: widget-support
+.. csv-filter::
+   :header-rows: 1
+   :file: ../../data/widgets_by_platform.csv
+   :included_cols: 4,5,6,7,8,9
+   :exclude: {0: '(?!^(MultilineTextInput|Component)$)'}
 
 .. |y| image:: /_static/yes.png
     :width: 16

--- a/docs/reference/api/widgets/numberinput.rst
+++ b/docs/reference/api/widgets/numberinput.rst
@@ -1,11 +1,12 @@
 Number Input
 ============
 
-======= ====== ========= ===== ========= ========
- macOS   GTK+   Windows   iOS   Android   Django
-======= ====== ========= ===== ========= ========
- |y|     |y|      |y|     |y|
-======= ====== ========= ===== ========= ========
+.. rst-class:: widget-support
+.. csv-filter::
+   :header-rows: 1
+   :file: ../../data/widgets_by_platform.csv
+   :included_cols: 4,5,6,7,8,9
+   :exclude: {0: '(?!^(NumberInput|Component)$)'}
 
 .. |y| image:: /_static/yes.png
     :width: 16

--- a/docs/reference/api/widgets/passwordinput.rst
+++ b/docs/reference/api/widgets/passwordinput.rst
@@ -1,11 +1,12 @@
 PasswordInput
 =============
 
-======= ====== ========= ===== ========= ========
- macOS   GTK+   Windows   iOS   Android   Django
-======= ====== ========= ===== ========= ========
- |y|     |y|    |y|       |y|   |y|
-======= ====== ========= ===== ========= ========
+.. rst-class:: widget-support
+.. csv-filter::
+   :header-rows: 1
+   :file: ../../data/widgets_by_platform.csv
+   :included_cols: 4,5,6,7,8,9
+   :exclude: {0: '(?!^(PasswordInput|Component)$)'}
 
 .. |y| image:: /_static/yes.png
     :width: 16

--- a/docs/reference/api/widgets/progressbar.rst
+++ b/docs/reference/api/widgets/progressbar.rst
@@ -1,11 +1,12 @@
 Progress Bar
 ============
 
-======= ====== ========= ===== ========= ========
- macOS   GTK+   Windows   iOS   Android   Django
-======= ====== ========= ===== ========= ========
- |y|     |y|              |y|
-======= ====== ========= ===== ========= ========
+.. rst-class:: widget-support
+.. csv-filter::
+   :header-rows: 1
+   :file: ../../data/widgets_by_platform.csv
+   :included_cols: 4,5,6,7,8,9
+   :exclude: {0: '(?!^(ProgressBar|Component)$)'}
 
 .. |y| image:: /_static/yes.png
     :width: 16

--- a/docs/reference/api/widgets/selection.rst
+++ b/docs/reference/api/widgets/selection.rst
@@ -1,11 +1,12 @@
 Selection
 =========
 
-======= ====== ========= ===== ========= ========
- macOS   GTK+   Windows   iOS   Android   Django
-======= ====== ========= ===== ========= ========
- |y|     |y|     |y|      |y|
-======= ====== ========= ===== ========= ========
+.. rst-class:: widget-support
+.. csv-filter::
+   :header-rows: 1
+   :file: ../../data/widgets_by_platform.csv
+   :included_cols: 4,5,6,7,8,9
+   :exclude: {0: '(?!^(Selection|Component)$)'}
 
 .. |y| image:: /_static/yes.png
     :width: 16

--- a/docs/reference/api/widgets/slider.rst
+++ b/docs/reference/api/widgets/slider.rst
@@ -1,11 +1,12 @@
 Slider
 ======
 
-======= ====== ========= ===== ========= ========
- macOS   GTK+   Windows   iOS   Android   Django
-======= ====== ========= ===== ========= ========
- |y|              |y|      |y|
-======= ====== ========= ===== ========= ========
+.. rst-class:: widget-support
+.. csv-filter::
+   :header-rows: 1
+   :file: ../../data/widgets_by_platform.csv
+   :included_cols: 4,5,6,7,8,9
+   :exclude: {0: '(?!^(Slider|Component)$)'}
 
 .. |y| image:: /_static/yes.png
     :width: 16

--- a/docs/reference/api/widgets/switch.rst
+++ b/docs/reference/api/widgets/switch.rst
@@ -1,11 +1,12 @@
 Switch
 ======
 
-======= ====== ========= ===== ========= ========
- macOS   GTK+   Windows   iOS   Android   Django
-======= ====== ========= ===== ========= ========
- |y|     |y|      |y|     |y|
-======= ====== ========= ===== ========= ========
+.. rst-class:: widget-support
+.. csv-filter::
+   :header-rows: 1
+   :file: ../../data/widgets_by_platform.csv
+   :included_cols: 4,5,6,7,8,9
+   :exclude: {0: '(?!^(Switch|Component)$)'}
 
 .. |y| image:: /_static/yes.png
     :width: 16

--- a/docs/reference/api/widgets/table.rst
+++ b/docs/reference/api/widgets/table.rst
@@ -1,11 +1,12 @@
 Table
 =====
 
-======= ====== ========= ===== ========= ========
- macOS   GTK+   Windows   iOS   Android   Django
-======= ====== ========= ===== ========= ========
- |y|     |y|    |y|
-======= ====== ========= ===== ========= ========
+.. rst-class:: widget-support
+.. csv-filter::
+   :header-rows: 1
+   :file: ../../data/widgets_by_platform.csv
+   :included_cols: 4,5,6,7,8,9
+   :exclude: {0: '(?!^(Table|Component)$)'}
 
 .. |y| image:: /_static/yes.png
     :width: 16

--- a/docs/reference/api/widgets/textinput.rst
+++ b/docs/reference/api/widgets/textinput.rst
@@ -1,11 +1,12 @@
 Text Input
 ==========
 
-======= ====== ========= ===== ========= ========
- macOS   GTK+   Windows   iOS   Android   Django
-======= ====== ========= ===== ========= ========
- |y|     |y|    |y|       |y|   |y|       |y|
-======= ====== ========= ===== ========= ========
+.. rst-class:: widget-support
+.. csv-filter::
+   :header-rows: 1
+   :file: ../../data/widgets_by_platform.csv
+   :included_cols: 4,5,6,7,8,9
+   :exclude: {0: '(?!^(TextInput|Component)$)'}
 
 .. |y| image:: /_static/yes.png
     :width: 16

--- a/docs/reference/api/widgets/tree.rst
+++ b/docs/reference/api/widgets/tree.rst
@@ -1,11 +1,12 @@
 Tree
 ====
 
-======= ====== ========= ===== ========= ========
- macOS   GTK+   Windows   iOS   Android   Django
-======= ====== ========= ===== ========= ========
- |y|     |y|
-======= ====== ========= ===== ========= ========
+.. rst-class:: widget-support
+.. csv-filter::
+   :header-rows: 1
+   :file: ../../data/widgets_by_platform.csv
+   :included_cols: 4,5,6,7,8,9
+   :exclude: {0: '(?!^(Tree|Component)$)'}
 
 .. |y| image:: /_static/yes.png
     :width: 16

--- a/docs/reference/api/widgets/webview.rst
+++ b/docs/reference/api/widgets/webview.rst
@@ -1,11 +1,12 @@
 WebView
 =======
 
-======= ====== ========= ===== ========= ========
- macOS   GTK+   Windows   iOS   Android   Django
-======= ====== ========= ===== ========= ========
- |y|     |y|    |y|       |y|             |y|
-======= ====== ========= ===== ========= ========
+.. rst-class:: widget-support
+.. csv-filter::
+   :header-rows: 1
+   :file: ../../data/widgets_by_platform.csv
+   :included_cols: 4,5,6,7,8,9
+   :exclude: {0: '(?!^(WebView|Component)$)'}
 
 .. |y| image:: /_static/yes.png
     :width: 16

--- a/docs/reference/api/widgets/widget.rst
+++ b/docs/reference/api/widgets/widget.rst
@@ -1,11 +1,12 @@
 Widget
 ======
 
-======= ====== ========= ===== ========= ========
- macOS   GTK+   Windows   iOS   Android   Django
-======= ====== ========= ===== ========= ========
- |y|     |y|    |y|       |y|             |y|
-======= ====== ========= ===== ========= ========
+.. rst-class:: widget-support
+.. csv-filter::
+   :header-rows: 1
+   :file: ../../data/widgets_by_platform.csv
+   :included_cols: 4,5,6,7,8,9
+   :exclude: {0: '(?!^(Widget|Component)$)'}
 
 .. |y| image:: /_static/yes.png
     :width: 16

--- a/docs/reference/api/window.rst
+++ b/docs/reference/api/window.rst
@@ -1,14 +1,15 @@
 Window
 ======
 
-======= ====== ========= ===== ========= ========
- macOS   GTK+   Windows   iOS   Android   Django
-======= ====== ========= ===== ========= ========
- |y|     |y|    |y|       |y|   |y|       |y|
-======= ====== ========= ===== ========= ========
+.. rst-class:: widget-support
+.. csv-filter::
+   :header-rows: 1
+   :file: ../data/widgets_by_platform.csv
+   :included_cols: 4,5,6,7,8,9
+   :exclude: {0: '(?!(Window|Component))'}
 
 .. |y| image:: /_static/yes.png
-    :width: 32
+    :width: 16
 
 A window for displaying components to the user
 

--- a/docs/reference/data/widgets_by_platform.csv
+++ b/docs/reference/data/widgets_by_platform.csv
@@ -1,0 +1,30 @@
+Component,Type,Component,Description,macOS,GTK+,Windows,iOS,Android,Django
+Application,Core Component,:class:`~toga.app.App`,The application itself,|y|,|y|,|y|,|y|,|y|,|y|
+Window,Core Component,:class:`~toga.window.Window`,Window object,|y|,|y|,|y|,|y|,|y|,|y|
+MainWindow,Core Component,:class:`~toga.app.MainWindow`,Main window of the application,|y|,|y|,|y|,|y|,|y|,|y|
+Button,General Widget,:class:`~toga.widgets.button.Button`,Basic clickable Button,|y|,|y|,|y|,|y|,|y|,|y|
+Canvas,General Widget,:class:`~toga.widgets.canvas.Canvas`,Area you can draw on,|y|,|y|,,|y|,,
+DetailedList,General Widget,:class:`~toga.widgets.detailedlist.DetailedList`,A list of complex content,|y|,,,|y|,,
+ImageView,General Widget,:class:`~toga.widgets.imageview.ImageView`,Image Viewer,|y|,|y|,|y|,|y|,,
+Label,General Widget,:class:`~toga.widgets.label.Label`,Text label,|y|,|y|,|y|,|y|,|y|,
+MultilineTextInput,General Widget,:class:`~toga.widgets.multilinetextinput.MultilineTextInput`,Multi-line Text Input field,|y|,|y|,|y|,|y|,,
+NumberInput,General Widget,:class:`~toga.widgets.numberinput.NumberInput`,Number Input field,|y|,|y|,|y|,|y|,,
+PasswordInput,General Widget,:class:`~toga.widgets.passwordinput.PasswordInput`,A text input that hides it’s input,|y|,|y|,|y|,|y|,|y|,
+ProgressBar,General Widget,:class:`~toga.widgets.progressbar.ProgressBar`,Progress Bar,|y|,|y|,,|y|,,
+Selection,General Widget,:class:`~toga.widgets.selection.Selection`,Selection,|y|,|y|,|y|,|y|,,
+Slider,General Widget,:class:`~toga.widgets.slider.Slider`,Slider,|y|,,|y|,|y|,,
+Switch,General Widget,:class:`~toga.widgets.switch.Switch`,Switch,|y|,|y|,|y|,|y|,,
+Table,General Widget,:class:`~toga.widgets.table.Table`,Table of data,|y|,|y|,|y|,,,
+TextInput,General Widget,:class:`~toga.widgets.textinput.TextInput`,Text Input field,|y|,|y|,|y|,|y|,|y|,|y|
+Tree,General Widget,:class:`~toga.widgets.tree.Tree`,Tree of data,|y|,|y|,,,,
+WebView,General Widget,:class:`~toga.widgets.webview.WebView`,A panel for displaying HTML,|y|,|y|,|y|,,|y|,|y|
+Widget,General Widget,:class:`~toga.widgets.base.Widget`,The base widget,|y|,|y|,|y|,|y|,,|y|
+Box,Layout Widget,:class:`~toga.widgets.box.Box`,Container for components,|y|,|y|,|y|,|y|,|y|,|y|
+ScrollContainer,Layout Widget,:class:`~toga.widgets.scrollcontainer.ScrollContainer`,Scrollable Container,|y|,|y|,|y|,|y|,,
+SplitContainer,Layout Widget,:class:`~toga.widgets.splitcontainer.SplitContainer`,Split Container,|y|,|y|,|y|,,,
+OptionContainer,Layout Widget,:class:`~toga.widgets.optioncontainer.OptionContainer`,Option Container,|y|,|y|,|y|,,,
+Font,Resource,:class:`~toga.fonts.Font`,Fonts,|y|,|y|,,|y|,,
+Command,Resource,:class:`~toga.command.Command`,Command,|y|,|y|,,,,
+Group,Resource,:class:`~toga.command.Group`,Command group,|y|,|y|,|y|,|y|,|y|,|y|
+Icon,Resource,:class:`~toga.icons.Icon`,"An icon for buttons, menus, etc",|y|,|y|,|y|,,,
+Image,Resource,:class:`~toga.images.Image`,An image,|y|,|y|,|y|,|y|,,

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -8,5 +8,6 @@ Reference
    :maxdepth: 1
 
    platforms
+   widgets_by_platform
    api/index
    style/index

--- a/docs/reference/widgets_by_platform.rst
+++ b/docs/reference/widgets_by_platform.rst
@@ -1,0 +1,59 @@
+=========================
+Toga widgets by platforms
+=========================
+
+Core Components
+===============
+
+.. rst-class:: widget-descriptions
+.. csv-filter::
+   :file: data/widgets_by_platform.csv
+   :header-rows: 1
+   :exclude: {1: '(?!(Type|Core Component))'}
+   :included_cols: 2,3,4,5,6,7,8,9
+   :class: longtable
+   :stub-columns: 1
+   :widths: 3 5 1 1 1 1 1 1
+
+
+General Widgets
+===============
+
+.. rst-class:: widget-descriptions
+.. csv-filter::
+   :file: data/widgets_by_platform.csv
+   :header-rows: 1
+   :exclude: {1: '(?!(Type|General Widget))'}
+   :included_cols: 2,3,4,5,6,7,8,9
+   :class: longtable
+   :stub-columns: 1
+   :widths: 3 5 1 1 1 1 1 1
+
+Layout Widgets
+==============
+
+.. rst-class:: widget-descriptions
+.. csv-filter::
+   :file: data/widgets_by_platform.csv
+   :header-rows: 1
+   :exclude: {1: '(?!(Type|Layout Widget))'}
+   :included_cols: 2,3,4,5,6,7,8,9
+   :class: longtable
+   :stub-columns: 1
+   :widths: 3 5 1 1 1 1 1 1
+
+Resources
+=========
+
+.. rst-class:: widget-descriptions
+.. csv-filter::
+   :file: data/widgets_by_platform.csv
+   :header-rows: 1
+   :exclude: {1: '(?!(Type|Resource))'}
+   :included_cols: 2,3,4,5,6,7,8,9
+   :class: longtable
+   :stub-columns: 1
+   :widths: 3 5 1 1 1 1 1 1
+
+.. |y| image:: /_static/yes.png
+    :width: 16


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Toga documentation used to have a comprehensive table of platform support for each widget, as well as small platform support tables on each individual widget page. As these were filled out manually, they could contain inaccurate information when someone changed one page but not the other. 

This PR introduces a central table for platform support in `.csv` format, which is used to create `.rst` tables for documentation automatically.
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Fixes #527 524

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
