### PR TITLE
Fix on_change & value fetching for NumberInput, TextInput

### DIFF
--- a/src/android/toga_android/widgets/numberinput.py
+++ b/src/android/toga_android/widgets/numberinput.py
@@ -32,7 +32,7 @@ class TogaNumberInputWatcher(TextWatcher):
 
         # Toga `NumberInput` stores the value as a property on the `interface`.
         self.interface.value = new_value
-        
+
         # Call user on_change function, if needed.
         if self.interface.on_change:
             self.interface.on_change(widget=self.interface)

--- a/src/android/toga_android/widgets/textinput.py
+++ b/src/android/toga_android/widgets/textinput.py
@@ -11,28 +11,29 @@ from .base import Widget
 
 
 class TogaTextWatcher(TextWatcher):
-    def __init__(self, text_input_interface):
+    def __init__(self, impl):
         super().__init__()
-        self.interface = text_input_interface
+        self.impl = impl
+        self.interface = impl.interface
 
-    def beforeTextChanged(self, _charSequence, _i, _i1, _i2):
+    def beforeTextChanged(self, _charSequence, _start, _count, _after):
         pass
 
     def afterTextChanged(self, _editable):
         if self.interface.on_change:
             self.interface.on_change(widget=self.interface)
 
-    def onTextChanged(self, _charSequence, _i, _i1, _i2):
+    def onTextChanged(self, _charSequence, _start, _before, _count):
         pass
 
 
 class TextInput(Widget):
     def create(self):
         self.native = EditText(self._native_activity)
-        self.native.addTextChangedListener(TogaTextWatcher(self.interface))
+        self.native.addTextChangedListener(TogaTextWatcher(self))
 
     def get_value(self):
-        return self.interface._impl.native.getText().toString()
+        return self.native.getText().toString()
 
     def set_readonly(self, value):
         self.native.setFocusable(not value)

--- a/src/android/toga_android/widgets/textinput.py
+++ b/src/android/toga_android/widgets/textinput.py
@@ -5,16 +5,37 @@ from ..libs.android_widgets import (
     EditText,
     Gravity,
     View__MeasureSpec,
+    TextWatcher,
 )
 from .base import Widget
+
+
+class TogaTextWatcher(TextWatcher):
+    def __init__(self, text_input_interface):
+        super().__init__()
+        self.interface = text_input_interface
+
+    def beforeTextChanged(self, _charSequence, _i, _i1, _i2):
+        pass
+
+    def afterTextChanged(self, _editable):
+        if self.interface.on_change:
+            self.interface.on_change(widget=self.interface)
+
+    def onTextChanged(self, _charSequence, _i, _i1, _i2):
+        pass
 
 
 class TextInput(Widget):
     def create(self):
         self.native = EditText(self._native_activity)
+        self.native.addTextChangedListener(TogaTextWatcher(self.interface))
+
+    def get_value(self):
+        return self.interface._impl.native.getText().toString()
 
     def set_readonly(self, value):
-        self.native.setEnabled(not value)
+        self.native.setFocusable(not value)
 
     def set_placeholder(self, value):
         # Android EditText's setHint() requires a Python string.
@@ -32,9 +53,6 @@ class TextInput(Widget):
 
     def set_font(self, value):
         self.interface.factory.not_implemented("TextInput.set_font()")
-
-    def get_value(self):
-        return self.native.getText().toString()
 
     def set_value(self, value):
         self.native.setText(value)


### PR DESCRIPTION
This makes TravelTips work. See screenshot.

![image](https://user-images.githubusercontent.com/25457/82016649-58c61b80-9636-11ea-867c-6100ba041f55.png)

Layout is still broken-ish, but that's separate IMHO.

In the process, I noticed that `NumberInput` stores the `value` as a property of the `interface`, but `TextInput` does not (it uses a `get_value()` method). That's fine, but it seems a little weird.

I also fixed a problem where setting these to readonly would in fact make them not store any value. :)

I did manually test the `TextInput` as well by adding a `toga.TextInput` to TravelTips with an on_change() function that prints the value. It works fine. :)

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
