### PR TITLE
[WIP] rendering fixes

### DIFF
--- a/examples/layout/README.rst
+++ b/examples/layout/README.rst
@@ -9,4 +9,4 @@ Quickstart
 To run this example:
 
     $ pip install toga
-    $ python -m layout_test
+    $ python -m layout

--- a/examples/layout/layout/app.py
+++ b/examples/layout/layout/app.py
@@ -3,7 +3,7 @@ from toga.style import Pack
 from toga.constants import ROW, COLUMN, CENTER
 
 
-class ExampleBoxApp(toga.App):
+class ExampleLayoutApp(toga.App):
 
     def startup(self):
 
@@ -45,7 +45,7 @@ class ExampleBoxApp(toga.App):
         icon = toga.Icon('')
         self.image_view = toga.ImageView(icon, style=Pack(padding=10, width=60, height=60))
 
-        # this tests addind children during init, before we have an implementaiton
+        # this tests adding children during init, before we have an implementation
         self.button_box = toga.Box(
             children=[
                 self.button_add,
@@ -58,14 +58,18 @@ class ExampleBoxApp(toga.App):
         )
 
         self.box = toga.Box(
-            children=[self.button_box, self.scroll_view],
+            children=[],
             style=Pack(direction=ROW, padding=10, alignment=CENTER, flex=1)
         )
 
-        # add a couple of labels to get us started
         # this tests adding children when we already have an impl but no window or app
+        self.box.add(self.button_box)
+        self.box.add(self.scroll_view)
+
+        # add a couple of labels to get us started
         for i in range(3):
             self.add_label()
+
 
         self.main_window = toga.MainWindow()
         self.main_window.content = self.box
@@ -111,7 +115,7 @@ class ExampleBoxApp(toga.App):
 
 
 def main():
-    return ExampleBoxApp('Layout Test', 'org.beeware.widgets.layout_test')
+    return ExampleLayoutApp('Layout', 'org.beeware.widgets.layout')
 
 
 if __name__ == '__main__':

--- a/examples/layout/layout/app.py
+++ b/examples/layout/layout/app.py
@@ -70,7 +70,6 @@ class ExampleLayoutApp(toga.App):
         for i in range(3):
             self.add_label()
 
-
         self.main_window = toga.MainWindow()
         self.main_window.content = self.box
         self.main_window.show()

--- a/src/cocoa/toga_cocoa/widgets/base.py
+++ b/src/cocoa/toga_cocoa/widgets/base.py
@@ -29,11 +29,15 @@ class Widget:
     @container.setter
     def container(self, container):
 
-        if container is None:
+        if self.container and not container:
+            # existing container should be removed
             self.constraints.container = None
             self._container = None
             self.native.removeFromSuperview()
-        else:
+        elif self.container:
+            raise RuntimeError('Already have a container')
+        elif container:
+            # setting container
             self._container = container
             self._container.native.addSubview(self.native)
             self.constraints.container = container

--- a/src/cocoa/toga_cocoa/widgets/base.py
+++ b/src/cocoa/toga_cocoa/widgets/base.py
@@ -84,7 +84,7 @@ class Widget:
     # INTERFACE
 
     def add_child(self, child):
-        child.container = self.container or self
+        child.container = self.container
 
     def insert_child(self, index, child):
         self.add_child(child)

--- a/src/cocoa/toga_cocoa/widgets/base.py
+++ b/src/cocoa/toga_cocoa/widgets/base.py
@@ -84,7 +84,12 @@ class Widget:
     # INTERFACE
 
     def add_child(self, child):
-        child.container = self.container
+
+        if self.viewport:
+            # we are the the top level NSView
+            child.container = self
+        else:
+            child.container = self.container
 
     def insert_child(self, index, child):
         self.add_child(child)

--- a/src/cocoa/toga_cocoa/widgets/base.py
+++ b/src/cocoa/toga_cocoa/widgets/base.py
@@ -43,6 +43,15 @@ class Widget:
 
         self.rehint()
 
+
+    @property
+    def viewport(self):
+        return self._viewport
+
+    @viewport.setter
+    def viewport(self, viewport):
+        self._viewport = viewport
+
     def set_enabled(self, value):
         self.native.enabled = self.interface.enabled
 

--- a/src/cocoa/toga_cocoa/widgets/base.py
+++ b/src/cocoa/toga_cocoa/widgets/base.py
@@ -28,14 +28,14 @@ class Widget:
 
     @container.setter
     def container(self, container):
-
-        if self.container and not container:
-            # existing container should be removed
-            self.constraints.container = None
-            self._container = None
-            self.native.removeFromSuperview()
-        elif self.container:
-            raise RuntimeError('Already have a container')
+        if self.container:
+            if container:
+                raise RuntimeError('Already have a container')
+            else:
+                # existing container should be removed
+                self.constraints.container = None
+                self._container = None
+                self.native.removeFromSuperview()
         elif container:
             # setting container
             self._container = container

--- a/src/cocoa/toga_cocoa/widgets/base.py
+++ b/src/cocoa/toga_cocoa/widgets/base.py
@@ -47,7 +47,6 @@ class Widget:
 
         self.rehint()
 
-
     @property
     def viewport(self):
         return self._viewport


### PR DESCRIPTION
This fixes rendering issues on macOS when adding children to a `toga.Box` after the Box has been created but before it acquires a window. The related issue is #937.

This PR has the following changes:

- Fixes prematurely setting a wrong container for `toga_cocoa.Widget`.
- Introduce and use the `viewport` property to check if a widget is top-level, i.e., the content of a window or another widgets.
- Raise a RuntimeError when trying to set a container if a widget already has one. This prevents `native.addSubview` from being called twice and should hopefully prevent regressions.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
