### PR TITLE
Adjust Android implementation minimally to pass flake8

### DIFF
--- a/src/android/setup.py
+++ b/src/android/setup.py
@@ -1,4 +1,4 @@
-#/usr/bin/env python
+#!/usr/bin/env python
 import io
 import re
 

--- a/src/android/toga_android/app.py
+++ b/src/android/toga_android/app.py
@@ -1,4 +1,4 @@
-from .libs import IPythonApp, MainActivity
+from .libs.activity import IPythonApp, MainActivity
 from .window import Window
 
 
@@ -18,9 +18,6 @@ class TogaApp(IPythonApp):
 
     def onStart(self):
         print("Toga app: onStart")
-
-    def onResume(self):
-        print("Toga app: onResume")
 
     def onResume(self):
         print("Toga app: onResume")

--- a/src/android/toga_android/dialogs.py
+++ b/src/android/toga_android/dialogs.py
@@ -1,7 +1,7 @@
 
 
-class TogaAlertDialogBuilder(extends=android.app.AlertDialog[Builder]):
-    @super({context: android.content.Context})
+class TogaAlertDialogBuilder:
+    # TODO: Extend `android.app.AlertDialog[Builder]`. Provide app as `context`.
     def __init__(self, context, message):
         self.setMessage(message)
 
@@ -31,4 +31,3 @@ def stack_trace(window, title, message, content, retry=False):
 
 def save_file(window, title, suggested_filename, file_types):
     window.platform.not_implemented('dialogs.save_file()')
-

--- a/src/android/toga_android/layout.py
+++ b/src/android/toga_android/layout.py
@@ -1,19 +1,19 @@
 
-class TogaLayout(extends=android.view.ViewGroup):
-    @super({context: android.content.Context})
+class TogaLayout:
+    # TODO: Extend `android.view.ViewGroup`. Provide app as `context`.
     def __init__(self, context, interface):
         self.interface = interface
 
     def shouldDelayChildPressedState(self) -> bool:
         return False
 
-    def onMeasure(self, width: int, height: int) -> void:
+    def onMeasure(self, width: int, height: int):
         # print("ON MEASURE %sx%s" % (width, height))
         self.measureChildren(width, height)
         self.interface.rehint()
         self.setMeasuredDimension(width, height)
 
-    def onLayout(self, changed: bool, left: int, top: int, right: int, bottom: int) -> void:
+    def onLayout(self, changed: bool, left: int, top: int, right: int, bottom: int):
         # print("ON LAYOUT %s %sx%s -> %sx%s" % (changed, left, top, right, bottom))
         device_scale = self.interface.app._impl.device_scale
 
@@ -27,7 +27,8 @@ class TogaLayout(extends=android.view.ViewGroup):
         # print("LAYOUT: There are %d children" % count)
         for i in range(0, count):
             child = self.getChildAt(i)
-            # print("    child: %s" % child, child.getMeasuredHeight(), child.getMeasuredWidth(), child.getWidth(), child.getHeight())
+            # print("    child: %s" % child, child.getMeasuredHeight(), child.getMeasuredWidth(),
+            #       child.getWidth(), child.getHeight())
             # print("    layout: ", child.interface.layout)
             child.layout(
                 child.interface.layout.absolute.left * device_scale,

--- a/src/android/toga_android/layout.py
+++ b/src/android/toga_android/layout.py
@@ -13,7 +13,7 @@ class TogaLayout:
         self.interface.rehint()
         self.setMeasuredDimension(width, height)
 
-    def onLayout(self, changed: bool, left: int, top: int, right: int, bottom: int):
+    def onLayout(self, changed: bool, left: int, top: int, right: int, bottom: int) -> None:
         # print("ON LAYOUT %s %sx%s -> %sx%s" % (changed, left, top, right, bottom))
         device_scale = self.interface.app._impl.device_scale
 
@@ -27,9 +27,8 @@ class TogaLayout:
         # print("LAYOUT: There are %d children" % count)
         for i in range(0, count):
             child = self.getChildAt(i)
-            # print("    child: %s" % child, child.getMeasuredHeight(), child.getMeasuredWidth(),
-            #       child.getWidth(), child.getHeight())
-            # print("    layout: ", child.interface.layout)
+            # See "Size, padding and margins" at https://developer.android.com/reference/android/view/View
+            # for reference information on `height`, `getMeasuredHeight()`, etc.
             child.layout(
                 child.interface.layout.absolute.left * device_scale,
                 child.interface.layout.absolute.top * device_scale,

--- a/src/android/toga_android/libs/__init__.py
+++ b/src/android/toga_android/libs/__init__.py
@@ -1,1 +1,0 @@
-from .activity import *

--- a/src/android/toga_android/widgets/base.py
+++ b/src/android/toga_android/widgets/base.py
@@ -32,7 +32,7 @@ class Widget:
     def set_enabled(self, value):
         self.native.enabled = self.interface.enabled
 
-    ### APPLICATOR
+    # APPLICATOR
 
     def set_bounds(self, x, y, width, height):
         # No implementation required here; the new sizing will be picked up
@@ -50,7 +50,7 @@ class Widget:
         # By default, background color can't be changed.
         pass
 
-    ### INTERFACE
+    # INTERFACE
 
     def add_child(self, child):
         if self.container:

--- a/src/android/toga_android/widgets/button.py
+++ b/src/android/toga_android/widgets/button.py
@@ -3,18 +3,18 @@ from travertino.size import at_least
 from .base import Widget
 
 
-class TogaButton(extends=android.widget.Button):
-    @super({context: android.content.Context})
+class TogaButton:
+    # TODO: Extend `android.widget.Button`. Provide app as `context`.
     def __init__(self, context, interface):
         self._interface = interface
 
 
-class TogaButtonListener(implements=android.view.View[OnClickListener]):
-    @super({})
+class TogaButtonListener:
+    # TODO: Extend `android.view.View[OnClickListener]`.
     def __init__(self, interface):
         self._interface = interface
 
-    def onClick(self, v: android.view.View) -> None:
+    def onClick(self, v) -> None:
         self._interface.on_press(self._interface)
 
 

--- a/src/android/toga_android/widgets/label.py
+++ b/src/android/toga_android/widgets/label.py
@@ -2,16 +2,22 @@ from android.view import Gravity
 
 from travertino.size import at_least
 
-from toga.constants import *
+from toga.constants import (
+    LEFT_ALIGNED,
+    RIGHT_ALIGNED,
+    CENTER_ALIGNED,
+    JUSTIFIED_ALIGNED,
+    NATURAL_ALIGNED,
+)
 
 
-class TogaLabel(extends=android.widget.TextView):
-    @super({context: android.content.Context})
+class TogaLabel:
+    # TODO: Extend `android.widget.TextView`. Provide app as `context`.
     def __init__(self, context, interface):
         self.interface = interface
 
 
-class Label(Widget):
+class Label:
     def create(self):
         self.native = TogaLabel(self.app.native, self.interface)
         self.native.setSingleLine()

--- a/src/android/toga_android/widgets/passwordinput.py
+++ b/src/android/toga_android/widgets/passwordinput.py
@@ -1,8 +1,7 @@
-from .textinput import TextInput, TogaTextInput
+from .textinput import TextInput
 
 
 class PasswordInput(TextInput):
     def create(self):
         super().create()
         self.native.inputType = 'textPassword'
-

--- a/src/android/toga_android/widgets/textinput.py
+++ b/src/android/toga_android/widgets/textinput.py
@@ -3,8 +3,8 @@ from travertino.size import at_least
 from .base import Widget
 
 
-class TogaTextInput(extends=android.widget.EditText):
-    @super({context: android.content.Context})
+class TogaTextInput:
+    # TODO: Extend `android.widget.EditText`. Provide app as `context`.
     def __init__(self, context, interface):
         self.interface = interface
 

--- a/src/android/toga_android/window.py
+++ b/src/android/toga_android/window.py
@@ -1,3 +1,5 @@
+from .layout import TogaLayout
+
 
 class AndroidViewport:
     def __init__(self, native):
@@ -43,9 +45,6 @@ class Window:
         pass
 
     def set_size(self, size):
-        pass
-
-    def set_app(self, app):
         pass
 
     def create_toolbar(self):


### PR DESCRIPTION
This pull request adjusts the Android implementation to pass `flake8`.

The reason I want to do this now, rather than later, is that as I write new code and test it on Android, I find myself writing code that would obviously crash, but I don't see it until it crashes on-device, which I find to be a painful waste of a ~2 minute debug loop, and I'd rather have `flake8` warn me first.

@freakboy3742 already gave me permission to delete the old Android code, but for now I like having it around, since it helps remind me of how things are going to work in the future.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct

## Testing done

I booted up my example app from https://github.com/beeware/toga/pull/853 and verified that it continues to not crash.