### PR TITLE
Implement GTK Widget.set_hidden [WIP]

### DIFF
--- a/examples/hide_show/hide_show/__main__.py
+++ b/examples/hide_show/hide_show/__main__.py
@@ -2,3 +2,4 @@ from hide_show.app import main
 
 if __name__ == "__main__":
     main().main_loop()
+    

--- a/examples/hide_show/hide_show/__main__.py
+++ b/examples/hide_show/hide_show/__main__.py
@@ -1,0 +1,4 @@
+from hide_show.app import main
+
+if __name__ == "__main__":
+    main().main_loop()

--- a/examples/hide_show/hide_show/__main__.py
+++ b/examples/hide_show/hide_show/__main__.py
@@ -2,4 +2,3 @@ from hide_show.app import main
 
 if __name__ == "__main__":
     main().main_loop()
-    

--- a/examples/hide_show/hide_show/app.py
+++ b/examples/hide_show/hide_show/app.py
@@ -1,0 +1,92 @@
+from toga import App, Box, Button, Label, ScrollContainer
+from toga.style import Pack
+
+def build(app):
+
+    # wrapper that generates a visibility-toggler for the target widget
+    def toggle_visibility_of(target):
+        def handler(button):
+            # widget is the button, target is what is being acted on
+            if target.style.visibility == 'visible':
+                target.style.visibility = 'hidden'
+                button.label = button.label[0] + " (hidden)"  # label[0] is the button number
+            else:
+                target.style.visibility = 'visible'
+                button.label = button.label[0]
+        
+        return handler
+
+    root = Box(style=Pack(direction="column"))
+
+    root.add(Label("This app tests the behavior of the visibility style property."))
+    root.add(Label("Instructions: click each button (there are 8) and verify that the indicated label vanishes."))
+
+    # CASE 1 - target is a single widget
+    # ======
+    root.add(Label("Case 1: target is a single widget"))
+    case1_target = Label("Click button 1 to toggle my visibility")
+    root.add(case1_target)
+    root.add(Button("1", on_press=toggle_visibility_of(case1_target)))  
+
+
+    # CASE 2 - target is a box that is a grandchild of the window
+    # ======
+    root.add(Label("Case 2: target is a box that is a grandchild of the window", style=Pack(padding_top=10)))
+    case2_target = Box(children=[
+        Label("Click button 2 to toggle my visibility"),
+    ], style=Pack(direction="column"))
+    root.add(case2_target)
+    root.add(Button("2", on_press=toggle_visibility_of(case2_target)))
+
+
+    # CASE 3 -  target is the direct child of the window
+    # ======
+    root.add(Label("Case 3: target is the direct child of the window", style=Pack(padding_top=10)))
+    case3_target = root
+    # root.add(case3_target)  # can't add root to itself!
+    root.add(Label("Click button 3 to hide the root widget. You will have to restart this app"))
+    root.add(Button("3", on_press=toggle_visibility_of(root)))
+
+
+    # CASE 4 - target is a scroll container
+    # ======
+    root.add(Label("Case 4: target is a scroll container", style=Pack(padding_top=10)))
+    case4_target = ScrollContainer(content=Label("Click button 4 to toggle my visibility"))
+    root.add(case4_target)
+    root.add(Button("4", on_press=toggle_visibility_of(case4_target)))
+
+
+    # CASE 5 - target is a label that is a direct child of a scroll container
+    # ======
+    root.add(Label("Case 5: target is a label that is a direct child of a scroll container", style=Pack(padding_top=10)))
+    case5_target = Label("Click button 5 to toggle my visibility")
+    root.add(ScrollContainer(content=case5_target))
+    root.add(Button("5", on_press=toggle_visibility_of(case5_target)))
+
+
+    # CASE 6 - target is a box that is a direct child of a scroll container
+    # ======
+    root.add(Label("Case 6: target is a box that is a direct child of a scroll container", style=Pack(padding_top=10)))
+    case6_target = Box(children=[Label("Click button 6 to toggle my visibility")])
+    root.add(ScrollContainer(content=case6_target))
+    root.add(Button("6", on_press=toggle_visibility_of(case6_target)))
+
+
+    # CASE 7 - target is a box that is a grandchild of scroll container
+    root.add(Label("Case 7: target is a box that is a grandchild of a scroll container", style=Pack(padding_top=10)))
+    case7_target = Box(children=[Label("Click button 7 to toggle my visibility")])
+    root.add(ScrollContainer(content=Box(children=[case7_target])))
+    root.add(Button("7", on_press=toggle_visibility_of(case7_target)))
+
+    # CASE 8 - target is a box that is a great grandchild of the window
+    root.add(Label("Case 8: target is a box that is a great grandchild of the window", style=Pack(padding_top=10)))
+    case8_target = Box(children=[Label("Click button 8 to toggle my visibility")])
+    root.add(ScrollContainer(content=Box(children=[
+        Box(children=[
+            case8_target])])))
+    root.add(Button("8", on_press=toggle_visibility_of(case8_target)))
+
+    return root
+
+def main():
+    return App("Hide / Show Test", "org.beeware.hide_show", startup=build)

--- a/examples/hide_show/hide_show/app.py
+++ b/examples/hide_show/hide_show/app.py
@@ -1,90 +1,104 @@
-from toga import App, Box, Button, Label, ScrollContainer
+from toga import App, Box, Button, Label, ScrollContainer, Switch
 from toga.style import Pack
 
 def build(app):
 
     # wrapper that generates a visibility-toggler for the target widget
     def toggle_visibility_of(target):
-        def handler(button):
+        def handler(switch):
             # widget is the button, target is what is being acted on
-            if target.style.visibility == 'visible':
-                target.style.visibility = 'hidden'
-                button.label = button.label[0] + " (hidden)"  # label[0] is the button number
-            else:
+            if switch.is_on:
                 target.style.visibility = 'visible'
-                button.label = button.label[0]
+            else:
+                target.style.visibility = 'hidden'
         
         return handler
 
-    root = Box(style=Pack(direction="column"))
+    root = Box(id="root", style=Pack(direction="column"))
 
     root.add(Label("This app tests the behavior of the visibility style property."))
     root.add(Label("Instructions: click each button (there are 8) and verify that the indicated label vanishes."))
 
     # CASE 1 - target is a single widget
     # ======
-    root.add(Label("Case 1: target is a single widget"))
-    case1_target = Label("Click button 1 to toggle my visibility")
+    case1_target = Label("Click switch 1 to toggle my visibility")
+    root.add(Switch("Case 1: target is a single widget", is_on=True, style=Pack(flex=1),
+        on_toggle=toggle_visibility_of(case1_target)))
     root.add(case1_target)
-    root.add(Button("1", on_press=toggle_visibility_of(case1_target)))  
 
 
     # CASE 2 - target is a box that is a grandchild of the window
     # ======
-    root.add(Label("Case 2: target is a box that is a grandchild of the window", style=Pack(padding_top=10)))
     case2_target = Box(children=[
-        Label("Click button 2 to toggle my visibility"),
+        Label("Click switch 2 to toggle my visibility"),
     ], style=Pack(direction="column"))
+    root.add(Switch("Case 2: target is a box that is a grandchild of the window", is_on=True, style=Pack(flex=1),
+        on_toggle=toggle_visibility_of(case2_target)))
     root.add(case2_target)
-    root.add(Button("2", on_press=toggle_visibility_of(case2_target)))
 
 
-    # CASE 3 -  target is the direct child of the window
+    # CASE 8 - target is a box that is a great grandchild of the window
     # ======
-    root.add(Label("Case 3: target is the direct child of the window", style=Pack(padding_top=10)))
-    case3_target = root
-    # root.add(case3_target)  # can't add root to itself!
-    root.add(Label("Click button 3 to hide the root widget. You will have to restart this app"))
-    root.add(Button("3", on_press=toggle_visibility_of(root)))
+    case8_target = Box(children=[Label("Click switch 8 to toggle my visibility")])
+    root.add(Switch("Case 8: target is a box that is a great grandchild of the window", is_on=True, style=Pack(flex=1),
+        on_toggle=toggle_visibility_of(case8_target)))
+    root.add(ScrollContainer(content=
+        Box(children=[
+            Box(children=[
+                case8_target])])))
 
 
     # CASE 4 - target is a scroll container
     # ======
-    root.add(Label("Case 4: target is a scroll container", style=Pack(padding_top=10)))
-    case4_target = ScrollContainer(content=Label("Click button 4 to toggle my visibility"))
+    case4_target = ScrollContainer(content=Label("Click switch 4 to toggle my visibility"))
+    root.add(Switch("Case 4: target is a scroll container", is_on=True, style=Pack(flex=1),
+        on_toggle=toggle_visibility_of(case4_target)))
     root.add(case4_target)
-    root.add(Button("4", on_press=toggle_visibility_of(case4_target)))
 
 
     # CASE 5 - target is a label that is a direct child of a scroll container
     # ======
-    root.add(Label("Case 5: target is a label that is a direct child of a scroll container", style=Pack(padding_top=10)))
-    case5_target = Label("Click button 5 to toggle my visibility")
+    case5_target = Label("Click switch 5 to toggle my visibility")
+    root.add(Switch("Case 5: target is a label that is a direct child of a scroll container", is_on=True, style=Pack(flex=1),
+        on_toggle=toggle_visibility_of(case5_target)))
     root.add(ScrollContainer(content=case5_target))
-    root.add(Button("5", on_press=toggle_visibility_of(case5_target)))
 
 
     # CASE 6 - target is a box that is a direct child of a scroll container
     # ======
-    root.add(Label("Case 6: target is a box that is a direct child of a scroll container", style=Pack(padding_top=10)))
-    case6_target = Box(children=[Label("Click button 6 to toggle my visibility")])
+    case6_target = Box(children=[Label("Click switch 6 to toggle my visibility")])
+    root.add(Switch("Case 6: target is a box that is a direct child of a scroll container", is_on=True, style=Pack(flex=1),
+        on_toggle=toggle_visibility_of(case6_target)))
     root.add(ScrollContainer(content=case6_target))
-    root.add(Button("6", on_press=toggle_visibility_of(case6_target)))
 
 
     # CASE 7 - target is a box that is a grandchild of scroll container
-    root.add(Label("Case 7: target is a box that is a grandchild of a scroll container", style=Pack(padding_top=10)))
-    case7_target = Box(children=[Label("Click button 7 to toggle my visibility")])
+    case7_target = Box(children=[Label("Click switch 7 to toggle my visibility")])
+    root.add(Switch("Case 7: target is a box that is a grandchild of a scroll container", is_on=True, style=Pack(flex=1),
+        on_toggle=toggle_visibility_of(case7_target)))
     root.add(ScrollContainer(content=Box(children=[case7_target])))
-    root.add(Button("7", on_press=toggle_visibility_of(case7_target)))
 
-    # CASE 8 - target is a box that is a great grandchild of the window
-    root.add(Label("Case 8: target is a box that is a great grandchild of the window", style=Pack(padding_top=10)))
-    case8_target = Box(children=[Label("Click button 8 to toggle my visibility")])
-    root.add(ScrollContainer(content=Box(children=[
-        Box(children=[
-            case8_target])])))
-    root.add(Button("8", on_press=toggle_visibility_of(case8_target)))
+    # CASE 9 - 
+    case9_target = Box(id="case9_target", style=Pack(direction="column"), children=[
+        Label(id="case9_hidden_label", text="I should always be invisible! If you see me, this test failed", style=Pack(visibility="hidden")),
+        Label("Click switch 9 to toggle my visibility")
+    ])
+    root.add(Switch("Case 9: target is a box with a hidden label and a visible label", is_on=True, style=Pack(flex=1),
+        on_toggle=toggle_visibility_of(case9_target)))
+    root.add(case9_target)
+
+    # CASE 10 - initially hidden container content
+    root.add(ScrollContainer(content=
+        Label("I should always be invisible! If you see me, this test failed",
+            style=Pack(visibility="hidden"))))
+
+    # CASE 3 - target is the direct child of the window
+    # ======
+    case3_target = root
+    root.add(Switch("Case 3: target is the direct child of the window", is_on=True, style=Pack(flex=1),
+        on_toggle=toggle_visibility_of(root)))
+    # root.add(case3_target)  # can't add root to itself!
+    root.add(Label("Click switch 3 to hide the root widget. You will have to restart this app"))
 
     return root
 

--- a/examples/hide_show/hide_show/app.py
+++ b/examples/hide_show/hide_show/app.py
@@ -17,10 +17,10 @@ def build(app):
 
     root = Box(id="root", style=Pack(direction="column"))
 
-    root.add(Label("This app tests the behavior of the visibility style \
-        property."))
-    root.add(Label("Instructions: click each button (there are 8) and verify \
-        that the indicated label vanishes."))
+    root.add(Label("This app tests the behavior of the visibility style "
+                   "property."))
+    root.add(Label("Instructions: click each button (there are 8) and verify "
+                   "that the indicated label vanishes."))
 
     # CASE 1 - target is a single widget
     # ======
@@ -44,24 +44,25 @@ def build(app):
         on_toggle=toggle_visibility_of(case2_target)))
     root.add(case2_target)
 
-    # CASE 8 - target is a box that is a great grandchild of the window
+    # CASE 3 - target is a box that is a great grandchild of the window
     # ======
-    case8_target = Box(children=[
-        Label("Click switch 8 to toggle my visibility")])
+    case3_target = Box(children=[
+        Label("Click switch 3 to toggle my visibility")])
     root.add(Switch(
-        "Case 8: target is a box that is a great grandchild of the window",
+        "Case 3: target is a box that is a great grandchild of the window",
         is_on=True,
         style=Pack(flex=1),
-        on_toggle=toggle_visibility_of(case8_target)))
+        on_toggle=toggle_visibility_of(case3_target)))
     root.add(ScrollContainer(
         content=Box(children=[
             Box(children=[
-                case8_target])])))
+                case3_target])])))
 
     # CASE 4 - target is a scroll container
     # ======
     case4_target = ScrollContainer(
-        content=Label("Click switch 4 to toggle my visibility"))
+        content=Label("Click \nswitch 4 \nto toggle \nmy visibility"),
+        style=Pack())
     root.add(Switch(
         label="Case 4: target is a scroll container",
         is_on=True,
@@ -71,10 +72,10 @@ def build(app):
 
     # CASE 5 - target is a label that is a direct child of a scroll container
     # ======
-    case5_target = Label("Click switch 5 to toggle my visibility")
+    case5_target = Label("Click \nswitch 5 \nto toggle \nmy visibility")
     root.add(Switch(
-        label="Case 5: target is a label that is a direct child of a scroll \
-            container",
+        label="Case 5: target is a label that is a direct child of a scroll "
+              "container",
         is_on=True,
         style=Pack(flex=1),
         on_toggle=toggle_visibility_of(case5_target)))
@@ -83,10 +84,10 @@ def build(app):
     # CASE 6 - target is a box that is a direct child of a scroll container
     # ======
     case6_target = Box(children=[
-        Label("Click switch 6 to toggle my visibility")])
+        Label("Click \nswitch 6 \nto toggle \nmy visibility")])
     root.add(Switch(
-        label="Case 6: target is a box that is a direct child of a scroll \
-            container",
+        label="Case 6: target is a box that is a direct child of a scroll "
+              "container",
         is_on=True,
         style=Pack(flex=1),
         on_toggle=toggle_visibility_of(case6_target)))
@@ -94,51 +95,52 @@ def build(app):
 
     # CASE 7 - target is a box that is a grandchild of scroll container
     case7_target = Box(children=[
-        Label("Click switch 7 to toggle my visibility")])
+        Label("Click \nswitch 7 \nto toggle \nmy visibility")])
     root.add(Switch(
-        label="Case 7: target is a box that is a grandchild of a scroll \
-            container",
+        label="Case 7: target is a box that is a grandchild of a scroll "
+              "container",
         is_on=True,
         style=Pack(flex=1),
         on_toggle=toggle_visibility_of(case7_target)))
     root.add(ScrollContainer(content=Box(children=[case7_target])))
 
-    # CASE 9 - target is a box with a hidden label and a visible label
-    case9_target = Box(
-        id="case9_target",
+    # CASE 8 - target is a box with a hidden label and a visible label
+    case8_target = Box(
+        id="case8_target",
         style=Pack(direction="column"),
         children=[
             Label(
-                id="case9_hidden_label",
-                text="I should always be invisible! If you see me, this test \
-                    failed",
+                id="case8_hidden_label",
+                text="I should always be invisible! If you see me, this test "
+                     "failed",
                 style=Pack(visibility="hidden")),
-            Label("Click switch 9 to toggle my visibility")])
+            Label("Click switch 8 to toggle my visibility")])
     root.add(Switch(
-        label="Case 9: target is a box with a hidden label and visible label",
+        label="Case 8: target is a box with a hidden label and visible label",
+        is_on=True,
+        style=Pack(flex=1),
+        on_toggle=toggle_visibility_of(case8_target)))
+    root.add(case8_target)
+
+    # CASE 9 - target is the direct child of the window
+    # =======
+    case9_target = root
+    root.add(Switch(
+        label="Case 9: target is the direct child of the window",
         is_on=True,
         style=Pack(flex=1),
         on_toggle=toggle_visibility_of(case9_target)))
-    root.add(case9_target)
+    # root.add(case9_target)  # can't add root to itself!
+    root.add(Label("Click switch 9 to hide the root widget. You will have to "
+                   "restart this app"))
 
     # CASE 10 - initially hidden container content
+    # ======
     root.add(ScrollContainer(
         content=Label(
-            text="I should always be invisible! If you see me, this test \
-                failed",
+            text="I should always be invisible! If you see me, this test "
+                 "failed",
             style=Pack(visibility="hidden"))))
-
-    # CASE 3 - target is the direct child of the window
-    # ======
-    case3_target = root
-    root.add(Switch(
-        label="Case 3: target is the direct child of the window",
-        is_on=True,
-        style=Pack(flex=1),
-        on_toggle=toggle_visibility_of(case3_target)))
-    # root.add(case3_target)  # can't add root to itself!
-    root.add(Label("Click switch 3 to hide the root widget. You will have to \
-        restart this app"))
 
     return root
 

--- a/examples/hide_show/hide_show/app.py
+++ b/examples/hide_show/hide_show/app.py
@@ -19,7 +19,7 @@ def build(app):
 
     root.add(Label("This app tests the behavior of the visibility style "
                    "property."))
-    root.add(Label("Instructions: click each button (there are 8) and verify "
+    root.add(Label("Instructions: click each button (there are 9) and verify "
                    "that the indicated label vanishes."))
 
     # CASE 1 - target is a single widget

--- a/examples/hide_show/hide_show/app.py
+++ b/examples/hide_show/hide_show/app.py
@@ -1,5 +1,6 @@
-from toga import App, Box, Button, Label, ScrollContainer, Switch
+from toga import App, Box, Label, ScrollContainer, Switch
 from toga.style import Pack
+
 
 def build(app):
 
@@ -11,96 +12,136 @@ def build(app):
                 target.style.visibility = 'visible'
             else:
                 target.style.visibility = 'hidden'
-        
+
         return handler
 
     root = Box(id="root", style=Pack(direction="column"))
 
-    root.add(Label("This app tests the behavior of the visibility style property."))
-    root.add(Label("Instructions: click each button (there are 8) and verify that the indicated label vanishes."))
+    root.add(Label("This app tests the behavior of the visibility style \
+        property."))
+    root.add(Label("Instructions: click each button (there are 8) and verify \
+        that the indicated label vanishes."))
 
     # CASE 1 - target is a single widget
     # ======
     case1_target = Label("Click switch 1 to toggle my visibility")
-    root.add(Switch("Case 1: target is a single widget", is_on=True, style=Pack(flex=1),
+    root.add(Switch(
+        label="Case 1: target is a single widget",
+        is_on=True,
+        style=Pack(flex=1),
         on_toggle=toggle_visibility_of(case1_target)))
     root.add(case1_target)
-
 
     # CASE 2 - target is a box that is a grandchild of the window
     # ======
     case2_target = Box(children=[
         Label("Click switch 2 to toggle my visibility"),
     ], style=Pack(direction="column"))
-    root.add(Switch("Case 2: target is a box that is a grandchild of the window", is_on=True, style=Pack(flex=1),
+    root.add(Switch(
+        label="Case 2: target is a box that is a grandchild of the window",
+        is_on=True,
+        style=Pack(flex=1),
         on_toggle=toggle_visibility_of(case2_target)))
     root.add(case2_target)
 
-
     # CASE 8 - target is a box that is a great grandchild of the window
     # ======
-    case8_target = Box(children=[Label("Click switch 8 to toggle my visibility")])
-    root.add(Switch("Case 8: target is a box that is a great grandchild of the window", is_on=True, style=Pack(flex=1),
+    case8_target = Box(children=[
+        Label("Click switch 8 to toggle my visibility")])
+    root.add(Switch(
+        "Case 8: target is a box that is a great grandchild of the window",
+        is_on=True,
+        style=Pack(flex=1),
         on_toggle=toggle_visibility_of(case8_target)))
-    root.add(ScrollContainer(content=
-        Box(children=[
+    root.add(ScrollContainer(
+        content=Box(children=[
             Box(children=[
                 case8_target])])))
 
-
     # CASE 4 - target is a scroll container
     # ======
-    case4_target = ScrollContainer(content=Label("Click switch 4 to toggle my visibility"))
-    root.add(Switch("Case 4: target is a scroll container", is_on=True, style=Pack(flex=1),
+    case4_target = ScrollContainer(
+        content=Label("Click switch 4 to toggle my visibility"))
+    root.add(Switch(
+        label="Case 4: target is a scroll container",
+        is_on=True,
+        style=Pack(flex=1),
         on_toggle=toggle_visibility_of(case4_target)))
     root.add(case4_target)
-
 
     # CASE 5 - target is a label that is a direct child of a scroll container
     # ======
     case5_target = Label("Click switch 5 to toggle my visibility")
-    root.add(Switch("Case 5: target is a label that is a direct child of a scroll container", is_on=True, style=Pack(flex=1),
+    root.add(Switch(
+        label="Case 5: target is a label that is a direct child of a scroll \
+            container",
+        is_on=True,
+        style=Pack(flex=1),
         on_toggle=toggle_visibility_of(case5_target)))
     root.add(ScrollContainer(content=case5_target))
 
-
     # CASE 6 - target is a box that is a direct child of a scroll container
     # ======
-    case6_target = Box(children=[Label("Click switch 6 to toggle my visibility")])
-    root.add(Switch("Case 6: target is a box that is a direct child of a scroll container", is_on=True, style=Pack(flex=1),
+    case6_target = Box(children=[
+        Label("Click switch 6 to toggle my visibility")])
+    root.add(Switch(
+        label="Case 6: target is a box that is a direct child of a scroll \
+            container",
+        is_on=True,
+        style=Pack(flex=1),
         on_toggle=toggle_visibility_of(case6_target)))
     root.add(ScrollContainer(content=case6_target))
 
-
     # CASE 7 - target is a box that is a grandchild of scroll container
-    case7_target = Box(children=[Label("Click switch 7 to toggle my visibility")])
-    root.add(Switch("Case 7: target is a box that is a grandchild of a scroll container", is_on=True, style=Pack(flex=1),
+    case7_target = Box(children=[
+        Label("Click switch 7 to toggle my visibility")])
+    root.add(Switch(
+        label="Case 7: target is a box that is a grandchild of a scroll \
+            container",
+        is_on=True,
+        style=Pack(flex=1),
         on_toggle=toggle_visibility_of(case7_target)))
     root.add(ScrollContainer(content=Box(children=[case7_target])))
 
-    # CASE 9 - 
-    case9_target = Box(id="case9_target", style=Pack(direction="column"), children=[
-        Label(id="case9_hidden_label", text="I should always be invisible! If you see me, this test failed", style=Pack(visibility="hidden")),
-        Label("Click switch 9 to toggle my visibility")
-    ])
-    root.add(Switch("Case 9: target is a box with a hidden label and a visible label", is_on=True, style=Pack(flex=1),
+    # CASE 9 - target is a box with a hidden label and a visible label
+    case9_target = Box(
+        id="case9_target",
+        style=Pack(direction="column"),
+        children=[
+            Label(
+                id="case9_hidden_label",
+                text="I should always be invisible! If you see me, this test \
+                    failed",
+                style=Pack(visibility="hidden")),
+            Label("Click switch 9 to toggle my visibility")])
+    root.add(Switch(
+        label="Case 9: target is a box with a hidden label and visible label",
+        is_on=True,
+        style=Pack(flex=1),
         on_toggle=toggle_visibility_of(case9_target)))
     root.add(case9_target)
 
     # CASE 10 - initially hidden container content
-    root.add(ScrollContainer(content=
-        Label("I should always be invisible! If you see me, this test failed",
+    root.add(ScrollContainer(
+        content=Label(
+            text="I should always be invisible! If you see me, this test \
+                failed",
             style=Pack(visibility="hidden"))))
 
     # CASE 3 - target is the direct child of the window
     # ======
     case3_target = root
-    root.add(Switch("Case 3: target is the direct child of the window", is_on=True, style=Pack(flex=1),
-        on_toggle=toggle_visibility_of(root)))
+    root.add(Switch(
+        label="Case 3: target is the direct child of the window",
+        is_on=True,
+        style=Pack(flex=1),
+        on_toggle=toggle_visibility_of(case3_target)))
     # root.add(case3_target)  # can't add root to itself!
-    root.add(Label("Click switch 3 to hide the root widget. You will have to restart this app"))
+    root.add(Label("Click switch 3 to hide the root widget. You will have to \
+        restart this app"))
 
     return root
+
 
 def main():
     return App("Hide / Show Test", "org.beeware.hide_show", startup=build)

--- a/src/gtk/toga_gtk/widgets/base.py
+++ b/src/gtk/toga_gtk/widgets/base.py
@@ -69,26 +69,23 @@ class Widget:
 
         my_interface_hidden = (self.interface.style.visibility == "hidden")
 
-        if self.native:
-            if my_interface_hidden or hidden:
-                # if self.native is a container widget, each native child will
-                # be hidden too
-                self.native.hide()
+        if my_interface_hidden or hidden:
+            # if self.native is a container widget, each native child will
+            # be hidden too
+            self.native.hide()
 
-                if self.interface.can_have_children:
-                    for child in self.interface.children:
-                        child._impl.set_hidden(True)
+            if self.interface.can_have_children:
+                for child in self.interface.children:
+                    child._impl.set_hidden(True)
 
-            else:
-                # if self.native is a container widget, each native child will
-                # be shown (if it is not hidden by its own style property)
-                self.native.show()
-
-                if self.interface.can_have_children:
-                    for child in self.interface.children:
-                        child._impl.set_hidden(False)
         else:
-            raise Exception("cannot hide widget: no native widget to hide")
+            # if self.native is a container widget, each native child will
+            # be shown (if it is not hidden by its own style property)
+            self.native.show()
+
+            if self.interface.can_have_children:
+                for child in self.interface.children:
+                    child._impl.set_hidden(False)
 
     def set_font(self, font):
         # By default, fon't can't be changed

--- a/src/gtk/toga_gtk/widgets/base.py
+++ b/src/gtk/toga_gtk/widgets/base.py
@@ -46,11 +46,48 @@ class Widget:
         pass
 
     def set_hidden(self, hidden):
+        # Rules: any given widget must be invisible if...
+        # 1. it's visibility style property equals "hidden"
+        # 2. it has an invisible anscestor
+        #
+        # set_hidden calls are expected from two sources:
+        # 1. the style engine, when self.interface.style.visibility is changed
+        # 2. this widget's parent, when it's style.visibility is changed
+        # Therefore, if the provided argument of set_hidden does not match this
+        # widget's current state, the call is assumed to have originated from the parent
+        #
+        # Note on iterating childring:
+        # Container widgets store children in their `content` property and their `children` property
+        # will always return []. Iterating a container's `children` property is a do-nothing, but
+        # that is acceptible in this case because hiding a container will in turn hide the native
+        # container, which will cause all native children to be hidden. 
+        #
+        # In GTK, all widgets are initially hidden
+        
+
+        my_interface_hidden = (self.interface.style.visibility == "hidden")
+
         if self.native:
-            if hidden:
+            if my_interface_hidden or hidden:
+                # if self.native is a container widget, each native child will be hidden too
                 self.native.hide()
+                
+                if self.interface.can_have_children:
+                    for child in self.interface.children:
+                        child._impl.set_hidden(True)
+
             else:
+                # if self.native is a container widget, each native child will be shown (if 
+                # it is not hidden by its own style property)
                 self.native.show()
+
+                if self.interface.can_have_children:
+                    for child in self.interface.children:
+                        child._impl.set_hidden(False)
+
+            print("LOG: {}.set_hidden({}), native visible = {}".format(self.interface, hidden, self.native.get_visible()))
+        else:
+            raise Exception("cannot hide widget: no native widget to hide")
 
     def set_font(self, font):
         # By default, fon't can't be changed

--- a/src/gtk/toga_gtk/widgets/base.py
+++ b/src/gtk/toga_gtk/widgets/base.py
@@ -54,38 +54,39 @@ class Widget:
         # 1. the style engine, when self.interface.style.visibility is changed
         # 2. this widget's parent, when it's style.visibility is changed
         # Therefore, if the provided argument of set_hidden does not match this
-        # widget's current state, the call is assumed to have originated from the parent
+        # widget's current state, the call is assumed to have originated from
+        # the parent
         #
         # Note on iterating childring:
-        # Container widgets store children in their `content` property and their `children` property
-        # will always return []. Iterating a container's `children` property is a do-nothing, but
-        # that is acceptible in this case because hiding a container will in turn hide the native
-        # container, which will cause all native children to be hidden. 
+        # Container widgets store children in their `content` property and
+        # their `children` property will always return []. Iterating a
+        # container's `children` property is a do-nothing, but that is
+        # acceptible in this case because hiding a container will in
+        # turn hide the native container, which will cause all native children
+        # to be hidden.
         #
         # In GTK, all widgets are initially hidden
-        
 
         my_interface_hidden = (self.interface.style.visibility == "hidden")
 
         if self.native:
             if my_interface_hidden or hidden:
-                # if self.native is a container widget, each native child will be hidden too
+                # if self.native is a container widget, each native child will
+                # be hidden too
                 self.native.hide()
-                
+
                 if self.interface.can_have_children:
                     for child in self.interface.children:
                         child._impl.set_hidden(True)
 
             else:
-                # if self.native is a container widget, each native child will be shown (if 
-                # it is not hidden by its own style property)
+                # if self.native is a container widget, each native child will
+                # be shown (if it is not hidden by its own style property)
                 self.native.show()
 
                 if self.interface.can_have_children:
                     for child in self.interface.children:
                         child._impl.set_hidden(False)
-
-            print("LOG: {}.set_hidden({}), native visible = {}".format(self.interface, hidden, self.native.get_visible()))
         else:
             raise Exception("cannot hide widget: no native widget to hide")
 
@@ -101,14 +102,15 @@ class Widget:
         # By default, background color can't be changed
         pass
 
-    ### INTERFACE
+    # INTERFACE
 
     def add_child(self, child):
         if self.container:
             child.container = self.container
 
     def rehint(self):
-        # print("REHINT", self, self.native.get_preferred_width(), self.native.get_preferred_height())
+        # print("REHINT", self, self.native.get_preferred_width(),
+        #     self.native.get_preferred_height())
         width = self.native.get_preferred_width()
         height = self.native.get_preferred_height()
 

--- a/src/gtk/toga_gtk/widgets/base.py
+++ b/src/gtk/toga_gtk/widgets/base.py
@@ -46,7 +46,11 @@ class Widget:
         pass
 
     def set_hidden(self, hidden):
-        self.interface.factory.not_implemented('Widget.set_hidden()')
+        if self.native:
+            if hidden:
+                self.native.hide()
+            else:
+                self.native.show()
 
     def set_font(self, font):
         # By default, fon't can't be changed

--- a/src/gtk/toga_gtk/window.py
+++ b/src/gtk/toga_gtk/window.py
@@ -100,6 +100,20 @@ class Window:
     def show(self):
         self.native.show_all()
 
+        # Unlike other platforms, Gtk widgets are initially hidden, with the expectation
+        # that the developer will call show_all() on the window when launching the app.
+        # show_all() will undo the effects of Toga's style engine, so elements may need re-hidden
+        def fix_hidden(widget):
+            if widget.style.visibility == "hidden":
+                widget._impl.set_hidden(True)
+            if hasattr(widget, "content"):  # for containers
+                fix_hidden(widget.content)
+            else:
+                for child in widget.children:  # for all other widgets
+                    fix_hidden(child)
+
+        fix_hidden(self.interface.content)
+
         # Now that the content is visible, we can do our initial hinting,
         # and use that as the basis for setting the minimum window size.
         self.interface.content._impl.rehint()


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Implement Widget.set_hidden for GTK+ 
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

Though this is such a simple commit, I'm not quite ready for merge. After some testing,
I've determined that in one particular circumstance, a widget will not disappear when hidden.
**Any box that is not the direct child of the window or *x*Container widget will be unaffected by set_hidden(True)**
In other words, the only boxes that behave are those that are the `content` of a container.

I'm not sure why yet. The native widget for a box in GTK is a subclass of Gtk.Fixed which has .show() and .hide() methods, which are called directly by toga_gtk/Widget.set_hidden(). I have confirmed that these methods are being called on the offending boxes.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
