### PR TITLE
Detect Android the same way as the CPython test suite

### DIFF
--- a/src/core/toga/platform.py
+++ b/src/core/toga/platform.py
@@ -30,16 +30,13 @@ def get_platform_factory(factory=None):
     elif sys.platform == 'watchos':
         from toga_watchOS import factory
         return factory
-    elif sys.platform == 'android':
-        from toga_android import factory
-        return factory
     elif sys.platform == 'darwin':
         from toga_cocoa import factory
         return factory
     elif sys.platform == 'linux':
-        # In the future, we will use a different way to detect Android.
-        # See https://github.com/beeware/Python-Android-support/issues/8
-        if os.environ.get('ANDROID_ROOT'):
+        # Rely on `sys.getandroidapilevel`, which only exists on Android; see
+        # https://github.com/beeware/Python-Android-support/issues/8
+        if hasattr(sys, 'getandroidapilevel'):
             from toga_android import factory
             return factory
         from toga_gtk import factory

--- a/src/core/toga/platform.py
+++ b/src/core/toga/platform.py
@@ -24,11 +24,8 @@ def get_platform_factory(factory=None):
     if sys.platform == 'ios':
         from toga_iOS import factory
         return factory
-    elif sys.platform == 'tvos':
-        from toga_tvOS import factory
-        return factory
-    elif sys.platform == 'watchos':
-        from toga_watchOS import factory
+    elif sys.platform == 'android':
+        from toga_android import factory
         return factory
     elif sys.platform == 'darwin':
         from toga_cocoa import factory
@@ -43,6 +40,12 @@ def get_platform_factory(factory=None):
         return factory
     elif sys.platform == 'win32':
         from toga_winforms import factory
+        return factory
+    elif sys.platform == 'tvos':
+        from toga_tvOS import factory
+        return factory
+    elif sys.platform == 'watchos':
+        from toga_watchOS import factory
         return factory
     else:
         raise RuntimeError("Couldn't identify a supported host platform.")


### PR DESCRIPTION
Per discussion at https://github.com/beeware/Python-Android-support/issues/8 , we can detect that we're running on Android the same way the CPython test suite detects it's running on Android.

This is pretty trivial, but I want to submit this pull request because (a) it deletes unused code (I can't find a situation where `sys.platform` is `android`) and (b) IMHO it simplifies life for other people who might want to integrate Toga into their own Android-Python packaging ecosystem, since we and the stdlib are doing things the same way. I am personally aesthetically very much attracted to the idea of consistency between us and CPython upstream.

## Manual testing performed

Using this Toga library, I booted up a helloworld app on Android, and indeed it launched properly. :)

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
