### PR TITLE
Add a stub toga.App to avoid test ordering failure.

### DIFF
--- a/src/core/tests/test_icon.py
+++ b/src/core/tests/test_icon.py
@@ -1,4 +1,3 @@
-import os
 import unittest
 from unittest.mock import MagicMock
 
@@ -8,6 +7,13 @@ import toga_dummy
 
 class TestIcon(unittest.TestCase):
     def setUp(self):
+        # We need a test app to for icon loading to work
+        self.app = toga.App(
+            formal_name="Test App",
+            app_id="org.beeware.test-app",
+            factory=toga_dummy.factory,
+        )
+
         self.factory = MagicMock()
         self.factory.Icon = MagicMock(return_value=MagicMock(spec=toga_dummy.factory.Icon))
 


### PR DESCRIPTION
We're seeing failures in production because of test ordering.
