### PR TITLE
gtk - only warn once for each non-implemented feature

### DIFF
--- a/src/gtk/toga_gtk/factory.py
+++ b/src/gtk/toga_gtk/factory.py
@@ -29,9 +29,13 @@ from .widgets.tree import Tree
 from .widgets.webview import WebView
 from .window import Window
 
+feature_seen = set()
+
 
 def not_implemented(feature):
-    print('[GTK+] Not implemented: {}'.format(feature))
+    if not feature in feature_seen:
+        print('[GTK+] Not implemented: {}'.format(feature))
+        feature_seen.add(feature)
 
 
 __all__ = [

--- a/src/gtk/toga_gtk/factory.py
+++ b/src/gtk/toga_gtk/factory.py
@@ -33,7 +33,7 @@ feature_seen = set()
 
 
 def not_implemented(feature):
-    if not feature in feature_seen:
+    if feature not in feature_seen:
         print('[GTK+] Not implemented: {}'.format(feature))
         feature_seen.add(feature)
 


### PR DESCRIPTION
stops multiple identical (thus useless) messages spewing to the console

I wonder if really should be using logging, I'm not a fan of apps that blurt all their stuff into the terminal...

Signed-off-by: Eliot Blennerhassett <eliot@blennerhassett.gen.nz>
## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
