### PR TITLE
Fix bug in windows colors

### DIFF
--- a/src/winforms/toga_winforms/colors.py
+++ b/src/winforms/toga_winforms/colors.py
@@ -11,7 +11,12 @@ def native_color(c):
     except KeyError:
         if isinstance(c, str):
             c = NAMED_COLOR[c]
-        color = Color.FromArgb(int(c.rgba.a * 255), c.rgba.r, c.rgba.g, c.rgba.b)
+        color = Color.FromArgb(
+            int(c.rgba.a * 255),
+            int(c.rgba.r),
+            int(c.rgba.g),
+            int(c.rgba.b)
+        )
         CACHE[c] = color
 
     return color


### PR DESCRIPTION
Validates that the received rgb is integer based

when running *Toga Chart* got the following error:
```
Traceback (most recent call last):
  File "c:\\users\\saroa\\repositories\\toga\\src\\winforms\\toga_winforms\\widgets\\canvas.py", line 65, in create_brush
    return SolidBrush(native_color(color))
  File "c:\\users\\saroa\\repositories\\toga\\src\\winforms\\toga_winforms\\colors.py", line 14, in native_color
    color = Color.FromArgb(int(c.rgba.a * 255), c.rgba.r, c.rgba.g, c.rgba.b)
TypeError : No method matches given arguments for FromArgb
```

This is happening because the color values are calculated as `255 * value`, which results in a **float** values instead of **int**. In order to make sure that this kind of problems won't happen, added a value check close to the place where it is needed

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
