### PR TITLE
Gtk  all menu items in standard menubar.

### DIFF
--- a/src/gtk/toga_gtk/app.py
+++ b/src/gtk/toga_gtk/app.py
@@ -73,6 +73,7 @@ class App:
         self.actions = None
 
     def gtk_startup(self, data=None):
+        # Set up the default commands for the interface.
         self.interface.commands.add(
             Command(None, 'About ' + self.interface.name, group=toga.Group.HELP),
             Command(None, 'Preferences', group=toga.Group.APP),
@@ -95,11 +96,13 @@ class App:
         self._actions = {}
         self.create_menus()
 
+        # Now that we have menus, make the app take responsibility for
+        # showing the menubar.
+        # This is required because of inconsistencies in how the Gnome
+        # shell operates on different windowing environments;
+        # see #872 for details.
         settings = Gtk.Settings.get_default()
         settings.set_property("gtk-shell-shows-menubar", False)
-        # settings.set_property("gtk-shell-shows-app-menu", False)
-
-        # self.interface.main_window._impl.create_toolbar()
 
     def _create_app_commands(self):
         # No extra menus
@@ -122,7 +125,7 @@ class App:
                         submenu.append_section(None, section)
 
                     if label == '*':
-                        label = self.interface.name.replace(' ', '')
+                        label = self.interface.name
                     menubar.append_submenu(label, submenu)
 
                     label = None
@@ -164,7 +167,7 @@ class App:
 
             if submenu:
                 if label == '*':
-                    label = self.interface.name.replace(' ', '')
+                    label = self.interface.name
                 menubar.append_submenu(label, submenu)
 
             # Set the menu for the app.

--- a/src/gtk/toga_gtk/app.py
+++ b/src/gtk/toga_gtk/app.py
@@ -74,7 +74,7 @@ class App:
 
     def gtk_startup(self, data=None):
         self.interface.commands.add(
-            Command(None, 'About ' + self.interface.name, group=toga.Group.APP),
+            Command(None, 'About ' + self.interface.name, group=toga.Group.HELP),
             Command(None, 'Preferences', group=toga.Group.APP),
             # Quit should always be the last item, in a section on it's own
             Command(
@@ -94,6 +94,11 @@ class App:
         # then force the creation of the menus.
         self._actions = {}
         self.create_menus()
+
+        settings = Gtk.Settings.get_default()
+        settings.set_property("gtk-shell-shows-menubar", False)
+        #settings.set_property("gtk-shell-shows-app-menu", False)
+
         # self.interface.main_window._impl.create_toolbar()
 
     def _create_app_commands(self):
@@ -117,9 +122,8 @@ class App:
                         submenu.append_section(None, section)
 
                     if label == '*':
-                        self.native.set_app_menu(submenu)
-                    else:
-                        menubar.append_submenu(label, submenu)
+                        label = self.interface.name.replace(' ', '')
+                    menubar.append_submenu(label, submenu)
 
                     label = None
                     submenu = None
@@ -160,9 +164,8 @@ class App:
 
             if submenu:
                 if label == '*':
-                    self.native.set_app_menu(submenu)
-                else:
-                    menubar.append_submenu(label, submenu)
+                    label = self.interface.name.replace(' ', '')
+                menubar.append_submenu(label, submenu)
 
             # Set the menu for the app.
             self.native.set_menubar(menubar)

--- a/src/gtk/toga_gtk/app.py
+++ b/src/gtk/toga_gtk/app.py
@@ -97,7 +97,7 @@ class App:
 
         settings = Gtk.Settings.get_default()
         settings.set_property("gtk-shell-shows-menubar", False)
-        #settings.set_property("gtk-shell-shows-app-menu", False)
+        # settings.set_property("gtk-shell-shows-app-menu", False)
 
         # self.interface.main_window._impl.create_toolbar()
 

--- a/src/gtk/toga_gtk/app.py
+++ b/src/gtk/toga_gtk/app.py
@@ -78,7 +78,7 @@ class App:
             Command(None, 'Preferences', group=toga.Group.APP),
             # Quit should always be the last item, in a section on it's own
             Command(
-                lambda widget, data: self.exit(),
+                lambda widget: self.exit(),
                 'Quit ' + self.interface.name,
                 shortcut=toga.Key.MOD_1 + 'q',
                 group=toga.Group.APP,


### PR DESCRIPTION
What was in the Appmenu becomes a menu item with the name of the application.
Move the About item into the Help menu where all other apps have it.
Fix a small bug in the Quit menu item.

Appearance is consistent Wayland vs X11, whether Gnome shell has appmenu visible or not.

Fixes #872 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
