### PR TITLE
Return a Python string from Android TextInput

### DIFF
--- a/src/android/toga_android/widgets/textinput.py
+++ b/src/android/toga_android/widgets/textinput.py
@@ -26,7 +26,7 @@ class TextInput(Widget):
         self.interface.factory.not_implemented("TextInput.set_font()")
 
     def get_value(self):
-        return self.native.getText()
+        return self.native.getText().toString()
 
     def set_value(self, value):
         self.native.setText(value)


### PR DESCRIPTION
Call `toString()` so that we get a Java string, which rubicon-java converts to a Python string.

Without this, sample code below (== https://toga.readthedocs.io/en/latest/tutorial/tutorial-1.html ) prints `float() argument must be a string or a number, not 'java/lang/CharSequence'`.

<details>
<summary>
Sample code (from Toga tutorial 2)
</summary>

```python
import toga
from toga.style.pack import *


def build(app):
    c_box = toga.Box()
    f_box = toga.Box()
    box = toga.Box()

    c_input = toga.TextInput(readonly=True)
    f_input = toga.TextInput()

    c_label = toga.Label("Celsius", style=Pack(text_align=LEFT))
    f_label = toga.Label("Fahrenheit", style=Pack(text_align=LEFT))
    join_label = toga.Label("is equivalent to", style=Pack(text_align=RIGHT))

    def calculate(widget):
        try:
            c_input.value = (float(f_input.value) - 32.0) * 5.0 / 9.0
        except Exception as e:
            print("Received exception", e)
            c_input.value = "???"

    button = toga.Button("Calculate", on_press=calculate)

    f_box.add(f_input)
    f_box.add(f_label)

    c_box.add(join_label)
    c_box.add(c_input)
    c_box.add(c_label)

    box.add(f_box)
    box.add(c_box)
    box.add(button)

    box.style.update(direction=COLUMN, padding_top=10)
    f_box.style.update(direction=ROW, padding=5)
    c_box.style.update(direction=ROW, padding=5)

    c_input.style.update(flex=1)
    f_input.style.update(flex=1, padding_left=160)
    c_label.style.update(width=100, padding_left=10)
    f_label.style.update(width=100, padding_left=10)
    join_label.style.update(width=150, padding_right=10)

    button.style.update(padding=15, flex=1)

    return box


def main():
    return toga.App("Temperature Converter", "org.beeware.f_to_c", startup=build)

```

</details>

With this, the convert works (see screenshot).

Note that there are medium-bad layout bugs. I'd like to defer those to other PRs.

### Screenshot before click

![image](https://user-images.githubusercontent.com/25457/81613329-22b53d00-9393-11ea-874b-50a1e312e126.png)

### Screenshot after click

![image](https://user-images.githubusercontent.com/25457/81613346-2b0d7800-9393-11ea-883c-36d982c2eb3a.png)


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented (vacuously true)
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
