### PR TITLE
Enable or Disable tab in optionContainer

### DIFF
--- a/examples/optioncontainer/README.rst
+++ b/examples/optioncontainer/README.rst
@@ -1,0 +1,12 @@
+Option Container Example
+========================
+
+Test app for the Option Container Example widget.
+
+Quickstart
+~~~~~~~~~~
+
+To run this example:
+
+    $ pip install toga
+    $ python -m optioncontainer

--- a/examples/optioncontainer/optioncontainer/__init__.py
+++ b/examples/optioncontainer/optioncontainer/__init__.py
@@ -1,0 +1,9 @@
+# Examples of valid version strings
+# __version__ = '1.2.3.dev1'  # Development release 1
+# __version__ = '1.2.3a1'     # Alpha Release 1
+# __version__ = '1.2.3b1'     # Beta Release 1
+# __version__ = '1.2.3rc1'    # RC Release 1
+# __version__ = '1.2.3'       # Final Release
+# __version__ = '1.2.3.post1' # Post Release 1
+
+__version__ = '0.0.1'

--- a/examples/optioncontainer/optioncontainer/__main__.py
+++ b/examples/optioncontainer/optioncontainer/__main__.py
@@ -1,0 +1,4 @@
+from optioncontainer.app import main
+
+if __name__ == '__main__':
+    main().main_loop()

--- a/examples/optioncontainer/optioncontainer/app.py
+++ b/examples/optioncontainer/optioncontainer/app.py
@@ -5,17 +5,14 @@ from toga.constants import COLUMN
 
 class ExampleOptionContainerApp(toga.App):
 
-    def on_enable1(self, button):
+    def on_enable(self, button):
         self.optioncontainer.content[0].enabled = not self.optioncontainer.content[0].enabled
 
-    def on_enable2(self, button):
-        self.optioncontainer.content[1].enabled = not self.optioncontainer.content[1].enabled
-
     def on_change_label(self, button):
-        self.optioncontainer.content[1].label = 'Now I have another label!'
+        self.optioncontainer.content[0].label = 'Now I have another label!'
 
     def on_remove(self, button):
-        self.optioncontainer.remove(2)
+        self.optioncontainer.remove(0)
 
     def startup(self):
         # Set up main window
@@ -23,14 +20,14 @@ class ExampleOptionContainerApp(toga.App):
 
         self.optioncontainer = toga.OptionContainer()
 
-        btn_toggle_1 = toga.Button('Toggle Enabled Option 1', on_press=self.on_enable1)
-        btn_toggle_2 = toga.Button('Toggle Enabled Option 2', on_press=self.on_enable2)
-        btn_change_label = toga.Button('Change Label in Option 2', on_press=self.on_change_label)
-        btn_remove_option = toga.Button('Remove Tab', on_press=self.on_remove)
+        style_btn = Pack(padding_bottom=2)
+        btn_toggle_1 = toga.Button('Toggle enabled first option', on_press=self.on_enable, style=style_btn)
+        btn_change_label = toga.Button('Change label in first option', on_press=self.on_change_label, style=style_btn)
+        btn_remove_option = toga.Button('Remove first tab', on_press=self.on_remove, style=style_btn)
 
-        label_box1 = toga.Label('This is Box 1 ')
-        label_box2 = toga.Label('This is Box 2 ')
-        label_box3 = toga.Label('This is Box 3 ')
+        label_box1 = toga.Label('This is Box 1 ', style=Pack(padding=10))
+        label_box2 = toga.Label('This is Box 2 ', style=Pack(padding=10))
+        label_box3 = toga.Label('This is Box 3 ', style=Pack(padding=10))
 
         box1 = toga.Box(children=[label_box1])
         box2 = toga.Box(children=[label_box2])
@@ -43,7 +40,7 @@ class ExampleOptionContainerApp(toga.App):
         # Outermost box
         outer_box = toga.Box(
             children=[
-                btn_toggle_1, btn_toggle_2,
+                btn_toggle_1,
                 btn_change_label, btn_remove_option,
                 self.optioncontainer
             ],

--- a/examples/optioncontainer/optioncontainer/app.py
+++ b/examples/optioncontainer/optioncontainer/app.py
@@ -6,22 +6,18 @@ from toga.constants import COLUMN, ROW
 class ExampleOptionContainerApp(toga.App):
 
     def _create_options(self):
+        label_box0 = toga.Label('This is Box 0 ', style=Pack(padding=10))
         label_box1 = toga.Label('This is Box 1 ', style=Pack(padding=10))
         label_box2 = toga.Label('This is Box 2 ', style=Pack(padding=10))
-        label_box3 = toga.Label('This is Box 3 ', style=Pack(padding=10))
 
+        box0 = toga.Box(children=[label_box0])
         box1 = toga.Box(children=[label_box1])
         box2 = toga.Box(children=[label_box2])
-        box3 = toga.Box(children=[label_box3])
 
-        self.optioncontainer.add('Option1', box1)
-        self.optioncontainer.add('Option2', box2)
-        self.optioncontainer.add('Option3', box3)
+        self.optioncontainer.add('Option 0', box0)
+        self.optioncontainer.add('Option 1', box1)
+        self.optioncontainer.add('Option 2', box2)
         self._refresh_select()
-
-    def _remove_all(self):
-        while len(self.optioncontainer.content) > 0:
-            self.optioncontainer.remove(0)
 
     def _refresh_select(self):
         items = []
@@ -30,7 +26,7 @@ class ExampleOptionContainerApp(toga.App):
         self.select_option.items = items
 
     def on_add_option(self, button):
-        self.optioncontainer.add('Option', toga.Box())
+        self.optioncontainer.add('New Option', toga.Box())
         self._refresh_select()
 
     def on_enable(self, button):
@@ -45,10 +41,6 @@ class ExampleOptionContainerApp(toga.App):
         index = int(self.select_option.value)
         del self.optioncontainer.content[index]
         self._refresh_select()
-
-    def on_reset_optioncontainer(self, button):
-        self._remove_all()
-        self._create_options()
 
     def startup(self):
         # Set up main window
@@ -80,9 +72,8 @@ class ExampleOptionContainerApp(toga.App):
         self.optioncontainer = toga.OptionContainer(style=Pack(padding_bottom=20))
         self._create_options()
 
-        btn_reset = toga.Button('Reset demo', on_press=self.on_reset_optioncontainer)
         btn_add = toga.Button('Add Option', on_press=self.on_add_option)
-        box_general_actions = toga.Box(style=Pack(padding_bottom=10), children=[btn_reset, btn_add])
+        box_general_actions = toga.Box(style=Pack(padding_bottom=10), children=[btn_add])
 
         # Outermost box
         outer_box = toga.Box(

--- a/examples/optioncontainer/optioncontainer/app.py
+++ b/examples/optioncontainer/optioncontainer/app.py
@@ -29,18 +29,24 @@ class ExampleOptionContainerApp(toga.App):
         self.optioncontainer.add('New Option', toga.Box())
         self._refresh_select()
 
-    def on_enable(self, button):
+    def on_enable_option(self, button):
         index = int(self.select_option.value)
-        self.optioncontainer.content[index].enabled = not self.optioncontainer.content[index].enabled
+        try:
+            self.optioncontainer.content[index].enabled = not self.optioncontainer.content[index].enabled
+        except toga.OptionContainer.OptionException as e:
+            self.main_window.info_dialog('Oops', str(e))
 
-    def on_change_title(self, button):
+    def on_change_option_title(self, button):
         index = int(self.select_option.value)
         self.optioncontainer.content[index].label = self.input_change_title.value
 
-    def on_remove(self, button):
-        index = int(self.select_option.value)
-        del self.optioncontainer.content[index]
-        self._refresh_select()
+    def on_remove_option(self, button):
+        try:
+            index = int(self.select_option.value)
+            del self.optioncontainer.content[index]
+            self._refresh_select()
+        except toga.OptionContainer.OptionException as e:
+            self.main_window.info_dialog('Oops', str(e))
 
     def startup(self):
         # Set up main window
@@ -56,28 +62,61 @@ class ExampleOptionContainerApp(toga.App):
         label_select = toga.Label('Select an Option position:', style=style_flex)
         self.select_option = toga.Selection(style=style_flex)
         # buttons
-        btn_remove = toga.Button('Remove', on_press=self.on_remove, style=style_flex)
-        btn_enabled = toga.Button('Toggle enabled', on_press=self.on_enable, style=style_flex)
+        btn_remove = toga.Button(
+            'Remove',
+            on_press=self.on_remove_option,
+            style=style_flex
+        )
+        btn_enabled = toga.Button(
+            'Toggle enabled',
+            on_press=self.on_enable_option,
+            style=style_flex
+        )
         # change label
         self.input_change_title = toga.TextInput(style=style_flex)
-        btn_change_title = toga.Button('Change title', on_press=self.on_change_title,
-                                       style=style_flex)
+        btn_change_title = toga.Button(
+            'Change title',
+            on_press=self.on_change_option_title,
+            style=style_flex
+        )
 
-        box_select = toga.Box(style=style_select, children=[label_select, self.select_option])
-        box_actions_col1 = toga.Box(style=style_row, children=[btn_remove, btn_enabled])
-        box_actions_col2 = toga.Box(style=style_row, children=[self.input_change_title, btn_change_title])
-        box_actions = toga.Box(style=style_col, children=[box_actions_col1, box_actions_col2])
-        box_container_actions = toga.Box(style=style_row, children=[box_select, box_actions])
+        box_select = toga.Box(
+            style=style_select,
+            children=[label_select, self.select_option]
+        )
+        box_actions_col1 = toga.Box(
+            style=style_row,
+            children=[btn_remove, btn_enabled]
+        )
+        box_actions_col2 = toga.Box(
+            style=style_row,
+            children=[self.input_change_title, btn_change_title]
+        )
+        box_actions = toga.Box(
+            style=style_col,
+            children=[box_actions_col1, box_actions_col2]
+        )
+        box_container_actions = toga.Box(
+            style=style_row,
+            children=[box_select, box_actions]
+        )
 
         self.optioncontainer = toga.OptionContainer(style=Pack(padding_bottom=20))
         self._create_options()
 
         btn_add = toga.Button('Add Option', on_press=self.on_add_option)
-        box_general_actions = toga.Box(style=Pack(padding_bottom=10), children=[btn_add])
+        box_general_actions = toga.Box(
+            style=Pack(padding_bottom=10),
+            children=[btn_add]
+        )
 
         # Outermost box
         outer_box = toga.Box(
-            children=[box_general_actions, box_container_actions, self.optioncontainer],
+            children=[
+                box_general_actions,
+                box_container_actions,
+                self.optioncontainer
+            ],
             style=Pack(
                 flex=1,
                 direction=COLUMN,

--- a/examples/optioncontainer/optioncontainer/app.py
+++ b/examples/optioncontainer/optioncontainer/app.py
@@ -1,0 +1,72 @@
+import toga
+from toga.style import Pack
+from toga.constants import COLUMN
+
+
+class ExampleOptionContainerApp(toga.App):
+
+    def on_enable1(self, button):
+        self.optioncontainer.content[0].enabled = not self.optioncontainer.content[0].enabled
+
+    def on_enable2(self, button):
+        self.optioncontainer.content[1].enabled = not self.optioncontainer.content[1].enabled
+
+    def on_change_label(self, button):
+        self.optioncontainer.content[1].label = 'Now I have another label!'
+
+    def on_remove(self, button):
+        self.optioncontainer.remove(2)
+
+    def startup(self):
+        # Set up main window
+        self.main_window = toga.MainWindow(title=self.name)
+
+        self.optioncontainer = toga.OptionContainer()
+
+        btn_toggle_1 = toga.Button('Toggle Enabled Option 1', on_press=self.on_enable1)
+        btn_toggle_2 = toga.Button('Toggle Enabled Option 2', on_press=self.on_enable2)
+        btn_change_label = toga.Button('Change Label in Option 2', on_press=self.on_change_label)
+        btn_remove_option = toga.Button('Remove Tab', on_press=self.on_remove)
+
+        label_box1 = toga.Label('This is Box 1 ')
+        label_box2 = toga.Label('This is Box 2 ')
+        label_box3 = toga.Label('This is Box 3 ')
+
+        box1 = toga.Box(children=[label_box1])
+        box2 = toga.Box(children=[label_box2])
+        box3 = toga.Box(children=[label_box3])
+
+        self.optioncontainer.add('Option1', box1)
+        self.optioncontainer.add('Option2', box2)
+        self.optioncontainer.add('Option3', box3)
+
+        # Outermost box
+        outer_box = toga.Box(
+            children=[
+                btn_toggle_1, btn_toggle_2,
+                btn_change_label, btn_remove_option,
+                self.optioncontainer
+            ],
+            style=Pack(
+                flex=1,
+                direction=COLUMN,
+                padding=10,
+                width=500,
+                height=300
+            )
+        )
+
+        # Add the content on the main window
+        self.main_window.content = outer_box
+
+        # Show the main window
+        self.main_window.show()
+
+
+def main():
+    return ExampleOptionContainerApp('Option Container Example', 'org.beeware.widgets.optioncontainer')
+
+
+if __name__ == '__main__':
+    app = main()
+    app.main_loop()

--- a/examples/optioncontainer/optioncontainer/app.py
+++ b/examples/optioncontainer/optioncontainer/app.py
@@ -1,30 +1,11 @@
 import toga
 from toga.style import Pack
-from toga.constants import COLUMN
+from toga.constants import COLUMN, ROW
 
 
 class ExampleOptionContainerApp(toga.App):
 
-    def on_enable(self, button):
-        self.optioncontainer.content[0].enabled = not self.optioncontainer.content[0].enabled
-
-    def on_change_label(self, button):
-        self.optioncontainer.content[0].label = 'Now I have another label!'
-
-    def on_remove(self, button):
-        self.optioncontainer.remove(0)
-
-    def startup(self):
-        # Set up main window
-        self.main_window = toga.MainWindow(title=self.name)
-
-        self.optioncontainer = toga.OptionContainer()
-
-        style_btn = Pack(padding_bottom=2)
-        btn_toggle_1 = toga.Button('Toggle enabled first option', on_press=self.on_enable, style=style_btn)
-        btn_change_label = toga.Button('Change label in first option', on_press=self.on_change_label, style=style_btn)
-        btn_remove_option = toga.Button('Remove first tab', on_press=self.on_remove, style=style_btn)
-
+    def _create_options(self):
         label_box1 = toga.Label('This is Box 1 ', style=Pack(padding=10))
         label_box2 = toga.Label('This is Box 2 ', style=Pack(padding=10))
         label_box3 = toga.Label('This is Box 3 ', style=Pack(padding=10))
@@ -36,20 +17,80 @@ class ExampleOptionContainerApp(toga.App):
         self.optioncontainer.add('Option1', box1)
         self.optioncontainer.add('Option2', box2)
         self.optioncontainer.add('Option3', box3)
+        self._refresh_select()
+
+    def _remove_all(self):
+        while len(self.optioncontainer.content) > 0:
+            self.optioncontainer.remove(0)
+
+    def _refresh_select(self):
+        items = []
+        for i in range(len(self.optioncontainer.content)):
+            items.append(str(i))
+        self.select_option.items = items
+
+    def on_add_option(self, button):
+        self.optioncontainer.add('Option', toga.Box())
+        self._refresh_select()
+
+    def on_enable(self, button):
+        index = int(self.select_option.value)
+        self.optioncontainer.content[index].enabled = not self.optioncontainer.content[index].enabled
+
+    def on_change_title(self, button):
+        index = int(self.select_option.value)
+        self.optioncontainer.content[index].label = self.input_change_title.value
+
+    def on_remove(self, button):
+        index = int(self.select_option.value)
+        del self.optioncontainer.content[index]
+        self._refresh_select()
+
+    def on_reset_optioncontainer(self, button):
+        self._remove_all()
+        self._create_options()
+
+    def startup(self):
+        # Set up main window
+        self.main_window = toga.MainWindow(title=self.name)
+
+        # styles
+        style_flex = Pack(flex=1, padding=5)
+        style_row = Pack(direction=ROW, flex=1)
+        style_select = Pack(direction=ROW, flex=1, padding_right=10)
+        style_col = Pack(direction=COLUMN, flex=1)
+
+        # select
+        label_select = toga.Label('Select an Option position:', style=style_flex)
+        self.select_option = toga.Selection(style=style_flex)
+        # buttons
+        btn_remove = toga.Button('Remove', on_press=self.on_remove, style=style_flex)
+        btn_enabled = toga.Button('Toggle enabled', on_press=self.on_enable, style=style_flex)
+        # change label
+        self.input_change_title = toga.TextInput(style=style_flex)
+        btn_change_title = toga.Button('Change title', on_press=self.on_change_title,
+                                       style=style_flex)
+
+        box_select = toga.Box(style=style_select, children=[label_select, self.select_option])
+        box_actions_col1 = toga.Box(style=style_row, children=[btn_remove, btn_enabled])
+        box_actions_col2 = toga.Box(style=style_row, children=[self.input_change_title, btn_change_title])
+        box_actions = toga.Box(style=style_col, children=[box_actions_col1, box_actions_col2])
+        box_container_actions = toga.Box(style=style_row, children=[box_select, box_actions])
+
+        self.optioncontainer = toga.OptionContainer(style=Pack(padding_bottom=20))
+        self._create_options()
+
+        btn_reset = toga.Button('Reset demo', on_press=self.on_reset_optioncontainer)
+        btn_add = toga.Button('Add Option', on_press=self.on_add_option)
+        box_general_actions = toga.Box(style=Pack(padding_bottom=10), children=[btn_reset, btn_add])
 
         # Outermost box
         outer_box = toga.Box(
-            children=[
-                btn_toggle_1,
-                btn_change_label, btn_remove_option,
-                self.optioncontainer
-            ],
+            children=[box_general_actions, box_container_actions, self.optioncontainer],
             style=Pack(
                 flex=1,
                 direction=COLUMN,
                 padding=10,
-                width=500,
-                height=300
             )
         )
 

--- a/examples/optioncontainer/optioncontainer/resources/README
+++ b/examples/optioncontainer/optioncontainer/resources/README
@@ -1,0 +1,1 @@
+Put any icons or images in this directory.

--- a/examples/optioncontainer/pyproject.toml
+++ b/examples/optioncontainer/pyproject.toml
@@ -1,0 +1,44 @@
+[build-system]
+requires = ["briefcase"]
+
+[tool.briefcase]
+project_name = "Option Container Example"
+bundle = "org.beeware"
+version = "0.3.0.dev20"
+url = "https://beeware.org"
+license = "BSD license"
+author = 'Tiberius Yak'
+author_email = "tiberius@beeware.org"
+
+[tool.briefcase.app.optioncontainer]
+formal_name = "Option Container Example"
+description = "A testing app"
+sources = ['optioncontainer']
+requires = []
+
+
+[tool.briefcase.app.optioncontainer.macOS]
+requires = [
+    'toga-cocoa',
+]
+
+[tool.briefcase.app.optioncontainer.linux]
+requires = [
+    'toga-gtk',
+]
+
+[tool.briefcase.app.optioncontainer.windows]
+requires = [
+    'toga-winforms',
+]
+
+# Mobile deployments
+[tool.briefcase.app.optioncontainer.iOS]
+requires = [
+    'toga-iOS',
+]
+
+[tool.briefcase.app.optioncontainer.android]
+requires = [
+    'toga-android',
+]

--- a/src/cocoa/toga_cocoa/widgets/optioncontainer.py
+++ b/src/cocoa/toga_cocoa/widgets/optioncontainer.py
@@ -11,6 +11,10 @@ from toga_cocoa.window import CocoaViewport
 from .base import Widget
 
 
+class OptionException(ValueError):
+    pass
+
+
 class TogaTabViewDelegate(NSObject):
     @objc_method
     def tabView_didSelectTabViewItem_(self, view, item) -> None:
@@ -54,11 +58,12 @@ class OptionContainer(Widget):
         self.native.addTabViewItem(item)
 
     def remove_content(self, index):
-        try:
-            tabview = self.native.tabViewItemAtIndex(index)
-            self.native.removeTabViewItem(tabview)
-        except Exception as e:
-            print(e)
+        if self.native.numberOfTabViewItem == 1:
+            # don't allow remove if there is one tab left
+            raise OptionException('Option cannot be deleted because there is only one left')
+
+        tabview = self.native.tabViewItemAtIndex(index)
+        self.native.removeTabViewItem(tabview)
 
     def set_on_select(self, handler):
         pass
@@ -67,17 +72,22 @@ class OptionContainer(Widget):
         tabview = self.native.tabViewItemAtIndex(index)
         if not enabled and tabview == self.native.selectedTabViewItem:
             # Don't allow to disable selected tab
-            raise Exception('Disable selected Option is not allowed')
+            raise OptionException('Selected Option cannot be disabled')
+
+        if self.native.numberOfTabViewItem == 1:
+            # don't allow disable if there is one tab left
+            raise OptionException('Option cannot be disabled because there is only one left')
+
         tabview._setTabEnabled(enabled)
 
-    def is_enabled(self, index):
+    def is_option_enabled(self, index):
         tabview = self.native.tabViewItemAtIndex(index)
         return tabview._isTabEnabled()
 
-    def set_label(self, index, value):
+    def set_option_label(self, index, value):
         tabview = self.native.tabViewItemAtIndex(index)
         tabview.label = value
 
-    def get_label(self, index):
+    def get_option_label(self, index):
         tabview = self.native.tabViewItemAtIndex(index)
         return tabview.label

--- a/src/cocoa/toga_cocoa/widgets/optioncontainer.py
+++ b/src/cocoa/toga_cocoa/widgets/optioncontainer.py
@@ -58,11 +58,27 @@ class OptionContainer(Widget):
         self.native.addTabViewItem(item)
 
     def remove_content(self, index):
-        if self.native.numberOfTabViewItem == 1:
+        if self.native.numberOfTabViewItems == 1:
             # don't allow remove if there is one tab left
             raise OptionException('Cannot remove last remaining option')
 
+        # check if option siblings are all disabled, then raise error
+        is_only_enabled = True
+        indexes_to_check = [*range(self.native.numberOfTabViewItems)]
+        indexes_to_check.remove(index)
+        for siblingindex in indexes_to_check:
+            if self.is_option_enabled(siblingindex):
+                is_only_enabled = False
+                continue
+        if is_only_enabled:
+            raise OptionException('Cannot remove last remaining option enabled')
+
         tabview = self.native.tabViewItemAtIndex(index)
+
+        if tabview == self.native.selectedTabViewItem:
+            # Don't allow remove a selected tab
+            raise OptionException('Currently selected option cannot be removed')
+
         self.native.removeTabViewItem(tabview)
 
     def set_on_select(self, handler):
@@ -71,7 +87,7 @@ class OptionContainer(Widget):
     def set_option_enabled(self, index, enabled):
         tabview = self.native.tabViewItemAtIndex(index)
         if not enabled and tabview == self.native.selectedTabViewItem:
-            # Don't allow to disable selected tab
+            # Don't allow disable a selected tab
             raise OptionException('Currently selected option cannot be disabled')
 
         if not enabled and self.native.numberOfTabViewItems == 1:

--- a/src/cocoa/toga_cocoa/widgets/optioncontainer.py
+++ b/src/cocoa/toga_cocoa/widgets/optioncontainer.py
@@ -60,7 +60,7 @@ class OptionContainer(Widget):
     def remove_content(self, index):
         if self.native.numberOfTabViewItem == 1:
             # don't allow remove if there is one tab left
-            raise OptionException('Option cannot be deleted because there is only one left')
+            raise OptionException('Cannot remove last remaining option')
 
         tabview = self.native.tabViewItemAtIndex(index)
         self.native.removeTabViewItem(tabview)
@@ -72,11 +72,11 @@ class OptionContainer(Widget):
         tabview = self.native.tabViewItemAtIndex(index)
         if not enabled and tabview == self.native.selectedTabViewItem:
             # Don't allow to disable selected tab
-            raise OptionException('Selected Option cannot be disabled')
+            raise OptionException('Currently selected option cannot be disabled')
 
-        if self.native.numberOfTabViewItem == 1:
+        if not enabled and self.native.numberOfTabViewItems == 1:
             # don't allow disable if there is one tab left
-            raise OptionException('Option cannot be disabled because there is only one left')
+            raise OptionException('Cannot disable last remaining option')
 
         tabview._setTabEnabled(enabled)
 

--- a/src/cocoa/toga_cocoa/widgets/optioncontainer.py
+++ b/src/cocoa/toga_cocoa/widgets/optioncontainer.py
@@ -1,6 +1,11 @@
 from rubicon.objc import at
 
-from toga_cocoa.libs import *
+from toga_cocoa.libs import (
+    NSObject,
+    objc_method,
+    NSTabView,
+    NSTabViewItem
+)
 from toga_cocoa.window import CocoaViewport
 
 from .base import Widget
@@ -49,16 +54,30 @@ class OptionContainer(Widget):
         self.native.addTabViewItem(item)
 
     def remove_content(self, index):
-        tabview = self.native.tabViewItemAtIndex(index)
-        self.native.removeTabViewItem(tabview)
+        try:
+            tabview = self.native.tabViewItemAtIndex(index)
+            self.native.removeTabViewItem(tabview)
+        except Exception as e:
+            print(e)
 
     def set_on_select(self, handler):
         pass
 
     def set_option_enabled(self, index, enabled):
         tabview = self.native.tabViewItemAtIndex(index)
+        if not enabled and tabview == self.native.selectedTabViewItem:
+            # Don't allow to disable selected tab
+            raise Exception('Disable selected Option is not allowed')
         tabview._setTabEnabled(enabled)
+
+    def is_enabled(self, index):
+        tabview = self.native.tabViewItemAtIndex(index)
+        return tabview._isTabEnabled()
 
     def set_label(self, index, value):
         tabview = self.native.tabViewItemAtIndex(index)
         tabview.label = value
+
+    def get_label(self, index):
+        tabview = self.native.tabViewItemAtIndex(index)
+        return tabview.label

--- a/src/cocoa/toga_cocoa/widgets/optioncontainer.py
+++ b/src/cocoa/toga_cocoa/widgets/optioncontainer.py
@@ -11,10 +11,6 @@ from toga_cocoa.window import CocoaViewport
 from .base import Widget
 
 
-class OptionException(ValueError):
-    pass
-
-
 class TogaTabViewDelegate(NSObject):
     @objc_method
     def tabView_didSelectTabViewItem_(self, view, item) -> None:
@@ -58,26 +54,12 @@ class OptionContainer(Widget):
         self.native.addTabViewItem(item)
 
     def remove_content(self, index):
-        if self.native.numberOfTabViewItems == 1:
-            # don't allow remove if there is one tab left
-            raise OptionException('Cannot remove last remaining option')
-
-        # check if option siblings are all disabled, then raise error
-        is_only_enabled = True
-        indexes_to_check = [*range(self.native.numberOfTabViewItems)]
-        indexes_to_check.remove(index)
-        for siblingindex in indexes_to_check:
-            if self.is_option_enabled(siblingindex):
-                is_only_enabled = False
-                continue
-        if is_only_enabled:
-            raise OptionException('Cannot remove last remaining option enabled')
-
         tabview = self.native.tabViewItemAtIndex(index)
-
         if tabview == self.native.selectedTabViewItem:
-            # Don't allow remove a selected tab
-            raise OptionException('Currently selected option cannot be removed')
+            # Don't allow removal of a selected tab
+            raise self.interface.OptionException(
+                'Currently selected option cannot be removed'
+            )
 
         self.native.removeTabViewItem(tabview)
 
@@ -86,13 +68,11 @@ class OptionContainer(Widget):
 
     def set_option_enabled(self, index, enabled):
         tabview = self.native.tabViewItemAtIndex(index)
-        if not enabled and tabview == self.native.selectedTabViewItem:
+        if tabview == self.native.selectedTabViewItem:
             # Don't allow disable a selected tab
-            raise OptionException('Currently selected option cannot be disabled')
-
-        if not enabled and self.native.numberOfTabViewItems == 1:
-            # don't allow disable if there is one tab left
-            raise OptionException('Cannot disable last remaining option')
+            raise self.interface.OptionException(
+                'Currently selected option cannot be disabled'
+            )
 
         tabview._setTabEnabled(enabled)
 

--- a/src/cocoa/toga_cocoa/widgets/optioncontainer.py
+++ b/src/cocoa/toga_cocoa/widgets/optioncontainer.py
@@ -68,7 +68,7 @@ class OptionContainer(Widget):
 
     def set_option_enabled(self, index, enabled):
         tabview = self.native.tabViewItemAtIndex(index)
-        if tabview == self.native.selectedTabViewItem:
+        if not enabled and tabview == self.native.selectedTabViewItem:
             # Don't allow disable a selected tab
             raise self.interface.OptionException(
                 'Currently selected option cannot be disabled'

--- a/src/cocoa/toga_cocoa/widgets/optioncontainer.py
+++ b/src/cocoa/toga_cocoa/widgets/optioncontainer.py
@@ -50,3 +50,7 @@ class OptionContainer(Widget):
 
     def set_on_select(self, handler):
         pass
+
+    def set_option_enabled(self, index, enabled):
+        tabview = self.native.tabViewItemAtIndex(index)
+        tabview._setTabEnabled(enabled)

--- a/src/cocoa/toga_cocoa/widgets/optioncontainer.py
+++ b/src/cocoa/toga_cocoa/widgets/optioncontainer.py
@@ -48,9 +48,17 @@ class OptionContainer(Widget):
         item.view = widget.native
         self.native.addTabViewItem(item)
 
+    def remove_content(self, index):
+        tabview = self.native.tabViewItemAtIndex(index)
+        self.native.removeTabViewItem(tabview)
+
     def set_on_select(self, handler):
         pass
 
     def set_option_enabled(self, index, enabled):
         tabview = self.native.tabViewItemAtIndex(index)
         tabview._setTabEnabled(enabled)
+
+    def set_label(self, index, value):
+        tabview = self.native.tabViewItemAtIndex(index)
+        tabview.label = value

--- a/src/cocoa/toga_cocoa/widgets/selection.py
+++ b/src/cocoa/toga_cocoa/widgets/selection.py
@@ -38,7 +38,7 @@ class Selection(Widget):
         self.native.selectItemWithTitle(item)
 
     def get_selected_item(self):
-        return self.native.titleOfSelectedItem
+        return str(self.native.titleOfSelectedItem)
 
     def set_on_select(self, handler):
         pass

--- a/src/core/toga/widgets/optioncontainer.py
+++ b/src/core/toga/widgets/optioncontainer.py
@@ -84,3 +84,6 @@ class OptionContainer(Widget):
         """
         self._on_select = wrapped_handler(self, handler)
         self._impl.set_on_select(self._on_select)
+
+    def set_option_enabled(self, index, enabled=True):
+        self._impl.set_option_enabled(index, enabled)

--- a/src/core/toga/widgets/optioncontainer.py
+++ b/src/core/toga/widgets/optioncontainer.py
@@ -28,7 +28,7 @@ class OptionItem:
 
     @property
     def enabled(self):
-        return self._interface._impl.is_enabled(self.index)
+        return self._interface._impl.is_option_enabled(self.index)
 
     @enabled.setter
     def enabled(self, enabled):
@@ -36,11 +36,11 @@ class OptionItem:
 
     @property
     def label(self):
-        return self._interface._impl.get_label(self.index)
+        return self._interface._impl.get_option_label(self.index)
 
     @label.setter
     def label(self, value):
-        self._interface._impl.set_label(self.index, value)
+        self._interface._impl.set_option_label(self.index, value)
 
     def refresh(self):
         self._widget.refresh()

--- a/src/core/toga/widgets/optioncontainer.py
+++ b/src/core/toga/widgets/optioncontainer.py
@@ -108,6 +108,8 @@ class OptionContainer(Widget):
             Each tuple in the list is composed of a title for the option and
             the widget tree that is displayed in the option.
     """
+    class OptionException(ValueError):
+        pass
 
     def __init__(self, id=None, style=None, content=None, on_select=None, factory=None):
         super().__init__(id=id, style=style, factory=factory)

--- a/src/core/toga/widgets/selection.py
+++ b/src/core/toga/widgets/selection.py
@@ -43,11 +43,10 @@ class Selection(Widget):
     @items.setter
     def items(self, items):
         self._impl.remove_all_items()
+        self._items = items
 
         for i in items:
             self._impl.add_item(i)
-
-        self._items = items
 
     @property
     def value(self):

--- a/src/dummy/toga_dummy/widgets/optioncontainer.py
+++ b/src/dummy/toga_dummy/widgets/optioncontainer.py
@@ -8,5 +8,20 @@ class OptionContainer(Widget):
     def add_content(self, label, widget):
         self._action('add content', label=label, widget=widget)
 
+    def remove_content(self, index):
+        self._action('remove content', index=index)
+
     def set_on_select(self, handler):
         self._set_value('on_select', handler)
+
+    def set_option_enabled(self, index, enabled):
+        self._action('set option enabled', index=index)
+
+    def is_enabled(self, index):
+        self._action('is enabled', index=index)
+
+    def set_label(self, index, value):
+        self._action('set option label', index=index, value=value)
+
+    def get_label(self, index):
+        self._action('get label', index=index)

--- a/src/dummy/toga_dummy/widgets/optioncontainer.py
+++ b/src/dummy/toga_dummy/widgets/optioncontainer.py
@@ -17,11 +17,11 @@ class OptionContainer(Widget):
     def set_option_enabled(self, index, enabled):
         self._action('set option enabled', index=index)
 
-    def is_enabled(self, index):
+    def is_option_enabled(self, index):
         self._action('is enabled', index=index)
 
-    def set_label(self, index, value):
+    def set_option_label(self, index, value):
         self._action('set option label', index=index, value=value)
 
-    def get_label(self, index):
+    def get_option_label(self, index):
         self._action('get label', index=index)

--- a/src/gtk/toga_gtk/widgets/optioncontainer.py
+++ b/src/gtk/toga_gtk/widgets/optioncontainer.py
@@ -21,3 +21,18 @@ class OptionContainer(Widget):
     def set_on_select(self, handler):
         # No special handling required
         pass
+
+    def remove_content(self, index):
+        return NotImplementedError
+
+    def set_option_enabled(self, index, enabled):
+        return NotImplementedError
+
+    def is_option_enabled(self, index):
+        return NotImplementedError
+
+    def set_option_label(self, index, value):
+        return NotImplementedError
+
+    def get_option_label(self, index):
+        return NotImplementedError

--- a/src/gtk/toga_gtk/widgets/optioncontainer.py
+++ b/src/gtk/toga_gtk/widgets/optioncontainer.py
@@ -23,16 +23,16 @@ class OptionContainer(Widget):
         pass
 
     def remove_content(self, index):
-        return NotImplementedError
+        self.interface.factory.not_implemented('OptionContainer.remove_content()')
 
     def set_option_enabled(self, index, enabled):
-        return NotImplementedError
+        self.interface.factory.not_implemented('OptionContainer.set_option_enabled()')
 
     def is_option_enabled(self, index):
-        return NotImplementedError
+        self.interface.factory.not_implemented('OptionContainer.is_option_enabled()')
 
     def set_option_label(self, index, value):
-        return NotImplementedError
+        self.interface.factory.not_implemented('OptionContainer.set_option_label()')
 
     def get_option_label(self, index):
-        return NotImplementedError
+        self.interface.factory.not_implemented('OptionContainer.get_option_label()')

--- a/src/gtk/toga_gtk/widgets/selection.py
+++ b/src/gtk/toga_gtk/widgets/selection.py
@@ -17,11 +17,9 @@ class Selection(Widget):
             self.interface.on_select(widget)
 
     def remove_all_items(self):
-        # self._text.clear()
         self.native.remove_all()
 
     def add_item(self, item):
-        # self._text.append(item)
         self.native.append_text(item)
 
         # Gtk.ComboBox does not select the first item, so it's done here.

--- a/src/winforms/toga_winforms/widgets/optioncontainer.py
+++ b/src/winforms/toga_winforms/widgets/optioncontainer.py
@@ -25,5 +25,20 @@ class OptionContainer(Widget):
         item.Controls.Add(widget.native)
         self.native.Controls.Add(item)
 
+    def remove_content(self, index):
+        self.interface.factory.not_implemented('OptionContainer.remove_content()')
+
     def set_on_select(self, handler):
         self.interface.factory.not_implemented('OptionContainer.set_on_select()')
+
+    def set_option_enabled(self, index, value):
+        self.interface.factory.not_implemented('OptionContainer.is_option_enabled()')
+
+    def is_option_enabled(self, index):
+        self.interface.factory.not_implemented('OptionContainer.is_option_enabled()')
+
+    def set_option_label(self, index, value):
+        self.interface.factory.not_implemented('OptionContainer.set_option_label()')
+
+    def get_option_label(self, index):
+        self.interface.factory.not_implemented('OptionContainer.get_option_label()')


### PR DESCRIPTION
Signed-off-by: Ignacio Cabeza <ignaciocabeza@gmail.com>

Added method to enable or disable an option of the OptionContainer for Cocoa
This is a WIP. 

![image](https://user-images.githubusercontent.com/479689/77219482-2685c980-6b71-11ea-8a79-8650b22ed95b.png)

```python
import toga
from toga.constants import COLUMN, ROW
from toga.style import Pack

class ExampleApp(toga.App):
        
    def on_enable(self, button):
        self.optioncontainer.set_option_enabled(1, True)

    def on_disable(self, button):
        self.optioncontainer.set_option_enabled(1, False)

    def startup(self):
        self.main_window = toga.MainWindow(title="Test Window")
        self.button = toga.Button('enable tab 1', on_press=self.on_enable)
        self.button2 = toga.Button('disable tab 1', on_press=self.on_disable)

        box1 = toga.Box()
        box2 = toga.Box()
        self.optioncontainer = toga.OptionContainer()
        self.optioncontainer.add('Option1', box1)
        self.optioncontainer.add('Option2', box2)
        
        controls = [
            self.button,
            self.button2,
            self.optioncontainer
        ]

        self.box = toga.Box(children=controls, style=Pack(direction=COLUMN, flex=1))
        self.main_window.content = self.box
        self.main_window.show()

def main():
    return ExampleApp('Test', 'org.beeware.widgets.testing')

if __name__ == '__main__':
    app = main()
    app.main_loop()
```

I think a better way would be to have a `OptionItem` class and store all instance of OptionItem inside of an OptionContainer and use it in this way:
```python
...
self.optioncontainer.add('Option1', box1)
...

self.optioncontanier.get(1).enabled = False
self.optioncontanier.get(1).label = "I want to change the label
```


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
