### PR TITLE
Fix box children layout with gtk on wayland

### DIFF
--- a/src/gtk/toga_gtk/widgets/box.py
+++ b/src/gtk/toga_gtk/widgets/box.py
@@ -53,8 +53,8 @@ class TogaBox(Gtk.Fixed):
                     # print("update ", widget.interface, widget.interface.layout)
                     widget.interface._impl.rehint()
                     widget_allocation = Gdk.Rectangle()
-                    widget_allocation.x = widget.interface.layout.absolute_content_left
-                    widget_allocation.y = widget.interface.layout.absolute_content_top
+                    widget_allocation.x = widget.interface.layout.absolute_content_left + allocation.x
+                    widget_allocation.y = widget.interface.layout.absolute_content_top + allocation.y
                     widget_allocation.width = widget.interface.layout.content_width
                     widget_allocation.height = widget.interface.layout.content_height
 


### PR DESCRIPTION
Propagate the box x,y offsets to the children
Without this,  widgets appear offset up and left, putting them partially outside the app bounding box.

Signed-off-by: Eliot Blennerhassett <eliot@blennerhassett.gen.nz>

Fixes  #139 (maybe)

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
