### PR TITLE
Add Dialog

### DIFF
--- a/src/android/toga_android/app.py
+++ b/src/android/toga_android/app.py
@@ -12,7 +12,6 @@ class TogaApp(IPythonApp):
         super().__init__()
         self._interface = app
         MainActivity.setPythonApp(self)
-        self.native = MainActivity.singletonThis
         print('Python app launched & stored in Android Activity class')
 
     def onCreate(self):
@@ -36,19 +35,29 @@ class TogaApp(IPythonApp):
     def onRestart(self):
         print("Toga app: onRestart")
 
+    @property
+    def native(self):
+        # We access `MainActivity.singletonThis` freshly each time, rather than
+        # storing a reference in `__init__()`, because it's not safe to use the
+        # same reference over time because `rubicon-java` creates a JNI local
+        # reference.
+        return MainActivity.singletonThis
+
 
 class App:
     def __init__(self, interface):
         self.interface = interface
         self.interface._impl = self
         self._listener = None
-        self.native = None
+
+    @property
+    def native(self):
+        return self._listener.native if self._listener else None
 
     def create(self):
         # The `_listener` listens for activity event callbacks. For simplicity,
         # the app's `.native` is the listener's native Java class.
         self._listener = TogaApp(self)
-        self.native = self._listener.native
         # Call user code to populate the main window
         self.interface.startup()
 

--- a/src/android/toga_android/dialogs.py
+++ b/src/android/toga_android/dialogs.py
@@ -1,33 +1,34 @@
+from .libs.android_widgets import AlertDialog__Builder, DialogInterface__OnClickListener
 
 
-class TogaAlertDialogBuilder:
-    # TODO: Extend `android.app.AlertDialog[Builder]`. Provide app as `context`.
-    def __init__(self, context, message):
-        self.setMessage(message)
+class NoOpListener(DialogInterface__OnClickListener):
+    def onClick(self, dialog, which):
+        pass
 
 
 def info(window, title, message):
-    builder = TogaAlertDialogBuilder(window.app._impl, message)
-    builder.setPositiveButton("OK", None)
-    dialog = builder.create()
-    dialog.show()
+    builder = AlertDialog__Builder(window.app.native)
+    builder.setTitle(title)
+    builder.setMessage(message)
+    builder.setPositiveButton("OK", NoOpListener())
+    builder.show()
 
 
 def question(window, title, message):
-    window.platform.not_implemented('dialogs.question()')
+    window.platform.not_implemented("dialogs.question()")
 
 
 def confirm(window, title, message):
-    window.platform.not_implemented('dialogs.confirm()')
+    window.platform.not_implemented("dialogs.confirm()")
 
 
 def error(window, title, message):
-    window.platform.not_implemented('dialogs.error()')
+    window.platform.not_implemented("dialogs.error()")
 
 
 def stack_trace(window, title, message, content, retry=False):
-    window.platform.not_implemented('dialogs.stack_trace()')
+    window.platform.not_implemented("dialogs.stack_trace()")
 
 
 def save_file(window, title, suggested_filename, file_types):
-    window.platform.not_implemented('dialogs.save_file()')
+    window.platform.not_implemented("dialogs.save_file()")

--- a/src/android/toga_android/libs/android_widgets.py
+++ b/src/android/toga_android/libs/android_widgets.py
@@ -1,6 +1,8 @@
 from rubicon.java import JavaClass, JavaInterface
 
 Button = JavaClass("android/widget/Button")
+AlertDialog__Builder = JavaClass("android/app/AlertDialog$Builder")
+DialogInterface__OnClickListener = JavaInterface("android/content/DialogInterface$OnClickListener")
 EditText = JavaClass("android/widget/EditText")
 Gravity = JavaClass("android/view/Gravity")
 OnClickListener = JavaInterface("android/view/View$OnClickListener")

--- a/src/android/toga_android/window.py
+++ b/src/android/toga_android/window.py
@@ -1,3 +1,6 @@
+from . import dialogs
+
+
 class AndroidViewport:
     def __init__(self, native):
         self.native = native
@@ -56,7 +59,7 @@ class Window:
         self.interface.factory.not_implemented('Window.set_full_screen()')
 
     def info_dialog(self, title, message):
-        self.interface.factory.not_implemented('Window.info_dialog()')
+        dialogs.info(self, title, message)
 
     def question_dialog(self, title, message):
         self.interface.factory.not_implemented('Window.question_dialog()')


### PR DESCRIPTION
Add an Android info dialog.

## Manual testing

<details>
<summary>
Sample app code
</summary>

```python
"""
My first application
"""
import toga
from toga.constants import RIGHT
from toga.style import Pack
from toga.style.pack import COLUMN, ROW


class HelloWorld(toga.App):
    def startup(self):
        main_box = toga.Box(style=Pack(direction=COLUMN))

        name_label = toga.Label("Your name: ", style=Pack(padding=(0, 5)))
        self.name_input = toga.TextInput(style=Pack(flex=1))

        name_box = toga.Box(style=Pack(direction=ROW, padding=5))
        name_box.add(name_label)
        name_box.add(self.name_input)

        button = toga.Button(
            "Say Hello!", on_press=self.say_hello, style=Pack(padding=5)
        )

        main_box.add(name_box)
        main_box.add(button)

        self.main_window = toga.MainWindow(title=self.formal_name)
        self.main_window.content = main_box
        self.main_window.show()

    def say_hello(self, widget):
        self.main_window.info_dialog(
            "Hi there!", "Hello, {}".format(self.name_input.value)
        )


def main():
    return HelloWorld()
```

</details>

results in this screenshot when you type something into the text input and click the button.

![image](https://user-images.githubusercontent.com/25457/81602363-51c2b300-9381-11ea-9c9c-e66993b08db8.png)

## Unrelated changes

I ran `black` on `dialogs.py`. I think this is peaceful, but if you prefer I avoid the noise, I can remove that from this PR.

I converted `app.native` to make a new reference each time it's accessed. See https://github.com/beeware/rubicon-java/issues/38 . This is simple-ish, and it works for now in this PR, and I propose we think hard about that global vs. local refs question at some future point.

## PR Checklist:
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
