### PR TITLE
don't ignore `font_weight` for system font in Cocoa

### DIFF
--- a/src/cocoa/toga_cocoa/fonts.py
+++ b/src/cocoa/toga_cocoa/fonts.py
@@ -1,6 +1,6 @@
 from toga.fonts import (
     MESSAGE,
-    NORMAL,
+    NORMAL, BOLD,
     SYSTEM,
     SERIF,
     SANS_SERIF,
@@ -21,7 +21,10 @@ class Font:
             font = _FONT_CACHE[self.interface]
         except KeyError:
             if self.interface.family == SYSTEM:
-                font = NSFont.systemFontOfSize(self.interface.size)
+                if self.interface.weight == BOLD:
+                    font = NSFont.boldSystemFontOfSize(self.interface.size)
+                else:
+                    font = NSFont.systemFontOfSize(self.interface.size)
             elif self.interface.family == MESSAGE:
                 font = NSFont.messageFontOfSize(self.interface.size)
             else:


### PR DESCRIPTION
When setting a Pack style with `font_weight=BOLD` in Cocoa, the setting is only used when specifying a non-system font family and ignored otherwise.

This PR fixes the behaviour, by calling `NSFont.boldSystemFontOfSize` to get the correct font.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
