### PR TITLE
Winforms table performance improvements

### DIFF
--- a/src/winforms/toga_winforms/widgets/table.py
+++ b/src/winforms/toga_winforms/widgets/table.py
@@ -19,9 +19,11 @@ class Table(Widget):
 
         self.native.FullRowSelect = True
         self.native.Multiselect = self.interface.multiple_select
+        self.native.DoubleBuffered = True
         self.native.Columns.AddRange(dataColumn)
 
     def change_source(self, source):
+        self.native.BeginUpdate()
         self.native.Items.Clear()
         items = []
         for row in self.interface.data:
@@ -31,8 +33,10 @@ class Table(Widget):
             row._impl = _impl
             items.append(_impl)
         self.native.Items.AddRange(items)
+        self.native.EndUpdate()
 
     def update_data(self):
+        self.native.BeginUpdate()
         self.native.Items.Clear()
         items = []
         for row in self.interface.data:
@@ -42,12 +46,15 @@ class Table(Widget):
             row._impl = _impl
             items.append(_impl)
         self.native.Items.AddRange(items)
+        self.native.EndUpdate()
 
     def insert(self, index, item):
+        self.native.BeginUpdate()
         item._impl = WinForms.ListViewItem([
             getattr(item, attr) for attr in self.interface._accessors
         ])
         self.native.Items.Insert(index, item._impl)
+        self.native.EndUpdate()
 
     def change(self, item):
         self.interface.factory.not_implemented('Table.change()')

--- a/src/winforms/toga_winforms/widgets/table.py
+++ b/src/winforms/toga_winforms/widgets/table.py
@@ -23,19 +23,25 @@ class Table(Widget):
 
     def change_source(self, source):
         self.native.Items.Clear()
-        for index, row in enumerate(self.interface.data):
-            row._impl = WinForms.ListViewItem([
+        items = []
+        for row in self.interface.data:
+            _impl = WinForms.ListViewItem([
                 getattr(row, attr) for attr in self.interface._accessors
             ])
-            self.native.Items.Insert(index, row._impl)
+            row._impl = _impl
+            items.append(_impl)
+        self.native.Items.AddRange(items)
 
     def update_data(self):
         self.native.Items.Clear()
-        for index, row in enumerate(self.interface.data):
-            row._impl = WinForms.ListViewItem([
+        items = []
+        for row in self.interface.data:
+            _impl = WinForms.ListViewItem([
                 getattr(row, attr) for attr in self.interface._accessors
             ])
-            self.native.Items.Insert(index, row._impl)
+            row._impl = _impl
+            items.append(_impl)
+        self.native.Items.AddRange(items)
 
     def insert(self, index, item):
         item._impl = WinForms.ListViewItem([


### PR DESCRIPTION
- Enable double buffering
- Use `BeginUpdate()` and `EndUpdate()` to bundle multiple changes to table

Improves visual performance in frequently changing tables by removing flicker and making updates faster.

## PR Checklist:

- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
