### PR TITLE
Fix layout, mostly by computing width properly

### DIFF
--- a/src/android/toga_android/widgets/label.py
+++ b/src/android/toga_android/widgets/label.py
@@ -18,17 +18,21 @@ class Label(Widget):
         self.native.setText(value)
 
     def rehint(self):
-        # With the Android TextView, we use `measureText()` to compute the width
-        # of the text -- calling `measure()` seems to ignore the text, perhaps
-        # because the TextView is willing to truncate the text. We do use
-        # height information from `measure()`, which seems fine.
-        text = self.native.getText().toString()
-        width = self.native.getPaint().measureText(text)
-        self.interface.intrinsic.width = at_least(width)
+        # Ask the Android TextView first for the height it would use in its
+        # wildest dreams. This is the height of one line of text.
         self.native.measure(
             View__MeasureSpec.UNSPECIFIED, View__MeasureSpec.UNSPECIFIED
         )
-        self.interface.intrinsic.height = self.native.getMeasuredHeight()
+        one_line_height = self.native.getMeasuredHeight()
+        self.interface.intrinsic.height = one_line_height
+        # Ask it how wide it would be if it had to be just one line tall.
+        self.native.measure(
+            View__MeasureSpec.UNSPECIFIED,
+            View__MeasureSpec.makeMeasureSpec(
+                one_line_height, View__MeasureSpec.AT_MOST
+            ),
+        )
+        self.interface.intrinsic.width = at_least(self.native.getMeasuredWidth())
 
     def set_alignment(self, value):
         self.native.setGravity(

--- a/src/android/toga_android/widgets/label.py
+++ b/src/android/toga_android/widgets/label.py
@@ -18,10 +18,16 @@ class Label(Widget):
         self.native.setText(value)
 
     def rehint(self):
+        # With the Android TextView, we use `measureText()` to compute the width
+        # of the text -- calling `measure()` seems to ignore the text, perhaps
+        # because the TextView is willing to truncate the text. We do use
+        # height information from `measure()`, which seems fine.
+        text = self.native.getText().toString()
+        width = self.native.getPaint().measureText(text)
+        self.interface.intrinsic.width = at_least(width)
         self.native.measure(
             View__MeasureSpec.UNSPECIFIED, View__MeasureSpec.UNSPECIFIED
         )
-        self.interface.intrinsic.width = at_least(self.native.getMeasuredWidth())
         self.interface.intrinsic.height = self.native.getMeasuredHeight()
 
     def set_alignment(self, value):

--- a/src/android/toga_android/widgets/textinput.py
+++ b/src/android/toga_android/widgets/textinput.py
@@ -66,5 +66,7 @@ class TextInput(Widget):
         self.native.measure(
             View__MeasureSpec.UNSPECIFIED, View__MeasureSpec.UNSPECIFIED
         )
-        self.interface.intrinsic.width = at_least(self.native.getMeasuredWidth())
+        # Use arbitrary minimum 100px width for TextInput.
+        self.interface.intrinsic.width = at_least(100)
+        # Use the widget's desired height to avoid adding white vertical space.
         self.interface.intrinsic.height = self.native.getMeasuredHeight()

--- a/src/android/toga_android/widgets/textinput.py
+++ b/src/android/toga_android/widgets/textinput.py
@@ -63,10 +63,8 @@ class TextInput(Widget):
         pass
 
     def rehint(self):
+        self.interface.intrinsic.width = at_least(self.interface.MIN_WIDTH)
         self.native.measure(
             View__MeasureSpec.UNSPECIFIED, View__MeasureSpec.UNSPECIFIED
         )
-        # Use arbitrary minimum 100px width for TextInput.
-        self.interface.intrinsic.width = at_least(100)
-        # Use the widget's desired height to avoid adding white vertical space.
         self.interface.intrinsic.height = self.native.getMeasuredHeight()

--- a/src/android/toga_android/window.py
+++ b/src/android/toga_android/window.py
@@ -8,11 +8,11 @@ class AndroidViewport:
 
     @property
     def width(self):
-        return self.native.getMeasuredWidth()
+        return self.native.getContext().getResources().getDisplayMetrics().widthPixels
 
     @property
     def height(self):
-        return self.native.getMeasuredHeight()
+        return self.native.getContext().getResources().getDisplayMetrics().heightPixels
 
 
 class Window:


### PR DESCRIPTION
Before this change, `AndroidViewport` was providing a screen
width of 0 to the layout engine. This meant that layout would
assume there was no spare space, so something `at_least(N)`
pixels wide would always be rendered at `N` pixels wide --
no space for anything else.

This commit also fixes other widgets so they look better.

By the way, there are a bajillion ways to measure text on Android. One would hope that `measure()` would do it, but nope. I did one of the ones that works. I'm proud of it. :D I'm a little confused how anyone successfully writes code against Android.

## Manual testing

See TravelTips screenshot.

![image](https://user-images.githubusercontent.com/25457/82179846-21ed4100-9894-11ea-97d1-704a99d9b938.png)

Note that `My curr...` is truncated. I think this is because TravelTips hard-codes a width for that widget. I haven't even checked if it does, but hey, it works fine with a modified Toga Tutorial 2 app.

![image](https://user-images.githubusercontent.com/25457/82179932-53fea300-9894-11ea-8e29-15a139c56875.png)

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
