### PR TITLE
More windows canvas abillities

### DIFF
--- a/examples/canvas/canvas/app.py
+++ b/examples/canvas/canvas/app.py
@@ -131,7 +131,7 @@ class ExampleCanvasApp(toga.App):
 
     def draw_half_ellipse(self, context, h, w, factor):
         x_center = w / 2
-        y_center = h/ 2
+        y_center = h / 2
         rx = factor / 3
         ry = factor / 4
 

--- a/examples/canvas/canvas/app.py
+++ b/examples/canvas/canvas/app.py
@@ -18,6 +18,11 @@ SMILE = "smile"
 SEA = "sea"
 TEXT = "text"
 
+CONTINUOUS = "continuous"
+DASH_1_1 = "dash 1-1"
+DASH_1_2 = "dash 1-2"
+DASH_2_3_1 = "dash 2-3-1"
+
 
 class ExampleCanvasApp(toga.App):
 
@@ -37,6 +42,12 @@ class ExampleCanvasApp(toga.App):
             SEA: self.draw_sea,
             TEXT: self.draw_text
         }
+        self.dash_patterns = {
+            CONTINUOUS: None,
+            DASH_1_1: [1, 1],
+            DASH_1_2: [1, 2],
+            DASH_2_3_1: [2, 3, 1]
+        }
         self.shape_selection = toga.Selection(
             items=list(self.drawing_shape_instructions.keys()),
             on_select=self.refresh_canvas
@@ -49,6 +60,10 @@ class ExampleCanvasApp(toga.App):
             range=(1, 10),
             default=1,
             on_slide=self.refresh_canvas
+        )
+        self.dash_pattern_selection = toga.Selection(
+            items=list(self.dash_patterns.keys()),
+            on_select=self.refresh_canvas
         )
         box = toga.Box(
             style=Pack(direction=COLUMN),
@@ -64,7 +79,9 @@ class ExampleCanvasApp(toga.App):
                 toga.Box(
                     style=Pack(direction=ROW),
                     children=[
-                        self.line_width_slider
+                        toga.Label("Line Width:"),
+                        self.line_width_slider,
+                        self.dash_pattern_selection
                     ]
                 ),
                 self.canvas
@@ -161,7 +178,8 @@ class ExampleCanvasApp(toga.App):
         if self.context_selection.value == STROKE:
             return canvas.stroke(
                 color=str(self.color_selection.value),
-                line_width=self.line_width_slider.value
+                line_width=self.line_width_slider.value,
+                line_dash=self.dash_patterns[self.dash_pattern_selection.value]
             )
         return canvas.fill(color=str(self.color_selection.value))
 

--- a/examples/canvas/canvas/app.py
+++ b/examples/canvas/canvas/app.py
@@ -12,6 +12,7 @@ FILL = "Fill"
 TRIANGLE = "triangle"
 RECTANGLE = "rectangle"
 ELLIPSE = "ellipse"
+HALF_ELLIPSE = "half ellipse"
 ICE_CREAM = "ice cream"
 SMILE = "smile"
 SEA = "sea"
@@ -29,6 +30,7 @@ class ExampleCanvasApp(toga.App):
             TRIANGLE: self.draw_triangle,
             RECTANGLE: self.draw_rectangle,
             ELLIPSE: self.draw_ellipse,
+            HALF_ELLIPSE: self.draw_half_ellipse,
             ICE_CREAM: self.draw_ice_cream,
             SMILE: self.draw_smile,
             SEA: self.draw_sea
@@ -107,6 +109,15 @@ class ExampleCanvasApp(toga.App):
         ry = factor / 4
 
         context.ellipse(w / 2, h / 2, rx, ry)
+
+    def draw_half_ellipse(self, context, h, w, factor):
+        x_center = w / 2
+        y_center = h/ 2
+        rx = factor / 3
+        ry = factor / 4
+
+        with context.closed_path(x_center + rx, y_center) as closer:
+            closer.ellipse(x_center, y_center, rx, ry, 0, 0, math.pi)
 
     def draw_ice_cream(self, context, h, w, factor):
         dx = w / 2

--- a/examples/canvas/canvas/app.py
+++ b/examples/canvas/canvas/app.py
@@ -1,6 +1,6 @@
 import math
 
-from travertino.constants import BLACK, BLUE, GREEN, RED, YELLOW
+from travertino.constants import BLACK, BLUE, GREEN, RED, YELLOW, SANS_SERIF
 
 import toga
 from toga.style import Pack
@@ -16,6 +16,7 @@ HALF_ELLIPSE = "half ellipse"
 ICE_CREAM = "ice cream"
 SMILE = "smile"
 SEA = "sea"
+TEXT = "text"
 
 
 class ExampleCanvasApp(toga.App):
@@ -33,7 +34,8 @@ class ExampleCanvasApp(toga.App):
             HALF_ELLIPSE: self.draw_half_ellipse,
             ICE_CREAM: self.draw_ice_cream,
             SMILE: self.draw_smile,
-            SEA: self.draw_sea
+            SEA: self.draw_sea,
+            TEXT: self.draw_text
         }
         self.shape_selection = toga.Selection(
             items=list(self.drawing_shape_instructions.keys()),
@@ -146,6 +148,14 @@ class ExampleCanvasApp(toga.App):
                 dy - 1 * factor / 5)
             closer.line_to(dx + 1 * factor / 5, dy + 1 * factor / 5)
             closer.line_to(dx - 1 * factor / 5, dy + 1 * factor / 5)
+
+    def draw_text(self, context, h, w, factor):
+        text = 'This is a text'
+        dx = w / 2
+        dy = h / 2
+        font = toga.Font(family=SANS_SERIF, size=20)
+        width, height = font.measure(text, tight=True)
+        context.write_text(text, dx - width / 2, dy, font)
 
     def get_context(self, canvas):
         if self.context_selection.value == STROKE:

--- a/src/cocoa/toga_cocoa/widgets/selection.py
+++ b/src/cocoa/toga_cocoa/widgets/selection.py
@@ -38,7 +38,7 @@ class Selection(Widget):
         self.native.selectItemWithTitle(item)
 
     def get_selected_item(self):
-        return self.native.titleOfSelectedItem
+        return str(self.native.titleOfSelectedItem)
 
     def set_on_select(self, handler):
         pass

--- a/src/winforms/toga_winforms/fonts.py
+++ b/src/winforms/toga_winforms/fonts.py
@@ -1,4 +1,4 @@
-from .libs import WinFont
+from .libs import WinFont, WinForms
 from .libs import FontFamily, FontStyle, Single, win_font_family
 
 _FONT_CACHE = {}
@@ -24,5 +24,5 @@ class Font:
         self.native = font
 
     def measure(self, text, tight=False):
-        raise NotImplementedError('measure() not implemented on winforms.Font')
-        # return width, height
+        size = WinForms.TextRenderer.MeasureText(text, self.native)
+        return size.Width, size.Height

--- a/src/winforms/toga_winforms/fonts.py
+++ b/src/winforms/toga_winforms/fonts.py
@@ -15,7 +15,8 @@ class Font:
             font_style = win_font_style(
                 self.interface.weight,
                 self.interface.style,
-                font_family)
+                font_family
+            )
             font = WinFont.Overloads[FontFamily, Single, FontStyle](
                 font_family, self.interface.size, font_style
             )

--- a/src/winforms/toga_winforms/fonts.py
+++ b/src/winforms/toga_winforms/fonts.py
@@ -1,5 +1,6 @@
 from .libs import WinFont, WinForms
 from .libs import FontFamily, FontStyle, Single, win_font_family
+from .libs.fonts import win_font_style
 
 _FONT_CACHE = {}
 
@@ -11,11 +12,10 @@ class Font:
             font = _FONT_CACHE[self.interface]
         except KeyError:
             font_family = win_font_family(self.interface.family)
-            font_style = FontStyle.Regular
-            if self.interface.weight.lower() == "bold" and font_family.IsStyleAvailable(FontStyle.Bold):
-                font_style += FontStyle.Bold
-            if self.interface.style.lower() == "italic" and font_family.IsStyleAvailable(FontStyle.Italic):
-                font_style += FontStyle.Italic
+            font_style = win_font_style(
+                self.interface.weight,
+                self.interface.style,
+                font_family)
             font = WinFont.Overloads[FontFamily, Single, FontStyle](
                 font_family, self.interface.size, font_style
             )

--- a/src/winforms/toga_winforms/libs/__init__.py
+++ b/src/winforms/toga_winforms/libs/__init__.py
@@ -13,6 +13,7 @@ from .winforms import (  # noqa: F401
     Single,
     Size,
     SolidBrush,
+    StringFormat,
     Threading,
     Uri,
     WinDateTime,

--- a/src/winforms/toga_winforms/libs/__init__.py
+++ b/src/winforms/toga_winforms/libs/__init__.py
@@ -10,6 +10,7 @@ from .winforms import (  # noqa: F401
     Point,
     PointF,
     Rectangle,
+    RectangleF,
     Single,
     Size,
     SolidBrush,

--- a/src/winforms/toga_winforms/libs/fonts.py
+++ b/src/winforms/toga_winforms/libs/fonts.py
@@ -1,4 +1,4 @@
-from .winforms import ContentAlignment, FontFamily, WinForms, SystemFonts, Text
+from .winforms import ContentAlignment, FontFamily, WinForms, SystemFonts, Text, FontStyle
 
 from toga.constants import LEFT, RIGHT, CENTER, JUSTIFY
 from toga.fonts import (
@@ -52,3 +52,14 @@ def win_font_family(value):
                 value, SystemFonts.DefaultFont.FontFamily)
         )
         return SystemFonts.DefaultFont.FontFamily
+
+
+def win_font_style(weight, style, font_family):
+    font_style = FontStyle.Regular
+    if weight.lower() == "bold" and font_family.IsStyleAvailable(
+            FontStyle.Bold):
+        font_style += FontStyle.Bold
+    if style.lower() == "italic" and font_family.IsStyleAvailable(
+            FontStyle.Italic):
+        font_style += FontStyle.Italic
+    return font_style

--- a/src/winforms/toga_winforms/libs/winforms.py
+++ b/src/winforms/toga_winforms/libs/winforms.py
@@ -23,7 +23,7 @@ from System.Drawing import StringFormat  # noqa: E402, F401
 from System.Drawing import Text, Color, Bitmap  # noqa: E402, F401
 from System.Drawing import Graphics  # noqa: E402, F401
 from System.Drawing import Pen, SolidBrush  # noqa: E402, F401
-from System.Drawing import Rectangle  # noqa: E402, F401
+from System.Drawing import Rectangle, RectangleF  # noqa: E402, F401
 from System.Drawing.Drawing2D import GraphicsPath  # noqa: E402, F401
 
 from System.Threading.Tasks import Task  # noqa: E402, F401

--- a/src/winforms/toga_winforms/libs/winforms.py
+++ b/src/winforms/toga_winforms/libs/winforms.py
@@ -19,6 +19,7 @@ from System.Drawing import Icon as WinIcon  # noqa: E402, F401
 from System.Drawing import Image as WinImage  # noqa: E402, F401
 from System.Drawing import ContentAlignment, Size, Point, PointF  # noqa: E402, F401
 from System.Drawing import FontFamily, FontStyle, SystemFonts  # noqa: E402, F401
+from System.Drawing import StringFormat  # noqa: E402, F401
 from System.Drawing import Text, Color, Bitmap  # noqa: E402, F401
 from System.Drawing import Graphics  # noqa: E402, F401
 from System.Drawing import Pen, SolidBrush  # noqa: E402, F401

--- a/src/winforms/toga_winforms/widgets/canvas.py
+++ b/src/winforms/toga_winforms/widgets/canvas.py
@@ -63,7 +63,9 @@ class Canvas(Box):
         draw_context.last_point = (x, y)
 
     def line_to(self, x, y, draw_context, *args, **kwargs):
-        draw_context.path.AddLine(*draw_context.last_point, x, y)
+        ox, oy = int(draw_context.last_point[0]), int(draw_context.last_point[1])
+        x, y = int(x), int(y)
+        draw_context.path.AddLine(ox, oy, x, y)
         draw_context.last_point = (x, y)
 
     # Basic shapes
@@ -83,30 +85,72 @@ class Canvas(Box):
         draw_context.path.AddCurve([point1, point2, point3])
         draw_context.last_point = (x, y)
 
-    def arc(self, x, y, radius, startangle, endangle, anticlockwise, draw_context, *args, **kwargs):
-        x_min, y_min = x - radius, y - radius
-        draw_context.path.AddArc(
-            x_min, y_min, 2 * radius, 2 * radius, math.degrees(startangle), math.degrees(endangle - startangle)
-        )
-        draw_context.last_point = (
-            x + radius * math.cos(endangle),
-            y + radius * math.sin(endangle)
+    def arc(
+            self,
+            x,
+            y,
+            radius,
+            startangle,
+            endangle,
+            anticlockwise,
+            draw_context,
+            *args,
+            **kwargs
+    ):
+        self.ellipse(
+            x,
+            y,
+            radius,
+            radius,
+            0,
+            startangle,
+            endangle,
+            anticlockwise,
+            draw_context,
+            *args,
+            **kwargs
         )
 
-    def ellipse(self, x, y, radiusx, radiusy, rotation, startangle, endangle, anticlockwise,
-                draw_context, *args, **kwargs):
+    def ellipse(
+            self,
+            x,
+            y,
+            radiusx,
+            radiusy,
+            rotation,
+            startangle,
+            endangle,
+            anticlockwise,
+            draw_context,
+            *args,
+            **kwargs):
         if draw_context.path is not None:
-            draw_context.path.AddEllipse(
-                x - radiusx, y - radiusy, 2 * radiusx, 2 * radiusy
+            draw_context.path.AddArc(
+                x - radiusx,
+                y - radiusy,
+                2 * radiusx,
+                2 * radiusy,
+                math.degrees(startangle),
+                math.degrees(endangle - startangle)
             )
         else:
             pen = self.create_pen(
                 color=kwargs.get("stroke_color", None),
                 line_width=kwargs.get("text_line_width", None)
             )
-            draw_context.graphics.DrawEllipse(
-                pen, x - radiusx, y - radiusy, 2 * radiusx, 2 * radiusy
+            draw_context.graphics.DrawArc(
+                pen,
+                x - radiusx,
+                y - radiusy,
+                2 * radiusx,
+                2 * radiusy,
+                math.degrees(startangle),
+                math.degrees(endangle - startangle)
             )
+        draw_context.last_point = (
+            x + radiusx * math.cos(endangle),
+            y + radiusy * math.sin(endangle)
+        )
 
     def rect(self, x, y, width, height, draw_context, *args, **kwargs):
         rect = Rectangle(int(x), int(y), int(width), int(height))

--- a/src/winforms/toga_winforms/widgets/canvas.py
+++ b/src/winforms/toga_winforms/widgets/canvas.py
@@ -53,10 +53,12 @@ class Canvas(Box):
     def redraw(self):
         self.native.Invalidate()
 
-    def create_pen(self, color=None, line_width=None):
+    def create_pen(self, color=None, line_width=None, line_dash=None):
         pen = Pen(native_color(color))
         if line_width is not None:
             pen.Width = line_width
+        if line_dash is not None:
+            pen.DashPattern = line_dash
         return pen
 
     def create_brush(self, color):
@@ -148,7 +150,8 @@ class Canvas(Box):
         else:
             pen = self.create_pen(
                 color=kwargs.get("stroke_color", None),
-                line_width=kwargs.get("text_line_width", None)
+                line_width=kwargs.get("text_line_width", None),
+                line_dash=kwargs.get("text_line_dash", None)
             )
             draw_context.graphics.DrawArc(
                 pen,
@@ -171,7 +174,8 @@ class Canvas(Box):
         else:
             pen = self.create_pen(
                 color=kwargs.get("stroke_color", None),
-                line_width=kwargs.get("text_line_width", None)
+                line_width=kwargs.get("text_line_width", None),
+                line_dash=kwargs.get("text_line_dash", None)
             )
             draw_context.graphics.DrawRectangle(pen, rect)
 
@@ -186,7 +190,7 @@ class Canvas(Box):
 
     def stroke(self, color, line_width, line_dash, draw_context, *args, **kwargs):
         if draw_context.path is not None:
-            pen = self.create_pen(color=color, line_width=line_width)
+            pen = self.create_pen(color=color, line_width=line_width, line_dash=line_dash)
             draw_context.graphics.DrawPath(pen, draw_context.path)
 
     # Transformations

--- a/src/winforms/toga_winforms/widgets/canvas.py
+++ b/src/winforms/toga_winforms/widgets/canvas.py
@@ -163,7 +163,7 @@ class Canvas(Box):
         )
 
     def rect(self, x, y, width, height, draw_context, *args, **kwargs):
-        rect = RectangleF(x, y, width, height)
+        rect = RectangleF(float(x), float(y), float(width), float(height))
         if draw_context.path is not None:
             draw_context.path.AddRectangle(rect)
         else:

--- a/src/winforms/toga_winforms/widgets/canvas.py
+++ b/src/winforms/toga_winforms/widgets/canvas.py
@@ -9,7 +9,7 @@ from toga_winforms.libs import (
     Pen,
     SolidBrush,
     GraphicsPath,
-    Rectangle,
+    RectangleF,
     PointF,
     StringFormat,
     win_font_family
@@ -138,12 +138,10 @@ class Canvas(Box):
             draw_context,
             *args,
             **kwargs):
+        rect = RectangleF(float(x - radiusx), float(y - radiusy), float(2 * radiusx), float(2 * radiusy))
         if draw_context.path is not None:
             draw_context.path.AddArc(
-                x - radiusx,
-                y - radiusy,
-                2 * radiusx,
-                2 * radiusy,
+                rect,
                 math.degrees(startangle),
                 math.degrees(endangle - startangle)
             )
@@ -155,10 +153,7 @@ class Canvas(Box):
             )
             draw_context.graphics.DrawArc(
                 pen,
-                x - radiusx,
-                y - radiusy,
-                2 * radiusx,
-                2 * radiusy,
+                rect,
                 math.degrees(startangle),
                 math.degrees(endangle - startangle)
             )
@@ -168,7 +163,7 @@ class Canvas(Box):
         )
 
     def rect(self, x, y, width, height, draw_context, *args, **kwargs):
-        rect = Rectangle(int(x), int(y), int(width), int(height))
+        rect = RectangleF(x, y, width, height)
         if draw_context.path is not None:
             draw_context.path.AddRectangle(rect)
         else:
@@ -177,7 +172,7 @@ class Canvas(Box):
                 line_width=kwargs.get("text_line_width", None),
                 line_dash=kwargs.get("text_line_dash", None)
             )
-            draw_context.graphics.DrawRectangle(pen, rect)
+            draw_context.graphics.DrawRectangles(pen, [rect])
 
     # Drawing Paths
 


### PR DESCRIPTION
Added support for:

## Ellipse Arcs

![ellipse_arc](https://user-images.githubusercontent.com/19425795/80574977-7aef5500-8a0b-11ea-81e6-90ed0cc2958f.png)

## Dash Pattern

![dash_pattern](https://user-images.githubusercontent.com/19425795/80575004-83479000-8a0b-11ea-9c3b-a19dfbfd3387.png)

## Text

![text](https://user-images.githubusercontent.com/19425795/80575160-c1dd4a80-8a0b-11ea-9007-583f2b7e5ce5.png)

## What's missing?

The drawing of tutorial 4 seems to be rendered fine:

![tiberius_no_text](https://user-images.githubusercontent.com/19425795/80575421-36b08480-8a0c-11ea-99e3-91c10ae0288a.png)

But when I add the text box:

![tiberius_with_text](https://user-images.githubusercontent.com/19425795/80575529-6a8baa00-8a0c-11ea-9895-6278889f365a.png)

I can't seem to find the reason for that. I checked if there's an anchoring problem, but seems like it is not the case. I suggest merging this pull request and I'll try figuring out what's wrong in another pull request. If there's another Windows developer that can take a look at it, It would be great.

## PR Checklist:
- [X] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
