### PR TITLE
In autogenerated assertions, provide fn.__doc__ as error_msg

### DIFF
--- a/src/dummy/toga_dummy/test_implementation.py
+++ b/src/dummy/toga_dummy/test_implementation.py
@@ -263,7 +263,7 @@ def collect_dummy_files(required_files):
 
 def make_test_function(element, element_list, error_msg=None):
     def fn(self):
-        self.assertIn(element, element_list, msg=error_msg)
+        self.assertIn(element, element_list, msg=error_msg if error_msg else fn.__doc__)
 
     return fn
 
@@ -276,7 +276,9 @@ def make_test_class(path, cls, expected, actual, skip):
         test_class = unittest.skip(skip)(test_class)
 
     fn = make_test_function(cls, actual.class_names)
-    fn.__doc__ = "The class {} is defined in {}".format(cls, path)
+    fn.__doc__ = (
+        "Expect class {} to be defined in {}, to be consistent with dummy implementation"
+    ).format(cls, path)
     test_class.test_class_exists = fn
 
     for method in expected.methods_of_class(cls):


### PR DESCRIPTION
I'm submitting this change in the hopes of improving the error messages people will get as they add/modify Toga backends. I'm open to other implementation ideas.

When working on a different pull request, I found myself staring at `pytest` output that said:

```
==============================================================================
FAIL: tests/test_implementation.py::MainWindowImplTest::test_class_exists
------------------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/asheesh/projects/beeware/beeware-tutorial/toga/src/dummy/toga_dummy/test_implementation.py", line 266, in fn
    self.assertIn(element, element_list, msg=error_msg if error_msg else fn.__doc__)
  File "/usr/local/Cellar/python/3.7.7/Frameworks/Python.framework/Versions/3.7/lib/python3.7/unittest/case.py", line 1119, in assertIn
    self.fail(self._formatMessage(msg, standardMsg))
  File "/usr/local/Cellar/python/3.7.7/Frameworks/Python.framework/Versions/3.7/lib/python3.7/unittest/case.py", line 693, in fail
    raise self.failureException(msg)
AssertionError: 'MainWindow' not found in dict_keys(['TogaApp', 'App'])

------------------------------------------------------------------------------
Ran 282 tests in 0.86s

FAILED (failures=1, skipped=110)
```

It seems `fn.__doc__` isn't added to pytest's test failure output. I had many questions when I saw this: Why was this the list of dict_items? Where did it come from? Where did the Android tests come from? etc.

This PR makes two changes that would have resolved my confusion:

- It adjusts `fn.__doc__` for this test to state the idea, that the backend implementations are supposed to mirror the file paths used in the dummy. This would have told me why there was a test failure.

- It prints `fn.__doc__` when an assertion failed. This would have told me the information very helpfully in the test source, but not printed out. Without this change, adjusting `fn.__doc__` wouldn't do much good.

## Manual testing performed

If you apply this local patch:

```
diff --git a/src/android/toga_android/app.py b/src/android/toga_android/app.py
index 182a9c5b..578b0465 100644
--- a/src/android/toga_android/app.py
+++ b/src/android/toga_android/app.py
@@ -1,9 +1,7 @@
 from .libs.activity import IPythonApp, MainActivity
-from .window import Window
+from .window import Window, MainWindow
 
 
-class MainWindow(Window):
-    pass
 
 
 class TogaApp(IPythonApp):
diff --git a/src/android/toga_android/factory.py b/src/android/toga_android/factory.py
index 6293a265..58cbc271 100644
--- a/src/android/toga_android/factory.py
+++ b/src/android/toga_android/factory.py
@@ -1,9 +1,9 @@
-from .app import App, MainWindow
+from .app import App
 from .paths import paths
 
 from .widgets.box import Box
 from .icons import Icon
-from .window import Window
+from .window import Window, MainWindow
 
 
 def not_implemented(feature):
```

you can get this output:

```
sss...............................................................ssssF...................ssssssssssssss...ssssssssssssssssss.........................sssssssssssssssssss...........ssssssssss...........ssssssssss...ssssssssssssssssssssssssssssssss....................................
==============================================================================
FAIL: tests/test_implementation.py::MainWindowImplTest::test_class_exists
------------------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/asheesh/projects/beeware/beeware-tutorial/toga/src/dummy/toga_dummy/test_implementation.py", line 266, in fn
    self.assertIn(element, element_list, msg=error_msg if error_msg else fn.__doc__)
  File "/usr/local/Cellar/python/3.7.7/Frameworks/Python.framework/Versions/3.7/lib/python3.7/unittest/case.py", line 1119, in assertIn
    self.fail(self._formatMessage(msg, standardMsg))
  File "/usr/local/Cellar/python/3.7.7/Frameworks/Python.framework/Versions/3.7/lib/python3.7/unittest/case.py", line 693, in fail
    raise self.failureException(msg)
AssertionError: 'MainWindow' not found in dict_keys(['TogaApp', 'App']) : Expect class MainWindow to be defined in android/toga_android/app.py, to be consistent with dummy implementation

------------------------------------------------------------------------------
Ran 282 tests in 0.86s

FAILED (failures=1, skipped=110)
```

Yay!

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
