### PR TITLE
Fix direction argument in SplitContainer doc

### DIFF
--- a/docs/reference/api/containers/splitcontainer.rst
+++ b/docs/reference/api/containers/splitcontainer.rst
@@ -38,9 +38,9 @@ Split direction is set on instantiation using the `direction` keyword argument. 
 
     import toga
 
-    split = toga.SplitContainer()
+    split = toga.SplitContainer(direction=toga.SplitContainer.HORIZONTAL)
     left_container = toga.Box()
-    right_container = toga.ScrollContainer(direction=toga.ScrollContainer.HORIZONTAL)
+    right_container = toga.ScrollContainer()
 
     split.content = [left_container, right_container]
 


### PR DESCRIPTION
Fix `direction` argument in usage example in `SplitContainer` documentation so it is applied to the `SplitContainer` and not `ScrollContainer`

This is a new pull request to replace an older pull request (#320), which has conflicts.

NOTE: the direction argument is generated as `direction = True`, which does not make sense.

Possible alternatives are:

Use `horizontal` instead of `direction`
```python
class toga.widgets.splitcontainer.SplitContainer(id=None, style=None, horizontal=False, content=None, factory=None)
```

Use strings instead of booleans
```python
class SplitContainer(Widget):
    """..."""
    HORIZONTAL = 'horizontal'
    VERTICAL = 'vertical'
```

Use `Enum` or (`IntEnum`?)
```python
class SplitContainer(Widget):
    """..."""

    @unique
    class Direction(Enum):
        HORIZONTAL = 0
        VERTICAL = 1

    def __init__(self, id=None, style=None, direction=Direction.VERTICAL, content=None, factory=None):
        ...
```
