### PR TITLE
Added rotation example to Canvas

### DIFF
--- a/examples/canvas/canvas/app.py
+++ b/examples/canvas/canvas/app.py
@@ -84,6 +84,11 @@ class ExampleCanvasApp(toga.App):
             default=0,
             on_slide=self.refresh_canvas
         )
+        self.rotation_slider = toga.Slider(
+            range=(-math.pi, math.pi),
+            default=0,
+            on_slide=self.refresh_canvas
+        )
         box = toga.Box(
             style=Pack(direction=COLUMN),
             children=[
@@ -110,8 +115,16 @@ class ExampleCanvasApp(toga.App):
                         toga.Label("X Translate:"),
                         self.sx_slider,
                         toga.Label("Y Translate:"),
-                        self.sy_slider,
-                        toga.Button(label="Reset translate", on_press=self.reset_translate)
+                        self.sy_slider
+                    ]
+                ),
+                toga.Box(
+                    style=Pack(direction=ROW),
+                    children=[
+                        toga.Label("Rotation:"),
+                        self.rotation_slider,
+                        toga.Button(label="Reset translate",
+                                    on_press=self.reset_translate)
                     ]
                 ),
                 self.canvas
@@ -129,13 +142,16 @@ class ExampleCanvasApp(toga.App):
     def reset_translate(self, widget):
         self.sx_slider.value = 0
         self.sy_slider.value = 0
+        self.rotation_slider.value = 0
         self.refresh_canvas(widget)
 
     def render_drawing(self, canvas, w, h):
         canvas.clear()
         sx = w / 2 * self.sx_slider.value
         sy = h / 2 * self.sy_slider.value
-        canvas.translate(sx, sy)
+        canvas.translate(w / 2 + sx, h / 2 + sy)
+        canvas.rotate(self.rotation_slider.value)
+        canvas.translate(-w / 2, -h / 2)
         with self.get_context(canvas) as context:
             self.draw_shape(context, h, w)
         canvas.reset_transform()


### PR DESCRIPTION
This is another example of `Canvas`. Now one can rotate the drawings:

![image](https://user-images.githubusercontent.com/19425795/81568970-3c607f80-93a7-11ea-8c34-da0a78ba65a6.png)

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
