### PR TITLE
Rely on rubicon-java for Android implementation

### DIFF
--- a/src/android/toga_android/app.py
+++ b/src/android/toga_android/app.py
@@ -1,5 +1,4 @@
-from rubicon.java import JavaClass, JavaInterface
-
+from .libs import IPythonApp, MainActivity
 from .window import Window
 
 
@@ -7,17 +6,11 @@ class MainWindow(Window):
     pass
 
 
-# The `IPythonApp` interface in Java allows Python code to
-# run on Android activity lifecycle hooks such as `onCreate()`.
-IPythonApp = JavaInterface('org/beeware/android/IPythonApp')
-
-
 class TogaApp(IPythonApp):
     def __init__(self, app):
         super().__init__()
         self._interface = app
-        activity_class = JavaClass('org/beeware/android/MainActivity')
-        activity_class.setPythonApp(self)
+        MainActivity.setPythonApp(self)
         print('Python app launched & stored in Android Activity class')
 
     def onCreate(self):

--- a/src/android/toga_android/app.py
+++ b/src/android/toga_android/app.py
@@ -1,4 +1,4 @@
-from android import PythonActivity
+from rubicon.java import JavaClass, JavaInterface
 
 from .window import Window
 
@@ -7,9 +7,21 @@ class MainWindow(Window):
     pass
 
 
-class TogaApp:
+# The `IPythonApp` interface in Java allows Python code to
+# run on Android activity lifecycle hooks such as `onCreate()`.
+IPythonApp = JavaInterface('org/beeware/android/IPythonApp')
+
+
+class TogaApp(IPythonApp):
     def __init__(self, app):
+        super().__init__()
         self._interface = app
+        activity_class = JavaClass('org/beeware/android/MainActivity')
+        activity_class.setPythonApp(self)
+        print('Python app launched & stored in Android Activity class')
+
+    def onCreate(self):
+        print("Toga app: onCreate")
 
     def onStart(self):
         print("Toga app: onStart")
@@ -41,21 +53,16 @@ class App:
         self.interface._impl = self
 
     def create(self):
-        # Connect this app to the PythonActivity
         self._listener = TogaApp(self)
-
-        # Set the Python activity listener to be this app.
-        self.native = PythonActivity.setListener(self._listener)
-
-        self.startup()
 
     def open_document(self, fileURL):
         print("Can't open document %s (yet)" % fileURL)
 
     def main_loop(self):
-        # Main loop is a no-op on Android; the app loop is integrated with the
-        # main Android event loop.
-        pass
+        # Connect the Python code to the Java Activity.
+        self.create()
+        # The app loop is integrated with the main Android event loop,
+        # so there is no further work to do.
 
     def set_main_window(self, window):
         pass

--- a/src/android/toga_android/factory.py
+++ b/src/android/toga_android/factory.py
@@ -1,33 +1,9 @@
 from .app import App, MainWindow
-# from .color import color
-# from .command import Command
-# from .font import font
 from .paths import paths
 
 from .widgets.box import Box
-from .widgets.button import Button
-# from .widgets.canvas import Canvas
-# from .widgets.detailedlist import DetailedList
-# from .widgets.icon import Icon
-# from .widgets.image import *
-# from .widgets.imageview import *
-from .widgets.label import Label
-# from .widgets.multilinetextinput import *
-# from .widgets.numberinput import NumberInput
-# from .widgets.optioncontainer import *
-# from .widgets.passwordinput import *
-# from .widgets.progressbar import *
-# from .widgets.scrollcontainer import *
-# from .widgets.selection import Selection
-# from .widgets.slider import *
-# from .widgets.splitcontainer import *
-# from .widgets.switch import *
-# from .widgets.table import *
-from .widgets.textinput import TextInput
-# from .widgets.tree import *
-# from .widgets.webview import *
+from .icons import Icon
 from .window import Window
-
 
 def not_implemented(feature):
     print('[Android] Not implemented: {}'.format(feature))
@@ -35,34 +11,11 @@ def not_implemented(feature):
 
 __all__ = [
     'not_implemented',
-
-    'App', 'MainWindow',
-    # 'color',
-    # 'Command',
-    # 'font',
+    'App',
+    'MainWindow',
     'paths',
-
     'Box',
-    'Button',
-    # 'Canvas',
     'DetailedList',
-    # 'Icon',
-    # 'Image',
-    # 'ImageView',
-    'Label',
-    # 'MultilineTextInput',
-    # 'NumberInput',
-    # 'OptionContainer',
-    # 'PasswordInput',
-    # 'ProgressBar',
-    # 'ScrollContainer',
-    # 'Selection',
-    # 'Slider',
-    # 'SplitContainer',
-    # 'Switch',
-    # 'Table',
-    'TextInput',
-    # 'Tree',
-    # 'WebView',
+    'Icon',
     'Window',
 ]

--- a/src/android/toga_android/factory.py
+++ b/src/android/toga_android/factory.py
@@ -5,6 +5,7 @@ from .widgets.box import Box
 from .icons import Icon
 from .window import Window
 
+
 def not_implemented(feature):
     print('[Android] Not implemented: {}'.format(feature))
 
@@ -15,7 +16,6 @@ __all__ = [
     'MainWindow',
     'paths',
     'Box',
-    'DetailedList',
     'Icon',
     'Window',
 ]

--- a/src/android/toga_android/icons.py
+++ b/src/android/toga_android/icons.py
@@ -1,9 +1,9 @@
 class Icon:
-    EXTENSIONS = ['.png']
+    EXTENSIONS = [".png"]
     SIZES = None
 
     def __init__(self, interface, path):
         self.interface = interface
         self.interface._impl = self
         self.path = path
-        interface.factory.not_implemented('Icon')
+        interface.factory.not_implemented("Icon")

--- a/src/android/toga_android/icons.py
+++ b/src/android/toga_android/icons.py
@@ -3,5 +3,5 @@ class Icon:
     EXTENSIONS = ['.png']
     path = ''
 
-    def __init__(self, *args, **kwargs):
-        print('[Android] Not implemented: Icon')
+    def __init__(self, interface, **kwargs):
+        interface.factory.not_implemented('Icon')

--- a/src/android/toga_android/icons.py
+++ b/src/android/toga_android/icons.py
@@ -1,0 +1,7 @@
+class Icon:
+    SIZES = None
+    EXTENSIONS = ['.png']
+    path = ''
+
+    def __init__(self, *args, **kwargs):
+        print('[Android] Not implemented: Icon')

--- a/src/android/toga_android/icons.py
+++ b/src/android/toga_android/icons.py
@@ -1,7 +1,9 @@
 class Icon:
-    SIZES = None
     EXTENSIONS = ['.png']
-    path = ''
+    SIZES = None
 
-    def __init__(self, interface, **kwargs):
+    def __init__(self, interface, path):
+        self.interface = interface
+        self.interface._impl = self
+        self.path = path
         interface.factory.not_implemented('Icon')

--- a/src/android/toga_android/libs/__init__.py
+++ b/src/android/toga_android/libs/__init__.py
@@ -1,0 +1,1 @@
+from .activity import *

--- a/src/android/toga_android/libs/activity.py
+++ b/src/android/toga_android/libs/activity.py
@@ -1,0 +1,11 @@
+from rubicon.java import JavaClass, JavaInterface
+
+# The Android cookiecutter template creates an app whose main Activity is
+# called `MainActivity`. The activity assumes that we will store a reference
+# to an implementation/subclass of `IPythonApp` in it.
+MainActivity = JavaClass('org/beeware/android/MainActivity')
+
+
+# The `IPythonApp` interface in Java allows Python code to
+# run on Android activity lifecycle hooks such as `onCreate()`.
+IPythonApp = JavaInterface('org/beeware/android/IPythonApp')

--- a/src/core/toga/icons.py
+++ b/src/core/toga/icons.py
@@ -32,6 +32,8 @@ class Icon:
         :param factory: The platform factory to bind to.
         :returns: The platform implementation
         """
+        # `factory` is now available; store it so the `_impl` can access it.
+        self.factory = factory
         if self._impl is None:
             try:
                 if self.system:

--- a/src/core/toga/platform.py
+++ b/src/core/toga/platform.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from functools import lru_cache
 
@@ -36,6 +37,11 @@ def get_platform_factory(factory=None):
         from toga_cocoa import factory
         return factory
     elif sys.platform == 'linux':
+        # In the future, we will use a different way to detect Android.
+        # See https://github.com/beeware/Python-Android-support/issues/8
+        if os.environ.get('ANDROID_ROOT'):
+            from toga_android import factory
+            return factory
         from toga_gtk import factory
         return factory
     elif sys.platform == 'win32':


### PR DESCRIPTION
This pull request makes minimal changes in toga_android so that it starts up using rubicon-java for communication between Python and Android, as well as the current Python-Android-support and gradle cookiecutter template.

I did take the liberty of removing commented-out code in this PR.

The `not_implemented` function is duplicated into `icons.py` (from `factory.py`, where it remains). This is because I want to avoid circular dependencies, and presumably I’m going to implement Icon at some point, so the duplication will go away.

Note that rubicon-java is available due to Python-Android-support bundling it, and therefore it's not specified anywhere in an explicit dependency list. This is totally OK with me for now, but I wanted to flag it in case it merits further thought.

## Validation

Here's how I validated this.

```
git clone https://github.com/paulproteus/trivial-briefcase-toga-empty-app
cd trivial-briefcase-toga-empty-app
briefcase create android && briefcase update android -d && briefcase build android && briefcase run android -d emulator-5554
```

Then you will see this in the emulator, i.e., no crash. :)

![Screen Shot 2020-04-17 at 7 59 55 PM](https://user-images.githubusercontent.com/25457/79626579-069ce380-80e6-11ea-8a3e-db0c2f5385fc.png)


You can also see printed output in `adb logcat -s stdio`:

```
/Users/asheesh/.briefcase/tools/android_sdk/platform-tools/adb logcat -s stdio
--------- beginning of system
--------- beginning of crash
--------- beginning of main
04-17 19:38:56.347  9036  9054 D stdio   : Starting to capture stdout/stderr to Android log.
04-17 19:38:56.347  9036  9054 D stdio   : stdout now successfully routes into the stdio logger.
04-17 19:39:09.318  9036  9054 D stdio   : Start Python runtime...
04-17 19:39:09.319  9036  9054 D stdio   : Initializing Python runtime...
04-17 19:39:09.444  9036  9054 D stdio   : Initializing Python threads...
04-17 19:39:09.444  9036  9054 D stdio   : Import rubicon...
04-17 19:39:09.451  9036  9054 D stdio   : Rubicon namespace package not registered!
04-17 19:39:10.745  9036  9054 D stdio   : [Android] Not implemented: Icon
04-17 19:39:10.777  9036  9054 D stdio   : Python app launched & stored in Android Activity class
04-17 19:39:10.777  9036  9054 D stdio   : 
04-17 19:39:10.778  9036  9054 D stdio   : Toga app: onCreate
04-17 19:39:10.793  9036  9054 D stdio   : Toga app: onStart
04-17 19:39:10.795  9036  9054 D stdio   : Toga app: onResume
```

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
