### PR TITLE
Change the window size of the switch example 

### DIFF
--- a/examples/switch/switch/app.py
+++ b/examples/switch/switch/app.py
@@ -7,9 +7,7 @@ class SwitchApp(toga.App):
     def startup(self):
         # Window class
         #   Main window of the application with title and size
-        self.main_window = toga.MainWindow(title=self.name, size=(300, 150))
-
-        switch_style = Pack(padding=24)
+        self.main_window = toga.MainWindow(title=self.name, size=(350, 200))
 
         # Add the content on the main window
         self.main_window.content = toga.Box(


### PR DESCRIPTION
Change the window size of the switch example

<!--- Describe your changes in detail -->
The window height was too small to display the third checkbox.

Removed unused variable.

<!--- What problem does this change solve? -->
It is no longer required to resize the window (height) to see the third checkbox.

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
