### PR TITLE
Fix canvas fillrule bug.

### DIFF
--- a/src/core/toga/widgets/canvas.py
+++ b/src/core/toga/widgets/canvas.py
@@ -8,6 +8,11 @@ from toga.handlers import wrapped_handler
 from .base import Widget
 
 
+EVENODD = "evenodd"
+NONZERO = "nonzero"
+FILLRULES = [NONZERO, EVENODD]
+
+
 class Context:
     """The user-created :class:`Context <Context>` drawing object to populate a
     drawing with visual context.
@@ -129,7 +134,7 @@ class Context:
         self.redraw()
 
     @contextmanager
-    def fill(self, color=BLACK, fill_rule="nonzero", preserve=False):
+    def fill(self, color=BLACK, fill_rule=NONZERO, preserve=False):
         """Constructs and yields a :class:`Fill <Fill>`.
 
         A drawing operator that fills the current path according to the current
@@ -146,10 +151,13 @@ class Context:
             :class:`Fill <Fill>` object.
 
         """
-        if fill_rule is "evenodd":
-            fill = Fill(color, fill_rule, preserve)
-        else:
-            fill = Fill(color, "nonzero", preserve)
+        if fill_rule not in FILLRULES:
+            raise ValueError(
+                "fillrule should be one of the followings: {}".format(
+                    ", ".join(FILLRULES)
+                )
+            )
+        fill = Fill(color, fill_rule, preserve)
         fill.canvas = self.canvas
         yield self.add_draw_obj(fill)
         self.redraw()
@@ -384,7 +392,7 @@ class Fill(Context):
 
     """
 
-    def __init__(self, color=BLACK, fill_rule="nonzero", preserve=False):
+    def __init__(self, color=BLACK, fill_rule=NONZERO, preserve=False):
         super().__init__()
         self.color = color
         self.fill_rule = fill_rule


### PR DESCRIPTION
using the python keyword "is" for comparison is wrong since it's comparing pointers instead of values. This caused a bug when trying to choose a fillrule

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
