### PR TITLE
expand image class to support two extra format, data and image object

### DIFF
--- a/src/cocoa/toga_cocoa/images.py
+++ b/src/cocoa/toga_cocoa/images.py
@@ -1,15 +1,22 @@
-from toga_cocoa.libs import NSImage, NSURL
+from toga_cocoa.libs import NSImage, NSURL,NSData
 
 
 class Image:
-    def __init__(self, interface, path=None, url=None):
+    def __init__(self, interface, path=None, url=None, data=None,image=None):
         self.interface = interface
         self.path = path
         self.url = url
+        self.data = data
+        self.image=image
 
         if path:
             self.native = NSImage.alloc().initWithContentsOfFile(str(path))
         elif url:
             self.native = NSImage.alloc().initByReferencingURL(
-                NSURL.URLWithString_(url)
-            )
+                NSURL.URLWithString_(url))
+        elif data:
+            self.native = NSImage.alloc().initWithData(data)
+        elif image:
+            self.native = NSImage(image)
+            
+            


### PR DESCRIPTION
to expand image class to support the image format from image data (basically from buffer) and from the image object such as UIImage for ios or NSimage for macos

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
