### PR TITLE
Slider can be descrete or continous

### DIFF
--- a/examples/slider/slider/app.py
+++ b/examples/slider/slider/app.py
@@ -40,7 +40,7 @@ class SliderApp(toga.App):
                         range=(1, 10),
                         default=10,
                         style=Pack(width=150),
-                        number_of_ticks=10
+                        ticks_count=10
                     ),
                 ]),
 
@@ -61,7 +61,7 @@ class SliderApp(toga.App):
                     toga.Slider(
                         on_slide=self.my_on_slide,
                         range=(MIN_VAL, MAX_VAL),
-                        number_of_ticks=MAX_VAL - MIN_VAL + 1, style=slider_style
+                        ticks_count=MAX_VAL - MIN_VAL + 1, style=slider_style
                     ),
                 ]),
             ],

--- a/examples/slider/slider/app.py
+++ b/examples/slider/slider/app.py
@@ -32,7 +32,7 @@ class SliderApp(toga.App):
 
                 toga.Box(style=box_style, children=[
                     toga.Label(
-                        "On a scale of 1 to 10, how easy is GUI with Toga?",
+                        "On a scale of 1 to 10, how easy is building a Toga GUI?",
                         style=label_style
                     ),
 
@@ -40,7 +40,7 @@ class SliderApp(toga.App):
                         range=(1, 10),
                         default=10,
                         style=Pack(width=150),
-                        ticks_count=10
+                        tick_count=10
                     ),
                 ]),
 
@@ -61,7 +61,7 @@ class SliderApp(toga.App):
                     toga.Slider(
                         on_slide=self.my_on_slide,
                         range=(MIN_VAL, MAX_VAL),
-                        ticks_count=MAX_VAL - MIN_VAL + 1, style=slider_style
+                        tick_count=MAX_VAL - MIN_VAL + 1, style=slider_style
                     ),
                 ]),
             ],

--- a/examples/slider/slider/app.py
+++ b/examples/slider/slider/app.py
@@ -23,15 +23,18 @@ class SliderApp(toga.App):
             children=[
 
                 toga.Box(style=box_style, children=[
-                    toga.Label("Default Slider is a continuous range between 0 to 1",
-                        style=label_style),
-
+                    toga.Label(
+                        "Default Slider is a continuous range between 0 to 1",
+                        style=label_style
+                    ),
                     toga.Slider(style=slider_style),
                 ]),
 
                 toga.Box(style=box_style, children=[
-                    toga.Label("On a scale of 1 to 10, how easy is GUI with Toga?",
-                        style=label_style),
+                    toga.Label(
+                        "On a scale of 1 to 10, how easy is GUI with Toga?",
+                        style=label_style
+                    ),
 
                     toga.Slider(
                         range=(1, 10),

--- a/examples/slider/slider/app.py
+++ b/examples/slider/slider/app.py
@@ -2,6 +2,9 @@ import toga
 from toga.style import Pack
 from toga.constants import COLUMN, ROW
 
+MIN_VAL = -5
+MAX_VAL = 15
+
 
 class SliderApp(toga.App):
     def startup(self):
@@ -20,17 +23,22 @@ class SliderApp(toga.App):
             children=[
 
                 toga.Box(style=box_style, children=[
-                    toga.Label("default Slider -- range is 0 to 1",
+                    toga.Label("Default Slider is a continuous range between 0 to 1",
                         style=label_style),
 
                     toga.Slider(style=slider_style),
                 ]),
 
                 toga.Box(style=box_style, children=[
-                    toga.Label("on a scale of 1 to 10, how easy is GUI with Toga?",
+                    toga.Label("On a scale of 1 to 10, how easy is GUI with Toga?",
                         style=label_style),
 
-                    toga.Slider(range=(1, 10), default=10, style=Pack(width=150)),
+                    toga.Slider(
+                        range=(1, 10),
+                        default=10,
+                        style=Pack(width=150),
+                        number_of_ticks=10
+                    ),
                 ]),
 
                 toga.Box(style=box_style, children=[
@@ -40,15 +48,18 @@ class SliderApp(toga.App):
                 ]),
 
                 toga.Box(style=box_style, children=[
-                    toga.Label("give a Slider some style!", style=label_style),
+                    toga.Label("Give a Slider some style!", style=label_style),
 
                     toga.Slider(style=slider_style)
                 ]),
 
                 toga.Box(style=box_style, children=[
                     self.sliderValueLabel,
-
-                    toga.Slider(on_slide=self.my_on_slide, range=(-40, 58), style=slider_style),
+                    toga.Slider(
+                        on_slide=self.my_on_slide,
+                        range=(MIN_VAL, MAX_VAL),
+                        number_of_ticks=MAX_VAL - MIN_VAL + 1, style=slider_style
+                    ),
                 ]),
             ],
             style=Pack(direction=COLUMN, padding=24)
@@ -58,7 +69,7 @@ class SliderApp(toga.App):
 
     def my_on_slide(self, slider):
         # get the current value of the slider with `slider.value`
-        self.sliderValueLabel.text = "The slider value changed to {0}".format(int(slider.value))
+        self.sliderValueLabel.text = "The slider value changed to {0}".format(slider.value)
 
 
 def main():

--- a/examples/slider/slider/app.py
+++ b/examples/slider/slider/app.py
@@ -9,7 +9,7 @@ MAX_VAL = 15
 class SliderApp(toga.App):
     def startup(self):
         # Main window of the application with title and size
-        self.main_window = toga.MainWindow(title=self.name, size=(700, 500))
+        self.main_window = toga.MainWindow(title=self.name, size=(1000, 500))
 
         # set up common styls
         label_style = Pack(flex=1, padding_right=24)

--- a/src/cocoa/toga_cocoa/widgets/slider.py
+++ b/src/cocoa/toga_cocoa/widgets/slider.py
@@ -21,16 +21,16 @@ class Slider(Widget):
         self.native.target = self.native
         self.native.action = SEL('onSlide:')
 
-        self.set_number_of_ticks(self.interface.number_of_ticks)
+        self.set_ticks_count(self.interface.ticks_count)
 
         self.add_constraints()
 
-    def set_number_of_ticks(self, number_of_ticks):
-        if number_of_ticks is None:
+    def set_ticks_count(self, ticks_count):
+        if ticks_count is None:
             self.native.allowsTickMarkValuesOnly = False
         else:
             self.native.allowsTickMarkValuesOnly = True
-            self.native.numberOfTickMarks = number_of_ticks
+            self.native.numberOfTickMarks = ticks_count
 
     def get_value(self):
         return self.native.floatValue

--- a/src/cocoa/toga_cocoa/widgets/slider.py
+++ b/src/cocoa/toga_cocoa/widgets/slider.py
@@ -21,7 +21,16 @@ class Slider(Widget):
         self.native.target = self.native
         self.native.action = SEL('onSlide:')
 
+        self.set_number_of_ticks(self.interface.number_of_ticks)
+
         self.add_constraints()
+
+    def set_number_of_ticks(self, number_of_ticks):
+        if number_of_ticks is None:
+            self.native.allowsTickMarkValuesOnly = False
+        else:
+            self.native.allowsTickMarkValuesOnly = True
+            self.native.numberOfTickMarks = number_of_ticks
 
     def get_value(self):
         return self.native.floatValue

--- a/src/cocoa/toga_cocoa/widgets/slider.py
+++ b/src/cocoa/toga_cocoa/widgets/slider.py
@@ -21,16 +21,16 @@ class Slider(Widget):
         self.native.target = self.native
         self.native.action = SEL('onSlide:')
 
-        self.set_ticks_count(self.interface.ticks_count)
+        self.set_tick_count(self.interface.tick_count)
 
         self.add_constraints()
 
-    def set_ticks_count(self, ticks_count):
-        if ticks_count is None:
+    def set_tick_count(self, tick_count):
+        if tick_count is None:
             self.native.allowsTickMarkValuesOnly = False
         else:
             self.native.allowsTickMarkValuesOnly = True
-            self.native.numberOfTickMarks = ticks_count
+            self.native.numberOfTickMarks = tick_count
 
     def get_value(self):
         return self.native.floatValue

--- a/src/core/tests/widgets/test_slider.py
+++ b/src/core/tests/widgets/test_slider.py
@@ -9,7 +9,7 @@ class SliderTests(TestCase):
 
         self.default = 50
         self.range = (0, 100)
-        self.ticks_count = 10
+        self.tick_count = 10
 
         def callback(widget):
             pass
@@ -22,7 +22,7 @@ class SliderTests(TestCase):
                                   on_slide=self.on_slide,
                                   enabled=self.enabled,
                                   factory=toga_dummy.factory,
-                                  ticks_count=self.ticks_count)
+                                  tick_count=self.tick_count)
 
     def test_widget_created(self):
         self.assertEqual(self.slider._impl.interface, self.slider)
@@ -80,11 +80,11 @@ class SliderTests(TestCase):
         self.slider.enabled = False
         self.assertEqual(self.slider.enabled, False)
 
-    def test_get_ticks_count(self):
-        ticks_count = self.slider.ticks_count
-        self.assertEqual(self.ticks_count, ticks_count)
+    def test_get_tick_count(self):
+        tick_count = self.slider.tick_count
+        self.assertEqual(self.tick_count, tick_count)
 
-    def test_set_ticks_count(self):
-        new_ticks_count = 5
-        self.slider.ticks_count = new_ticks_count
-        self.assertValueSet(self.slider, 'ticks_count', new_ticks_count)
+    def test_set_tick_count(self):
+        new_tick_count = 5
+        self.slider.tick_count = new_tick_count
+        self.assertValueSet(self.slider, 'tick_count', new_tick_count)

--- a/src/core/tests/widgets/test_slider.py
+++ b/src/core/tests/widgets/test_slider.py
@@ -9,6 +9,7 @@ class SliderTests(TestCase):
 
         self.default = 50
         self.range = (0, 100)
+        self.number_of_ticks = 10
 
         def callback(widget):
             pass
@@ -20,7 +21,8 @@ class SliderTests(TestCase):
                                   range=self.range,
                                   on_slide=self.on_slide,
                                   enabled=self.enabled,
-                                  factory=toga_dummy.factory)
+                                  factory=toga_dummy.factory,
+                                  number_of_ticks=self.number_of_ticks)
 
     def test_widget_created(self):
         self.assertEqual(self.slider._impl.interface, self.slider)
@@ -77,3 +79,12 @@ class SliderTests(TestCase):
         self.assertEqual(self.slider.enabled, self.enabled)
         self.slider.enabled = False
         self.assertEqual(self.slider.enabled, False)
+
+    def test_get_number_of_ticks(self):
+        number_of_ticks = self.slider.number_of_ticks
+        self.assertEqual(self.number_of_ticks, number_of_ticks)
+
+    def test_set_number_of_ticks(self):
+        new_number_of_ticks = 5
+        self.slider.number_of_ticks = new_number_of_ticks
+        self.assertValueSet(self.slider, 'number_of_ticks', new_number_of_ticks)

--- a/src/core/tests/widgets/test_slider.py
+++ b/src/core/tests/widgets/test_slider.py
@@ -9,7 +9,7 @@ class SliderTests(TestCase):
 
         self.default = 50
         self.range = (0, 100)
-        self.number_of_ticks = 10
+        self.ticks_count = 10
 
         def callback(widget):
             pass
@@ -22,7 +22,7 @@ class SliderTests(TestCase):
                                   on_slide=self.on_slide,
                                   enabled=self.enabled,
                                   factory=toga_dummy.factory,
-                                  number_of_ticks=self.number_of_ticks)
+                                  ticks_count=self.ticks_count)
 
     def test_widget_created(self):
         self.assertEqual(self.slider._impl.interface, self.slider)
@@ -80,11 +80,11 @@ class SliderTests(TestCase):
         self.slider.enabled = False
         self.assertEqual(self.slider.enabled, False)
 
-    def test_get_number_of_ticks(self):
-        number_of_ticks = self.slider.number_of_ticks
-        self.assertEqual(self.number_of_ticks, number_of_ticks)
+    def test_get_ticks_count(self):
+        ticks_count = self.slider.ticks_count
+        self.assertEqual(self.ticks_count, ticks_count)
 
-    def test_set_number_of_ticks(self):
-        new_number_of_ticks = 5
-        self.slider.number_of_ticks = new_number_of_ticks
-        self.assertValueSet(self.slider, 'number_of_ticks', new_number_of_ticks)
+    def test_set_ticks_count(self):
+        new_ticks_count = 5
+        self.slider.ticks_count = new_ticks_count
+        self.assertValueSet(self.slider, 'ticks_count', new_ticks_count)

--- a/src/core/toga/widgets/slider.py
+++ b/src/core/toga/widgets/slider.py
@@ -11,7 +11,7 @@ class Slider(Widget):
         style (:obj:`Style`):
         default (float): Default value of the slider
         range (``tuple``): Min and max values of the slider in this form (min, max).
-        ticks_count (``int``): How many ticks in range. if None, slider is continuous.
+        tick_count (``int``): How many ticks in range. if None, slider is continuous.
         on_slide (``callable``): The function that is executed on_slide.
         enabled (bool): Whether user interaction is possible or not.
         factory (:obj:`module`): A python module that is capable to return a
@@ -23,7 +23,7 @@ class Slider(Widget):
             style=None,
             default=None,
             range=None,
-            ticks_count=None,
+            tick_count=None,
             on_slide=None,
             enabled=True,
             factory=None
@@ -31,13 +31,13 @@ class Slider(Widget):
         super().__init__(id=id, style=style, factory=factory)
 
         # Needed for _impl initialization
-        self._ticks_count = None
+        self._tick_count = None
         self._on_slide = None
 
         self._impl = self.factory.Slider(interface=self)
 
         self.range = range
-        self.ticks_count = ticks_count
+        self.tick_count = tick_count
         self.value = default
         self.on_slide = on_slide
         self.enabled = enabled
@@ -86,13 +86,13 @@ class Slider(Widget):
         self._impl.set_range((_min, _max))
 
     @property
-    def ticks_count(self):
-        return self._ticks_count
+    def tick_count(self):
+        return self._tick_count
 
-    @ticks_count.setter
-    def ticks_count(self, ticks_count):
-        self._ticks_count = ticks_count
-        self._impl.set_ticks_count(ticks_count)
+    @tick_count.setter
+    def tick_count(self, tick_count):
+        self._tick_count = tick_count
+        self._impl.set_tick_count(tick_count)
 
     @property
     def on_slide(self):

--- a/src/core/toga/widgets/slider.py
+++ b/src/core/toga/widgets/slider.py
@@ -11,7 +11,7 @@ class Slider(Widget):
         style (:obj:`Style`):
         default (float): Default value of the slider
         range (``tuple``): Min and max values of the slider in this form (min, max).
-        number_of_ticks (``int``): How many ticks in range. if None, slider is continuous.
+        ticks_count (``int``): How many ticks in range. if None, slider is continuous.
         on_slide (``callable``): The function that is executed on_slide.
         enabled (bool): Whether user interaction is possible or not.
         factory (:obj:`module`): A python module that is capable to return a
@@ -23,7 +23,7 @@ class Slider(Widget):
             style=None,
             default=None,
             range=None,
-            number_of_ticks=None,
+            ticks_count=None,
             on_slide=None,
             enabled=True,
             factory=None
@@ -31,13 +31,13 @@ class Slider(Widget):
         super().__init__(id=id, style=style, factory=factory)
 
         # Needed for _impl initialization
-        self._number_of_ticks = None
+        self._ticks_count = None
         self._on_slide = None
 
         self._impl = self.factory.Slider(interface=self)
 
         self.range = range
-        self.number_of_ticks = number_of_ticks
+        self.ticks_count = ticks_count
         self.value = default
         self.on_slide = on_slide
         self.enabled = enabled
@@ -86,13 +86,13 @@ class Slider(Widget):
         self._impl.set_range((_min, _max))
 
     @property
-    def number_of_ticks(self):
-        return self._number_of_ticks
+    def ticks_count(self):
+        return self._ticks_count
 
-    @number_of_ticks.setter
-    def number_of_ticks(self, number_of_ticks):
-        self._number_of_ticks = number_of_ticks
-        self._impl.set_number_of_ticks(number_of_ticks)
+    @ticks_count.setter
+    def ticks_count(self, ticks_count):
+        self._ticks_count = ticks_count
+        self._impl.set_ticks_count(ticks_count)
 
     @property
     def on_slide(self):

--- a/src/core/toga/widgets/slider.py
+++ b/src/core/toga/widgets/slider.py
@@ -11,22 +11,38 @@ class Slider(Widget):
         style (:obj:`Style`):
         default (float): Default value of the slider
         range (``tuple``): Min and max values of the slider in this form (min, max).
+        number_of_ticks (``int``): How many ticks in range. if None, slider is continuous.
         on_slide (``callable``): The function that is executed on_slide.
         enabled (bool): Whether user interaction is possible or not.
         factory (:obj:`module`): A python module that is capable to return a
             implementation of this class with the same name. (optional & normally not needed)
     """
-    MIN_WIDTH = 100
-
-    def __init__(self, id=None, style=None, default=None, range=None, on_slide=None, enabled=True, factory=None):
+    def __init__(
+            self,
+            id=None,
+            style=None,
+            default=None,
+            range=None,
+            number_of_ticks=None,
+            on_slide=None,
+            enabled=True,
+            factory=None
+    ):
         super().__init__(id=id, style=style, factory=factory)
-        self._on_slide = None # needed for _impl initialization
+
+        # Needed for _impl initialization
+        self._number_of_ticks = None
+        self._on_slide = None
+
         self._impl = self.factory.Slider(interface=self)
 
         self.range = range
+        self.number_of_ticks = number_of_ticks
         self.value = default
         self.on_slide = on_slide
         self.enabled = enabled
+
+    MIN_WIDTH = 100
 
     @property
     def value(self):
@@ -68,6 +84,15 @@ class Slider(Widget):
             raise ValueError('Range min value has to be smaller than max value.')
         self._range = (_min, _max)
         self._impl.set_range((_min, _max))
+
+    @property
+    def number_of_ticks(self):
+        return self._number_of_ticks
+
+    @number_of_ticks.setter
+    def number_of_ticks(self, number_of_ticks):
+        self._number_of_ticks = number_of_ticks
+        self._impl.set_number_of_ticks(number_of_ticks)
 
     @property
     def on_slide(self):

--- a/src/dummy/toga_dummy/widgets/slider.py
+++ b/src/dummy/toga_dummy/widgets/slider.py
@@ -14,6 +14,9 @@ class Slider(Widget):
     def set_range(self, range):
         self._set_value('range', range)
 
+    def set_number_of_ticks(self, number_of_ticks):
+        self._set_value('number_of_ticks', number_of_ticks)
+
     def rehint(self):
         self._action('rehint Slider')
 

--- a/src/dummy/toga_dummy/widgets/slider.py
+++ b/src/dummy/toga_dummy/widgets/slider.py
@@ -14,8 +14,8 @@ class Slider(Widget):
     def set_range(self, range):
         self._set_value('range', range)
 
-    def set_number_of_ticks(self, number_of_ticks):
-        self._set_value('number_of_ticks', number_of_ticks)
+    def set_ticks_count(self, ticks_count):
+        self._set_value('ticks_count', ticks_count)
 
     def rehint(self):
         self._action('rehint Slider')

--- a/src/dummy/toga_dummy/widgets/slider.py
+++ b/src/dummy/toga_dummy/widgets/slider.py
@@ -14,8 +14,8 @@ class Slider(Widget):
     def set_range(self, range):
         self._set_value('range', range)
 
-    def set_ticks_count(self, ticks_count):
-        self._set_value('ticks_count', ticks_count)
+    def set_tick_count(self, tick_count):
+        self._set_value('tick_count', tick_count)
 
     def rehint(self):
         self._action('rehint Slider')

--- a/src/gtk/toga_gtk/widgets/slider.py
+++ b/src/gtk/toga_gtk/widgets/slider.py
@@ -32,8 +32,8 @@ class Slider(Widget):
         self.adj.set_lower(self.interface.range[0])
         self.adj.set_upper(self.interface.range[1])
 
-    def set_number_of_ticks(self, number_of_ticks):
-        self.interface.factory.not_implemented('Slider.number_of_ticks()')
+    def set_ticks_count(self, ticks_count):
+        self.interface.factory.not_implemented('Slider.ticks_count()')
 
     def rehint(self):
         # print("REHINT", self, self.native.get_preferred_width(), self.native.get_preferred_height())

--- a/src/gtk/toga_gtk/widgets/slider.py
+++ b/src/gtk/toga_gtk/widgets/slider.py
@@ -32,7 +32,7 @@ class Slider(Widget):
         self.adj.set_lower(self.interface.range[0])
         self.adj.set_upper(self.interface.range[1])
 
-    def set_number_of_ticks(self):
+    def set_number_of_ticks(self, number_of_ticks):
         self.interface.factory.not_implemented('Slider.number_of_ticks()')
 
     def rehint(self):

--- a/src/gtk/toga_gtk/widgets/slider.py
+++ b/src/gtk/toga_gtk/widgets/slider.py
@@ -32,8 +32,8 @@ class Slider(Widget):
         self.adj.set_lower(self.interface.range[0])
         self.adj.set_upper(self.interface.range[1])
 
-    def set_ticks_count(self, ticks_count):
-        self.interface.factory.not_implemented('Slider.ticks_count()')
+    def set_tick_count(self, tick_count):
+        self.interface.factory.not_implemented('Slider.tick_count()')
 
     def rehint(self):
         # print("REHINT", self, self.native.get_preferred_width(), self.native.get_preferred_height())

--- a/src/gtk/toga_gtk/widgets/slider.py
+++ b/src/gtk/toga_gtk/widgets/slider.py
@@ -32,6 +32,9 @@ class Slider(Widget):
         self.adj.set_lower(self.interface.range[0])
         self.adj.set_upper(self.interface.range[1])
 
+    def set_number_of_ticks(self):
+        self.interface.factory.not_implemented('Slider.number_of_ticks()')
+
     def rehint(self):
         # print("REHINT", self, self.native.get_preferred_width(), self.native.get_preferred_height())
         width = self.native.get_preferred_width()

--- a/src/iOS/toga_iOS/widgets/slider.py
+++ b/src/iOS/toga_iOS/widgets/slider.py
@@ -33,7 +33,7 @@ class Slider(Widget):
         self.native.minimumValue = range[0]
         self.native.maximumValue = range[1]
 
-    def set_number_of_ticks(self):
+    def set_number_of_ticks(self, number_of_ticks):
         self.interface.factory.not_implemented('Slider.number_of_ticks()')
 
     def rehint(self):

--- a/src/iOS/toga_iOS/widgets/slider.py
+++ b/src/iOS/toga_iOS/widgets/slider.py
@@ -33,8 +33,8 @@ class Slider(Widget):
         self.native.minimumValue = range[0]
         self.native.maximumValue = range[1]
 
-    def set_number_of_ticks(self, number_of_ticks):
-        self.interface.factory.not_implemented('Slider.number_of_ticks()')
+    def set_ticks_count(self, ticks_count):
+        self.interface.factory.not_implemented('Slider.ticks_count()')
 
     def rehint(self):
         fitting_size = self.native.systemLayoutSizeFittingSize_(CGSize(0, 0))

--- a/src/iOS/toga_iOS/widgets/slider.py
+++ b/src/iOS/toga_iOS/widgets/slider.py
@@ -33,6 +33,9 @@ class Slider(Widget):
         self.native.minimumValue = range[0]
         self.native.maximumValue = range[1]
 
+    def set_number_of_ticks(self):
+        self.interface.factory.not_implemented('Slider.number_of_ticks()')
+
     def rehint(self):
         fitting_size = self.native.systemLayoutSizeFittingSize_(CGSize(0, 0))
         self.interface.intrinsic.width = at_least(fitting_size.width)

--- a/src/iOS/toga_iOS/widgets/slider.py
+++ b/src/iOS/toga_iOS/widgets/slider.py
@@ -33,8 +33,8 @@ class Slider(Widget):
         self.native.minimumValue = range[0]
         self.native.maximumValue = range[1]
 
-    def set_ticks_count(self, ticks_count):
-        self.interface.factory.not_implemented('Slider.ticks_count()')
+    def set_tick_count(self, tick_count):
+        self.interface.factory.not_implemented('Slider.tick_count()')
 
     def rehint(self):
         fitting_size = self.native.systemLayoutSizeFittingSize_(CGSize(0, 0))

--- a/src/winforms/toga_winforms/widgets/slider.py
+++ b/src/winforms/toga_winforms/widgets/slider.py
@@ -30,21 +30,21 @@ class Slider(Widget):
         self.native = TogaSlider(self.interface)
         self.set_enabled(self.interface._enabled)
         self.native.Minimum = 0
-        self.set_number_of_ticks(self.interface.number_of_ticks)
+        self.set_ticks_count(self.interface.ticks_count)
 
     def get_value(self):
         actual_value = self.native.Value
-        actual_number_of_ticks = self.native.Maximum
+        actual_ticks_count = self.native.Maximum
         minimum, maximum = self.interface.range
         span = maximum - minimum
-        value = actual_value / actual_number_of_ticks * span + minimum
+        value = actual_value / actual_ticks_count * span + minimum
         return value
 
     def set_value(self, value):
         minimum, maximum = self.interface.range
         span = maximum - minimum
-        actual_number_of_ticks = self.native.Maximum
-        self.native.Value = (value - minimum) / span * actual_number_of_ticks
+        actual_ticks_count = self.native.Maximum
+        self.native.Value = (value - minimum) / span * actual_ticks_count
 
     def set_range(self, range):
         pass
@@ -53,13 +53,13 @@ class Slider(Widget):
         self.interface.intrinsic.width = at_least(self.native.PreferredSize.Width)
         self.interface.intrinsic.height = self.native.PreferredSize.Height
 
-    def set_number_of_ticks(self, number_of_ticks):
-        if number_of_ticks is None:
+    def set_ticks_count(self, ticks_count):
+        if ticks_count is None:
             self.native.TickStyle = NONE_TICK_STYLE
             self.native.Maximum = DEFAULT_NUMBER_OF_TICKS
         else:
             self.native.TickStyle = BOTTOM_RIGHT_TICK_STYLE
-            self.native.Maximum = number_of_ticks - 1
+            self.native.Maximum = ticks_count - 1
 
     def set_on_slide(self, handler):
         pass

--- a/src/winforms/toga_winforms/widgets/slider.py
+++ b/src/winforms/toga_winforms/widgets/slider.py
@@ -26,6 +26,17 @@ class TogaSlider(WinForms.TrackBar):
 
 
 class Slider(Widget):
+    """
+    Implementation details:
+
+    The slider widget is using .Net "TrackBar" class. Since TrackBar can only be
+    discrete (ie. have integer values), we implement our slider as a TrackBar
+    between 0 and ticks_count. In order to have value between the desired minimum
+    and maximum, we trnaslate the value linearly to the desired interval.
+
+    When ticks_count is not defined, we use 100 as the default number of ticks since
+    it is big enough to make the TrackBar feel continous.
+    """
     def create(self):
         self.native = TogaSlider(self.interface)
         self.set_enabled(self.interface._enabled)

--- a/src/winforms/toga_winforms/widgets/slider.py
+++ b/src/winforms/toga_winforms/widgets/slider.py
@@ -31,31 +31,31 @@ class Slider(Widget):
 
     The slider widget is using .Net "TrackBar" class. Since TrackBar can only be
     discrete (ie. have integer values), we implement our slider as a TrackBar
-    between 0 and ticks_count. In order to have value between the desired minimum
+    between 0 and tick_count. In order to have value between the desired minimum
     and maximum, we trnaslate the value linearly to the desired interval.
 
-    When ticks_count is not defined, we use 100 as the default number of ticks since
+    When tick_count is not defined, we use 100 as the default number of ticks since
     it is big enough to make the TrackBar feel continous.
     """
     def create(self):
         self.native = TogaSlider(self.interface)
         self.set_enabled(self.interface._enabled)
         self.native.Minimum = 0
-        self.set_ticks_count(self.interface.ticks_count)
+        self.set_tick_count(self.interface.tick_count)
 
     def get_value(self):
         actual_value = self.native.Value
-        actual_ticks_count = self.native.Maximum
+        actual_tick_count = self.native.Maximum
         minimum, maximum = self.interface.range
         span = maximum - minimum
-        value = actual_value / actual_ticks_count * span + minimum
+        value = actual_value / actual_tick_count * span + minimum
         return value
 
     def set_value(self, value):
         minimum, maximum = self.interface.range
         span = maximum - minimum
-        actual_ticks_count = self.native.Maximum
-        self.native.Value = (value - minimum) / span * actual_ticks_count
+        actual_tick_count = self.native.Maximum
+        self.native.Value = (value - minimum) / span * actual_tick_count
 
     def set_range(self, range):
         pass
@@ -64,13 +64,13 @@ class Slider(Widget):
         self.interface.intrinsic.width = at_least(self.native.PreferredSize.Width)
         self.interface.intrinsic.height = self.native.PreferredSize.Height
 
-    def set_ticks_count(self, ticks_count):
-        if ticks_count is None:
+    def set_tick_count(self, tick_count):
+        if tick_count is None:
             self.native.TickStyle = NONE_TICK_STYLE
             self.native.Maximum = DEFAULT_NUMBER_OF_TICKS
         else:
             self.native.TickStyle = BOTTOM_RIGHT_TICK_STYLE
-            self.native.Maximum = ticks_count - 1
+            self.native.Maximum = tick_count - 1
 
     def set_on_slide(self, handler):
         pass

--- a/src/winforms/toga_winforms/widgets/slider.py
+++ b/src/winforms/toga_winforms/widgets/slider.py
@@ -5,6 +5,15 @@ from toga_winforms.libs import WinForms
 from .base import Widget
 
 
+# This is a patch related to python: "None" is a saved word in python,
+# which means we cannot use WinForms.TickStyle.None directly. Therefore, we use getattr
+NONE_TICK_STYLE = getattr(WinForms.TickStyle, "None")
+
+BOTTOM_RIGHT_TICK_STYLE = WinForms.TickStyle.BottomRight
+
+DEFAULT_NUMBER_OF_TICKS = 100
+
+
 class TogaSlider(WinForms.TrackBar):
     def __init__(self, interface):
         super().__init__()
@@ -20,20 +29,37 @@ class Slider(Widget):
     def create(self):
         self.native = TogaSlider(self.interface)
         self.set_enabled(self.interface._enabled)
+        self.native.Minimum = 0
+        self.set_number_of_ticks(self.interface.number_of_ticks)
 
     def get_value(self):
-        return self.native.Value
+        actual_value = self.native.Value
+        actual_number_of_ticks = self.native.Maximum
+        minimum, maximum = self.interface.range
+        span = maximum - minimum
+        value = actual_value / actual_number_of_ticks * span + minimum
+        return value
 
     def set_value(self, value):
-        self.native.Value = value
+        minimum, maximum = self.interface.range
+        span = maximum - minimum
+        actual_number_of_ticks = self.native.Maximum
+        self.native.Value = (value - minimum) / span * actual_number_of_ticks
 
     def set_range(self, range):
-        self.native.Minimum = self.interface.range[0]
-        self.native.Maximum = self.interface.range[1]
+        pass
 
     def rehint(self):
         self.interface.intrinsic.width = at_least(self.native.PreferredSize.Width)
         self.interface.intrinsic.height = self.native.PreferredSize.Height
+
+    def set_number_of_ticks(self, number_of_ticks):
+        if number_of_ticks is None:
+            self.native.TickStyle = NONE_TICK_STYLE
+            self.native.Maximum = DEFAULT_NUMBER_OF_TICKS
+        else:
+            self.native.TickStyle = BOTTOM_RIGHT_TICK_STYLE
+            self.native.Maximum = number_of_ticks - 1
 
     def set_on_slide(self, handler):
         pass


### PR DESCRIPTION
Added the option to mike slider discrete/continuous. This is helpful when you want integer values vs float values from the slider.

Implemented in Windows and OS. This will print "not_implemented" message in GTK and iOS

Fixes #893

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
