### PR TITLE
make on_change event trigger with every key stroke

### DIFF
--- a/src/gtk/toga_gtk/widgets/numberinput.py
+++ b/src/gtk/toga_gtk/widgets/numberinput.py
@@ -16,12 +16,13 @@ class NumberInput(Widget):
         self.native.set_adjustment(self.adjustment)
         self.native.set_numeric(True)
 
-        self.native.connect("value-changed", self.gtk_on_change)
+        self.native.connect("changed", self.gtk_on_change)
 
         self.rehint()
 
     def gtk_on_change(self, widget):
-        self.interface._value = Decimal(self.native.get_value()).quantize(self.interface.step)
+        value = widget.get_text().replace(",", ".") or 0
+        self.interface._value = Decimal(value).quantize(self.interface.step)
         if self.interface.on_change:
             self.interface.on_change(widget)
 


### PR DESCRIPTION
Modify `NumberInput` widget `on_change` behavior under **gtk** implementation.
Previously, `on_change` event was only being called when submitting the value by pressing the ENTER key or unfocusing the widget. 
Now the callback is called every time a character is inserted/deleted inside the `Entry` box.
This value is only accessible as a string, so an extra step is needed to convert it to a valid numeric format (`.replace(",", ".")`) and we need to take into account the empty string case, which we take as a zero value.

This PR refers to a bug found during the PyCon 2020 Virtual Sprint.


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
