### PR TITLE
Fixes #798 - Ensure winforms table is cleared when data source changes.

### DIFF
--- a/examples/table/table/app.py
+++ b/examples/table/table/app.py
@@ -35,6 +35,9 @@ class ExampleTableApp(toga.App):
     def clear_handler(self, widget, **kwargs):
         self.table1.data.clear()
 
+    def reset_handler(self, widget, **kwargs):
+        self.table1.data = bee_movies[3:]
+
     def startup(self):
         self.main_window = toga.MainWindow(title=self.name)
 
@@ -66,7 +69,11 @@ class ExampleTableApp(toga.App):
         btn_insert = toga.Button('Insert Row', on_press=self.insert_handler, style=btn_style)
         btn_delete = toga.Button('Delete Row', on_press=self.delete_handler, style=btn_style)
         btn_clear = toga.Button('Clear Table', on_press=self.clear_handler, style=btn_style)
-        btn_box = toga.Box(children=[btn_insert, btn_delete, btn_clear], style=Pack(direction=ROW))
+        btn_reset = toga.Button('Reset Table', on_press=self.reset_handler, style=btn_style)
+        btn_box = toga.Box(
+            children=[btn_insert, btn_delete, btn_clear, btn_reset],
+            style=Pack(direction=ROW)
+        )
 
         # Most outer box
         outer_box = toga.Box(

--- a/src/winforms/toga_winforms/widgets/table.py
+++ b/src/winforms/toga_winforms/widgets/table.py
@@ -22,6 +22,7 @@ class Table(Widget):
         self.native.Columns.AddRange(dataColumn)
 
     def change_source(self, source):
+        self.native.Items.Clear()
         for index, row in enumerate(self.interface.data):
             row._impl = WinForms.ListViewItem([
                 getattr(row, attr) for attr in self.interface._accessors


### PR DESCRIPTION
When changing the data source on a table, the Winforms backend didn't clear the existing content.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
