### PR TITLE
Fixes #824 - Ensure that winforms table content is always a string

### DIFF
--- a/src/cocoa/toga_cocoa/libs/appkit.py
+++ b/src/cocoa/toga_cocoa/libs/appkit.py
@@ -564,12 +564,14 @@ NSTableCellView = ObjCClass('NSTableCellView')
 NSTableColumn = ObjCClass('NSTableColumn')
 NSTableView = ObjCClass('NSTableView')
 
-NSTableViewNoColumnAutoresizing = 0
-NSTableViewUniformColumnAutoresizingStyle = 1
-NSTableViewSequentialColumnAutoresizingStyle = 2
-NSTableViewReverseSequentialColumnAutoresizingStyle = 3
-NSTableViewLastColumnOnlyAutoresizingStyle = 4
-NSTableViewFirstColumnOnlyAutoresizingStyle = 5
+
+class NSTableViewColumnAutoresizingStyle(Enum):
+    NoAutoresizing = 0
+    Uniform = 1
+    Sequential = 2
+    ReverseSequential = 3
+    LastColumnOnly = 4
+    FirstColumnOnly = 5
 
 
 class NSTableViewAnimation(Enum):

--- a/src/cocoa/toga_cocoa/widgets/detailedlist.py
+++ b/src/cocoa/toga_cocoa/widgets/detailedlist.py
@@ -4,7 +4,7 @@ from travertino.size import at_least
 from toga_cocoa.libs import (
     NSBezelBorder,
     NSMenu,
-    NSTableViewUniformColumnAutoresizingStyle,
+    NSTableViewColumnAutoresizingStyle,
     NSTableColumn,
     NSTableView,
 )
@@ -101,7 +101,7 @@ class DetailedList(Widget):
         self.detailedlist = TogaList.alloc().init()
         self.detailedlist.interface = self.interface
         self.detailedlist._impl = self
-        self.detailedlist.columnAutoresizingStyle = NSTableViewUniformColumnAutoresizingStyle
+        self.detailedlist.columnAutoresizingStyle = NSTableViewColumnAutoresizingStyle.Uniform
 
         # TODO: Optionally enable multiple selection
         self.detailedlist.allowsMultipleSelection = False

--- a/src/cocoa/toga_cocoa/widgets/table.py
+++ b/src/cocoa/toga_cocoa/widgets/table.py
@@ -1,8 +1,14 @@
+from rubicon.objc import at
 from travertino.size import at_least
 
-from toga.sources import to_accessor
-from toga_cocoa.libs import *
-
+from toga_cocoa.libs import (
+    objc_method,
+    NSBezelBorder,
+    NSScrollView,
+    NSTableColumn,
+    NSTableView,
+    NSTableViewColumnAutoresizingStyle
+)
 from .base import Widget
 from .internal.cells import TogaIconCell
 from .internal.data import TogaData
@@ -98,7 +104,7 @@ class Table(Widget):
         self.table = TogaTable.alloc().init()
         self.table.interface = self.interface
         self.table._impl = self
-        self.table.columnAutoresizingStyle = NSTableViewUniformColumnAutoresizingStyle
+        self.table.columnAutoresizingStyle = NSTableViewColumnAutoresizingStyle.Uniform
 
         self.table.allowsMultipleSelection = self.interface.multiple_select
 

--- a/src/cocoa/toga_cocoa/widgets/table.py
+++ b/src/cocoa/toga_cocoa/widgets/table.py
@@ -17,14 +17,17 @@ class TogaTable(NSTableView):
     @objc_method
     def tableView_objectValueForTableColumn_row_(self, table, column, row: int):
         data_row = self.interface.data[row]
+
+        # Obtain (constructing, if it doesn't already exist) the
+        # impl for the data row.
         try:
-            data = data_row._impls
+            data = data_row._impl
         except AttributeError:
             data = {
                 attr: TogaData.alloc().init()
                 for attr in self.interface._accessors
             }
-            data_row._impls = data
+            data_row._impl = data
 
         col_identifier = str(column.identifier)
 

--- a/src/cocoa/toga_cocoa/widgets/tree.py
+++ b/src/cocoa/toga_cocoa/widgets/tree.py
@@ -6,7 +6,7 @@ from toga_cocoa.libs import (
     NSOutlineView,
     NSScrollView,
     NSTableColumn,
-    NSTableViewUniformColumnAutoresizingStyle,
+    NSTableViewColumnAutoresizingStyle,
     NSIndexSet,
     NSTableViewAnimation,
     CGRectMake,
@@ -192,7 +192,7 @@ class Tree(Widget):
         self.tree = TogaTree.alloc().init()
         self.tree.interface = self.interface
         self.tree._impl = self
-        self.tree.columnAutoresizingStyle = NSTableViewUniformColumnAutoresizingStyle
+        self.tree.columnAutoresizingStyle = NSTableViewColumnAutoresizingStyle.Uniform
         self.tree.usesAlternatingRowBackgroundColors = True
 
         self.tree.allowsMultipleSelection = self.interface.multiple_select

--- a/src/winforms/toga_winforms/widgets/table.py
+++ b/src/winforms/toga_winforms/widgets/table.py
@@ -23,35 +23,24 @@ class Table(Widget):
         self.native.Columns.AddRange(dataColumn)
 
     def change_source(self, source):
-        self.native.BeginUpdate()
-        self.native.Items.Clear()
-        items = []
-        for row in self.interface.data:
-            _impl = WinForms.ListViewItem([
-                getattr(row, attr) for attr in self.interface._accessors
-            ])
-            row._impl = _impl
-            items.append(_impl)
-        self.native.Items.AddRange(items)
-        self.native.EndUpdate()
+        self.update_data()
 
     def update_data(self):
         self.native.BeginUpdate()
         self.native.Items.Clear()
         items = []
         for row in self.interface.data:
-            _impl = WinForms.ListViewItem([
-                getattr(row, attr) for attr in self.interface._accessors
+            row._impl = WinForms.ListViewItem([
+                str(getattr(row, attr)) for attr in self.interface._accessors
             ])
-            row._impl = _impl
-            items.append(_impl)
+            items.append(row._impl)
         self.native.Items.AddRange(items)
         self.native.EndUpdate()
 
     def insert(self, index, item):
         self.native.BeginUpdate()
         item._impl = WinForms.ListViewItem([
-            getattr(item, attr) for attr in self.interface._accessors
+            str(getattr(item, attr)) for attr in self.interface._accessors
         ])
         self.native.Items.Insert(index, item._impl)
         self.native.EndUpdate()

--- a/src/winforms/toga_winforms/widgets/table.py
+++ b/src/winforms/toga_winforms/widgets/table.py
@@ -25,15 +25,27 @@ class Table(Widget):
     def change_source(self, source):
         self.update_data()
 
+    def row_data(self, item):
+        # TODO: Winforms can't support icons in tree cells; so, if the data source
+        # specifies an icon, strip it when converting to row data.
+        def strip_icon(item, attr):
+            val = getattr(item, attr)
+            if isinstance(val, tuple):
+                return str(val[1])
+            return str(val)
+
+        return [item] + [
+            strip_icon(item, attr)
+            for attr in self.interface._accessors
+        ]
+
     def update_data(self):
         self.native.BeginUpdate()
         self.native.Items.Clear()
         items = []
-        for row in self.interface.data:
-            row._impl = WinForms.ListViewItem([
-                str(getattr(row, attr)) for attr in self.interface._accessors
-            ])
-            items.append(row._impl)
+        for item in self.interface.data:
+            item._impl = WinForms.ListViewItem(self.row_data(item))
+            items.append(item._impl)
         self.native.Items.AddRange(items)
         self.native.EndUpdate()
 


### PR DESCRIPTION
Implementing a fix suggested by @yconst, ensure that row content for Winforms tables are always cast to strings; and, if the content potentially contains an icon, that the icon is stripped out.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
