### PR TITLE
Explicitly set enabled property for Button in init

### DIFF
--- a/examples/button/button/app.py
+++ b/examples/button/button/app.py
@@ -1,3 +1,5 @@
+import random
+
 import toga
 from toga.style import Pack
 from toga.colors import RED, BLUE
@@ -27,7 +29,13 @@ class ExampleButtonApp(toga.App):
         )
 
         # Button with label and enable option
-        button2 = toga.Button('Disabled', enabled=False, style=Pack(flex=1))
+        # Keep a reference to it so it can be enabled by another button.
+        self.button2 = toga.Button(
+            'Button is disabled!',
+            enabled=False,
+            style=Pack(flex=1),
+            on_press=self.callbackDisable,
+        )
 
         # Button with label and style option
         button3 = toga.Button('Bigger', style=Pack(width=200))
@@ -43,7 +51,7 @@ class ExampleButtonApp(toga.App):
             style=style_inner_box,
             children=[
                 button1,
-                button2,
+                self.button2,
                 button3,
                 button4a,
                 button4b,
@@ -84,7 +92,16 @@ class ExampleButtonApp(toga.App):
     def callbackLabel(self, button):
         # Some action when you hit the button
         #   In this case the label will change
-        button.label = 'Magic!!'
+        button.label = 'Magic {val}!!'.format(val=random.randint(0, 100))
+
+        # If the disabled button isn't enabled, enable it.
+        if not self.button2.enabled:
+            self.button2.enabled = True
+            self.button2.label = 'Disable button'
+
+    def callbackDisable(self, button):
+        button.enabled = False
+        button.label = 'Button is disabled!'
 
     def callbackLarger(self, button):
         # Some action when you hit the button

--- a/src/core/toga/widgets/button.py
+++ b/src/core/toga/widgets/button.py
@@ -26,6 +26,7 @@ class Button(Widget):
         # Set all the properties
         self.label = label
         self.on_press = on_press
+        self.enabled = enabled
 
     @property
     def label(self):


### PR DESCRIPTION
Set `self.enabled` property explicitly during init. Setting the property as part of super init has no effect because `_impl` is still `None`. Other components set the property in a similar manner.

Addresses Button cannot be set to not be enabled upon initialization.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
