### PR TITLE
renamed NSAlertStyle constants

### DIFF
--- a/src/cocoa/toga_cocoa/dialogs.py
+++ b/src/cocoa/toga_cocoa/dialogs.py
@@ -1,9 +1,7 @@
 from .libs import (
     NSAlert,
-    NSInformationalAlertStyle,
+    NSAlertStyle,
     NSAlertFirstButtonReturn,
-    NSWarningAlertStyle,
-    NSCriticalAlertStyle,
     NSScrollView,
     NSMakeRect,
     NSBezelBorder,
@@ -18,7 +16,7 @@ from .libs import (
 def info(window, title, message):
     alert = NSAlert.alloc().init()
     alert.icon = window.app.icon._impl.native
-    alert.setAlertStyle_(NSInformationalAlertStyle)
+    alert.setAlertStyle_(NSAlertStyle.Informational.value)
     alert.setMessageText_(title)
     alert.setInformativeText_(message)
 
@@ -28,7 +26,7 @@ def info(window, title, message):
 def question(window, title, message):
     alert = NSAlert.alloc().init()
     alert.icon = window.app.icon._impl.native
-    alert.setAlertStyle_(NSInformationalAlertStyle)
+    alert.setAlertStyle_(NSAlertStyle.Informational.value)
     alert.setMessageText_(title)
     alert.setInformativeText_(message)
 
@@ -42,7 +40,7 @@ def question(window, title, message):
 def confirm(window, title, message):
     alert = NSAlert.alloc().init()
     alert.icon = window.app.icon._impl.native
-    alert.setAlertStyle_(NSWarningAlertStyle)
+    alert.setAlertStyle_(NSAlertStyle.Warning.value)
     alert.setMessageText_(title)
     alert.setInformativeText_(message)
 
@@ -56,7 +54,7 @@ def confirm(window, title, message):
 def error(window, title, message):
     alert = NSAlert.alloc().init()
     alert.icon = window.app.icon._impl.native
-    alert.setAlertStyle_(NSCriticalAlertStyle)
+    alert.setAlertStyle_(NSAlertStyle.Critical.value)
     alert.setMessageText_(title)
     alert.setInformativeText_(message)
 
@@ -66,7 +64,7 @@ def error(window, title, message):
 def stack_trace(window, title, message, content, retry=False):
     alert = NSAlert.alloc().init()
     alert.icon = window.app.icon._impl.native
-    alert.setAlertStyle_(NSCriticalAlertStyle)
+    alert.setAlertStyle_(NSAlertStyle.Critical)
     alert.setMessageText_(title)
     alert.setInformativeText_(message)
 

--- a/src/cocoa/toga_cocoa/dialogs.py
+++ b/src/cocoa/toga_cocoa/dialogs.py
@@ -16,7 +16,7 @@ from .libs import (
 def info(window, title, message):
     alert = NSAlert.alloc().init()
     alert.icon = window.app.icon._impl.native
-    alert.setAlertStyle_(NSAlertStyle.Informational.value)
+    alert.setAlertStyle_(NSAlertStyle.Informational)
     alert.setMessageText_(title)
     alert.setInformativeText_(message)
 
@@ -26,7 +26,7 @@ def info(window, title, message):
 def question(window, title, message):
     alert = NSAlert.alloc().init()
     alert.icon = window.app.icon._impl.native
-    alert.setAlertStyle_(NSAlertStyle.Informational.value)
+    alert.setAlertStyle_(NSAlertStyle.Informational)
     alert.setMessageText_(title)
     alert.setInformativeText_(message)
 
@@ -40,7 +40,7 @@ def question(window, title, message):
 def confirm(window, title, message):
     alert = NSAlert.alloc().init()
     alert.icon = window.app.icon._impl.native
-    alert.setAlertStyle_(NSAlertStyle.Warning.value)
+    alert.setAlertStyle_(NSAlertStyle.Warning)
     alert.setMessageText_(title)
     alert.setInformativeText_(message)
 
@@ -54,7 +54,7 @@ def confirm(window, title, message):
 def error(window, title, message):
     alert = NSAlert.alloc().init()
     alert.icon = window.app.icon._impl.native
-    alert.setAlertStyle_(NSAlertStyle.Critical.value)
+    alert.setAlertStyle_(NSAlertStyle.Critical)
     alert.setMessageText_(title)
     alert.setInformativeText_(message)
 
@@ -64,7 +64,7 @@ def error(window, title, message):
 def stack_trace(window, title, message, content, retry=False):
     alert = NSAlert.alloc().init()
     alert.icon = window.app.icon._impl.native
-    alert.setAlertStyle_(NSAlertStyle.Critical.value)
+    alert.setAlertStyle_(NSAlertStyle.Critical)
     alert.setMessageText_(title)
     alert.setInformativeText_(message)
 

--- a/src/cocoa/toga_cocoa/dialogs.py
+++ b/src/cocoa/toga_cocoa/dialogs.py
@@ -64,7 +64,7 @@ def error(window, title, message):
 def stack_trace(window, title, message, content, retry=False):
     alert = NSAlert.alloc().init()
     alert.icon = window.app.icon._impl.native
-    alert.setAlertStyle_(NSAlertStyle.Critical)
+    alert.setAlertStyle_(NSAlertStyle.Critical.value)
     alert.setMessageText_(title)
     alert.setInformativeText_(message)
 

--- a/src/cocoa/toga_cocoa/libs/appkit.py
+++ b/src/cocoa/toga_cocoa/libs/appkit.py
@@ -23,9 +23,12 @@ NSAffineTransform = ObjCClass('NSAffineTransform')
 # NSAlert.h
 NSAlert = ObjCClass('NSAlert')
 
-NSWarningAlertStyle = 0
-NSInformationalAlertStyle = 1
-NSCriticalAlertStyle = 2
+
+class NSAlertStyle(Enum):
+    Warning = 0  # NSAlertStyleWarning
+    Informational = 1  # NSAlertStyleInformational
+    Critical = 2  # NSAlertStyleCritical
+
 
 NSAlertFirstButtonReturn = 1000
 NSAlertSecondButtonReturn = 1001


### PR DESCRIPTION
The old constants `NSWarningAlertStyle` etc have been deprecated in macOS 10.13 in favour of `NSAlertStyleWarning` etc (see [AppKit docs](https://developer.apple.com/documentation/appkit/nsalertstyle?language=objc)). The values of the constants have not changed so we maintain backward compatibility.

