### PR TITLE
Fix for set_value and placeholder in multilinetextinput [Cocoa]

### DIFF
--- a/src/cocoa/toga_cocoa/widgets/multilinetextinput.py
+++ b/src/cocoa/toga_cocoa/widgets/multilinetextinput.py
@@ -42,7 +42,7 @@ class MultilineTextInput(Widget):
         self.add_constraints()
 
     def set_placeholder(self, value):
-        self.text.placeholderString = self.interface.value
+        self.text.placeholderString = self.interface.placeholder
 
     def set_readonly(self, value):
         self.text.editable = not self.interface.readonly
@@ -51,7 +51,7 @@ class MultilineTextInput(Widget):
         return self.text.string
 
     def set_value(self, value):
-        self.text.string = self.interface.value
+        self.text.string = value
 
     def set_color(self, value):
         if value:


### PR DESCRIPTION
Signed-off-by: Ignacio Cabeza <ignaciocabeza@gmail.com>

Fixed `set_value` because `clear()` was not working
Fixed `set_placeholder`

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
