### PR TITLE
Password input on change

### DIFF
--- a/examples/textinput/textinput/app.py
+++ b/examples/textinput/textinput/app.py
@@ -81,16 +81,16 @@ class TextInputApp(toga.App):
         # Outermost box
         box = toga.Box(
             children=[
-                    self.label,
-                    self.text_input,
-                    self.password_input,
-                    self.password_content_label,
-                    self.number_input,
-                    self.text_label,
-                    self.password_label,
-                    self.number_label,
-                    btn_extract,
-                ],
+                self.label,
+                self.text_input,
+                self.password_input,
+                self.password_content_label,
+                self.number_input,
+                self.text_label,
+                self.password_label,
+                self.number_label,
+                btn_extract,
+            ],
             style=Pack(
                 flex=1,
                 direction=COLUMN,

--- a/examples/textinput/textinput/app.py
+++ b/examples/textinput/textinput/app.py
@@ -1,6 +1,9 @@
 import toga
 from toga.constants import COLUMN
 from toga.style import Pack
+from string import ascii_uppercase, ascii_lowercase, digits
+
+EMPTY_PASSWORD = 'Empty password'
 
 
 class TextInputApp(toga.App):
@@ -49,14 +52,25 @@ class TextInputApp(toga.App):
         self.main_window = toga.MainWindow(title=self.name)
 
         # Labels to show responses.
-        self.label = toga.Label('Enter some values and press extract.', style=Pack(padding=10))
+        self.label = toga.Label(
+            'Enter some values and press extract.', style=Pack(padding=10)
+        )
         self.text_label = toga.Label('Ready.', style=Pack(padding=10))
         self.password_label = toga.Label('Ready.', style=Pack(padding=10))
+        self.password_content_label = toga.Label(
+            EMPTY_PASSWORD, style=Pack(padding_bottom=10, font_size=9)
+        )
         self.number_label = toga.Label('Ready.', style=Pack(padding=10))
 
         # Text inputs and a button
-        self.text_input = toga.TextInput(placeholder='Type something...', style=Pack(padding=10))
-        self.password_input = toga.PasswordInput(placeholder='Password...', style=Pack(padding=10))
+        self.text_input = toga.TextInput(
+            placeholder='Type something...', style=Pack(padding=10)
+        )
+        self.password_input = toga.PasswordInput(
+            placeholder='Password...',
+            style=Pack(padding=10),
+            on_change=self.on_password_change
+        )
         self.number_input = toga.NumberInput(style=Pack(padding=10))
         btn_extract = toga.Button(
             'Extract values',
@@ -67,19 +81,20 @@ class TextInputApp(toga.App):
         # Outermost box
         box = toga.Box(
             children=[
-                self.label,
-                self.text_input,
-                self.password_input,
-                self.number_input,
-                self.text_label,
-                self.password_label,
-                self.number_label,
-                btn_extract,
-            ],
+                    self.label,
+                    self.text_input,
+                    self.password_input,
+                    self.password_content_label,
+                    self.number_input,
+                    self.text_label,
+                    self.password_label,
+                    self.number_label,
+                    btn_extract,
+                ],
             style=Pack(
                 flex=1,
                 direction=COLUMN,
-                padding=10
+                padding=10,
             )
         )
 
@@ -88,6 +103,25 @@ class TextInputApp(toga.App):
 
         # Show the main window
         self.main_window.show()
+
+    def on_password_change(self, widget):
+        content = widget.value
+        self.password_content_label.text = self.get_password_content_label(content)
+
+    def get_password_content_label(self, content):
+        if content.strip() == "":
+            return EMPTY_PASSWORD
+        contains = set()
+        for letter in content:
+            if letter in ascii_uppercase:
+                contains.add("uppercase letters")
+            elif letter in ascii_lowercase:
+                contains.add("lowercase letters")
+            elif letter in digits:
+                contains.add("digits")
+            else:
+                contains.add("special characters")
+        return "Password contains: {}".format(', '.join(contains))
 
 
 def main():

--- a/src/cocoa/toga_cocoa/widgets/label.py
+++ b/src/cocoa/toga_cocoa/widgets/label.py
@@ -31,8 +31,7 @@ class Label(Widget):
             self.native.font = value._impl.native
 
     def set_text(self, value):
-        print(value)
-        self.native.stringValue = value
+        self.native.stringValue = self.interface._text
 
     def rehint(self):
         # Width & height of a label is known and fixed.

--- a/src/cocoa/toga_cocoa/widgets/label.py
+++ b/src/cocoa/toga_cocoa/widgets/label.py
@@ -31,7 +31,8 @@ class Label(Widget):
             self.native.font = value._impl.native
 
     def set_text(self, value):
-        self.native.stringValue = self.interface._text
+        print(value)
+        self.native.stringValue = value
 
     def rehint(self):
         # Width & height of a label is known and fixed.

--- a/src/cocoa/toga_cocoa/widgets/passwordinput.py
+++ b/src/cocoa/toga_cocoa/widgets/passwordinput.py
@@ -1,12 +1,16 @@
 from toga_cocoa.libs import NSSecureTextField, NSTextFieldSquareBezel
 
-from .textinput import TextInput
+from .textinput import TextInput, TogaTextFieldDelegate
 
 
 class PasswordInput(TextInput):
     def create(self):
         self.native = NSSecureTextField.new()
         self.native.interface = self.interface
+
+        delegate = TogaTextFieldDelegate.new()
+        delegate.interface = self.interface
+        self.native.delegate = delegate
 
         self.native.bezeled = True
         self.native.bezelStyle = NSTextFieldSquareBezel

--- a/src/core/toga/widgets/passwordinput.py
+++ b/src/core/toga/widgets/passwordinput.py
@@ -1,7 +1,7 @@
-from .base import Widget
+from .textinput import TextInput
 
 
-class PasswordInput(Widget):
+class PasswordInput(TextInput):
     """ This widgets behaves like a TextInput but does not reveal what text is entered.
 
     Args:
@@ -17,68 +17,16 @@ class PasswordInput(Widget):
     MIN_WIDTH = 100
 
     def __init__(self, id=None, style=None, factory=None,
-                initial=None, placeholder=None, readonly=False):
-        super().__init__(id=id, style=style, factory=factory)
+                initial=None, placeholder=None, readonly=False, on_change=None):
+        super(PasswordInput, self).__init__(
+            id=id,
+            style=style,
+            factory=factory,
+            initial=initial,
+            placeholder=placeholder,
+            readonly=readonly,
+            on_change=on_change
+        )
 
-        # Create a platform specific implementation of a PasswordInput
+    def _initiate_implementation(self):
         self._impl = self.factory.PasswordInput(interface=self)
-
-        self.value = initial
-        self.placeholder = placeholder
-        self.readonly = readonly
-
-    @property
-    def readonly(self):
-        """ Whether a user can write into the password input
-
-        Returns:
-            ``True`` if the user can only read,
-            ``False`` if the user can read and write into the input.
-        """
-        return self._readonly
-
-    @readonly.setter
-    def readonly(self, value):
-        self._readonly = value
-        self._impl.set_readonly(value)
-
-    @property
-    def placeholder(self):
-        """ The placeholder text is the displayed before the user input something.
-
-        Returns:
-            The placeholder text (str) of the widget.
-        """
-        return self._placeholder
-
-    @placeholder.setter
-    def placeholder(self, value):
-        if value is None:
-            self._placeholder = ''
-        else:
-            self._placeholder = str(value)
-        self._impl.set_placeholder(self._placeholder)
-        self._impl.rehint()
-
-    @property
-    def value(self):
-        """ The value of the text input field.
-
-        Returns:
-            The text as a ``str`` of the password input widget.
-        """
-        return self._impl.get_value()
-
-    @value.setter
-    def value(self, value):
-        if value is None:
-            v = ''
-        else:
-            v = str(value)
-        self._impl.set_value(v)
-        self._impl.rehint()
-
-    def clear(self):
-        """ Clears the input field of the widget.
-        """
-        self.value = ''

--- a/src/core/toga/widgets/passwordinput.py
+++ b/src/core/toga/widgets/passwordinput.py
@@ -2,39 +2,8 @@ from .textinput import TextInput
 
 
 class PasswordInput(TextInput):
-    """ This widgets behaves like a TextInput but does not reveal what text is entered.
-
-    Args:
-        id (str): An identifier for this widget.
-        style (:obj:`Style`): An optional style object. If no style is provided then
-            a new one will be created for the widget.
-        factory (:obj:`module`): A python module that is capable to return a
-            implementation of this class with the same name. (optional & normally not needed)
-        initial (str): The initial text that is displayed before the user inputs anything.
-        placeholder (str): The text that is displayed if no input text is present.
-        readonly (bool): Whether a user can write into the text input, defaults to `False`.
+    """This widget behaves like a TextInput, but obscures the text that is
+    entered by the user.
     """
-    MIN_WIDTH = 100
-
-    def __init__(
-            self,
-            id=None,
-            style=None,
-            factory=None,
-            initial=None,
-            placeholder=None,
-            readonly=False,
-            on_change=None
-    ):
-        super(PasswordInput, self).__init__(
-            id=id,
-            style=style,
-            factory=factory,
-            initial=initial,
-            placeholder=placeholder,
-            readonly=readonly,
-            on_change=on_change
-        )
-
-    def _initiate_implementation(self):
+    def _create(self):
         self._impl = self.factory.PasswordInput(interface=self)

--- a/src/core/toga/widgets/passwordinput.py
+++ b/src/core/toga/widgets/passwordinput.py
@@ -16,8 +16,16 @@ class PasswordInput(TextInput):
     """
     MIN_WIDTH = 100
 
-    def __init__(self, id=None, style=None, factory=None,
-                initial=None, placeholder=None, readonly=False, on_change=None):
+    def __init__(
+            self,
+            id=None,
+            style=None,
+            factory=None,
+            initial=None,
+            placeholder=None,
+            readonly=False,
+            on_change=None
+    ):
         super(PasswordInput, self).__init__(
             id=id,
             style=style,

--- a/src/core/toga/widgets/textinput.py
+++ b/src/core/toga/widgets/textinput.py
@@ -24,7 +24,7 @@ class TextInput(Widget):
         super().__init__(id=id, style=style, factory=factory)
 
         # Create a platform specific implementation of a TextInput
-        self._impl = self.factory.TextInput(interface=self)
+        self._initiate_implementation()
 
         self.on_change = on_change
         self.placeholder = placeholder
@@ -32,6 +32,9 @@ class TextInput(Widget):
 
         # Set the actual value last, as it may trigger change events, etc.
         self.value = initial
+
+    def _initiate_implementation(self):
+        self._impl = self.factory.TextInput(interface=self)
 
     @property
     def readonly(self):

--- a/src/core/toga/widgets/textinput.py
+++ b/src/core/toga/widgets/textinput.py
@@ -23,8 +23,8 @@ class TextInput(Widget):
             initial=None, placeholder=None, readonly=False, on_change=None):
         super().__init__(id=id, style=style, factory=factory)
 
-        # Create a platform specific implementation of a TextInput
-        self._initiate_implementation()
+        # Create a platform specific implementation of the widget
+        self._create()
 
         self.on_change = on_change
         self.placeholder = placeholder
@@ -33,7 +33,7 @@ class TextInput(Widget):
         # Set the actual value last, as it may trigger change events, etc.
         self.value = initial
 
-    def _initiate_implementation(self):
+    def _create(self):
         self._impl = self.factory.TextInput(interface=self)
 
     @property


### PR DESCRIPTION
`PasswordInput` now inherits from `TextInput`, which allows it to use all `TextInput` functionalities, including `on_change`.

Fixes #895

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
