### PR TITLE
Fix failing canvas example

### DIFF
--- a/examples/canvas/canvas/app.py
+++ b/examples/canvas/canvas/app.py
@@ -340,7 +340,7 @@ class ExampleCanvasApp(toga.App):
             weight=self.get_weight(),
             style=self.get_style(),
         )
-        width, height = font.measure(text, tight=True)
+        width, height = font.measure(text, self.canvas.dpi, tight=True)
         context.write_text(text, dx - width / 2, dy, font)
 
     def get_weight(self):

--- a/examples/canvas/canvas/app.py
+++ b/examples/canvas/canvas/app.py
@@ -340,7 +340,7 @@ class ExampleCanvasApp(toga.App):
             weight=self.get_weight(),
             style=self.get_style(),
         )
-        width, height = font.measure(text, self.canvas.dpi, tight=True)
+        width, height = self.canvas.measure_text(text, font, tight=True)
         context.write_text(text, dx - width / 2, dy, font)
 
     def get_weight(self):

--- a/examples/tutorial4/tutorial/app.py
+++ b/examples/tutorial4/tutorial/app.py
@@ -14,10 +14,11 @@ class StartApp(toga.App):
         # Create canvas and draw tiberius on it
         self.canvas = toga.Canvas(style=Pack(flex=1))
         box = toga.Box(children=[self.canvas])
-        self.draw_tiberius()
 
         # Add the content on the main window
         self.main_window.content = box
+
+        self.draw_tiberius()
 
         # Show the main window
         self.main_window.show()
@@ -87,7 +88,7 @@ class StartApp(toga.App):
         x = 32
         y = 185
         font = toga.Font(family=SANS_SERIF, size=20)
-        width, height = font.measure('Tiberius', tight=True)
+        width, height = self.canvas.measure_text('Tiberius', font, tight=True)
         with self.canvas.stroke(line_width=4.0) as rect_stroker:
             rect_stroker.rect(x - 2, y - height + 2, width, height + 2)
         with self.canvas.fill(color=rgb(149, 119, 73)) as text_filler:

--- a/src/cocoa/toga_cocoa/fonts.py
+++ b/src/cocoa/toga_cocoa/fonts.py
@@ -66,10 +66,13 @@ class Font:
 
         self.native = font
 
-    def measure(self, text, dpi, tight=False):
+    def measure(self, text, tight=False):
         textAttributes = NSMutableDictionary.alloc().init()
         textAttributes[NSFontAttributeName] = self.native
         text_string = NSAttributedString.alloc().initWithString_attributes_(text, textAttributes)
         size = text_string.size()
+
+        # TODO: This is a magic fudge factor...
+        # Replace the magic with SCIENCE.
         size.width += 3
         return size.width, size.height

--- a/src/cocoa/toga_cocoa/widgets/canvas.py
+++ b/src/cocoa/toga_cocoa/widgets/canvas.py
@@ -109,6 +109,10 @@ class Canvas(Widget):
     def redraw(self):
         self.native.needsDisplay = True
 
+    @property
+    def dpi(self):
+        return DISPLAY_DPI
+
     # Basic paths
 
     def new_path(self, draw_context, *args, **kwargs):
@@ -249,7 +253,7 @@ class Canvas(Widget):
         else:
             raise ValueError("No font to write with")
 
-        width, height = write_font.measure(text, dpi=DISPLAY_DPI)
+        width, height = write_font.measure(text, dpi=self.dpi)
         textAttributes = NSMutableDictionary.alloc().init()
         textAttributes[NSFontAttributeName] = write_font._impl.native
 

--- a/src/cocoa/toga_cocoa/widgets/canvas.py
+++ b/src/cocoa/toga_cocoa/widgets/canvas.py
@@ -5,7 +5,6 @@ from toga_cocoa.libs import (
     core_graphics,
     CGPathDrawingMode,
     CGRectMake,
-    DISPLAY_DPI,
     kCGPathStroke,
     kCGPathEOFill,
     kCGPathFill,
@@ -108,10 +107,6 @@ class Canvas(Widget):
 
     def redraw(self):
         self.native.needsDisplay = True
-
-    @property
-    def dpi(self):
-        return DISPLAY_DPI
 
     # Basic paths
 
@@ -264,7 +259,7 @@ class Canvas(Widget):
         else:
             raise ValueError("No font to write with")
 
-        width, height = self.measure_text(write_font, text)
+        width, height = self.measure_text(text, write_font)
         textAttributes = NSMutableDictionary.alloc().init()
         textAttributes[NSFontAttributeName] = write_font._impl.native
 

--- a/src/cocoa/toga_cocoa/widgets/canvas.py
+++ b/src/cocoa/toga_cocoa/widgets/canvas.py
@@ -244,6 +244,17 @@ class Canvas(Widget):
 
     # Text
 
+    def measure_text(self, text, font, tight=False):
+        textAttributes = NSMutableDictionary.alloc().init()
+        textAttributes[NSFontAttributeName] = font._impl.native
+        text_string = NSAttributedString.alloc().initWithString_attributes_(
+            text,
+            textAttributes
+        )
+        size = text_string.size()
+        size.width += 3
+        return size.width, size.height
+
     def write_text(self, text, x, y, font, *args, **kwargs):
         # Set font family and size
         if font:
@@ -253,7 +264,7 @@ class Canvas(Widget):
         else:
             raise ValueError("No font to write with")
 
-        width, height = write_font.measure(text, dpi=self.dpi)
+        width, height = self.measure_text(write_font, text)
         textAttributes = NSMutableDictionary.alloc().init()
         textAttributes[NSFontAttributeName] = write_font._impl.native
 

--- a/src/cocoa/toga_cocoa/widgets/canvas.py
+++ b/src/cocoa/toga_cocoa/widgets/canvas.py
@@ -240,15 +240,7 @@ class Canvas(Widget):
     # Text
 
     def measure_text(self, text, font, tight=False):
-        textAttributes = NSMutableDictionary.alloc().init()
-        textAttributes[NSFontAttributeName] = font._impl.native
-        text_string = NSAttributedString.alloc().initWithString_attributes_(
-            text,
-            textAttributes
-        )
-        size = text_string.size()
-        size.width += 3
-        return size.width, size.height
+        return font.bind(self.interface.factory).measure(text, tight=False)
 
     def write_text(self, text, x, y, font, *args, **kwargs):
         # Set font family and size

--- a/src/cocoa/toga_cocoa/widgets/canvas.py
+++ b/src/cocoa/toga_cocoa/widgets/canvas.py
@@ -240,7 +240,7 @@ class Canvas(Widget):
     # Text
 
     def measure_text(self, text, font, tight=False):
-        return font.bind(self.interface.factory).measure(text, tight=False)
+        return font.bind(self.interface.factory).measure(text, tight=tight)
 
     def write_text(self, text, x, y, font, *args, **kwargs):
         # Set font family and size

--- a/src/cocoa/toga_cocoa/window.py
+++ b/src/cocoa/toga_cocoa/window.py
@@ -18,9 +18,9 @@ def toolbar_identifier(cmd):
 
 
 class CocoaViewport:
-    def __init__(self, view):
+    def __init__(self, view, dpi):
         self.view = view
-        self.dpi = DISPLAY_DPI
+        self.dpi = dpi
 
     @property
     def width(self):
@@ -165,12 +165,16 @@ class Window:
 
         self.native.setToolbar_(self._toolbar_native)
 
+    @property
+    def dpi(self):
+        return DISPLAY_DPI
+
     def set_content(self, widget):
         # Set the window's view to the be the widget's native object.
         self.native.contentView = widget.native
 
         # Set the widget's viewport to be based on the window's content.
-        widget.viewport = CocoaViewport(widget.native)
+        widget.viewport = CocoaViewport(view=widget.native, dpi=self.dpi)
 
         # Add all children to the content widget.
         for child in widget.interface.children:

--- a/src/cocoa/toga_cocoa/window.py
+++ b/src/cocoa/toga_cocoa/window.py
@@ -18,9 +18,8 @@ def toolbar_identifier(cmd):
 
 
 class CocoaViewport:
-    def __init__(self, view, dpi):
+    def __init__(self, view):
         self.view = view
-        self.dpi = dpi
 
     @property
     def width(self):
@@ -29,6 +28,10 @@ class CocoaViewport:
     @property
     def height(self):
         return self.view.frame.size.height
+
+    @property
+    def dpi(self):
+        return DISPLAY_DPI
 
 
 class WindowDelegate(NSObject):
@@ -165,16 +168,12 @@ class Window:
 
         self.native.setToolbar_(self._toolbar_native)
 
-    @property
-    def dpi(self):
-        return DISPLAY_DPI
-
     def set_content(self, widget):
         # Set the window's view to the be the widget's native object.
         self.native.contentView = widget.native
 
         # Set the widget's viewport to be based on the window's content.
-        widget.viewport = CocoaViewport(view=widget.native, dpi=self.dpi)
+        widget.viewport = CocoaViewport(view=widget.native)
 
         # Add all children to the content widget.
         for child in widget.interface.children:

--- a/src/core/tests/test_font.py
+++ b/src/core/tests/test_font.py
@@ -39,13 +39,3 @@ class FontTests(TestCase):
 
     def test_weight(self):
         self.assertEqual(self.font.weight, self.weight)
-
-    def test_measure(self):
-        self.font.measure('measured text', dpi=96, tight=True)
-        self.assertActionPerformedWith(
-            self.font,
-            'measure',
-            dpi=96,
-            text='measured text',
-            tight=True
-        )

--- a/src/core/toga/widgets/canvas.py
+++ b/src/core/toga/widgets/canvas.py
@@ -561,16 +561,6 @@ class Canvas(Context, Widget):
         self.on_alt_drag = on_alt_drag
 
     @property
-    def dpi(self):
-        """
-        Get the dpi of the underlying implementation.
-
-        Returns:
-             int. dpi of the implementation.
-        """
-        return self._impl.dpi
-
-    @property
     def on_resize(self):
         """The handler to invoke when the canvas is resized.
 

--- a/src/core/toga/widgets/canvas.py
+++ b/src/core/toga/widgets/canvas.py
@@ -778,6 +778,13 @@ class Canvas(Context, Widget):
         reset_transform = ResetTransform()
         return self.add_draw_obj(reset_transform)
 
+    ###########################################################################
+    # Text measurement
+    ###########################################################################
+
+    def measure_text(self, text, font, tight=False):
+        return self._impl.measure_text(text, font, tight=tight)
+
 
 class MoveTo:
     """A user-created :class:`MoveTo <MoveTo>` drawing object which moves the

--- a/src/core/toga/widgets/canvas.py
+++ b/src/core/toga/widgets/canvas.py
@@ -561,6 +561,16 @@ class Canvas(Context, Widget):
         self.on_alt_drag = on_alt_drag
 
     @property
+    def dpi(self):
+        """
+        Get the dpi of the underlying implementation.
+
+        Returns:
+             int. dpi of the implementation.
+        """
+        return self._impl.dpi
+
+    @property
     def on_resize(self):
         """The handler to invoke when the canvas is resized.
 

--- a/src/core/toga/window.py
+++ b/src/core/toga/window.py
@@ -178,10 +178,6 @@ class Window:
         self._is_full_screen = is_full_screen
         self._impl.set_full_screen(is_full_screen)
 
-    @property
-    def dpi(self):
-        return self._impl.dpi
-
     def close(self):
         self._impl.close()
 

--- a/src/core/toga/window.py
+++ b/src/core/toga/window.py
@@ -178,6 +178,10 @@ class Window:
         self._is_full_screen = is_full_screen
         self._impl.set_full_screen(is_full_screen)
 
+    @property
+    def dpi(self):
+        return self._impl.dpi
+
     def close(self):
         self._impl.close()
 

--- a/src/dummy/toga_dummy/fonts.py
+++ b/src/dummy/toga_dummy/fonts.py
@@ -5,6 +5,3 @@ class Font(LoggedObject):
     def __init__(self, interface):
         super().__init__()
         self.interface = interface
-
-    def measure(self, text, dpi, tight=False):
-        self._action('measure', text=text, dpi=dpi, tight=tight)

--- a/src/dummy/toga_dummy/test_implementation.py
+++ b/src/dummy/toga_dummy/test_implementation.py
@@ -388,6 +388,7 @@ TOGA_BASE_FILES = [
     'widgets/base.py',
     'widgets/box.py',
     'widgets/button.py',
+    'widgets/canvas.py',
     'widgets/imageview.py',
     'widgets/label.py',
     'widgets/multilinetextinput.py',

--- a/src/dummy/toga_dummy/widgets/canvas.py
+++ b/src/dummy/toga_dummy/widgets/canvas.py
@@ -89,6 +89,9 @@ class Canvas(Widget):
     def write_text(self, text, x, y, font, *args, **kwargs):
         self._action("write text", text=text, x=x, y=y, font=font)
 
+    def measure_text(self, text, font, tight=False):
+        self._action("measure text", text=text, font=font, tight=tight)
+
     # Rehint
 
     def rehint(self):

--- a/src/gtk/toga_gtk/fonts.py
+++ b/src/gtk/toga_gtk/fonts.py
@@ -1,17 +1,9 @@
 from toga.constants import ITALIC, OBLIQUE, SMALL_CAPS, BOLD, SYSTEM
 
-from .libs import Gtk, Pango
+from .libs import Pango
 
 
 _FONT_CACHE = {}
-
-
-class Measure(Gtk.Widget):
-    """Gtk.Widget for Font.measure in order to create a Pango Layout
-    """
-
-    def create(self):
-        pass
 
 
 class Font:
@@ -58,9 +50,9 @@ class Font:
 
         self.native = font
 
-    def measure(self, text, dpi, tight=False):
-        measure_widget = Measure()
-        layout = measure_widget.create_pango_layout(text)
+    def measure(self, text, widget, tight=False):
+        layout = widget.create_pango_layout(text)
+
         layout.set_font_description(self.native)
         ink, logical = layout.get_extents()
         if tight:

--- a/src/gtk/toga_gtk/widgets/canvas.py
+++ b/src/gtk/toga_gtk/widgets/canvas.py
@@ -164,18 +164,17 @@ class Canvas(Widget):
             draw_context.text_path(line)
             y += height
 
-    def measure_text(self, text, font, draw_context, *args, **kwargs):
-        # Set font family and size
-        if font:
-            draw_context.select_font_face(font.family)
-            draw_context.set_font_size(font.size)
-        elif self.native.font:
-            draw_context.select_font_face(self.native.font.get_family())
-            draw_context.set_font_size(self.native.font.get_size() / Pango.SCALE)
+    def measure_text(self, text, font, tight=False):
+        layout = self.native.create_pango_layout(text)
+        layout.set_font_description(font.bind(self.interface.factory).native)
+        ink, logical = layout.get_extents()
+        if tight:
+            width = (ink.width / Pango.SCALE) - (ink.width * 0.2) / Pango.SCALE
+            height = ink.height / Pango.SCALE
+        else:
+            width = (logical.width / Pango.SCALE) - (logical.width * 0.2) / Pango.SCALE
+            height = logical.height / Pango.SCALE
 
-        x_bearing, y_bearing, width, height, x_advance, y_advance = draw_context.text_extents(
-            text
-        )
         return width, height
 
     # Rehint

--- a/src/gtk/toga_gtk/widgets/canvas.py
+++ b/src/gtk/toga_gtk/widgets/canvas.py
@@ -159,23 +159,13 @@ class Canvas(Widget):
 
         # Support writing multiline text
         for line in text.splitlines():
-            width, height = write_font.measure(line, dpi=DISPLAY_DPI)
+            width, height = self.measure_text(line, write_font)
             draw_context.move_to(x, y)
             draw_context.text_path(line)
             y += height
 
     def measure_text(self, text, font, tight=False):
-        layout = self.native.create_pango_layout(text)
-        layout.set_font_description(font.bind(self.interface.factory).native)
-        ink, logical = layout.get_extents()
-        if tight:
-            width = (ink.width / Pango.SCALE) - (ink.width * 0.2) / Pango.SCALE
-            height = ink.height / Pango.SCALE
-        else:
-            width = (logical.width / Pango.SCALE) - (logical.width * 0.2) / Pango.SCALE
-            height = logical.height / Pango.SCALE
-
-        return width, height
+        return font.bind(self.interface.factory).measure(text, widget=self.native)
 
     # Rehint
 

--- a/src/gtk/toga_gtk/widgets/canvas.py
+++ b/src/gtk/toga_gtk/widgets/canvas.py
@@ -165,7 +165,7 @@ class Canvas(Widget):
             y += height
 
     def measure_text(self, text, font, tight=False):
-        return font.bind(self.interface.factory).measure(text, widget=self.native)
+        return font.bind(self.interface.factory).measure(text, widget=self.native, tight=tight)
 
     # Rehint
 

--- a/src/iOS/toga_iOS/fonts.py
+++ b/src/iOS/toga_iOS/fonts.py
@@ -65,10 +65,13 @@ class Font:
 
         self.native = font
 
-    def measure(self, text, dpi, tight=False):
+    def measure(self, text, tight=False):
         textAttributes = NSMutableDictionary.alloc().init()
         textAttributes[NSFontAttributeName] = self.native
         text_string = NSAttributedString.alloc().initWithString_attributes_(text, textAttributes)
         size = text_string.size()
+
+        # TODO: This is a magic fudge factor...
+        # Replace the magic with SCIENCE.
         size.width += 3
         return size.width, size.height

--- a/src/iOS/toga_iOS/widgets/canvas.py
+++ b/src/iOS/toga_iOS/widgets/canvas.py
@@ -198,7 +198,7 @@ class Canvas(Widget):
     # Text
 
     def measure_text(self, text, font, tight=False):
-        return font.bind(self.interface.factory).measure(text, tight=False)
+        return font.bind(self.interface.factory).measure(text, tight=tight)
 
     def write_text(self, text, x, y, font, *args, **kwargs):
         # Set font family and size

--- a/src/iOS/toga_iOS/widgets/canvas.py
+++ b/src/iOS/toga_iOS/widgets/canvas.py
@@ -179,6 +179,9 @@ class Canvas(Widget):
 
     # Text
 
+    def measure_text(self, text, font, tight=False):
+        return font.bind(self.interface.factory).measure(text, tight=False)
+
     def write_text(self, text, x, y, font, *args, **kwargs):
         # Set font family and size
         if font:

--- a/src/iOS/toga_iOS/widgets/canvas.py
+++ b/src/iOS/toga_iOS/widgets/canvas.py
@@ -51,6 +51,24 @@ class Canvas(Widget):
     def redraw(self):
         pass
 
+    def set_on_press(self, handler):
+        self.interface.factory.not_implemented('Canvas.set_on_press()')
+
+    def set_on_release(self, handler):
+        self.interface.factory.not_implemented('Canvas.set_on_release()')
+
+    def set_on_drag(self, handler):
+        self.interface.factory.not_implemented('Canvas.set_on_drag()')
+
+    def set_on_alt_press(self, handler):
+        self.interface.factory.not_implemented('Canvas.set_on_alt_press()')
+
+    def set_on_alt_release(self, handler):
+        self.interface.factory.not_implemented('Canvas.set_on_alt_release()')
+
+    def set_on_alt_drag(self, handler):
+        self.interface.factory.not_implemented('Canvas.set_on_alt_drag()')
+
     # Basic paths
 
     def new_path(self, draw_context, *args, **kwargs):

--- a/src/winforms/toga_winforms/widgets/canvas.py
+++ b/src/winforms/toga_winforms/widgets/canvas.py
@@ -254,9 +254,9 @@ class Canvas(Box):
     def measure_text(self, text, font, tight=False):
         size = WinForms.TextRenderer.MeasureText(text, font._impl.native)
         return (
-            self.__points_to_pixels(size.Width),
-            self.__points_to_pixels(size.Height),
+            self._points_to_pixels(size.Width),
+            self._points_to_pixels(size.Height),
         )
 
-    def __points_to_pixels(self, points):
+    def _points_to_pixels(self, points):
         return points * 72 / self.container.viewport.dpi

--- a/src/winforms/toga_winforms/widgets/canvas.py
+++ b/src/winforms/toga_winforms/widgets/canvas.py
@@ -57,6 +57,10 @@ class Canvas(Box):
         self.native.Paint += self.winforms_paint
         self.native.Resize += self.winforms_resize
 
+    @property
+    def dpi(self):
+        return self.container.viewport.dpi
+
     def set_on_resize(self, handler):
         pass
 
@@ -242,7 +246,7 @@ class Canvas(Box):
 
     # Text
     def write_text(self, text, x, y, font, draw_context, *args, **kwargs):
-        width, height = font.measure(text, dpi=self.container.viewport.dpi)
+        width, height = font.measure(text, dpi=self.dpi)
         origin = PointF(x, y - height)
         font_family = win_font_family(font.family)
         font_style = win_font_style(font.weight, font.style, font_family)
@@ -251,4 +255,5 @@ class Canvas(Box):
         )
 
     def measure_text(self, text, font, draw_context, *args, **kwargs):
-        width, height = font.measure(text, dpi=self.container.viewport.dpi)
+        width, height = font.measure(text, dpi=self.dpi)
+        return width, height

--- a/src/winforms/toga_winforms/widgets/canvas.py
+++ b/src/winforms/toga_winforms/widgets/canvas.py
@@ -15,7 +15,8 @@ from toga_winforms.libs import (
     RectangleF,
     PointF,
     StringFormat,
-    win_font_family
+    win_font_family,
+    WinForms
 )
 from ..libs.fonts import win_font_style
 
@@ -56,10 +57,6 @@ class Canvas(Box):
         super(Canvas, self).create()
         self.native.Paint += self.winforms_paint
         self.native.Resize += self.winforms_resize
-
-    @property
-    def dpi(self):
-        return self.container.viewport.dpi
 
     def set_on_resize(self, handler):
         pass
@@ -246,7 +243,7 @@ class Canvas(Box):
 
     # Text
     def write_text(self, text, x, y, font, draw_context, *args, **kwargs):
-        width, height = font.measure(text, dpi=self.dpi)
+        width, height = self.measure_text(text, font)
         origin = PointF(x, y - height)
         font_family = win_font_family(font.family)
         font_style = win_font_style(font.weight, font.style, font_family)
@@ -254,6 +251,12 @@ class Canvas(Box):
             text, font_family, font_style, float(height), origin, StringFormat()
         )
 
-    def measure_text(self, text, font, draw_context, *args, **kwargs):
-        width, height = font.measure(text, dpi=self.dpi)
-        return width, height
+    def measure_text(self, text, font, tight=False):
+        size = WinForms.TextRenderer.MeasureText(text, font._impl.native)
+        return (
+            self.__points_to_pixels(size.Width),
+            self.__points_to_pixels(size.Height),
+        )
+
+    def __points_to_pixels(self, points):
+        return points * 72 / self.container.viewport.dpi

--- a/src/winforms/toga_winforms/window.py
+++ b/src/winforms/toga_winforms/window.py
@@ -5,10 +5,10 @@ from .libs import WinForms, Size
 
 
 class WinFormsViewport:
-    def __init__(self, native, frame):
+    def __init__(self, native, frame, dpi):
         self.native = native
         self.frame = frame
-        self.dpi = self.native.CreateGraphics().DpiX
+        self.dpi = dpi
 
     @property
     def width(self):
@@ -34,6 +34,7 @@ class Window:
         self.native.Resize += self.winforms_resize
         self.toolbar_native = None
         self.toolbar_items = None
+        self._dpi = self.native.CreateGraphics().DpiX
 
     def create_toolbar(self):
         self.toolbar_native = WinForms.ToolStrip()
@@ -51,6 +52,10 @@ class Window:
                 item.Click += cmd._impl.as_handler()
                 cmd._impl.native.append(item)
             self.toolbar_native.Items.Add(item)
+
+    @property
+    def dpi(self):
+        return self._dpi
 
     def set_position(self, position):
         pass
@@ -83,7 +88,7 @@ class Window:
         self.native.Controls.Add(widget.native)
 
         # Set the widget's viewport to be based on the window's content.
-        widget.viewport = WinFormsViewport(self.native, self)
+        widget.viewport = WinFormsViewport(native=self.native, frame=self, dpi=self.dpi)
         widget.frame = self
 
         # Add all children to the content widget.

--- a/src/winforms/toga_winforms/window.py
+++ b/src/winforms/toga_winforms/window.py
@@ -5,10 +5,9 @@ from .libs import WinForms, Size
 
 
 class WinFormsViewport:
-    def __init__(self, native, frame, dpi):
+    def __init__(self, native, frame):
         self.native = native
         self.frame = frame
-        self.dpi = dpi
 
     @property
     def width(self):
@@ -19,6 +18,10 @@ class WinFormsViewport:
         # Subtract any vertical shift of the frame. This is to allow
         # for toolbars, or any other viewport-level decoration.
         return self.native.ClientSize.Height - self.frame.vertical_shift
+
+    @property
+    def dpi(self):
+        return self.native.CreateGraphics().DpiX
 
 
 class Window:
@@ -34,7 +37,6 @@ class Window:
         self.native.Resize += self.winforms_resize
         self.toolbar_native = None
         self.toolbar_items = None
-        self._dpi = self.native.CreateGraphics().DpiX
 
     def create_toolbar(self):
         self.toolbar_native = WinForms.ToolStrip()
@@ -52,10 +54,6 @@ class Window:
                 item.Click += cmd._impl.as_handler()
                 cmd._impl.native.append(item)
             self.toolbar_native.Items.Add(item)
-
-    @property
-    def dpi(self):
-        return self._dpi
 
     def set_position(self, position):
         pass
@@ -88,7 +86,7 @@ class Window:
         self.native.Controls.Add(widget.native)
 
         # Set the widget's viewport to be based on the window's content.
-        widget.viewport = WinFormsViewport(native=self.native, frame=self, dpi=self.dpi)
+        widget.viewport = WinFormsViewport(native=self.native, frame=self)
         widget.frame = self
 
         # Add all children to the content widget.


### PR DESCRIPTION
Since the API for `Font.measure` has been changed to include the `dpi` as a parameter, the `Canvas` example is failing. This PR fixes that.

In order to fix the problem I had to add a `dpi` property to `Canvas`. I think it is reasonable that the `Canvas` should have this property since it is the main widget that will need to take it under consideration. Another option is to add this property to `Window` and to call it via `canvas.window.dpi`, but I don't think it's a good design.

Would love to hear your feedback on this.

I implemented the `dpi` property in *Windows* and *Cocoa*, but I guess you need to do the same for *GTK* and other platforms

## Reproduce the bug

1. Run the `Canvas` example.
2. Choose the *text* shape
3. A syntax error is raised

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
