### PR TITLE
Allow Android `Icon` to use 32-pixel icons

### DIFF
--- a/src/android/toga_android/icons.py
+++ b/src/android/toga_android/icons.py
@@ -1,5 +1,5 @@
 class Icon:
-    EXTENSIONS = [".png"]
+    EXTENSIONS = [".png", "-32.png"]
     SIZES = None
 
     def __init__(self, interface, path):


### PR DESCRIPTION
This change allows Toga's `Icon` class to start. Toga's resources are in an OK place on Android; however, the default icon ends in -32.png, not .png.

## PR Checklist:
- [x] All new features have been tested (manually)
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
