### PR TITLE
Add a `resize` event to Canvas and a GTK impl.

### DIFF
--- a/examples/canvas/canvas/app.py
+++ b/examples/canvas/canvas/app.py
@@ -6,7 +6,7 @@ class ExampleCanvasApp(toga.App):
         # Set up main window
         self.main_window = toga.MainWindow(title=self.name, size=(148, 200))
 
-        canvas = toga.Canvas(style=Pack(flex=1))
+        canvas = toga.Canvas(style=Pack(flex=1), on_resize=self.resize_contents)
         box = toga.Box(children=[canvas])
 
         # Add the content on the main window
@@ -15,10 +15,28 @@ class ExampleCanvasApp(toga.App):
         # Show the main window
         self.main_window.show()
 
+        self.render_drawing(canvas, *self.main_window.size)
+
+    def render_drawing(self, canvas, w, h):
+        # Scale to the smallest axis to maintain aspect ratio
+        factor = min(w, h)
+
+        # calculate offsets to centralize drawing in the bigger axis
+        dx = (w - factor) / 2
+        dy = (h - factor) / 2
+
+        canvas.clear()
         with canvas.stroke() as stroker:
-            with stroker.closed_path(50, 50) as closer:
-                closer.line_to(100, 100)
-                closer.line_to(100, 50)
+            with stroker.closed_path(dx+factor/3, dy+factor/3) as closer:
+                closer.line_to(dx+2*factor/3, dy+2*factor/3)
+                closer.line_to(dx+2*factor/3, dy+factor/3)
+
+    def resize_contents(self, canvas):
+        self.render_drawing(
+            canvas,
+            canvas.layout.content_width,
+            canvas.layout.content_height
+        )
 
 
 def main():

--- a/src/cocoa/toga_cocoa/widgets/canvas.py
+++ b/src/cocoa/toga_cocoa/widgets/canvas.py
@@ -223,3 +223,6 @@ class Canvas(Widget):
         fitting_size = self.native.fittingSize()
         self.interface.intrinsic.height = fitting_size.height
         self.interface.intrinsic.width = fitting_size.width
+
+    def set_on_resize(self, handler):
+        self.interface.factory.not_implemented('Canvas.on_resize')

--- a/src/core/tests/widgets/test_canvas.py
+++ b/src/core/tests/widgets/test_canvas.py
@@ -598,3 +598,20 @@ class CanvasTests(TestCase):
             repr(write_text),
             "WriteText(text=hello, x=10, y=-4.2, font=<Font: 4pt serif>)",
         )
+
+    def test_on_resize(self):
+        self.assertIsNone(self.testing_canvas._on_resize)
+
+        # set a new callback
+        def callback(widget, **extra):
+            return 'called {} with {}'.format(type(widget), extra)
+
+        self.testing_canvas.on_resize = callback
+        self.assertEqual(self.testing_canvas.on_resize._raw, callback)
+        self.assertEqual(
+            self.testing_canvas.on_resize('widget', a=1),
+            "called <class 'toga.widgets.canvas.Canvas'> with {'a': 1}"
+        )
+        self.assertValueSet(
+            self.testing_canvas, 'on_resize', self.testing_canvas.on_resize
+        )

--- a/src/core/toga/widgets/canvas.py
+++ b/src/core/toga/widgets/canvas.py
@@ -3,6 +3,7 @@ from math import pi
 
 from toga.colors import color as parse_color, BLACK
 from toga.fonts import Font, SYSTEM
+from toga.handlers import wrapped_handler
 
 from .base import Widget
 

--- a/src/core/toga/widgets/canvas.py
+++ b/src/core/toga/widgets/canvas.py
@@ -502,17 +502,40 @@ class Canvas(Context, Widget):
         id (str):  An identifier for this widget.
         style (:obj:`Style`): An optional style object. If no
             style is provided then a new one will be created for the widget.
+        on_resize (:obj:`callable`): Function to call when resized.
         factory (:obj:`module`): A python module that is capable to return a
             implementation of this class with the same name. (optional &
             normally not needed)
     """
 
-    def __init__(self, id=None, style=None, factory=None):
+    def __init__(self, id=None, style=None, on_resize=None, factory=None):
         super().__init__(id=id, style=style, factory=factory)
         self._canvas = self
 
         # Create a platform specific implementation of Canvas
         self._impl = self.factory.Canvas(interface=self)
+
+        # Set all the properties
+        self.on_resize = on_resize
+
+    @property
+    def on_resize(self):
+        """The handler to invoke when the canvas is resized.
+
+        Returns:
+            The function ``callable`` that is called on canvas resize.
+        """
+        return self._on_resize
+
+    @on_resize.setter
+    def on_resize(self, handler):
+        """Set the handler to invoke when the canvas is resized.
+
+        Args:
+            handler (:obj:`callable`): The handler to invoke when the canvas is resized.
+        """
+        self._on_resize = wrapped_handler(self, handler)
+        self._impl.set_on_resize(self._on_resize)
 
     ###########################################################################
     # Transformations of a canvas

--- a/src/dummy/toga_dummy/widgets/canvas.py
+++ b/src/dummy/toga_dummy/widgets/canvas.py
@@ -93,3 +93,6 @@ class Canvas(Widget):
 
     def rehint(self):
         self._action('rehint Canvas')
+
+    def set_on_resize(self, handler):
+        pass

--- a/src/dummy/toga_dummy/widgets/canvas.py
+++ b/src/dummy/toga_dummy/widgets/canvas.py
@@ -95,4 +95,4 @@ class Canvas(Widget):
         self._action('rehint Canvas')
 
     def set_on_resize(self, handler):
-        pass
+        self._set_value('on_resize', handler)

--- a/src/gtk/toga_gtk/widgets/canvas.py
+++ b/src/gtk/toga_gtk/widgets/canvas.py
@@ -15,10 +15,6 @@ class Canvas(Widget):
         self.native.connect("draw", self.gtk_draw_callback)
         self.native.connect('size-allocate', self.on_size_allocate)
 
-        # Storing widget width and height so we can detect when it is resized
-        self.__old_width = None
-        self.__old_height = None
-
     def gtk_draw_callback(self, canvas, gtk_context):
         """Creates a draw callback
 

--- a/src/gtk/toga_gtk/widgets/canvas.py
+++ b/src/gtk/toga_gtk/widgets/canvas.py
@@ -34,8 +34,7 @@ class Canvas(Widget):
         new_width = self.native.get_allocated_width()
         new_height = self.native.get_allocated_height()
         if (
-            new_width != self.__old_width \
-            or new_height != self.__old_height
+            new_width != self.__old_width or new_height != self.__old_height
         ):
             if self.interface.on_resize:
                 # we intentionally want to call the event handlers before

--- a/src/gtk/toga_gtk/widgets/canvas.py
+++ b/src/gtk/toga_gtk/widgets/canvas.py
@@ -13,6 +13,7 @@ class Canvas(Widget):
         self.native = Gtk.DrawingArea()
         self.native.interface = self.interface
         self.native.connect("draw", self.gtk_draw_callback)
+        self.native.connect('size-allocate', self.on_size_allocate)
 
         # Storing widget width and height so we can detect when it is resized
         self.__old_width = None
@@ -25,26 +26,15 @@ class Canvas(Widget):
         callback function creates a Gtk+ canvas and Gtk+ context automatically
         using the canvas and gtk_context function arguments. This method calls
         the draw method on the interface Canvas to draw the objects.
-
-        Sine Gtk+ does not include a dedicate event for `resize` the way to
-        emulate it is by checking if the widget size was changed while
-        redrawing it. This works because resizing a widget in GTK also results
-        in a draw event.
         """
-        new_width = self.native.get_allocated_width()
-        new_height = self.native.get_allocated_height()
-        if (
-            new_width != self.__old_width or new_height != self.__old_height
-        ):
-            if self.interface.on_resize:
-                # we intentionally want to call the event handlers before
-                # calling _draw so that any changes they introduce will show up
-                # on screen immediately
-                self.interface.on_resize(self.interface)
-            self.__old_width = new_width
-            self.__old_height = new_height
-
         self.interface._draw(self, draw_context=gtk_context)
+
+    def on_size_allocate(self, widget, allocation):
+        """Called on widget resize, and calls the handler set on the interface,
+        if any.
+        """
+        if self.interface.on_resize:
+            self.interface.on_resize(self.interface)
 
     def set_on_resize(self, handler):
         pass

--- a/src/gtk/toga_gtk/widgets/canvas.py
+++ b/src/gtk/toga_gtk/widgets/canvas.py
@@ -13,7 +13,7 @@ class Canvas(Widget):
         self.native = Gtk.DrawingArea()
         self.native.interface = self.interface
         self.native.connect("draw", self.gtk_draw_callback)
-        self.native.connect('size-allocate', self.on_size_allocate)
+        self.native.connect('size-allocate', self.gtk_on_size_allocate)
 
     def gtk_draw_callback(self, canvas, gtk_context):
         """Creates a draw callback
@@ -25,7 +25,7 @@ class Canvas(Widget):
         """
         self.interface._draw(self, draw_context=gtk_context)
 
-    def on_size_allocate(self, widget, allocation):
+    def gtk_on_size_allocate(self, widget, allocation):
         """Called on widget resize, and calls the handler set on the interface,
         if any.
         """

--- a/src/iOS/toga_iOS/widgets/canvas.py
+++ b/src/iOS/toga_iOS/widgets/canvas.py
@@ -224,3 +224,6 @@ class Canvas(Widget):
         fitting_size = self.native.systemLayoutSizeFittingSize(CGSize(0, 0))
         self.interface.intrinsic.width = at_least(fitting_size.width)
         self.interface.intrinsic.height = at_least(fitting_size.height)
+
+    def set_on_resize(self, handler):
+        self.interface.factory.not_implemented('Canvas.on_resize')


### PR DESCRIPTION
When a windows containing a Canvas widget is resized, its usually
desirable to update the Canvas contents to match the new window size.
This patch provides a way to do so by introducing a `resize` event that
can be hooked into a callback.

The patch also includes an implementation of that event in GTK. It is
somewhat less straight-forward due to the fact that GTK does not seem to
include a `resize` event of its own.

Signed-off-by: Barak Korren <bkorren@redhat.com>

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
