### PR TITLE
Use `Window` as container; set `viewport` everywhere

### DIFF
--- a/src/android/toga_android/widgets/base.py
+++ b/src/android/toga_android/widgets/base.py
@@ -25,9 +25,10 @@ class Widget:
     @container.setter
     def container(self, container):
         self._container = container
+        self.viewport = container.viewport
 
         if self.native:
-            self._container.native.addSubview_(self.native)
+            self._container.native.addView(self.native)
 
         for child in self.interface.children:
             child._impl.container = container

--- a/src/android/toga_android/widgets/box.py
+++ b/src/android/toga_android/widgets/box.py
@@ -6,7 +6,3 @@ from ..libs.android_widgets import RelativeLayout
 class Box(Widget):
     def create(self):
         self.native = RelativeLayout(MainActivity.singletonThis)
-
-    def add_child(self, child):
-        super().add_child(child)
-        self.native.addView(child.native)

--- a/src/android/toga_android/window.py
+++ b/src/android/toga_android/window.py
@@ -16,7 +16,6 @@ class Window:
     def __init__(self, interface):
         self.interface = interface
         self.interface._impl = self
-        self.widget = None
         self.create()
 
     def create(self):

--- a/src/android/toga_android/window.py
+++ b/src/android/toga_android/window.py
@@ -1,22 +1,22 @@
 class AndroidViewport:
     def __init__(self, native):
         self.native = native
-        self.dpi = 96  # FIXME This is almost certainly wrong...
-        # self.dpi = ... self.interface.app._impl.device_scale
+        self.dpi = self.native.getContext().getResources().getDisplayMetrics().densityDpi
 
     @property
     def width(self):
-        return self.native.ClientSize.Width
+        return self.native.getMeasuredWidth()
 
     @property
     def height(self):
-        return self.native.ClientSize.Height
+        return self.native.getMeasuredHeight()
 
 
 class Window:
     def __init__(self, interface):
         self.interface = interface
         self.interface._impl = self
+        self.widget = None
         self.create()
 
     def create(self):
@@ -26,7 +26,9 @@ class Window:
         self.app = app
 
     def set_content(self, widget):
-        self.app.native.setContentView(widget.native)
+        self.widget = widget
+        # Set the widget's viewport to be based on the window's content.
+        self.widget.viewport = AndroidViewport(self.widget.native)
 
     def set_title(self, title):
         pass
@@ -41,7 +43,18 @@ class Window:
         pass
 
     def show(self):
-        pass
+        if not self.widget:
+            print("[Android] Showing an empty window is not supported.")
+            return
+
+        # Set the app's entire contentView to this window: only one Window can
+        # be displayed at a time.
+        self.app.native.setContentView(self.widget.native)
+
+        # Attach child widgets to the this window as their container.
+        for child in self.widget.interface.children:
+            child._impl.container = self.widget
+            child._impl.viewport = self.widget.viewport
 
     def set_full_screen(self, is_full_screen):
         self.interface.factory.not_implemented('Window.set_full_screen()')

--- a/src/android/toga_android/window.py
+++ b/src/android/toga_android/window.py
@@ -26,9 +26,17 @@ class Window:
         self.app = app
 
     def set_content(self, widget):
-        self.widget = widget
         # Set the widget's viewport to be based on the window's content.
-        self.widget.viewport = AndroidViewport(self.widget.native)
+        widget.viewport = AndroidViewport(widget.native)
+        # Set the app's entire contentView to this window. This means that calling
+        # Window.set_content() on any Window object automatically updates the app,
+        # meaning that every Window object acts as the MainWindow.
+        self.app.native.setContentView(widget.native)
+
+        # Attach child widgets to the this window as their container.
+        for child in widget.interface.children:
+            child._impl.container = widget
+            child._impl.viewport = widget.viewport
 
     def set_title(self, title):
         pass
@@ -43,18 +51,7 @@ class Window:
         pass
 
     def show(self):
-        if not self.widget:
-            print("[Android] Showing an empty window is not supported.")
-            return
-
-        # Set the app's entire contentView to this window: only one Window can
-        # be displayed at a time.
-        self.app.native.setContentView(self.widget.native)
-
-        # Attach child widgets to the this window as their container.
-        for child in self.widget.interface.children:
-            child._impl.container = self.widget
-            child._impl.viewport = self.widget.viewport
+        pass
 
     def set_full_screen(self, is_full_screen):
         self.interface.factory.not_implemented('Window.set_full_screen()')


### PR DESCRIPTION
Also:

- Use Android's built-in way to find the DPI for self.dpi
  (this reports 420 on my Android Virtual Device)

- Measure width & height as needed in `AndroidViewport`

- Remove now-unnecessary `add_child()` method on `Box`; we can rely on
  the base `Widget` class's existing `add_child()`.

This implementation waits for `show()` before actually making the window
visible. This works great, but it has the mild downside that it's possible
to `show()` a `Window` that has no widgets inside it, which is somewhat
ill-defined.

## Testing done

With this demo app -- https://github.com/paulproteus/briefcase-toga-button-demo-app/blob/master/src/helloworld/app.py -- you get this screenshot:

![image](https://user-images.githubusercontent.com/25457/80848696-f21e1800-8bc8-11ea-934f-523ac14c6986.png)

Simple, but nice.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
