### PR TITLE
Implement missing methods in Winforms OptionContainer

### DIFF
--- a/src/winforms/toga_winforms/widgets/optioncontainer.py
+++ b/src/winforms/toga_winforms/widgets/optioncontainer.py
@@ -7,6 +7,7 @@ from .base import Widget
 class OptionContainer(Widget):
     def create(self):
         self.native = WinForms.TabControl()
+        self.native.Selected += self.winforms_Selected
 
     def add_content(self, label, widget):
         widget.viewport = WinFormsViewport(self.native, self)
@@ -23,22 +24,32 @@ class OptionContainer(Widget):
         widget.AutoSize = True
 
         item.Controls.Add(widget.native)
-        self.native.Controls.Add(item)
+        self.native.TabPages.Add(item)
 
     def remove_content(self, index):
-        self.interface.factory.not_implemented('OptionContainer.remove_content()')
+        tab_page = self.native.TabPages[index]
+        self.native.TabPages.Remove(self.native.TabPages[index])
+        tab_page.Dispose()
 
     def set_on_select(self, handler):
-        self.interface.factory.not_implemented('OptionContainer.set_on_select()')
+        pass
 
     def set_option_enabled(self, index, enabled):
-        self.interface.factory.not_implemented('OptionContainer.is_option_enabled()')
+        """
+        Winforms documentation states that Enabled is not meaningful for this control.
+        Disabling option only disables the content of the tab, not the tab itself.
+        """
+        self.native.TabPages[index].Enabled = enabled
 
     def is_option_enabled(self, index):
-        self.interface.factory.not_implemented('OptionContainer.is_option_enabled()')
+        return self.native.TabPages[index].Enabled
 
     def set_option_label(self, index, value):
-        self.interface.factory.not_implemented('OptionContainer.set_option_label()')
+        self.native.TabPages[index].Text = value
 
     def get_option_label(self, index):
-        self.interface.factory.not_implemented('OptionContainer.get_option_label()')
+        return self.native.TabPages[index].Text
+
+    def winforms_Selected(self, sender, event):
+        if self.interface.on_select:
+            self.interface.on_press(self.interface)


### PR DESCRIPTION
Added all the missing methods from Winforms implementation.

Signed-off-by: Olga <obulat@gmail.com>

<!--- Describe your changes in detail -->
Added option label setter and getter, option enabled setter and getter, and setter for option change handler.
<!--- What problem does this change solve? -->
This change gets rid of all `Not implemented` warnings for OptionContainer widget in Winforms backend..
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
