### PR TITLE
Use defined size when resizable is False (Window/Cocoa)

### DIFF
--- a/examples/button/button/app.py
+++ b/examples/button/button/app.py
@@ -8,7 +8,11 @@ class ExampleButtonApp(toga.App):
     def startup(self):
         # Window class
         #   Main window of the application with title and size
-        self.main_window = toga.MainWindow(title=self.name, size=(200, 200))
+        #   Also make the window non-resizable and non-minimizable.
+        self.main_window = toga.MainWindow(
+            title=self.name, size=(800, 500),
+            resizeable=False, minimizable=False
+        )
 
         # Common style of the inner boxes
         style_inner_box = Pack(direction=ROW)
@@ -16,17 +20,21 @@ class ExampleButtonApp(toga.App):
         # Button class
         #   Simple button with label and callback function called when
         #   hit the button
-        button1 = toga.Button('Change Label', on_press=self.callbackLabel)
+        button1 = toga.Button(
+            'Change Label',
+            on_press=self.callbackLabel,
+            style=Pack(flex=1),
+        )
 
         # Button with label and enable option
-        button2 = toga.Button('Disabled', enabled=False)
+        button2 = toga.Button('Disabled', enabled=False, style=Pack(flex=1))
 
         # Button with label and style option
         button3 = toga.Button('Bigger', style=Pack(width=200))
 
-        # Button with label and callback function called when
-        #   hit the button
-        button4 = toga.Button('Resize Window', on_press=self.callbackResize)
+        # Button with label and callback function called
+        button4a = toga.Button('Make window larger', on_press=self.callbackLarger)
+        button4b = toga.Button('Make window smaller', on_press=self.callbackSmaller)
 
         # Box class
         # Container of components
@@ -37,7 +45,8 @@ class ExampleButtonApp(toga.App):
                 button1,
                 button2,
                 button3,
-                button4
+                button4a,
+                button4b,
             ]
         )
 
@@ -77,10 +86,15 @@ class ExampleButtonApp(toga.App):
         #   In this case the label will change
         button.label = 'Magic!!'
 
-    def callbackResize(self, button):
+    def callbackLarger(self, button):
         # Some action when you hit the button
         #   In this case the window size will change
-        self.main_window.size = (100, 100)
+        self.main_window.size = (1000, 600)
+
+    def callbackSmaller(self, button):
+        # Some action when you hit the button
+        #   In this case the window size will change
+        self.main_window.size = (200, 200)
 
 
 def main():

--- a/src/cocoa/toga_cocoa/window.py
+++ b/src/cocoa/toga_cocoa/window.py
@@ -9,8 +9,7 @@ from toga_cocoa.libs import (
     NSClosableWindowMask, NSResizableWindowMask, NSMiniaturizableWindowMask,
     NSWindow, NSBackingStoreBuffered, NSLayoutConstraint,
     NSLayoutAttributeBottom, NSLayoutAttributeLeft, NSLayoutAttributeRight,
-    NSLayoutAttributeTop, NSLayoutRelationGreaterThanOrEqual,
-    NSLayoutRelationEqual, NSSize
+    NSLayoutAttributeTop, NSLayoutRelationGreaterThanOrEqual, NSSize
 )
 
 
@@ -41,8 +40,14 @@ class WindowDelegate(NSObject):
     def windowDidResize_(self, notification) -> None:
         if self.interface.content:
             # print()
-            # print("Window resize", (notification.object.contentView.frame.size.width, notification.object.contentView.frame.size.height))
-            if notification.object.contentView.frame.size.width > 0.0 and notification.object.contentView.frame.size.height > 0.0:
+            # print("Window resize", (
+            #   notification.object.contentView.frame.size.width,
+            #   notification.object.contentView.frame.size.height
+            # ))
+            if (
+                notification.object.contentView.frame.size.width > 0.0
+                and notification.object.contentView.frame.size.height > 0.0
+            ):
                 # Set the window to the new size
                 self.interface.content.refresh()
 
@@ -171,8 +176,12 @@ class Window:
         for child in widget.interface.children:
             child._impl.container = widget
 
-        # Enforce a minimum size based on the content
-        self._min_width_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(
+        # Enforce a minimum size based on the content size.
+        # This is enforcing the *minimum* size; the window might actually be
+        # bigger. If the window is resizable, using >= allows the window to
+        # be dragged larged; if not resizable, it enforces the smallest
+        # size that can be programmattically set on the window.
+        self._min_width_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # NOQA: E501
             widget.native, NSLayoutAttributeRight,
             NSLayoutRelationGreaterThanOrEqual,
             widget.native, NSLayoutAttributeLeft,
@@ -180,7 +189,7 @@ class Window:
         )
         widget.native.addConstraint(self._min_width_constraint)
 
-        self._min_height_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(
+        self._min_height_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # NOQA: E501
             widget.native, NSLayoutAttributeBottom,
             NSLayoutRelationGreaterThanOrEqual,
             widget.native, NSLayoutAttributeTop,
@@ -197,7 +206,7 @@ class Window:
     def set_size(self, size):
         frame = self.native.frame
         frame.size = NSSize(self.interface._size[0], self.interface._size[1])
-        self.native.setFrame(frame, display=True, animate=False)
+        self.native.setFrame(frame, display=True, animate=True)
 
     def set_app(self, app):
         pass

--- a/src/cocoa/toga_cocoa/window.py
+++ b/src/cocoa/toga_cocoa/window.py
@@ -174,7 +174,7 @@ class Window:
         # Enforce a minimum size based on the content
         self._min_width_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(
             widget.native, NSLayoutAttributeRight,
-            NSLayoutRelationGreaterThanOrEqual if self.interface.resizeable else NSLayoutRelationEqual,
+            NSLayoutRelationGreaterThanOrEqual,
             widget.native, NSLayoutAttributeLeft,
             1.0, 100
         )
@@ -182,7 +182,7 @@ class Window:
 
         self._min_height_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(
             widget.native, NSLayoutAttributeBottom,
-            NSLayoutRelationGreaterThanOrEqual if self.interface.resizeable else NSLayoutRelationEqual,
+            NSLayoutRelationGreaterThanOrEqual,
             widget.native, NSLayoutAttributeTop,
             1.0, 100
         )

--- a/src/core/toga/app.py
+++ b/src/core/toga/app.py
@@ -19,8 +19,14 @@ from toga.window import Window
 class MainWindow(Window):
     _WINDOW_CLASS = 'MainWindow'
 
-    def __init__(self, id=None, title=None, position=(100, 100), size=(640, 480), factory=None):
-        super().__init__(id=id, title=title, position=position, size=size, factory=factory)
+    def __init__(self, id=None, title=None, position=(100, 100), size=(640, 480),
+                 toolbar=None, resizeable=True, minimizable=True,
+                 factory=None):
+        super().__init__(
+            id=id, title=title, position=position, size=size, toolbar=toolbar,
+            resizeable=resizeable, closeable=True, minimizable=minimizable,
+            factory=factory
+        )
 
 
 class App:


### PR DESCRIPTION
Signed-off-by: Ignacio Cabeza <ignaciocabeza@gmail.com>

## Description

When Window `resizable` property is `False`, the constraint `_min_width_constraint` and `_min_height_constraint`  is using `NSLayoutRelationEqual`. This causes not desired behaviour with the size of the `Window`. I changed to always use `NSLayoutRelationGreaterThanOrEqual`

Before change:
![](https://media.giphy.com/media/kFOJA9ZXaiH6rUQSFA/giphy.gif)

After change:
![](https://media.giphy.com/media/JtGdnzlv47dCZldy29/giphy.gif)

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
