### PR TITLE
Clarify padding type

### DIFF
--- a/docs/reference/style/pack.rst
+++ b/docs/reference/style/pack.rst
@@ -128,7 +128,7 @@ The amount of space to allocate between the edge of the box, and the edge of con
 ``padding``
 -----------
 
-**Values:** ``<integer>`` {1,4}
+**Values:** ``<integer>`` or ``<tuple>`` of length 1-4
 
 A shorthand for setting the top, right, bottom and left padding with a single declaration.
 


### PR DESCRIPTION
<!--- Describe your changes in detail -->
{1,4} is in Python (and in math) set of 2 digits. It means len in... regex?
