### PR TITLE
Make Canvas handle explicit redraws in GTK

### DIFF
--- a/src/gtk/toga_gtk/widgets/canvas.py
+++ b/src/gtk/toga_gtk/widgets/canvas.py
@@ -26,7 +26,7 @@ class Canvas(Widget):
         self.interface._draw(self, draw_context=gtk_context)
 
     def redraw(self):
-        pass
+        self.native.queue_draw()
 
     # Basic paths
 


### PR DESCRIPTION
The Canvas widget has a `redraw` method that is meant to allow for
asking it to redraw itself programatically. The backend implementation
for it in GTK was so far missing. In practice this manifested itself in
having the results of method calls on the Canvas Widget not show up on
screen until a redraw event was triggered E.g. by resizing the window.

This PR adds implementation for the `redraw` method in GTK.

Signed-off-by: Barak Korren <bkorren@redhat.com>

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
