### PR TITLE
Bind app icons in platform layer, not interface layer

### DIFF
--- a/src/cocoa/toga_cocoa/app.py
+++ b/src/cocoa/toga_cocoa/app.py
@@ -94,6 +94,7 @@ class App:
         self.native = NSApplication.sharedApplication
         self.native.setActivationPolicy(NSApplicationActivationPolicyRegular)
 
+        self.interface.icon.bind(self.interface.factory)
         self.native.setApplicationIconImage_(self.interface.icon._impl.native)
 
         self.resource_path = os.path.dirname(os.path.dirname(NSBundle.mainBundle.bundlePath))

--- a/src/core/tests/test_app.py
+++ b/src/core/tests/test_app.py
@@ -36,13 +36,18 @@ class AppTests(TestCase):
         # App icon will default to a name autodetected from the running module
         self.assertEqual(self.app.icon.path, 'resources/toga')
 
-        # This icon name *will* exist (since it overlaps with the default
-        # icon name)
+        # This icon will not be bound, since app icons are bound by the
+        # platform layer.
+        self.assertIsNone(self.app.icon._impl)
+
+        # Bind it explicitly to validate binding can succeed.
+        self.app.icon.bind(self.app.factory)
         self.assertIsNotNone(self.app.icon._impl)
 
         # Set the icon to a different resource
         self.app.icon = "other.icns"
         self.assertEqual(self.app.icon.path, "other.icns")
+        self.app.icon.bind(self.app.factory)
 
         # This icon name will *not* exist. The Impl will be the DEFAULT_ICON's impl
         self.assertEqual(self.app.icon._impl, toga.Icon.DEFAULT_ICON._impl)

--- a/src/core/toga/app.py
+++ b/src/core/toga/app.py
@@ -346,8 +346,6 @@ class App:
         else:
             self._icon = Icon(icon_or_name)
 
-        self._icon.bind(self.factory)
-
     @property
     def main_window(self):
         """

--- a/src/gtk/toga_gtk/app.py
+++ b/src/gtk/toga_gtk/app.py
@@ -28,6 +28,7 @@ class MainWindow(Window):
     def create(self):
         super().create()
         self.native.set_role("MainWindow")
+        toga_App.app.icon.bind(self.interface.factory)
         self.native.set_icon(toga_App.app.icon._impl.native_72.get_pixbuf())
 
     def set_app(self, app):

--- a/src/winforms/toga_winforms/app.py
+++ b/src/winforms/toga_winforms/app.py
@@ -65,6 +65,7 @@ class App:
         self.interface.startup()
         self._menu_items = {}
         self.create_menus()
+        self.interface.icon.bind(self.interface.factory)
         self.interface.main_window._impl.native.Icon = \
             self.interface.icon._impl.native
 


### PR DESCRIPTION
This allows mobile platforms where app icons are meaningless to avoid
unnecessarily binding the icon.

## Testing

I still need to manually test these changes. I'm doing that now.

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
