### PR TITLE
Added selection handler to tree_source example

### DIFF
--- a/examples/tree_source/README.rst
+++ b/examples/tree_source/README.rst
@@ -3,9 +3,10 @@ Tree Source
 
 An example of using a custom data source with a tree.
 
-This is the same example as Tree; but instead of using dictionaries and lists,
-the code provides a custom data source that wraps the concept of decades and
-movies. This is a more realistic example of what you'd do in practice with a tree.
+This is a similar as Tree; but instead of using dictionaries and lists, the
+code provides a custom data source that wraps the file/folder names and dates
+of the current directory. This is a more realistic example of what you'd do in
+practice with a tree.
 
 Quickstart
 ~~~~~~~~~~

--- a/examples/tree_source/tree_source/app.py
+++ b/examples/tree_source/tree_source/app.py
@@ -136,8 +136,20 @@ class FileSystemSource(Node, Source):
 
 class ExampleTreeSourceApp(toga.App):
     def selection_handler(self, widget, node):
-        for file_index, n in enumerate(widget.selection, 1):
-            print('Selected[{0}] {1}'.format(file_index, n.path))
+        # A node is a dictionary of the last item that was clicked in the tree.
+        # node['node'].path would get you the file path to only that one item.
+        # self.label.text = f'Selected {node["node"].path}'
+        
+        # If you iterate over widget.selection, you can get the names and the 
+        # paths of everything selected (if multiple_select is enabled.)
+        # filepaths = [node.path for node in widget.selection]
+        files = len(widget.selection)
+        if files == 0:
+            self.label.text = 'A view of the current directory!'
+        elif files == 1:
+            self.label.text = f'You selected {files} item'
+        else:
+            self.label.text = f'You selected {files} items'
 
     def startup(self):
         # Set up main window
@@ -152,11 +164,12 @@ class ExampleTreeSourceApp(toga.App):
             multiple_select=True,
             on_select=self.selection_handler,
         )
+        self.label = toga.Label('A view of the current directory!', style=Pack(padding=10))
 
         # Outermost box
         outer_box = toga.Box(
             children=[
-                toga.Label('A view of the current directory!', style=Pack(padding=10)),
+                self.label,
                 self.tree,
             ],
             style=Pack(flex=1, direction=COLUMN)

--- a/examples/tree_source/tree_source/app.py
+++ b/examples/tree_source/tree_source/app.py
@@ -135,6 +135,9 @@ class FileSystemSource(Node, Source):
 
 
 class ExampleTreeSourceApp(toga.App):
+    def selection_handler(self, widget, node):
+        for file_index, n in enumerate(widget.selection, 1):
+            print('Selected[{0}] {1}'.format(file_index, n.path))
 
     def startup(self):
         # Set up main window
@@ -147,6 +150,7 @@ class ExampleTreeSourceApp(toga.App):
             data=self.fs_source,
             style=Pack(flex=1),
             multiple_select=True,
+            on_select=self.selection_handler,
         )
 
         # Outermost box

--- a/examples/tree_source/tree_source/app.py
+++ b/examples/tree_source/tree_source/app.py
@@ -139,17 +139,17 @@ class ExampleTreeSourceApp(toga.App):
         # A node is a dictionary of the last item that was clicked in the tree.
         # node['node'].path would get you the file path to only that one item.
         # self.label.text = f'Selected {node["node"].path}'
-        
-        # If you iterate over widget.selection, you can get the names and the 
+
+        # If you iterate over widget.selection, you can get the names and the
         # paths of everything selected (if multiple_select is enabled.)
         # filepaths = [node.path for node in widget.selection]
         files = len(widget.selection)
         if files == 0:
             self.label.text = 'A view of the current directory!'
         elif files == 1:
-            self.label.text = f'You selected {files} item'
+            self.label.text = 'You selected {0} item'.format(files)
         else:
-            self.label.text = f'You selected {files} items'
+            self.label.text = 'You selected {0} items'.format(files)
 
     def startup(self):
         # Set up main window


### PR DESCRIPTION
The `tree` example has a selection handler, but `tree_source` did not. It might be unclear to some, so I thought I'd add one for the `tree_source` example because it's a little different.

Also I could be wrong but I believe that readme defines the `tree` example with the movies, not the `tree_source` example with FileSystemSource. 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
