### PR TITLE
Canvas fill rule bug

### DIFF
--- a/examples/canvas/canvas/app.py
+++ b/examples/canvas/canvas/app.py
@@ -5,6 +5,7 @@ from travertino.constants import BLACK, BLUE, GREEN, RED, YELLOW, SANS_SERIF
 import toga
 from toga.style import Pack
 from toga.style.pack import ROW, COLUMN
+from toga.widgets.canvas import FillRule
 
 STROKE = "Stroke"
 FILL = "Fill"
@@ -61,7 +62,7 @@ class ExampleCanvasApp(toga.App):
             on_select=self.refresh_canvas
         )
         self.fill_rule_selection = toga.Selection(
-            items=["nonzero", "evenodd"],
+            items=[value.name.lower() for value in FillRule],
             on_select=self.refresh_canvas
         )
         self.line_width_slider = toga.Slider(

--- a/examples/canvas/canvas/app.py
+++ b/examples/canvas/canvas/app.py
@@ -17,6 +17,7 @@ HALF_ELLIPSE = "half ellipse"
 ICE_CREAM = "ice cream"
 SMILE = "smile"
 SEA = "sea"
+STAR = "star"
 TEXT = "text"
 
 CONTINUOUS = "continuous"
@@ -42,6 +43,7 @@ class ExampleCanvasApp(toga.App):
             ICE_CREAM: self.draw_ice_cream,
             SMILE: self.draw_smile,
             SEA: self.draw_sea,
+            STAR: self.draw_star,
             TEXT: self.draw_text
         }
         self.dash_patterns = {
@@ -56,6 +58,10 @@ class ExampleCanvasApp(toga.App):
         )
         self.color_selection = toga.Selection(
             items=[BLACK, BLUE, GREEN, RED, YELLOW],
+            on_select=self.refresh_canvas
+        )
+        self.fill_rule_selection = toga.Selection(
+            items=["nonzero", "evenodd"],
             on_select=self.refresh_canvas
         )
         self.line_width_slider = toga.Slider(
@@ -75,7 +81,8 @@ class ExampleCanvasApp(toga.App):
                     children=[
                         self.context_selection,
                         self.shape_selection,
-                        self.color_selection
+                        self.color_selection,
+                        self.fill_rule_selection
                     ]
                 ),
                 toga.Box(
@@ -187,6 +194,17 @@ class ExampleCanvasApp(toga.App):
             closer.line_to(dx + 1 * factor / 5, dy + 1 * factor / 5)
             closer.line_to(dx - 1 * factor / 5, dy + 1 * factor / 5)
 
+    def draw_star(self, context, h, w, factor):
+        sides = 5
+        dx = w / 2
+        dy = h / 2
+        radius = factor / 5
+        rotation_angle = 4 * math.pi / sides
+        with context.closed_path(dx, dy - radius) as closer:
+            for i in range(1, sides):
+                closer.line_to(dx + radius * math.sin(i * rotation_angle),
+                               dy - radius * math.cos(i * rotation_angle))
+
     def draw_text(self, context, h, w, factor):
         text = 'This is a text'
         dx = w / 2
@@ -202,7 +220,10 @@ class ExampleCanvasApp(toga.App):
                 line_width=self.line_width_slider.value,
                 line_dash=self.dash_patterns[self.dash_pattern_selection.value]
             )
-        return canvas.fill(color=str(self.color_selection.value))
+        return canvas.fill(
+            color=self.color_selection.value,
+            fill_rule=self.fill_rule_selection.value
+        )
 
     def refresh_canvas(self, widget):
         self.render_drawing(

--- a/src/cocoa/toga_cocoa/widgets/canvas.py
+++ b/src/cocoa/toga_cocoa/widgets/canvas.py
@@ -1,5 +1,6 @@
 from rubicon.objc import CGFloat, SEL
 
+from toga.widgets.canvas import EVENODD
 from toga_cocoa.libs import (
     core_graphics,
     CGPathDrawingMode,
@@ -145,7 +146,7 @@ class Canvas(Widget):
     # Drawing Paths
 
     def fill(self, color, fill_rule, preserve, draw_context, *args, **kwargs):
-        if fill_rule is "evenodd":
+        if fill_rule == EVENODD:
             mode = CGPathDrawingMode(kCGPathEOFill)
         else:
             mode = CGPathDrawingMode(kCGPathFill)

--- a/src/cocoa/toga_cocoa/widgets/canvas.py
+++ b/src/cocoa/toga_cocoa/widgets/canvas.py
@@ -1,6 +1,6 @@
 from rubicon.objc import CGFloat, SEL
 
-from toga.widgets.canvas import EVENODD
+from toga.widgets.canvas import FillRule
 from toga_cocoa.libs import (
     core_graphics,
     CGPathDrawingMode,
@@ -146,7 +146,7 @@ class Canvas(Widget):
     # Drawing Paths
 
     def fill(self, color, fill_rule, preserve, draw_context, *args, **kwargs):
-        if fill_rule == EVENODD:
+        if fill_rule == FillRule.EVENODD:
             mode = CGPathDrawingMode(kCGPathEOFill)
         else:
             mode = CGPathDrawingMode(kCGPathFill)

--- a/src/core/tests/widgets/test_canvas.py
+++ b/src/core/tests/widgets/test_canvas.py
@@ -125,6 +125,19 @@ class CanvasTests(TestCase):
                         )
         self.assertActionPerformedWith(self.testing_canvas, "fill")
 
+    def test_fill_raises_error_on_invalid_fill_rule(self):
+
+        def fill_context():
+            with self.testing_canvas.fill(fill_rule="unknown"):
+                pass
+
+        self.assertRaisesRegex(
+            ValueError,
+            "^fill rule should be one of the followings: nonzero, evenodd$",
+            fill_context
+        )
+        self.assertActionNotPerformed(self.testing_canvas, "fill")
+
     def test_draw_3circles(self):
         xc = 100
         yc = 150

--- a/src/core/tests/widgets/test_canvas.py
+++ b/src/core/tests/widgets/test_canvas.py
@@ -133,7 +133,7 @@ class CanvasTests(TestCase):
 
         self.assertRaisesRegex(
             ValueError,
-            "^fill rule should be one of the followings: nonzero, evenodd$",
+            "^fill rule should be one of the followings: evenodd, nonzero$",
             fill_context
         )
         self.assertActionNotPerformed(self.testing_canvas, "fill")
@@ -477,7 +477,7 @@ class CanvasTests(TestCase):
         ) as filler:
             self.assertEqual(
                 repr(filler),
-                "Fill(color=rgb(220, 20, 60), fill_rule=evenodd, preserve=True)",
+                "Fill(color=rgb(220, 20, 60), fill_rule=FillRule.EVENODD, preserve=True)",
             )
 
     def test_stroke_modify(self):

--- a/src/core/tests/widgets/test_canvas.py
+++ b/src/core/tests/widgets/test_canvas.py
@@ -5,6 +5,7 @@ from toga.colors import REBECCAPURPLE, BLANCHEDALMOND, CRIMSON, rgb
 from toga.fonts import SANS_SERIF, SERIF
 
 import toga_dummy
+from toga.widgets.canvas import FillRule
 from toga_dummy.utils import TestCase
 
 
@@ -467,7 +468,7 @@ class CanvasTests(TestCase):
             self.testing_canvas,
             "fill",
             color=rgb(102, 51, 153),
-            fill_rule="evenodd",
+            fill_rule=FillRule.EVENODD,
             preserve=True,
         )
 

--- a/src/core/toga/widgets/canvas.py
+++ b/src/core/toga/widgets/canvas.py
@@ -152,16 +152,6 @@ class Context:
             :class:`Fill <Fill>` object.
 
         """
-        if isinstance(fill_rule, str):
-
-            try:
-                fill_rule = FillRule[fill_rule.upper()]
-            except KeyError:
-                raise ValueError(
-                    "fill rule should be one of the followings: {}".format(
-                        ", ".join([value.name.lower() for value in FillRule])
-                    )
-                )
         fill = Fill(color, fill_rule, preserve)
         fill.canvas = self.canvas
         yield self.add_draw_obj(fill)
@@ -417,6 +407,23 @@ class Fill(Context):
             kwargs["fill_color"] = self.color
             obj._draw(impl, *args, **kwargs)
         impl.fill(self.color, self.fill_rule, self.preserve, *args, **kwargs)
+
+    @property
+    def fill_rule(self):
+        return self._fill_rule
+
+    @fill_rule.setter
+    def fill_rule(self, fill_rule):
+        if isinstance(fill_rule, str):
+            try:
+                fill_rule = FillRule[fill_rule.upper()]
+            except KeyError:
+                raise ValueError(
+                    "fill rule should be one of the followings: {}".format(
+                        ", ".join([value.name.lower() for value in FillRule])
+                    )
+                )
+        self._fill_rule = fill_rule
 
     @property
     def color(self):

--- a/src/core/toga/widgets/canvas.py
+++ b/src/core/toga/widgets/canvas.py
@@ -153,7 +153,7 @@ class Context:
         """
         if fill_rule not in FILLRULES:
             raise ValueError(
-                "fillrule should be one of the followings: {}".format(
+                "fill rule should be one of the followings: {}".format(
                     ", ".join(FILLRULES)
                 )
             )

--- a/src/core/toga/widgets/canvas.py
+++ b/src/core/toga/widgets/canvas.py
@@ -1,5 +1,6 @@
 from contextlib import contextmanager
 from math import pi
+from enum import Enum
 
 from toga.colors import color as parse_color, BLACK
 from toga.fonts import Font, SYSTEM
@@ -8,9 +9,13 @@ from toga.handlers import wrapped_handler
 from .base import Widget
 
 
+class FillRule(Enum):
+    EVENODD = 0
+    NONZERO = 1
+
+
 EVENODD = "evenodd"
 NONZERO = "nonzero"
-FILLRULES = [NONZERO, EVENODD]
 
 
 class Context:
@@ -134,7 +139,7 @@ class Context:
         self.redraw()
 
     @contextmanager
-    def fill(self, color=BLACK, fill_rule=NONZERO, preserve=False):
+    def fill(self, color=BLACK, fill_rule=FillRule.NONZERO, preserve=False):
         """Constructs and yields a :class:`Fill <Fill>`.
 
         A drawing operator that fills the current path according to the current
@@ -151,12 +156,16 @@ class Context:
             :class:`Fill <Fill>` object.
 
         """
-        if fill_rule not in FILLRULES:
-            raise ValueError(
-                "fill rule should be one of the followings: {}".format(
-                    ", ".join(FILLRULES)
+        if isinstance(fill_rule, str):
+
+            try:
+                fill_rule = FillRule[fill_rule.upper()]
+            except KeyError:
+                raise ValueError(
+                    "fill rule should be one of the followings: {}".format(
+                        ", ".join([value.name.lower() for value in FillRule])
+                    )
                 )
-            )
         fill = Fill(color, fill_rule, preserve)
         fill.canvas = self.canvas
         yield self.add_draw_obj(fill)
@@ -392,7 +401,7 @@ class Fill(Context):
 
     """
 
-    def __init__(self, color=BLACK, fill_rule=NONZERO, preserve=False):
+    def __init__(self, color=BLACK, fill_rule=FillRule.NONZERO, preserve=False):
         super().__init__()
         self.color = color
         self.fill_rule = fill_rule

--- a/src/core/toga/widgets/canvas.py
+++ b/src/core/toga/widgets/canvas.py
@@ -8,6 +8,11 @@ from toga.handlers import wrapped_handler
 from .base import Widget
 
 
+EVENODD = "evenodd"
+NONZERO = "nonzero"
+FILLRULES = [NONZERO, EVENODD]
+
+
 class Context:
     """The user-created :class:`Context <Context>` drawing object to populate a
     drawing with visual context.
@@ -129,7 +134,7 @@ class Context:
         self.redraw()
 
     @contextmanager
-    def fill(self, color=BLACK, fill_rule="nonzero", preserve=False):
+    def fill(self, color=BLACK, fill_rule=NONZERO, preserve=False):
         """Constructs and yields a :class:`Fill <Fill>`.
 
         A drawing operator that fills the current path according to the current
@@ -146,10 +151,13 @@ class Context:
             :class:`Fill <Fill>` object.
 
         """
-        if fill_rule is "evenodd":
-            fill = Fill(color, fill_rule, preserve)
-        else:
-            fill = Fill(color, "nonzero", preserve)
+        if fill_rule not in FILLRULES:
+            raise ValueError(
+                "fillrule should be one of the followings: {}".format(
+                    ", ".join(FILLRULES)
+                )
+            )
+        fill = Fill(color, fill_rule, preserve)
         fill.canvas = self.canvas
         yield self.add_draw_obj(fill)
         self.redraw()
@@ -384,7 +392,7 @@ class Fill(Context):
 
     """
 
-    def __init__(self, color=BLACK, fill_rule="nonzero", preserve=False):
+    def __init__(self, color=BLACK, fill_rule=NONZERO, preserve=False):
         super().__init__()
         self.color = color
         self.fill_rule = fill_rule

--- a/src/core/toga/widgets/canvas.py
+++ b/src/core/toga/widgets/canvas.py
@@ -14,10 +14,6 @@ class FillRule(Enum):
     NONZERO = 1
 
 
-EVENODD = "evenodd"
-NONZERO = "nonzero"
-
-
 class Context:
     """The user-created :class:`Context <Context>` drawing object to populate a
     drawing with visual context.

--- a/src/winforms/toga_winforms/libs/__init__.py
+++ b/src/winforms/toga_winforms/libs/__init__.py
@@ -2,6 +2,7 @@ from .winforms import (  # noqa: F401
     Bitmap,
     Color,
     Convert,
+    FillMode,
     FontFamily,
     FontStyle,
     Graphics,

--- a/src/winforms/toga_winforms/libs/winforms.py
+++ b/src/winforms/toga_winforms/libs/winforms.py
@@ -24,7 +24,7 @@ from System.Drawing import Text, Color, Bitmap  # noqa: E402, F401
 from System.Drawing import Graphics  # noqa: E402, F401
 from System.Drawing import Pen, SolidBrush  # noqa: E402, F401
 from System.Drawing import Rectangle, RectangleF  # noqa: E402, F401
-from System.Drawing.Drawing2D import GraphicsPath  # noqa: E402, F401
+from System.Drawing.Drawing2D import GraphicsPath, FillMode  # noqa: E402, F401
 
 from System.Threading.Tasks import Task  # noqa: E402, F401
 

--- a/src/winforms/toga_winforms/widgets/canvas.py
+++ b/src/winforms/toga_winforms/widgets/canvas.py
@@ -2,10 +2,11 @@ import math
 
 from travertino.colors import WHITE
 
-from toga.widgets.canvas import Context
+from toga.widgets.canvas import Context, FillRule
 from .box import Box
 from toga_winforms.colors import native_color
 from toga_winforms.libs import (
+    FillMode,
     Pen,
     SolidBrush,
     GraphicsPath,
@@ -181,7 +182,17 @@ class Canvas(Box):
 
     def fill(self, color, fill_rule, preserve, draw_context, *args, **kwargs):
         brush = self.create_brush(color)
+        fill_mode = self.native_fill_rule(fill_rule)
+        if fill_mode is not None:
+            draw_context.path.FillMode = fill_mode
         draw_context.graphics.FillPath(brush, draw_context.path)
+
+    def native_fill_rule(self, fill_rule):
+        if fill_rule == FillRule.EVENODD:
+            return FillMode.Alternate
+        if fill_rule == FillRule.NONZERO:
+            return FillMode.Winding
+        return None
 
     def stroke(self, color, line_width, line_dash, draw_context, *args, **kwargs):
         if draw_context.path is not None:


### PR DESCRIPTION
Fixed bug in `Canvas` fill rule in *toga core* and *toga coca*. also added to `Canvas` example usage of fill rule:

Stroke:
<img width="399" alt="Screen Shot 2020-05-02 at 10 25 30" src="https://user-images.githubusercontent.com/19425795/80858088-a2d6f680-8c5f-11ea-8a22-35bafb8fbf38.png">

Nonzero fill rule:

<img width="399" alt="Screen Shot 2020-05-02 at 10 26 32" src="https://user-images.githubusercontent.com/19425795/80858099-baae7a80-8c5f-11ea-9596-85fe102ccf71.png">

Evenodd fill rule:

![image](https://user-images.githubusercontent.com/19425795/80858117-df0a5700-8c5f-11ea-9e5d-9575d2b8673d.png)

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
