### PR TITLE
Canvas translate example

### DIFF
--- a/examples/canvas/canvas/app.py
+++ b/examples/canvas/canvas/app.py
@@ -74,6 +74,16 @@ class ExampleCanvasApp(toga.App):
             items=list(self.dash_patterns.keys()),
             on_select=self.refresh_canvas
         )
+        self.sx_slider = toga.Slider(
+            range=(-1, 1),
+            default=0,
+            on_slide=self.refresh_canvas
+        )
+        self.sy_slider = toga.Slider(
+            range=(-1, 1),
+            default=0,
+            on_slide=self.refresh_canvas
+        )
         box = toga.Box(
             style=Pack(direction=COLUMN),
             children=[
@@ -94,6 +104,16 @@ class ExampleCanvasApp(toga.App):
                         self.dash_pattern_selection
                     ]
                 ),
+                toga.Box(
+                    style=Pack(direction=ROW),
+                    children=[
+                        toga.Label("X Translate:"),
+                        self.sx_slider,
+                        toga.Label("Y Translate:"),
+                        self.sy_slider,
+                        toga.Button(label="Reset translate", on_press=self.reset_translate)
+                    ]
+                ),
                 self.canvas
             ]
         )
@@ -106,10 +126,19 @@ class ExampleCanvasApp(toga.App):
         # Show the main window
         self.main_window.show()
 
+    def reset_translate(self, widget):
+        self.sx_slider.value = 0
+        self.sy_slider.value = 0
+        self.refresh_canvas(widget)
+
     def render_drawing(self, canvas, w, h):
         canvas.clear()
+        sx = w / 2 * self.sx_slider.value
+        sy = h / 2 * self.sy_slider.value
+        canvas.translate(sx, sy)
         with self.get_context(canvas) as context:
             self.draw_shape(context, h, w)
+        canvas.reset_transform()
 
     def draw_shape(self, context, h, w):
         # Scale to the smallest axis to maintain aspect ratio

--- a/src/cocoa/toga_cocoa/widgets/label.py
+++ b/src/cocoa/toga_cocoa/widgets/label.py
@@ -37,5 +37,7 @@ class Label(Widget):
         # Width & height of a label is known and fixed.
         content_size = self.native.intrinsicContentSize()
         # print("REHINT label", self, content_size.width, content_size.height)
-        self.interface.intrinsic.width = at_least(content_size.width)
+        # 2020-05-11 The +1 is a hack; the label "X Translate:" gets truncated
+        # without the extra pixel.
+        self.interface.intrinsic.width = at_least(content_size.width + 1)
         self.interface.intrinsic.height = content_size.height

--- a/src/cocoa/toga_cocoa/widgets/slider.py
+++ b/src/cocoa/toga_cocoa/widgets/slider.py
@@ -27,7 +27,7 @@ class Slider(Widget):
         return self.native.floatValue
 
     def set_value(self, value):
-        self.native.doubleValue = self.interface.value
+        self.native.doubleValue = value
 
     def set_range(self, range):
         self.native.minValue = self.interface.range[0]

--- a/src/core/tests/widgets/test_slider.py
+++ b/src/core/tests/widgets/test_slider.py
@@ -27,7 +27,7 @@ class SliderTests(TestCase):
         self.assertActionPerformed(self.slider, 'create Slider')
 
     def test_parameter_are_all_set_correctly(self):
-        self.assertEqual(self.slider._value, self.default)
+        self.assertEqual(self.slider.value, self.default)
         self.assertEqual(self.slider.range, self.range)
         self.assertEqual(self.slider._range, self.range)
         self.assertEqual(self.slider.on_slide._raw, self.on_slide)
@@ -63,7 +63,7 @@ class SliderTests(TestCase):
 
     def test_new_value_is_None(self):
         self.slider.value = None
-        self.assertEqual(self.slider._value, 0.5)
+        self.assertEqual(self.slider.value, 0.5)
 
     def test_working_range_values(self):
         self.slider.range = (0, 100)

--- a/src/core/toga/widgets/slider.py
+++ b/src/core/toga/widgets/slider.py
@@ -38,19 +38,18 @@ class Slider(Widget):
         Raises:
             ValueError: If the new value is not in the range of min and max.
         """
-        self._value = self._impl.get_value()
-        return self._value
+        return self._impl.get_value()
 
     @value.setter
     def value(self, value):
         _min, _max = self.range
         if value is None:
-            self._value = 0.5
+            final = 0.5
         elif _min <= value <= _max:
-            self._value = value
+            final = value
         else:
             raise ValueError('Slider value ({}) is not in range ({}-{})'.format(value, _min, _max))
-        self._impl.set_value(self._value)
+        self._impl.set_value(final)
 
     @property
     def range(self):

--- a/src/gtk/toga_gtk/widgets/slider.py
+++ b/src/gtk/toga_gtk/widgets/slider.py
@@ -23,7 +23,7 @@ class Slider(Widget):
         pass
 
     def set_value(self, value):
-        self.adj.set_value(self.interface.value)
+        self.adj.set_value(value)
 
     def get_value(self):
         return self.native.get_value()

--- a/src/winforms/toga_winforms/widgets/slider.py
+++ b/src/winforms/toga_winforms/widgets/slider.py
@@ -25,7 +25,7 @@ class Slider(Widget):
         return self.native.Value
 
     def set_value(self, value):
-        self.native.Value = self.interface.value
+        self.native.Value = value
 
     def set_range(self, range):
         self.native.Minimum = self.interface.range[0]


### PR DESCRIPTION
Added a "translate" example for `Canvas`:

![image](https://user-images.githubusercontent.com/19425795/81075070-8e5e5c80-8ef2-11ea-9d0f-5be83cd9c87a.png)

This had surfaced two bugs in cocoa:
1. `Slider` set_value method didn't work - fixed that
2. `Label` text is cut for some reason (see "X Translate") - Didn't investigate the problem. I'll try to take a look at it in another PR.

## PR Checklist:
- [X] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
