### PR TITLE
Try getting CGContext if call to graphicsPort() raises TypeError

### DIFF
--- a/src/cocoa/toga_cocoa/libs/appkit.py
+++ b/src/cocoa/toga_cocoa/libs/appkit.py
@@ -91,6 +91,7 @@ NSSuperscriptAttributeName = objc_const(appkit, "NSSuperscriptAttributeName")
 NSGlyphInfoAttributeName = objc_const(appkit, "NSGlyphInfoAttributeName")
 
 NSViewBoundsDidChangeNotification = objc_const(appkit, 'NSViewBoundsDidChangeNotification')
+NSViewFrameDidChangeNotification = objc_const(appkit, 'NSViewFrameDidChangeNotification')
 
 ######################################################################
 # NSBezierPath.h

--- a/src/cocoa/toga_cocoa/libs/foundation.py
+++ b/src/cocoa/toga_cocoa/libs/foundation.py
@@ -3,7 +3,7 @@
 ##########################################################################
 from ctypes import cdll, c_bool, util
 
-from rubicon.objc import objc_const, NSPoint, NSRect, ObjCClass
+from rubicon.objc import NSPoint, NSRect, ObjCClass
 
 ######################################################################
 foundation = cdll.LoadLibrary(util.find_library('Foundation'))

--- a/src/cocoa/toga_cocoa/libs/foundation.py
+++ b/src/cocoa/toga_cocoa/libs/foundation.py
@@ -1,10 +1,9 @@
 ##########################################################################
 # System/Library/Frameworks/Foundation.framework
 ##########################################################################
-from ctypes import *
-from ctypes import util
+from ctypes import cdll, c_bool, util
 
-from rubicon.objc import *
+from rubicon.objc import objc_const, NSPoint, NSRect, ObjCClass
 
 ######################################################################
 foundation = cdll.LoadLibrary(util.find_library('Foundation'))

--- a/src/cocoa/toga_cocoa/widgets/canvas.py
+++ b/src/cocoa/toga_cocoa/widgets/canvas.py
@@ -1,4 +1,4 @@
-from rubicon.objc import CGFloat
+from rubicon.objc import CGFloat, SEL
 
 from toga_cocoa.libs import (
     core_graphics,
@@ -12,11 +12,13 @@ from toga_cocoa.libs import (
     NSForegroundColorAttributeName,
     NSGraphicsContext,
     NSMutableDictionary,
+    NSNotificationCenter,
     NSPoint,
     NSStrokeColorAttributeName,
     NSStrokeWidthAttributeName,
     NSRect,
     NSView,
+    NSViewFrameDidChangeNotification,
     objc_method,
 )
 from toga_cocoa.colors import native_color
@@ -37,12 +39,24 @@ class TogaCanvas(NSView):
         # Default Cocoa coordinate frame is around the wrong way.
         return True
 
+    @objc_method
+    def frameChanged_(self, notification) -> None:
+        if self.interface.on_resize:
+            self.interface.on_resize(self.interface)
+
 
 class Canvas(Widget):
     def create(self):
         self.native = TogaCanvas.alloc().init()
         self.native.interface = self.interface
         self.native._impl = self
+
+        NSNotificationCenter.defaultCenter.addObserver(
+            self.native,
+            selector=SEL("frameChanged:"),
+            name=NSViewFrameDidChangeNotification,
+            object=self.native
+        )
 
         # Add the layout constraints
         self.add_constraints()
@@ -225,4 +239,4 @@ class Canvas(Widget):
         self.interface.intrinsic.width = fitting_size.width
 
     def set_on_resize(self, handler):
-        self.interface.factory.not_implemented('Canvas.on_resize')
+        pass

--- a/src/cocoa/toga_cocoa/widgets/canvas.py
+++ b/src/cocoa/toga_cocoa/widgets/canvas.py
@@ -27,7 +27,10 @@ from .base import Widget
 class TogaCanvas(NSView):
     @objc_method
     def drawRect_(self, rect: NSRect) -> None:
-        context = NSGraphicsContext.currentContext.graphicsPort()
+        try:
+            context = NSGraphicsContext.currentContext.graphicsPort()
+        except TypeError:
+            context = NSGraphicsContext.currentContext.CGContext
 
         if self.interface.redraw:
             self.interface._draw(self._impl, draw_context=context)

--- a/src/cocoa/toga_cocoa/widgets/canvas.py
+++ b/src/cocoa/toga_cocoa/widgets/canvas.py
@@ -27,10 +27,7 @@ from .base import Widget
 class TogaCanvas(NSView):
     @objc_method
     def drawRect_(self, rect: NSRect) -> None:
-        try:
-            context = NSGraphicsContext.currentContext.graphicsPort()
-        except TypeError:
-            context = NSGraphicsContext.currentContext.CGContext
+        context = NSGraphicsContext.currentContext.CGContext
 
         if self.interface.redraw:
             self.interface._draw(self._impl, draw_context=context)


### PR DESCRIPTION
In getting graphics context on MacOS, first try `NSGraphicsContext.currentContext.graphicsPort()` and if `TypeError` is raised, try `NSGraphicsContext.currentContext.CGContext`.

Fixes `TypeError: 'int' object is not callable` in MacOS 10.15

Fixes #815

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
