### PR TITLE
Added the option to add default value to NumberInput

### DIFF
--- a/src/core/tests/widgets/test_numberinput.py
+++ b/src/core/tests/widgets/test_numberinput.py
@@ -72,3 +72,8 @@ class NumberInputTests(TestCase):
         self.nr_input.on_change = dummy_function
         self.nr_input.value = 2
         self.assertValueSet(self.nr_input, 'on_change', self.nr_input.on_change)
+
+    def test_default(self):
+        value = 5
+        nr_input = toga.NumberInput(default=value, factory=toga_dummy.factory)
+        self.assertEqual(nr_input.value, value)

--- a/src/core/toga/widgets/numberinput.py
+++ b/src/core/toga/widgets/numberinput.py
@@ -22,6 +22,7 @@ class NumberInput(Widget):
         step (number): Step size of the adjustment buttons.
         min_value (number): The minimum bound for the widget's value.
         max_value (number): The maximum bound for the widget's value.
+        default (number): Default value for the widget
         readonly (bool):  Whether a user can write/change the number input, defaults to `False`.
         on_change (``callable``): The handler to invoke when the value changes.
         **ex:

--- a/src/core/toga/widgets/numberinput.py
+++ b/src/core/toga/widgets/numberinput.py
@@ -29,7 +29,7 @@ class NumberInput(Widget):
     MIN_WIDTH = 100
 
     def __init__(self, id=None, style=None, factory=None, step=1,
-                 min_value=None, max_value=None, readonly=False, on_change=None):
+                 min_value=None, max_value=None, default=None, readonly=False, on_change=None):
         super().__init__(id=id, style=style, factory=factory)
         self._value = None
         self._on_change = None
@@ -40,6 +40,9 @@ class NumberInput(Widget):
         self.min_value = min_value
         self.max_value = max_value
         self.on_change = on_change
+
+        if default is not None:
+            self.value = default
 
     @property
     def readonly(self):


### PR DESCRIPTION
`NumberInput` widget should have the ability to construct with a default value.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
