### PR TITLE
Create `baseline_dpi` on each platform

### DIFF
--- a/src/android/toga_android/window.py
+++ b/src/android/toga_android/window.py
@@ -5,6 +5,9 @@ class AndroidViewport:
     def __init__(self, native):
         self.native = native
         self.dpi = self.native.getContext().getResources().getDisplayMetrics().densityDpi
+        # Toga needs to know how the current DPI compares to the platform default,
+        # which is 160: https://developer.android.com/training/multiscreen/screendensities
+        self.baseline_dpi = 160
 
     @property
     def width(self):

--- a/src/cocoa/toga_cocoa/libs/__init__.py
+++ b/src/cocoa/toga_cocoa/libs/__init__.py
@@ -3,7 +3,3 @@ from .core_graphics import *  # noqa: F401, F403
 from .core_text import *  # noqa: F401, F403
 from .foundation import *  # noqa: F401, F403
 from .webkit import *  # noqa: F401, F403
-
-# macOS always renders at 96dpi. Scaling is handled
-# transparently at the level of the screen compositor.
-DISPLAY_DPI = 96

--- a/src/cocoa/toga_cocoa/window.py
+++ b/src/cocoa/toga_cocoa/window.py
@@ -1,11 +1,10 @@
-from travertino.layout import Viewport
 from rubicon.objc import objc_method, NSMakeRect, NSMutableArray, NSObject, SEL
 
 from toga.command import Command as BaseCommand
 
 from toga_cocoa import dialogs
 from toga_cocoa.libs import (
-    DISPLAY_DPI, NSScreen, NSToolbar, NSToolbarItem, NSTitledWindowMask,
+    NSScreen, NSToolbar, NSToolbarItem, NSTitledWindowMask,
     NSClosableWindowMask, NSResizableWindowMask, NSMiniaturizableWindowMask,
     NSWindow, NSBackingStoreBuffered, NSLayoutConstraint,
     NSLayoutAttributeBottom, NSLayoutAttributeLeft, NSLayoutAttributeRight,
@@ -20,18 +19,19 @@ def toolbar_identifier(cmd):
 class CocoaViewport:
     def __init__(self, view):
         self.view = view
+        # macOS always renders at 96dpi. Scaling is handled
+        # transparently at the level of the screen compositor.
+        self.dpi = 96
+        self.baseline_dpi = self.dpi
 
     @property
     def width(self):
-        return self.view.frame.size.width
+        # If `view` is `None`, we'll treat this a 0x0 viewport.
+        return 0 if self.view is None else self.view.frame.size.width
 
     @property
     def height(self):
-        return self.view.frame.size.height
-
-    @property
-    def dpi(self):
-        return DISPLAY_DPI
+        return 0 if self.view is None else self.view.frame.size.height
 
 
 class WindowDelegate(NSObject):
@@ -222,7 +222,7 @@ class Window:
         # a minimum window size.
         self.interface.content.style.layout(
             self.interface.content,
-            Viewport(0, 0, dpi=DISPLAY_DPI)
+            CocoaViewport(view=None),
         )
         self._min_width_constraint.constant = self.interface.content.layout.width
         self._min_height_constraint.constant = self.interface.content.layout.height

--- a/src/core/tests/style/test_pack.py
+++ b/src/core/tests/style/test_pack.py
@@ -174,6 +174,7 @@ class PackLayoutTests(TestCase):
                 {'origin': (50, 50), 'content': (120, 30)}
             ]}
         )
+        
         # Normal size with high DPI equal to high baseline DPI
         root.style.layout(root, TestViewport(640, 480, dpi=160, baseline_dpi=160))
         self.assertLayout(

--- a/src/core/tests/style/test_pack.py
+++ b/src/core/tests/style/test_pack.py
@@ -1,7 +1,6 @@
 from unittest import TestCase
 from unittest.mock import Mock
 
-from travertino.layout import Viewport
 from travertino.node import Node
 from travertino.size import at_least
 
@@ -23,6 +22,14 @@ class TestNode(Node):
 
     def __repr__(self):
         return '<{} at {}>'.format(self.name, id(self))
+
+
+class TestViewport:
+    def __init__(self, width, height, dpi=96, baseline_dpi=96):
+        self.height = height
+        self.width = width
+        self.dpi = dpi
+        self.baseline_dpi = baseline_dpi
 
 
 class TestPackStyleApply(TestCase):
@@ -122,7 +129,7 @@ class PackLayoutTests(TestCase):
         )
 
         # Minimum size
-        root.style.layout(root, Viewport(0, 0, dpi=96))
+        root.style.layout(root, TestViewport(0, 0, dpi=96))
         self.assertLayout(
             root,
             (220, 130),
@@ -132,7 +139,7 @@ class PackLayoutTests(TestCase):
         )
 
         # Normal size
-        root.style.layout(root, Viewport(640, 480, dpi=96))
+        root.style.layout(root, TestViewport(640, 480, dpi=96))
         self.assertLayout(
             root,
             (640, 130),
@@ -142,7 +149,43 @@ class PackLayoutTests(TestCase):
         )
 
         # HiDPI normal size
-        root.style.layout(root, Viewport(640, 480, dpi=144))
+        root.style.layout(root, TestViewport(640, 480, dpi=144))
+        self.assertLayout(
+            root,
+            (640, 180),
+            {'origin': (0, 0), 'content': (640, 180), 'children': [
+                {'origin': (75, 75), 'content': (490, 30)}
+            ]}
+        )
+
+    def test_tutorial_0_high_baseline_dpi(self):
+        root = TestNode(
+            'app', style=Pack(), children=[
+                TestNode('button', style=Pack(flex=1, padding=50), size=(at_least(120), 30)),
+            ]
+        )
+
+        # Minimum size with high baseline DPI
+        root.style.layout(root, TestViewport(0, 0, dpi=160, baseline_dpi=160))
+        self.assertLayout(
+            root,
+            (220, 130),
+            {'origin': (0, 0), 'content': (220, 130), 'children': [
+                {'origin': (50, 50), 'content': (120, 30)}
+            ]}
+        )
+        # Normal size with high DPI equal to high baseline DPI
+        root.style.layout(root, TestViewport(640, 480, dpi=160, baseline_dpi=160))
+        self.assertLayout(
+            root,
+            (640, 130),
+            {'origin': (0, 0), 'content': (640, 130), 'children': [
+                {'origin': (50, 50), 'content': (540, 30)}
+            ]}
+        )
+
+        # HiDPI -- 1.5x baseline -- with higher baseline DPI
+        root.style.layout(root, TestViewport(640, 480, dpi=240, baseline_dpi=160))
         self.assertLayout(
             root,
             (640, 180),
@@ -168,7 +211,7 @@ class PackLayoutTests(TestCase):
         )
 
         # Minimum size
-        root.style.layout(root, Viewport(0, 0, dpi=96))
+        root.style.layout(root, TestViewport(0, 0, dpi=96))
         self.assertLayout(
             root,
             (380, 120),
@@ -187,7 +230,7 @@ class PackLayoutTests(TestCase):
         )
 
         # Normal size
-        root.style.layout(root, Viewport(640, 480, dpi=96))
+        root.style.layout(root, TestViewport(640, 480, dpi=96))
         self.assertLayout(
             root,
             (640, 120),
@@ -206,7 +249,7 @@ class PackLayoutTests(TestCase):
         )
 
         # HiDPI Normal size
-        root.style.layout(root, Viewport(640, 480, dpi=144))
+        root.style.layout(root, TestViewport(640, 480, dpi=144))
         self.assertLayout(
             root,
             (640, 142),
@@ -236,7 +279,7 @@ class PackLayoutTests(TestCase):
         )
 
         # Minimum size
-        root.style.layout(root, Viewport(0, 0, dpi=96))
+        root.style.layout(root, TestViewport(0, 0, dpi=96))
         self.assertLayout(
             root,
             (170, 125),
@@ -250,7 +293,7 @@ class PackLayoutTests(TestCase):
         )
 
         # Normal size
-        root.style.layout(root, Viewport(640, 480, dpi=96))
+        root.style.layout(root, TestViewport(640, 480, dpi=96))
         self.assertLayout(
             root,
             (640, 480),
@@ -264,7 +307,7 @@ class PackLayoutTests(TestCase):
         )
 
         # HiDPI Normal size
-        root.style.layout(root, Viewport(640, 480, dpi=144))
+        root.style.layout(root, TestViewport(640, 480, dpi=144))
         self.assertLayout(
             root,
             (640, 480),
@@ -289,7 +332,7 @@ class PackLayoutTests(TestCase):
         )
 
         # Minimum size
-        root.style.layout(root, Viewport(0, 0, dpi=96))
+        root.style.layout(root, TestViewport(0, 0, dpi=96))
         self.assertLayout(
             root,
             (160, 125),
@@ -303,7 +346,7 @@ class PackLayoutTests(TestCase):
         )
 
         # Normal size
-        root.style.layout(root, Viewport(640, 480, dpi=96))
+        root.style.layout(root, TestViewport(640, 480, dpi=96))
         self.assertLayout(
             root,
             (640, 480),
@@ -317,7 +360,7 @@ class PackLayoutTests(TestCase):
         )
 
         # HiDPI Normal size
-        root.style.layout(root, Viewport(640, 480, dpi=144))
+        root.style.layout(root, TestViewport(640, 480, dpi=144))
         self.assertLayout(
             root,
             (640, 480),

--- a/src/core/tests/style/test_pack.py
+++ b/src/core/tests/style/test_pack.py
@@ -174,7 +174,7 @@ class PackLayoutTests(TestCase):
                 {'origin': (50, 50), 'content': (120, 30)}
             ]}
         )
-        
+
         # Normal size with high DPI equal to high baseline DPI
         root.style.layout(root, TestViewport(640, 480, dpi=160, baseline_dpi=160))
         self.assertLayout(

--- a/src/gtk/toga_gtk/libs/__init__.py
+++ b/src/gtk/toga_gtk/libs/__init__.py
@@ -1,7 +1,2 @@
 from .gtk import *  # noqa: F401, F403
 from .utils import *  # noqa: F401, F403
-
-# GDK/GTK always renders at 96dpi. When HiDPI mode is enabled, it is
-# managed at the compositor level. See
-# https://wiki.archlinux.org/index.php/HiDPI#GDK_3_(GTK_3) for details
-DISPLAY_DPI = 96

--- a/src/gtk/toga_gtk/widgets/canvas.py
+++ b/src/gtk/toga_gtk/widgets/canvas.py
@@ -1,5 +1,5 @@
 from ..colors import native_color
-from ..libs import DISPLAY_DPI, Gtk, Pango, cairo
+from ..libs import Gtk, Pango, cairo
 from .base import Widget
 
 

--- a/src/gtk/toga_gtk/window.py
+++ b/src/gtk/toga_gtk/window.py
@@ -1,23 +1,30 @@
-from travertino.layout import Viewport
-
 from toga.command import GROUP_BREAK, SECTION_BREAK
 from toga.handlers import wrapped_handler
 
 from . import dialogs
-from .libs import DISPLAY_DPI, Gtk
+from .libs import Gtk
 
 
 class GtkViewport:
     def __init__(self, native):
         self.native = native
-        self.dpi = DISPLAY_DPI
+        # GDK/GTK always renders at 96dpi. When HiDPI mode is enabled, it is
+        # managed at the compositor level. See
+        # https://wiki.archlinux.org/index.php/HiDPI#GDK_3_(GTK_3) for details
+        self.dpi = 96
+        self.baseline_dpi = self.dpi
 
     @property
     def width(self):
+        # Treat `native=None` as a 0x0 viewport.
+        if self.native is None:
+            return 0
         return self.native.get_allocated_width()
 
     @property
     def height(self):
+        if self.native is None:
+            return 0
         return self.native.get_allocated_height()
 
 
@@ -105,7 +112,7 @@ class Window:
         self.interface.content._impl.rehint()
         self.interface.content.style.layout(
             self.interface.content,
-            Viewport(0, 0, dpi=DISPLAY_DPI)
+            GtkViewport(native=None)
         )
         self.interface.content._impl.min_width = self.interface.content.layout.width
         self.interface.content._impl.min_height = self.interface.content.layout.height

--- a/src/iOS/toga_iOS/window.py
+++ b/src/iOS/toga_iOS/window.py
@@ -7,6 +7,7 @@ class iOSViewport:
         self.view = view
         # iOS renders everything at 96dpi.
         self.dpi = 96
+        self.baseline_dpi = self.dpi
 
         self.kb_height = 0.0
 

--- a/src/winforms/toga_winforms/window.py
+++ b/src/winforms/toga_winforms/window.py
@@ -1,5 +1,4 @@
 from toga import GROUP_BREAK, SECTION_BREAK
-from travertino.layout import Viewport
 
 from .libs import WinForms, Size
 
@@ -8,19 +7,27 @@ class WinFormsViewport:
     def __init__(self, native, frame):
         self.native = native
         self.frame = frame
+        self.baseline_dpi = 96
 
     @property
     def width(self):
+        # Treat `native=None` as a 0x0 viewport
+        if self.native is None:
+            return 0
         return self.native.ClientSize.Width
 
     @property
     def height(self):
+        if self.native is None:
+            return 0
         # Subtract any vertical shift of the frame. This is to allow
         # for toolbars, or any other viewport-level decoration.
         return self.native.ClientSize.Height - self.frame.vertical_shift
 
     @property
     def dpi(self):
+        if self.native is None:
+            return self.baseline_dpi
         return self.native.CreateGraphics().DpiX
 
 
@@ -106,7 +113,7 @@ class Window:
         self.interface.content._impl.rehint()
         self.interface.content.style.layout(
             self.interface.content,
-            Viewport(width=0, height=0, dpi=self.native.CreateGraphics().DpiX)
+            WinFormsViewport(native=None, frame=None),
         )
         self.native.MinimumSize = Size(
             int(self.interface.content.layout.width),


### PR DESCRIPTION
This allows us to give Android a `baseline_dpi` of 160.

I've also added one automated test to `test_pack.py`.

Screenshots:

macOS -- looks unchanged with my helloworld app

![image](https://user-images.githubusercontent.com/25457/83719401-dd7bd800-a5eb-11ea-880d-858325e57f8a.png)

Android **with this change** -- widgets are no longer too far off to the right

![image](https://user-images.githubusercontent.com/25457/83719431-e9679a00-a5eb-11ea-98d9-0713bce713b8.png)

Android **before this change** -- widgets are too far off to the right

![image](https://user-images.githubusercontent.com/25457/83719542-2764be00-a5ec-11ea-9eba-e943a82c70b8.png)

## Manual testing

I manually tested on Android, macOS, and iOS. I haven't manually tested the GTK or Winforms backends, but I think that's OK in this case. Happy to test there if it's important.

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
