### PR TITLE
Correct the implementation of reset_transform on Cocoa canvas

### DIFF
--- a/src/cocoa/toga_cocoa/widgets/canvas.py
+++ b/src/cocoa/toga_cocoa/widgets/canvas.py
@@ -31,7 +31,8 @@ class TogaCanvas(NSView):
     @objc_method
     def drawRect_(self, rect: NSRect) -> None:
         context = NSGraphicsContext.currentContext.CGContext
-
+        # Save the "clean" state of the graphics context.
+        core_graphics.CGContextSaveGState(context)
         if self.interface.redraw:
             self.interface._draw(self._impl, draw_context=context)
 
@@ -187,9 +188,12 @@ class Canvas(Widget):
         core_graphics.CGContextTranslateCTM(draw_context, tx, ty)
 
     def reset_transform(self, draw_context, *args, **kwargs):
-        ctm = core_graphics.CGContextGetCTM(draw_context)
-        invert_transform = core_graphics.CGAffineTransformInvert(ctm)
-        core_graphics.CGContextConcatCTM(draw_context, invert_transform)
+        # Restore the "clean" state of the graphics context.
+        core_graphics.CGContextRestoreGState(draw_context)
+        # CoreGraphics has a stack-based state representation,
+        # so ensure that there is a new, clean version of the "clean"
+        # state on the stack.
+        core_graphics.CGContextSaveGState(draw_context)
 
     # Text
 


### PR DESCRIPTION
Refs beeware/toga_chart#9

The `reset_transform()` method on the macOS canvas was operating by attempting add an inverse transform. For some reason, this was resulting in an incomplete inversion.

This patch updates the mechanism to take a snapshot of a "clean" transform at when the draw context is created, and restores that snapshot when reset is invoked. As the transform state is a stack, a clean transform is immediately re-snapshotted so there is always exactly 1 transform in the stack.