### PR TITLE
support different fonts in `toga_cocoa.Switch`

### DIFF
--- a/src/cocoa/toga_cocoa/widgets/switch.py
+++ b/src/cocoa/toga_cocoa/widgets/switch.py
@@ -29,6 +29,10 @@ class Switch(Widget):
     def set_label(self, label):
         self.native.title = self.interface.label
 
+    def set_font(self, value):
+        if value:
+            self.native.font = value._impl.native
+
     def set_is_on(self, value):
         if value is True:
             self.native.state = NSOnState

--- a/src/cocoa/toga_cocoa/widgets/switch.py
+++ b/src/cocoa/toga_cocoa/widgets/switch.py
@@ -1,7 +1,13 @@
 from rubicon.objc import objc_method, SEL
 from travertino.size import at_least
 
-from toga_cocoa.libs import *
+from toga_cocoa.libs import (
+    NSButton,
+    NSOnState,
+    NSOffState,
+    NSRoundedBezelStyle,
+    NSSwitchButton,
+)
 
 from .base import Widget
 


### PR DESCRIPTION
And yet another small tweak: Is there any reason why one cannot set the font of a ``toga.Switch`` in Cocoa? The underlying `NSButton` supports settings a font attribute.

Let me know if all those PRs get annoying. I am trying to use Toga to put together a basic UI for a command-line tool and so I'm slowly going through the widgets as I need them...

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
