### PR TITLE
Fix bug with running toga in windows.

### DIFF
--- a/src/winforms/toga_winforms/app.py
+++ b/src/winforms/toga_winforms/app.py
@@ -115,7 +115,10 @@ class App:
         # remaining string.
         print("Traceback (most recent call last):")
         py_exc = winforms_exc.get_Exception()
-        tb_end_pos = py_exc.StackTrace.index("\\n']   at Python")
+        try:
+            tb_end_pos = py_exc.StackTrace.index("\\n']   at Python")
+        except ValueError:
+            tb_end_pos = -1
         tb_str = py_exc.StackTrace[2:tb_end_pos]
         for level in tb_str.split("', '"):
             for line in level.split("\\n"):

--- a/src/winforms/toga_winforms/app.py
+++ b/src/winforms/toga_winforms/app.py
@@ -117,8 +117,10 @@ class App:
         print("Traceback (most recent call last):")
         py_exc = winforms_exc.get_Exception()
         full_stack_trace = py_exc.StackTrace
-        regex = re.compile(r"^\[(?:'(.*?)\n', )*'(.*?)\n'\]   (?:.*?) Python\.Runtime",
-                           re.DOTALL | re.UNICODE)
+        regex = re.compile(
+            r"^\[(?:'(.*?)', )*(?:'(.*?)')\]   (?:.*?) Python\.Runtime",
+            re.DOTALL | re.UNICODE
+        )
 
         stacktrace_relevant_lines = regex.findall(full_stack_trace)
         if len(stacktrace_relevant_lines) == 0:


### PR DESCRIPTION
Stacktrace is not printed correctly.

When throwing stack trace in windows platform, the error message is not always ending with `"\\n']   at Python"`. I added a try-except close that can handle cases it doesn't
