### PR TITLE
Call user app startup code on Android

### DIFF
--- a/src/android/toga_android/app.py
+++ b/src/android/toga_android/app.py
@@ -47,6 +47,8 @@ class App:
 
     def create(self):
         self._listener = TogaApp(self)
+        # Call user code to populate the main window
+        self.interface.startup()
 
     def open_document(self, fileURL):
         print("Can't open document %s (yet)" % fileURL)


### PR DESCRIPTION
This is similar to how the Toga backend for Cocoa calls user app startup code.

Without this, user apps don't even really launch. 🤦 

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct

## Manual testing

I validated this by adding a `print()` to my `class HelloWorld`'s `def startup(self)` method in my sample app, and validated that it gets printed to the Android log with this change.

Before this change, it would not get printed.

(Additionally, my app creates a `Button`. This now successfully crashes. This is good news; I'll figure out how to make buttons :))
