### PR TITLE
Fix missing window content when added after `show` has been called

### DIFF
--- a/src/cocoa/toga_cocoa/widgets/base.py
+++ b/src/cocoa/toga_cocoa/widgets/base.py
@@ -1,5 +1,3 @@
-from travertino.layout import Viewport
-
 from toga_cocoa.constraints import Constraints
 
 
@@ -34,9 +32,6 @@ class Widget:
             child._impl.container = container
 
         self.rehint()
-        if self.interface.window and self.interface.window._impl.native.isVisible:
-            # refresh window content to reflect added subview
-            self.interface.window.content.refresh()
 
     def set_enabled(self, value):
         self.native.enabled = self.interface.enabled

--- a/src/cocoa/toga_cocoa/widgets/base.py
+++ b/src/cocoa/toga_cocoa/widgets/base.py
@@ -1,5 +1,3 @@
-from travertino.layout import Viewport
-
 from toga_cocoa.constraints import Constraints
 
 

--- a/src/cocoa/toga_cocoa/widgets/base.py
+++ b/src/cocoa/toga_cocoa/widgets/base.py
@@ -1,3 +1,5 @@
+from travertino.layout import Viewport
+
 from toga_cocoa.constraints import Constraints
 
 

--- a/src/cocoa/toga_cocoa/widgets/base.py
+++ b/src/cocoa/toga_cocoa/widgets/base.py
@@ -1,3 +1,5 @@
+from travertino.layout import Viewport
+
 from toga_cocoa.constraints import Constraints
 
 
@@ -32,6 +34,9 @@ class Widget:
             child._impl.container = container
 
         self.rehint()
+        if self.interface.window and self.interface.window._impl.native.isVisible:
+            # refresh window content to reflect added subview
+            self.interface.window.content.refresh()
 
     def set_enabled(self, value):
         self.native.enabled = self.interface.enabled

--- a/src/cocoa/toga_cocoa/widgets/base.py
+++ b/src/cocoa/toga_cocoa/widgets/base.py
@@ -36,17 +36,6 @@ class Widget:
             # refresh window content to reflect added subview
             self.interface.window.content.refresh()
 
-    @property
-    def viewport(self):
-        return self._viewport
-
-    @viewport.setter
-    def viewport(self, viewport):
-        self._viewport = viewport
-
-        for child in self.interface.children:
-            child._impl.viewport = viewport
-
     def set_enabled(self, value):
         self.native.enabled = self.interface.enabled
 
@@ -75,9 +64,8 @@ class Widget:
     # INTERFACE
 
     def add_child(self, child):
-        # if we don't have a window, we won't have a container of viewport
+        # if we don't have a window, we won't have a container
         if self.interface.window:
-            child.viewport = self.viewport or self.interface.window.content._impl.viewport
             child.container = self.container or self.interface.window.content._impl
 
     def add_constraints(self):

--- a/src/cocoa/toga_cocoa/widgets/base.py
+++ b/src/cocoa/toga_cocoa/widgets/base.py
@@ -46,10 +46,8 @@ class Widget:
         pass
 
     def set_hidden(self, hidden):
-        if self._container:
-            for view in self._container._impl.subviews:
-                if child._impl == view:
-                    view.setHidden(hidden)
+        if self.native:
+            self.native.setHidden(hidden)
 
     def set_font(self, font):
         pass

--- a/src/cocoa/toga_cocoa/widgets/base.py
+++ b/src/cocoa/toga_cocoa/widgets/base.py
@@ -75,8 +75,10 @@ class Widget:
     # INTERFACE
 
     def add_child(self, child):
-        child.viewport = self.viewport or self.interface.window.content._impl.viewport
-        child.container = self.container or self.interface.window.content._impl
+        # if we don't have a window, we won't have a container of viewport
+        if self.interface.window:
+            child.viewport = self.viewport or self.interface.window.content._impl.viewport
+            child.container = self.container or self.interface.window.content._impl
 
     def add_constraints(self):
         self.native.translatesAutoresizingMaskIntoConstraints = False

--- a/src/cocoa/toga_cocoa/widgets/base.py
+++ b/src/cocoa/toga_cocoa/widgets/base.py
@@ -32,6 +32,9 @@ class Widget:
             child._impl.container = container
 
         self.rehint()
+        if self.interface.window and self.interface.window._impl.native.isVisible:
+            # refresh window content to reflect added subview
+            self.interface.window.content.refresh()
 
     @property
     def viewport(self):
@@ -72,9 +75,8 @@ class Widget:
     ### INTERFACE
 
     def add_child(self, child):
-        if self.container:
-            child.container = self.container
         child.viewport = self.viewport or self.interface.window.content._impl.viewport
+        child.container = self.container or self.interface.window.content._impl
 
     def add_constraints(self):
         self.native.translatesAutoresizingMaskIntoConstraints = False

--- a/src/cocoa/toga_cocoa/widgets/base.py
+++ b/src/cocoa/toga_cocoa/widgets/base.py
@@ -50,7 +50,7 @@ class Widget:
     def set_enabled(self, value):
         self.native.enabled = self.interface.enabled
 
-    ### APPLICATOR
+    # APPLICATOR
 
     def set_bounds(self, x, y, width, height):
         # print("SET BOUNDS ON", self.interface, x, y, width, height)
@@ -72,7 +72,7 @@ class Widget:
     def set_background_color(self, color):
         pass
 
-    ### INTERFACE
+    # INTERFACE
 
     def add_child(self, child):
         child.viewport = self.viewport or self.interface.window.content._impl.viewport

--- a/src/cocoa/toga_cocoa/widgets/base.py
+++ b/src/cocoa/toga_cocoa/widgets/base.py
@@ -6,8 +6,8 @@ class Widget:
         self.interface = interface
         self.interface._impl = self
         self._container = None
+        self._viewport = None
         self.constraints = None
-        self.viewport = None
         self.native = None
         self.create()
         self.interface.style.reapply()
@@ -32,6 +32,17 @@ class Widget:
             child._impl.container = container
 
         self.rehint()
+
+    @property
+    def viewport(self):
+        return self._viewport
+
+    @viewport.setter
+    def viewport(self, viewport):
+        self._viewport = viewport
+
+        for child in self.interface.children:
+            child._impl.viewport = viewport
 
     def set_enabled(self, value):
         self.native.enabled = self.interface.enabled
@@ -63,6 +74,7 @@ class Widget:
     def add_child(self, child):
         if self.container:
             child.container = self.container
+        child.viewport = self.viewport or self.interface.window.content._impl.viewport
 
     def add_constraints(self):
         self.native.translatesAutoresizingMaskIntoConstraints = False

--- a/src/cocoa/toga_cocoa/widgets/box.py
+++ b/src/cocoa/toga_cocoa/widgets/box.py
@@ -3,6 +3,7 @@ from rubicon.objc import objc_method
 
 from toga_cocoa.libs import NSColor, NSView
 from toga_cocoa.colors import native_color
+from toga_cocoa.window import CocoaViewport
 
 from .base import Widget
 
@@ -23,6 +24,10 @@ class Box(Widget):
     def create(self):
         self.native = TogaView.alloc().init()
         self.native.wantsLayer = True
+
+        # allow adding subviews
+        self._container = self
+        self.viewport = CocoaViewport(self.native)
 
         # Add the layout constraints
         self.add_constraints()

--- a/src/cocoa/toga_cocoa/widgets/box.py
+++ b/src/cocoa/toga_cocoa/widgets/box.py
@@ -3,7 +3,6 @@ from rubicon.objc import objc_method
 
 from toga_cocoa.libs import NSColor, NSView
 from toga_cocoa.colors import native_color
-from toga_cocoa.window import CocoaViewport
 
 from .base import Widget
 
@@ -24,10 +23,6 @@ class Box(Widget):
     def create(self):
         self.native = TogaView.alloc().init()
         self.native.wantsLayer = True
-
-        # allow adding subviews
-        self._container = self
-        self.viewport = CocoaViewport(self.native)
 
         # Add the layout constraints
         self.add_constraints()

--- a/src/core/toga/widgets/base.py
+++ b/src/core/toga/widgets/base.py
@@ -66,6 +66,8 @@ class Widget(Node):
             super().add(child)
 
             child.app = self.app
+            child.window = self.window
+
             if self._impl:
                 self._impl.add_child(child._impl)
 

--- a/src/core/toga/widgets/base.py
+++ b/src/core/toga/widgets/base.py
@@ -116,6 +116,10 @@ class Widget(Node):
             for child in self._children:
                 child.window = window
 
+        content = getattr(self, '_content', None)
+        if content is not None:
+            content.window = window
+
     @property
     def enabled(self):
         return self._enabled


### PR DESCRIPTION
This PR fixes an issue where widgets would not appear on screen if they are added to a window after it has already been shown. This affects `toga_cocoa` but may be an issue with other backends as well.

The underlying fixes involve changes to both `toga_core` and `toga_cocoa`.

Changes to toga core:
- When a child is added to a widget, update its `window` attribute. Previously, only its `app` was updated.
- When `content` is added to a widget, update the content's `window` and `app`. I am not sure how "content" semantically differs from having a single child and which widgets can have content. At the moment, I am only aware of `ScrollContainer` and `Window`.

Changes to toga_cocoa:
- When a child is added to a widget, this is done by setting the child's `container` to the parent widget. This entails adding the native child as a subview of the native parent. Afterwards, `rehint` is called. However, the layout of the window will still need to adapt. I have therefore added a call to `self.interface.window.content.refresh`.
- When adding a new child to a `toga.Box` after `show` has been called,  the child will not appear. This is because `toga_cocoa.Box` does not have a container attribute or a viewport but adding a child relies on both. I have fixed this for now by setting `self._container = self` and `self.viewport = CocoaViewport(self.native)`. But I am not sure if this is the right approach and how `_container` is supposed to be used. As far as I can tell, it isn't used at all at the moment.