### PR TITLE
Add `TextInput` and `Label` widgets; start doing layout

### DIFF
--- a/src/android/toga_android/factory.py
+++ b/src/android/toga_android/factory.py
@@ -3,21 +3,25 @@ from .paths import paths
 
 from .widgets.box import Box
 from .widgets.button import Button
+from .widgets.label import Label
+from .widgets.textinput import TextInput
 from .icons import Icon
 from .window import Window
 
 
 def not_implemented(feature):
-    print('[Android] Not implemented: {}'.format(feature))
+    print("[Android] Not implemented: {}".format(feature))
 
 
 __all__ = [
-    'not_implemented',
-    'App',
-    'MainWindow',
-    'paths',
-    'Box',
-    'Button',
-    'Icon',
-    'Window',
+    "App",
+    "Box",
+    "Button",
+    "Icon",
+    "Label",
+    "MainWindow",
+    "TextInput",
+    "Window",
+    "not_implemented",
+    "paths",
 ]

--- a/src/android/toga_android/libs/android_widgets.py
+++ b/src/android/toga_android/libs/android_widgets.py
@@ -1,5 +1,12 @@
 from rubicon.java import JavaClass, JavaInterface
 
 Button = JavaClass("android/widget/Button")
+EditText = JavaClass("android/widget/EditText")
+Gravity = JavaClass("android/view/Gravity")
 OnClickListener = JavaInterface("android/view/View$OnClickListener")
 RelativeLayout = JavaClass("android/widget/RelativeLayout")
+RelativeLayout__LayoutParams = JavaClass("android/widget/RelativeLayout$LayoutParams")
+ScrollView = JavaClass("android/widget/ScrollView")
+TextView = JavaClass("android/widget/TextView")
+ViewGroup__LayoutParams = JavaClass("android/view/ViewGroup$LayoutParams")
+View__MeasureSpec = JavaClass("android/view/View$MeasureSpec")

--- a/src/android/toga_android/widgets/base.py
+++ b/src/android/toga_android/widgets/base.py
@@ -1,7 +1,4 @@
-from toga.constants import LEFT, RIGHT, CENTER, JUSTIFY
-
 from ..libs.activity import MainActivity
-from ..libs.android_widgets import Gravity
 
 
 class Widget:
@@ -20,16 +17,6 @@ class Widget:
 
     def set_window(self, window):
         pass
-
-    def set_alignment(self, value):
-        self.native.setGravity(
-            {
-                LEFT: Gravity.CENTER_VERTICAL | Gravity.LEFT,
-                RIGHT: Gravity.CENTER_VERTICAL | Gravity.RIGHT,
-                CENTER: Gravity.CENTER_VERTICAL | Gravity.CENTER_HORIZONTAL,
-                JUSTIFY: Gravity.CENTER_VERTICAL | Gravity.CENTER_HORIZONTAL,
-            }[value]
-        )
 
     @property
     def container(self):

--- a/src/android/toga_android/widgets/base.py
+++ b/src/android/toga_android/widgets/base.py
@@ -84,14 +84,4 @@ class Widget:
             child.container = self.container
 
     def rehint(self):
-        # An Android `View` subclass (of which all widgets are subclasses) can
-        # be measured against a measurement specification called a MeasureSpec.
-        # Note that this mutates the widget's `getMeasuredWidth()` and
-        # `getMeasuredHeight()`.
-        self.native.measure(
-            View__MeasureSpec.UNSPECIFIED, View__MeasureSpec.UNSPECIFIED
-        )
-        # We use `at_least()` below because without it, Travertino seems to
-        # decide to use a width of zero.
-        self.interface.intrinsic.width = at_least(self.native.getMeasuredWidth())
-        self.interface.intrinsic.height = self.native.getMeasuredHeight()
+        pass

--- a/src/android/toga_android/widgets/base.py
+++ b/src/android/toga_android/widgets/base.py
@@ -1,11 +1,7 @@
 from toga.constants import LEFT, RIGHT, CENTER, JUSTIFY
-from travertino.size import at_least
 
 from ..libs.activity import MainActivity
-from ..libs.android_widgets import (
-    Gravity,
-    View__MeasureSpec,
-)
+from ..libs.android_widgets import Gravity
 
 
 class Widget:

--- a/src/android/toga_android/widgets/base.py
+++ b/src/android/toga_android/widgets/base.py
@@ -95,6 +95,3 @@ class Widget:
         # decide to use a width of zero.
         self.interface.intrinsic.width = at_least(self.native.getMeasuredWidth())
         self.interface.intrinsic.height = self.native.getMeasuredHeight()
-
-    def set_size(self, size):
-        pass

--- a/src/android/toga_android/widgets/box.py
+++ b/src/android/toga_android/widgets/box.py
@@ -1,8 +1,18 @@
 from .base import Widget
 from ..libs.activity import MainActivity
-from ..libs.android_widgets import RelativeLayout
+from ..libs.android_widgets import RelativeLayout, RelativeLayout__LayoutParams
 
 
 class Box(Widget):
     def create(self):
         self.native = RelativeLayout(MainActivity.singletonThis)
+
+    def set_child_bounds(self, widget, x, y, width, height):
+        # We assume `widget.native` has already been added to this `RelativeLayout`.
+        #
+        # We use `topMargin` and `leftMargin` to perform absolute layout. Not very
+        # relative, but that's how we do it.
+        layout_params = RelativeLayout__LayoutParams(width, height)
+        layout_params.topMargin = y
+        layout_params.leftMargin = x
+        self.native.updateViewLayout(widget.native, layout_params)

--- a/src/android/toga_android/widgets/button.py
+++ b/src/android/toga_android/widgets/button.py
@@ -31,4 +31,8 @@ class Button(Widget):
         pass
 
     def rehint(self):
-        return super().rehint()
+        self.native.measure(
+            View__MeasureSpec.UNSPECIFIED, View__MeasureSpec.UNSPECIFIED
+        )
+        self.interface.intrinsic.width = at_least(self.native.getMeasuredWidth())
+        self.interface.intrinsic.height = self.native.getMeasuredHeight()

--- a/src/android/toga_android/widgets/button.py
+++ b/src/android/toga_android/widgets/button.py
@@ -29,3 +29,6 @@ class Button(Widget):
     def set_on_press(self, handler):
         # No special handling required
         pass
+
+    def rehint(self):
+        return super().rehint()

--- a/src/android/toga_android/widgets/button.py
+++ b/src/android/toga_android/widgets/button.py
@@ -1,3 +1,5 @@
+from travertino.size import at_least
+
 from .base import Widget
 from ..libs import android_widgets
 
@@ -24,7 +26,7 @@ class Button(Widget):
         self.native.setEnabled(value)
 
     def set_background_color(self, value):
-        self.interface.factory.not_implemented('Button.set_background_color()')
+        self.interface.factory.not_implemented("Button.set_background_color()")
 
     def set_on_press(self, handler):
         # No special handling required
@@ -32,7 +34,8 @@ class Button(Widget):
 
     def rehint(self):
         self.native.measure(
-            View__MeasureSpec.UNSPECIFIED, View__MeasureSpec.UNSPECIFIED
+            android_widgets.View__MeasureSpec.UNSPECIFIED,
+            android_widgets.View__MeasureSpec.UNSPECIFIED,
         )
         self.interface.intrinsic.width = at_least(self.native.getMeasuredWidth())
         self.interface.intrinsic.height = self.native.getMeasuredHeight()

--- a/src/android/toga_android/widgets/button.py
+++ b/src/android/toga_android/widgets/button.py
@@ -1,5 +1,3 @@
-from travertino.size import at_least
-
 from .base import Widget
 from ..libs import android_widgets
 
@@ -23,7 +21,7 @@ class Button(Widget):
         self.native.setText(self.interface.label)
 
     def set_enabled(self, value):
-        self.interface.factory.not_implemented('Button.set_enabled()')
+        self.native.setEnabled(value)
 
     def set_background_color(self, value):
         self.interface.factory.not_implemented('Button.set_background_color()')
@@ -31,9 +29,3 @@ class Button(Widget):
     def set_on_press(self, handler):
         # No special handling required
         pass
-
-    def rehint(self):
-        if self.native.getMeasuredWidth():
-            # print("REHINT button", self, self.native.getMeasuredWidth(), self.native.getMeasuredHeight())
-            self.interface.intrinsic.width = at_least(self.native.getMeasuredWidth() / self.app._impl.device_scale)
-            self.interface.intrinsic.height = self.native.getMeasuredHeight() / self.app._impl.device_scale

--- a/src/android/toga_android/widgets/label.py
+++ b/src/android/toga_android/widgets/label.py
@@ -1,40 +1,11 @@
-from android.view import Gravity
-
-from travertino.size import at_least
-
-from toga.constants import (
-    LEFT_ALIGNED,
-    RIGHT_ALIGNED,
-    CENTER_ALIGNED,
-    JUSTIFIED_ALIGNED,
-    NATURAL_ALIGNED,
-)
+from .base import Widget
+from ..libs.android_widgets import TextView
 
 
-class TogaLabel:
-    # TODO: Extend `android.widget.TextView`. Provide app as `context`.
-    def __init__(self, context, interface):
-        self.interface = interface
-
-
-class Label:
+class Label(Widget):
     def create(self):
-        self.native = TogaLabel(self.app.native, self.interface)
+        self.native = TextView(self._native_activity)
         self.native.setSingleLine()
 
-    def set_alignment(self, value):
-        self.native.setGravity({
-                LEFT_ALIGNED: Gravity.CENTER_VERTICAL | Gravity.LEFT,
-                RIGHT_ALIGNED: Gravity.CENTER_VERTICAL | Gravity.RIGHT,
-                CENTER_ALIGNED: Gravity.CENTER_VERTICAL | Gravity.CENTER_HORIZONTAL,
-                JUSTIFIED_ALIGNED: Gravity.CENTER_VERTICAL | Gravity.CENTER_HORIZONTAL,
-                NATURAL_ALIGNED: Gravity.CENTER_VERTICAL | Gravity.CENTER_HORIZONTAL,
-            }[value])
-
     def set_text(self, value):
-        self.native.setText(self.interface._text)
-
-    def rehint(self):
-        # print("REHINT label", self, self.native.getMeasuredWidth(), self.native.getMeasuredHeight())
-        self.interface.intrinsic.width = at_least(self.native.getMeasuredWidth() / self.app.device_scale)
-        self.interface.intrinsic.height = self.native.getMeasuredHeight() / self.app.device_scale
+        self.native.setText(value)

--- a/src/android/toga_android/widgets/label.py
+++ b/src/android/toga_android/widgets/label.py
@@ -1,5 +1,10 @@
+from travertino.size import at_least
+
 from .base import Widget
-from ..libs.android_widgets import TextView
+from ..libs.android_widgets import (
+    TextView,
+    View__MeasureSpec,
+)
 
 
 class Label(Widget):

--- a/src/android/toga_android/widgets/label.py
+++ b/src/android/toga_android/widgets/label.py
@@ -9,3 +9,9 @@ class Label(Widget):
 
     def set_text(self, value):
         self.native.setText(value)
+
+    def rehint(self):
+        return super().rehint()
+
+    def set_alignment(self, value):
+        return super().set_alignment(value)

--- a/src/android/toga_android/widgets/label.py
+++ b/src/android/toga_android/widgets/label.py
@@ -11,7 +11,11 @@ class Label(Widget):
         self.native.setText(value)
 
     def rehint(self):
-        return super().rehint()
+        self.native.measure(
+            View__MeasureSpec.UNSPECIFIED, View__MeasureSpec.UNSPECIFIED
+        )
+        self.interface.intrinsic.width = at_least(self.native.getMeasuredWidth())
+        self.interface.intrinsic.height = self.native.getMeasuredHeight()
 
     def set_alignment(self, value):
         return super().set_alignment(value)

--- a/src/android/toga_android/widgets/label.py
+++ b/src/android/toga_android/widgets/label.py
@@ -1,7 +1,9 @@
+from toga.constants import LEFT, RIGHT, CENTER, JUSTIFY
 from travertino.size import at_least
 
 from .base import Widget
 from ..libs.android_widgets import (
+    Gravity,
     TextView,
     View__MeasureSpec,
 )
@@ -23,4 +25,11 @@ class Label(Widget):
         self.interface.intrinsic.height = self.native.getMeasuredHeight()
 
     def set_alignment(self, value):
-        return super().set_alignment(value)
+        self.native.setGravity(
+            {
+                LEFT: Gravity.CENTER_VERTICAL | Gravity.LEFT,
+                RIGHT: Gravity.CENTER_VERTICAL | Gravity.RIGHT,
+                CENTER: Gravity.CENTER_VERTICAL | Gravity.CENTER_HORIZONTAL,
+                JUSTIFY: Gravity.CENTER_VERTICAL | Gravity.CENTER_HORIZONTAL,
+            }[value]
+        )

--- a/src/android/toga_android/widgets/textinput.py
+++ b/src/android/toga_android/widgets/textinput.py
@@ -1,43 +1,30 @@
-from travertino.size import at_least
-
+from ..libs.android_widgets import EditText
 from .base import Widget
-
-
-class TogaTextInput:
-    # TODO: Extend `android.widget.EditText`. Provide app as `context`.
-    def __init__(self, context, interface):
-        self.interface = interface
 
 
 class TextInput(Widget):
     def create(self):
-        self.native = TogaTextInput(self.app.native, self.interface)
+        self.native = EditText(self._native_activity)
 
     def set_readonly(self, value):
         # self.native.editable = not value
-        self.interface.factory.not_implemented('TextInput.set_readonly()')
+        self.interface.factory.not_implemented("TextInput.set_readonly()")
 
     def set_placeholder(self, value):
         # self.native.cell.placeholderString = self._placeholder
-        self.interface.factory.not_implemented('TextInput.set_placeholder()')
+        self.interface.factory.not_implemented("TextInput.set_placeholder()")
 
     def set_alignment(self, value):
-        self.interface.factory.not_implemented('TextInput.set_alignment()')
+        self.interface.factory.not_implemented("TextInput.set_alignment()")
 
     def set_font(self, value):
-        self.interface.factory.not_implemented('TextInput.set_font()')
+        self.interface.factory.not_implemented("TextInput.set_font()")
 
-    def get_value(self, value):
-        self.interface.factory.not_implemented('TextInput.get_value()')
+    def get_value(self):
+        return self.native.getText()
 
     def set_value(self, value):
         self.native.setText(value)
-
-    def rehint(self):
-        # Height of a text input is known and fixed.
-        # print("REHINT text input", self, self.native.getMeasuredWidth(), self.native.getMeasuredHeight())
-        self.interface.intrinsic.width = at_least(self.interface.MIN_WIDTH)
-        self.interface.intrinsic.height = self.native.getMeasuredHeight() / self.app.native.device_scale
 
     def set_on_change(self, handler):
         # No special handling required.

--- a/src/android/toga_android/widgets/textinput.py
+++ b/src/android/toga_android/widgets/textinput.py
@@ -29,3 +29,6 @@ class TextInput(Widget):
     def set_on_change(self, handler):
         # No special handling required.
         pass
+
+    def rehint(self):
+        return super().rehint()

--- a/src/android/toga_android/widgets/textinput.py
+++ b/src/android/toga_android/widgets/textinput.py
@@ -31,4 +31,8 @@ class TextInput(Widget):
         pass
 
     def rehint(self):
-        return super().rehint()
+        self.native.measure(
+            View__MeasureSpec.UNSPECIFIED, View__MeasureSpec.UNSPECIFIED
+        )
+        self.interface.intrinsic.width = at_least(self.native.getMeasuredWidth())
+        self.interface.intrinsic.height = self.native.getMeasuredHeight()

--- a/src/android/toga_android/widgets/textinput.py
+++ b/src/android/toga_android/widgets/textinput.py
@@ -1,4 +1,9 @@
-from ..libs.android_widgets import EditText
+from travertino.size import at_least
+
+from ..libs.android_widgets import (
+    EditText,
+    View__MeasureSpec,
+)
 from .base import Widget
 
 

--- a/src/android/toga_android/window.py
+++ b/src/android/toga_android/window.py
@@ -1,7 +1,3 @@
-from .libs.activity import MainActivity
-from .libs.android_widgets import ScrollView
-
-
 class AndroidViewport:
     def __init__(self, native):
         self.native = native
@@ -31,13 +27,10 @@ class Window:
     def set_content(self, widget):
         # Set the widget's viewport to be based on the window's content.
         widget.viewport = AndroidViewport(widget.native)
-        # Set the app's entire contentView to a scrollable view over the desired
-        # widget. This means that calling Window.set_content() on any Window
-        # object automatically updates the app, meaning that every Window
-        # object acts as the MainWindow.
-        scroll_view = ScrollView(MainActivity.singletonThis)
-        scroll_view.addView(widget.native)
-        self.app.native.setContentView(scroll_view)
+        # Set the app's entire contentView to the desired widget. This means that
+        # calling Window.set_content() on any Window object automatically updates
+        # the app, meaning that every Window object acts as the MainWindow.
+        self.app.native.setContentView(widget.native)
 
         # Attach child widgets to widget as their container.
         for child in widget.interface.children:

--- a/src/android/toga_android/window.py
+++ b/src/android/toga_android/window.py
@@ -1,3 +1,7 @@
+from .libs.activity import MainActivity
+from .libs.android_widgets import ScrollView
+
+
 class AndroidViewport:
     def __init__(self, native):
         self.native = native
@@ -27,12 +31,15 @@ class Window:
     def set_content(self, widget):
         # Set the widget's viewport to be based on the window's content.
         widget.viewport = AndroidViewport(widget.native)
-        # Set the app's entire contentView to this window. This means that calling
-        # Window.set_content() on any Window object automatically updates the app,
-        # meaning that every Window object acts as the MainWindow.
-        self.app.native.setContentView(widget.native)
+        # Set the app's entire contentView to a scrollable view over the desired
+        # widget. This means that calling Window.set_content() on any Window
+        # object automatically updates the app, meaning that every Window
+        # object acts as the MainWindow.
+        scroll_view = ScrollView(MainActivity.singletonThis)
+        scroll_view.addView(widget.native)
+        self.app.native.setContentView(scroll_view)
 
-        # Attach child widgets to the this window as their container.
+        # Attach child widgets to widget as their container.
         for child in widget.interface.children:
             child._impl.container = widget
             child._impl.viewport = widget.viewport


### PR DESCRIPTION
This PR adds `TextInput` and `Label`. It begins to do layout as well.

## Manual testing

<details>
<summary>
Sample code `app.py`:
</summary>

```python
"""
My first application
"""
import toga
from toga.constants import RIGHT
from toga.style import Pack
from toga.style.pack import COLUMN, ROW



class HelloWorld(toga.App):

    def startup(self):
        main_box = toga.Box(style=Pack(direction=COLUMN))

        name_label = toga.Label(
            'Your name: ',
            style=Pack(padding=(0, 5))
        )
        self.name_input = toga.TextInput(style=Pack(flex=1))

        main_box.add(name_label)
        main_box.add(self.name_input)

        button = toga.Button(
            'Say Hello!',
            on_press=self.say_hello,
            style=Pack(flex=1)
        )
        print("HELLO BUTTON DO NOT GO AWAY", button)

        main_box.add(button)
        print("main_box added the button, so where did it go")

        self.main_window = toga.MainWindow(title=self.formal_name)
        self.main_window.content = main_box
        self.main_window.show()

    def say_hello(self, widget):
        print("Hello", self.name_input.value)
        print("Hello say_hello")

def main():
    # XXX Hack
    class HasDunderPackage:
        __package__ = 'helloworld'
    import sys
    sys.modules['__main__'] = HasDunderPackage
    ## XXX End hack
    return HelloWorld()
```

</details>

With the sample code above, I get this screenshot:

![image](https://user-images.githubusercontent.com/25457/81256421-508e3080-8fe5-11ea-9c85-870b3ce3c0e3.png)

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested (manually)
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
