### PR TITLE
fixes #707: Change key names for detailed_list

### DIFF
--- a/src/core/toga/widgets/detailedlist.py
+++ b/src/core/toga/widgets/detailedlist.py
@@ -26,10 +26,20 @@ class DetailedList(Widget):
         >>>
         >>> dlist = toga.DetailedList(data=['Item 0', 'Item 1', 'Item 2'], on_select=selection_handler)
     """
+
     MIN_HEIGHT = 100
     MIN_WIDTH = 100
 
-    def __init__(self, id=None, data=None, on_delete=None, on_refresh=None, on_select=None, style=None, factory=None):
+    def __init__(
+        self,
+        id=None,
+        data=None,
+        on_delete=None,
+        on_refresh=None,
+        on_select=None,
+        style=None,
+        factory=None,
+    ):
         super().__init__(id=id, style=style, factory=factory)
         self._data = None
         self._impl = self.factory.DetailedList(interface=self)
@@ -52,9 +62,9 @@ class DetailedList(Widget):
     @data.setter
     def data(self, data):
         if data is None:
-            self._data = ListSource(data=[], accessors=['icon', 'label1', 'label2'])
+            self._data = ListSource(data=[], accessors=["icon", "title", "subtitle"])
         elif isinstance(data, (list, tuple)):
-            self._data = ListSource(data=data, accessors=['icon', 'label1', 'label2'])
+            self._data = ListSource(data=data, accessors=["icon", "title", "subtitle"])
         else:
             self._data = data
 
@@ -129,4 +139,3 @@ class DetailedList(Widget):
     def on_select(self, handler: callable):
         self._on_select = wrapped_handler(self, handler)
         self._impl.set_on_select(self._on_select)
-


### PR DESCRIPTION
<!--- Describe your changes in detail -->
It changes the key names for the data of detailed_list from "icon", "label1", and "label2" to "icon", "title", "subtitle" in the toga core, because both the macOS and iOS implementation if detailed list use these key names. I didn't test the iOS implementation since I don't have an iPhone.

<!--- What problem does this change solve? -->
It solves an issue where the default key names doesn't match the keywords of the implementation.

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
It fixes #707 
I think it also relates to #747 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
