### PR TITLE
Fixes #927 -- Correct version pinning in toga-demo.

### DIFF
--- a/demo/pyproject.toml
+++ b/demo/pyproject.toml
@@ -1,5 +1,3 @@
-[build-system]
-requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "Toga Demo"

--- a/demo/setup.py
+++ b/demo/setup.py
@@ -23,7 +23,7 @@ setup(
         'toga_demo': ['resources/*.icns', 'resources/*.png'],
     },
     install_requires=[
-        'toga==0.3.0.dev18'
+        'toga==0.3.0.dev20'
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Something evidently broke during the toga-demo release process for 0.3.0dev19, because it hard-codes a dependency on 0.3.0.dev18. 

The pyproject.toml PEP517 build dependecy is one possible cause of the problem.