### PR TITLE
Remove dependencies on pathlib from the interface layer

### DIFF
--- a/src/android/toga_android/paths.py
+++ b/src/android/toga_android/paths.py
@@ -1,6 +1,7 @@
 import sys
 from pathlib import Path
 
+import toga
 from toga import App
 
 
@@ -21,14 +22,11 @@ class Paths:
     def logs(self):
         return Path.home() / 'Library' / 'Logs' / App.app.app_id
 
-    def sys_resource(self, next_to):
-        """Return a path to a Toga system resource that resides next to the
-        given Python source file
-
-        Args:
-            next_to (str): A Python source file the resource is next to
+    @property
+    def sys_resources(self):
+        """Return a path to a Toga system resources
         """
-        return Path(next_to).parent
+        return Path(toga.__file__).parent
 
     def arbitrary(self, path):
         """Return an arbitrary path representing object

--- a/src/android/toga_android/paths.py
+++ b/src/android/toga_android/paths.py
@@ -21,5 +21,24 @@ class Paths:
     def logs(self):
         return Path.home() / 'Library' / 'Logs' / App.app.app_id
 
+    def sys_resource(self, next_to):
+        """Return a path to a Toga system resource that resides next to the
+        given Python source file
+
+        Args:
+            next_to (str): A Python source file the resource is next to
+        """
+        return Path(next_to).parent
+
+    def arbitrary(self, path):
+        """Return an arbitrary path representing object
+
+        Args:
+            path (str): A string with the path to wrap. If a relative path is
+                        given, it will be interpreted to be relative to the
+                        application module directory.
+        """
+        return self.app / Path(path)
+
 
 paths = Paths()

--- a/src/android/toga_android/paths.py
+++ b/src/android/toga_android/paths.py
@@ -26,8 +26,8 @@ class Paths:
         return Path.home() / 'Library' / 'Logs' / App.app.app_id
 
     @property
-    def sys_resources(self):
-        """Return a path to a Toga system resources
+    def toga(self):
+        """Return a path to a Toga resources
         """
         return Path(toga.__file__).parent
 

--- a/src/android/toga_android/paths.py
+++ b/src/android/toga_android/paths.py
@@ -6,6 +6,9 @@ from toga import App
 
 
 class Paths:
+    # Allow instantiating Path object via the factory
+    Path = Path
+
     @property
     def app(self):
         return Path(sys.modules[App.app.module_name].__file__).parent
@@ -27,16 +30,6 @@ class Paths:
         """Return a path to a Toga system resources
         """
         return Path(toga.__file__).parent
-
-    def arbitrary(self, path):
-        """Return an arbitrary path representing object
-
-        Args:
-            path (str): A string with the path to wrap. If a relative path is
-                        given, it will be interpreted to be relative to the
-                        application module directory.
-        """
-        return self.app / Path(path)
 
 
 paths = Paths()

--- a/src/cocoa/toga_cocoa/paths.py
+++ b/src/cocoa/toga_cocoa/paths.py
@@ -1,6 +1,7 @@
 import sys
 from pathlib import Path
 
+import toga
 from toga import App
 
 
@@ -21,14 +22,11 @@ class Paths:
     def logs(self):
         return Path.home() / 'Library' / 'Logs' / App.app.app_id
 
-    def sys_resource(self, next_to):
-        """Return a path to a Toga system resource that resides next to the
-        given Python source file
-
-        Args:
-            next_to (str): A Python source file the resource is next to
+    @property
+    def sys_resources(self):
+        """Return a path to a Toga system resources
         """
-        return Path(next_to).parent
+        return Path(toga.__file__).parent
 
     def arbitrary(self, path):
         """Return an arbitrary path representing object

--- a/src/cocoa/toga_cocoa/paths.py
+++ b/src/cocoa/toga_cocoa/paths.py
@@ -26,8 +26,8 @@ class Paths:
         return Path.home() / 'Library' / 'Logs' / App.app.app_id
 
     @property
-    def sys_resources(self):
-        """Return a path to a Toga system resources
+    def toga(self):
+        """Return a path to a Toga resources
         """
         return Path(toga.__file__).parent
 

--- a/src/cocoa/toga_cocoa/paths.py
+++ b/src/cocoa/toga_cocoa/paths.py
@@ -21,5 +21,14 @@ class Paths:
     def logs(self):
         return Path.home() / 'Library' / 'Logs' / App.app.app_id
 
+    def sys_resource(self, next_to):
+        """Return a path to a Toga system resource that resides next to the
+        given Python source file
+
+        Args:
+            next_to (str): A Python source file the resource is next to
+        """
+        return Path(next_to).parent
+
 
 paths = Paths()

--- a/src/cocoa/toga_cocoa/paths.py
+++ b/src/cocoa/toga_cocoa/paths.py
@@ -30,5 +30,15 @@ class Paths:
         """
         return Path(next_to).parent
 
+    def arbitrary(self, path):
+        """Return an arbitrary path representing object
+
+        Args:
+            path (str): A string with the path to wrap. If a relative path is
+                        given, it will be interpreted to be relative to the
+                        application module directory.
+        """
+        return self.app / Path(path)
+
 
 paths = Paths()

--- a/src/cocoa/toga_cocoa/paths.py
+++ b/src/cocoa/toga_cocoa/paths.py
@@ -6,6 +6,9 @@ from toga import App
 
 
 class Paths:
+    # Allow instantiating Path object via the factory
+    Path = Path
+
     @property
     def app(self):
         return Path(sys.modules[App.app.module_name].__file__).parent
@@ -27,16 +30,6 @@ class Paths:
         """Return a path to a Toga system resources
         """
         return Path(toga.__file__).parent
-
-    def arbitrary(self, path):
-        """Return an arbitrary path representing object
-
-        Args:
-            path (str): A string with the path to wrap. If a relative path is
-                        given, it will be interpreted to be relative to the
-                        application module directory.
-        """
-        return self.app / Path(path)
 
 
 paths = Paths()

--- a/src/core/toga/icons.py
+++ b/src/core/toga/icons.py
@@ -35,7 +35,7 @@ class Icon:
         if self._impl is None:
             try:
                 if self.system:
-                    resource_path = factory.paths.sys_resources
+                    resource_path = factory.paths.toga
                 else:
                     resource_path = factory.paths.app
 

--- a/src/core/toga/icons.py
+++ b/src/core/toga/icons.py
@@ -1,5 +1,4 @@
 import os
-from pathlib import Path
 
 
 class Icon:
@@ -36,7 +35,7 @@ class Icon:
         if self._impl is None:
             try:
                 if self.system:
-                    resource_path = Path(__file__).parent
+                    resource_path = factory.paths.sys_resource(__file__)
                 else:
                     resource_path = factory.paths.app
 

--- a/src/core/toga/icons.py
+++ b/src/core/toga/icons.py
@@ -35,7 +35,7 @@ class Icon:
         if self._impl is None:
             try:
                 if self.system:
-                    resource_path = factory.paths.sys_resource(__file__)
+                    resource_path = factory.paths.sys_resources
                 else:
                     resource_path = factory.paths.app
 

--- a/src/core/toga/images.py
+++ b/src/core/toga/images.py
@@ -26,7 +26,7 @@ class Image:
             if self.path.startswith('http://') or self.path.startswith('https://'):
                 self._impl = factory.Image(interface=self, url=self.path)
             else:
-                full_path = factory.paths.arbitrary(self.path)
+                full_path = factory.paths.app / factory.paths.Path(self.path)
                 if not full_path.exists():
                     raise FileNotFoundError(
                         'Image file {full_path!r} does not exist'.format(

--- a/src/core/toga/images.py
+++ b/src/core/toga/images.py
@@ -1,6 +1,3 @@
-from pathlib import Path
-
-
 class Image:
     """
     A representation of graphical content.
@@ -29,7 +26,7 @@ class Image:
             if self.path.startswith('http://') or self.path.startswith('https://'):
                 self._impl = factory.Image(interface=self, url=self.path)
             else:
-                full_path = factory.paths.app / Path(self.path)
+                full_path = factory.paths.arbitrary(self.path)
                 if not full_path.exists():
                     raise FileNotFoundError(
                         'Image file {full_path!r} does not exist'.format(

--- a/src/dummy/toga_dummy/paths.py
+++ b/src/dummy/toga_dummy/paths.py
@@ -1,6 +1,7 @@
 import sys
 from pathlib import Path
 
+import toga
 from toga import App
 
 
@@ -21,14 +22,11 @@ class Paths:
     def logs(self):
         return Path.home() / 'logs' / App.app.app_id
 
-    def sys_resource(self, next_to):
-        """Return a path to a Toga system resource that resides next to the
-        given Python source file
-
-        Args:
-            next_to (str): A Python source file the resource is next to
+    @property
+    def sys_resources(self):
+        """Return a path to a Toga system resources
         """
-        return Path(next_to).parent
+        return Path(toga.__file__).parent
 
     def arbitrary(self, path):
         """Return an arbitrary path representing object

--- a/src/dummy/toga_dummy/paths.py
+++ b/src/dummy/toga_dummy/paths.py
@@ -30,5 +30,15 @@ class Paths:
         """
         return Path(next_to).parent
 
+    def arbitrary(self, path):
+        """Return an arbitrary path representing object
+
+        Args:
+            path (str): A string with the path to wrap. If a relative path is
+                        given, it will be interpreted to be relative to the
+                        application module directory.
+        """
+        return self.app / Path(path)
+
 
 paths = Paths()

--- a/src/dummy/toga_dummy/paths.py
+++ b/src/dummy/toga_dummy/paths.py
@@ -26,8 +26,8 @@ class Paths:
         return Path.home() / 'logs' / App.app.app_id
 
     @property
-    def sys_resources(self):
-        """Return a path to a Toga system resources
+    def toga(self):
+        """Return a path to a Toga resources
         """
         return Path(toga.__file__).parent
 

--- a/src/dummy/toga_dummy/paths.py
+++ b/src/dummy/toga_dummy/paths.py
@@ -21,5 +21,14 @@ class Paths:
     def logs(self):
         return Path.home() / 'logs' / App.app.app_id
 
+    def sys_resource(self, next_to):
+        """Return a path to a Toga system resource that resides next to the
+        given Python source file
+
+        Args:
+            next_to (str): A Python source file the resource is next to
+        """
+        return Path(next_to).parent
+
 
 paths = Paths()

--- a/src/dummy/toga_dummy/paths.py
+++ b/src/dummy/toga_dummy/paths.py
@@ -6,6 +6,9 @@ from toga import App
 
 
 class Paths:
+    # Allow instantiating Path object via the factory
+    Path = Path
+
     @property
     def app(self):
         return Path(sys.modules[App.app.module_name].__file__).parent
@@ -27,16 +30,6 @@ class Paths:
         """Return a path to a Toga system resources
         """
         return Path(toga.__file__).parent
-
-    def arbitrary(self, path):
-        """Return an arbitrary path representing object
-
-        Args:
-            path (str): A string with the path to wrap. If a relative path is
-                        given, it will be interpreted to be relative to the
-                        application module directory.
-        """
-        return self.app / Path(path)
 
 
 paths = Paths()

--- a/src/gtk/toga_gtk/paths.py
+++ b/src/gtk/toga_gtk/paths.py
@@ -1,6 +1,7 @@
 import sys
 from pathlib import Path
 
+import toga
 from toga import App
 
 
@@ -21,14 +22,11 @@ class Paths:
     def logs(self):
         return Path.home() / '.cache' / App.app.name / 'log'
 
-    def sys_resource(self, next_to):
-        """Return a path to a Toga system resource that resides next to the
-        given Python source file
-
-        Args:
-            next_to (str): A Python source file the resource is next to
+    @property
+    def sys_resources(self):
+        """Return a path to a Toga system resources
         """
-        return Path(next_to).parent
+        return Path(toga.__file__).parent
 
     def arbitrary(self, path):
         """Return an arbitrary path representing object

--- a/src/gtk/toga_gtk/paths.py
+++ b/src/gtk/toga_gtk/paths.py
@@ -21,5 +21,14 @@ class Paths:
     def logs(self):
         return Path.home() / '.cache' / App.app.name / 'log'
 
+    def sys_resource(self, next_to):
+        """Return a path to a Toga system resource that resides next to the
+        given Python source file
+
+        Args:
+            next_to (str): A Python source file the resource is next to
+        """
+        return Path(next_to).parent
+
 
 paths = Paths()

--- a/src/gtk/toga_gtk/paths.py
+++ b/src/gtk/toga_gtk/paths.py
@@ -30,5 +30,15 @@ class Paths:
         """
         return Path(next_to).parent
 
+    def arbitrary(self, path):
+        """Return an arbitrary path representing object
+
+        Args:
+            path (str): A string with the path to wrap. If a relative path is
+                        given, it will be interpreted to be relative to the
+                        application module directory.
+        """
+        return self.app / Path(path)
+
 
 paths = Paths()

--- a/src/gtk/toga_gtk/paths.py
+++ b/src/gtk/toga_gtk/paths.py
@@ -26,8 +26,8 @@ class Paths:
         return Path.home() / '.cache' / App.app.name / 'log'
 
     @property
-    def sys_resources(self):
-        """Return a path to a Toga system resources
+    def toga(self):
+        """Return a path to a Toga resources
         """
         return Path(toga.__file__).parent
 

--- a/src/gtk/toga_gtk/paths.py
+++ b/src/gtk/toga_gtk/paths.py
@@ -6,6 +6,9 @@ from toga import App
 
 
 class Paths:
+    # Allow instantiating Path object via the factory
+    Path = Path
+
     @property
     def app(self):
         return Path(sys.modules[App.app.module_name].__file__).parent
@@ -27,16 +30,6 @@ class Paths:
         """Return a path to a Toga system resources
         """
         return Path(toga.__file__).parent
-
-    def arbitrary(self, path):
-        """Return an arbitrary path representing object
-
-        Args:
-            path (str): A string with the path to wrap. If a relative path is
-                        given, it will be interpreted to be relative to the
-                        application module directory.
-        """
-        return self.app / Path(path)
 
 
 paths = Paths()

--- a/src/iOS/toga_iOS/paths.py
+++ b/src/iOS/toga_iOS/paths.py
@@ -1,6 +1,7 @@
 import sys
 from pathlib import Path
 
+import toga
 from toga import App
 
 
@@ -21,14 +22,11 @@ class Paths:
     def logs(self):
         return Path.home() / 'Library' / 'Logs' / App.app.app_id
 
-    def sys_resource(self, next_to):
-        """Return a path to a Toga system resource that resides next to the
-        given Python source file
-
-        Args:
-            next_to (str): A Python source file the resource is next to
+    @property
+    def sys_resources(self):
+        """Return a path to a Toga system resources
         """
-        return Path(next_to).parent
+        return Path(toga.__file__).parent
 
     def arbitrary(self, path):
         """Return an arbitrary path representing object

--- a/src/iOS/toga_iOS/paths.py
+++ b/src/iOS/toga_iOS/paths.py
@@ -26,8 +26,8 @@ class Paths:
         return Path.home() / 'Library' / 'Logs' / App.app.app_id
 
     @property
-    def sys_resources(self):
-        """Return a path to a Toga system resources
+    def toga(self):
+        """Return a path to a Toga resources
         """
         return Path(toga.__file__).parent
 

--- a/src/iOS/toga_iOS/paths.py
+++ b/src/iOS/toga_iOS/paths.py
@@ -21,5 +21,14 @@ class Paths:
     def logs(self):
         return Path.home() / 'Library' / 'Logs' / App.app.app_id
 
+    def sys_resource(self, next_to):
+        """Return a path to a Toga system resource that resides next to the
+        given Python source file
+
+        Args:
+            next_to (str): A Python source file the resource is next to
+        """
+        return Path(next_to).parent
+
 
 paths = Paths()

--- a/src/iOS/toga_iOS/paths.py
+++ b/src/iOS/toga_iOS/paths.py
@@ -30,5 +30,15 @@ class Paths:
         """
         return Path(next_to).parent
 
+    def arbitrary(self, path):
+        """Return an arbitrary path representing object
+
+        Args:
+            path (str): A string with the path to wrap. If a relative path is
+                        given, it will be interpreted to be relative to the
+                        application module directory.
+        """
+        return self.app / Path(path)
+
 
 paths = Paths()

--- a/src/iOS/toga_iOS/paths.py
+++ b/src/iOS/toga_iOS/paths.py
@@ -6,6 +6,9 @@ from toga import App
 
 
 class Paths:
+    # Allow instantiating Path object via the factory
+    Path = Path
+
     @property
     def app(self):
         return Path(sys.modules[App.app.module_name].__file__).parent
@@ -27,16 +30,6 @@ class Paths:
         """Return a path to a Toga system resources
         """
         return Path(toga.__file__).parent
-
-    def arbitrary(self, path):
-        """Return an arbitrary path representing object
-
-        Args:
-            path (str): A string with the path to wrap. If a relative path is
-                        given, it will be interpreted to be relative to the
-                        application module directory.
-        """
-        return self.app / Path(path)
 
 
 paths = Paths()

--- a/src/winforms/toga_winforms/paths.py
+++ b/src/winforms/toga_winforms/paths.py
@@ -6,6 +6,9 @@ from toga import App
 
 
 class Paths:
+    # Allow instantiating Path object via the factory
+    Path = Path
+
     @property
     def app(self):
         return Path(sys.modules[App.app.module_name].__file__).parent
@@ -33,16 +36,6 @@ class Paths:
         """Return a path to a Toga system resources
         """
         return Path(toga.__file__).parent
-
-    def arbitrary(self, path):
-        """Return an arbitrary path representing object
-
-        Args:
-            path (str): A string with the path to wrap. If a relative path is
-                        given, it will be interpreted to be relative to the
-                        application module directory.
-        """
-        return self.app / Path(path)
 
 
 paths = Paths()

--- a/src/winforms/toga_winforms/paths.py
+++ b/src/winforms/toga_winforms/paths.py
@@ -36,5 +36,15 @@ class Paths:
         """
         return Path(next_to).parent
 
+    def arbitrary(self, path):
+        """Return an arbitrary path representing object
+
+        Args:
+            path (str): A string with the path to wrap. If a relative path is
+                        given, it will be interpreted to be relative to the
+                        application module directory.
+        """
+        return self.app / Path(path)
+
 
 paths = Paths()

--- a/src/winforms/toga_winforms/paths.py
+++ b/src/winforms/toga_winforms/paths.py
@@ -1,6 +1,7 @@
 import sys
 from pathlib import Path
 
+import toga
 from toga import App
 
 
@@ -27,14 +28,11 @@ class Paths:
     def logs(self):
         return Path.home() / 'Library' / 'Local' / self.author / App.app.formal_name / 'Logs'
 
-    def sys_resource(self, next_to):
-        """Return a path to a Toga system resource that resides next to the
-        given Python source file
-
-        Args:
-            next_to (str): A Python source file the resource is next to
+    @property
+    def sys_resources(self):
+        """Return a path to a Toga system resources
         """
-        return Path(next_to).parent
+        return Path(toga.__file__).parent
 
     def arbitrary(self, path):
         """Return an arbitrary path representing object

--- a/src/winforms/toga_winforms/paths.py
+++ b/src/winforms/toga_winforms/paths.py
@@ -27,5 +27,14 @@ class Paths:
     def logs(self):
         return Path.home() / 'Library' / 'Local' / self.author / App.app.formal_name / 'Logs'
 
+    def sys_resource(self, next_to):
+        """Return a path to a Toga system resource that resides next to the
+        given Python source file
+
+        Args:
+            next_to (str): A Python source file the resource is next to
+        """
+        return Path(next_to).parent
+
 
 paths = Paths()

--- a/src/winforms/toga_winforms/paths.py
+++ b/src/winforms/toga_winforms/paths.py
@@ -32,7 +32,7 @@ class Paths:
         return Path.home() / 'Library' / 'Local' / self.author / App.app.formal_name / 'Logs'
 
     @property
-    def sys_resources(self):
+    def toga(self):
         """Return a path to a Toga system resources
         """
         return Path(toga.__file__).parent


### PR DESCRIPTION
In some environments (E.g. web client) the use of `pathlib` does not make sense.

Move all the places where `pathlib.Path` objects are allocated in the interface layer down to the backends layer so that in platforms where `pathlib` does not exist the factory could provide an alternative.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
