### PR TITLE
Add placeholder, alignment, and readonly to Android TextInput

### DIFF
--- a/src/android/toga_android/widgets/textinput.py
+++ b/src/android/toga_android/widgets/textinput.py
@@ -1,7 +1,9 @@
+from toga.constants import LEFT, RIGHT, CENTER, JUSTIFY
 from travertino.size import at_least
 
 from ..libs.android_widgets import (
     EditText,
+    Gravity,
     View__MeasureSpec,
 )
 from .base import Widget
@@ -12,15 +14,21 @@ class TextInput(Widget):
         self.native = EditText(self._native_activity)
 
     def set_readonly(self, value):
-        # self.native.editable = not value
-        self.interface.factory.not_implemented("TextInput.set_readonly()")
+        self.native.setEnabled(not value)
 
     def set_placeholder(self, value):
-        # self.native.cell.placeholderString = self._placeholder
-        self.interface.factory.not_implemented("TextInput.set_placeholder()")
+        # Android EditText's setHint() requires a Python string.
+        self.native.setHint(value if value is not None else "")
 
     def set_alignment(self, value):
-        self.interface.factory.not_implemented("TextInput.set_alignment()")
+        self.native.setGravity(
+            {
+                LEFT: Gravity.CENTER_VERTICAL | Gravity.LEFT,
+                RIGHT: Gravity.CENTER_VERTICAL | Gravity.RIGHT,
+                CENTER: Gravity.CENTER_VERTICAL | Gravity.CENTER_HORIZONTAL,
+                JUSTIFY: Gravity.CENTER_VERTICAL | Gravity.CENTER_HORIZONTAL,
+            }[value]
+        )
 
     def set_font(self, value):
         self.interface.factory.not_implemented("TextInput.set_font()")


### PR DESCRIPTION
### Manual testing performed

For `set_alignment()`, the only testing I did was to ensure it doesn't crash. I'll test alignment more once I fix layout to have proper widths for these element.

For `set_readonly()`, I tested by validating that a `TextInput` which is not `editable`, if I click it, the app doesn't react.

For `set_placeholder()`, I added `C` placeholder to the Celsius `TextInput`. It does indeed show up, nicely grayed-out.

<details>
<summary>
Sample code -- very similar to Toga tutorial 2, but with two changes to test the above
</summary>

```python
import toga
from toga.style.pack import *


def build(app):
    c_box = toga.Box()
    f_box = toga.Box()
    box = toga.Box()

    c_input = toga.TextInput(readonly=True, placeholder="C")
    f_input = toga.TextInput()

    c_label = toga.Label("Celsius", style=Pack(text_align=LEFT))
    f_label = toga.Label("Fahrenheit", style=Pack(text_align=LEFT))
    join_label = toga.Label("is equivalent to", style=Pack(text_align=RIGHT))

    def calculate(widget):
        try:
            c_input.value = (float(f_input.value) - 32.0) * 5.0 / 9.0
        except Exception as e:
            print("Received exception", e)
            c_input.value = "???"

    button = toga.Button("Calculate", on_press=calculate)

    f_box.add(f_input)
    f_box.add(f_label)

    c_box.add(join_label)
    c_box.add(c_input)
    c_box.add(c_label)

    box.add(f_box)
    box.add(c_box)
    box.add(button)

    box.style.update(direction=COLUMN, padding_top=10)
    f_box.style.update(direction=ROW, padding=5)
    c_box.style.update(direction=ROW, padding=5)

    c_input.style.update(flex=1)
    f_input.style.update(flex=1, padding_left=160)
    c_label.style.update(width=100, padding_left=10)
    f_label.style.update(width=100, padding_left=10)
    join_label.style.update(width=150, padding_right=10)

    button.style.update(padding=15, flex=1)

    return box


def main():
    return toga.App("Temperature Converter", "org.beeware.f_to_c", startup=build)
```

</details>

![image](https://user-images.githubusercontent.com/25457/81615972-7b86d480-9397-11ea-86f6-96fc0c100241.png)


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested -- with one exception, see above
- [x] All new features have been documented (vacuously)
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
