### PR TITLE
View-based NSTableView

### DIFF
--- a/src/cocoa/toga_cocoa/widgets/internal/cells.py
+++ b/src/cocoa/toga_cocoa/widgets/internal/cells.py
@@ -64,64 +64,6 @@ class TogaIconView(NSTableCellView):
             self.textField.sizeToFit()
 
 
-class TogaIconCell(NSTextFieldCell):
-
-    @objc_method
-    def drawWithFrame_inView_(self, cellFrame: NSRect, view) -> None:
-        # The data to display.
-        try:
-            label = self.objectValue.attrs['label']
-            icon = self.objectValue.attrs['icon']
-        except AttributeError:
-            # Value is a simple string.
-            label = self.objectValue
-            icon = None
-
-        if icon and icon.native:
-            offset = 28.5
-
-            NSGraphicsContext.currentContext.saveGraphicsState()
-            yOffset = cellFrame.origin.y
-            if view.isFlipped:
-                xform = NSAffineTransform.transform()
-                xform.translateXBy(8, yBy=cellFrame.size.height)
-                xform.scaleXBy(1.0, yBy=-1.0)
-                xform.concat()
-                yOffset = 0.5 - cellFrame.origin.y
-
-            interpolation = NSGraphicsContext.currentContext.imageInterpolation
-            NSGraphicsContext.currentContext.imageInterpolation = NSImageInterpolationHigh
-
-            icon.native.drawInRect(
-                NSRect(NSPoint(cellFrame.origin.x, yOffset), NSSize(16.0, 16.0)),
-                fromRect=NSRect(NSPoint(0, 0), NSSize(icon.native.size.width, icon.native.size.height)),
-                operation=NSCompositingOperationSourceOver,
-                fraction=1.0
-            )
-
-            NSGraphicsContext.currentContext.imageInterpolation = interpolation
-            NSGraphicsContext.currentContext.restoreGraphicsState()
-        else:
-            # No icon; just the text label
-            offset = 5
-
-        if label:
-            # Find the right color for the text
-            if self.isHighlighted():
-                primaryColor = NSColor.alternateSelectedControlTextColor
-            else:
-                if False:
-                    primaryColor = NSColor.disabledControlTextColor
-                else:
-                    primaryColor = NSColor.textColor
-
-            textAttributes = NSMutableDictionary.alloc().init()
-            textAttributes[NSForegroundColorAttributeName] = primaryColor
-            textAttributes[NSFontAttributeName] = NSFont.systemFontOfSize(13)
-
-            at(label).drawInRect(cellFrame, withAttributes=textAttributes)
-
-
 # A TogaDetailedCell contains:
 # * an icon
 # * a main label

--- a/src/cocoa/toga_cocoa/widgets/table.py
+++ b/src/cocoa/toga_cocoa/widgets/table.py
@@ -26,7 +26,6 @@ class TogaTable(NSTableView):
 
     @objc_method
     def tableView_viewForTableColumn_row_(self, table, column, row: int):
-
         data_row = self.interface.data[row]
         col_identifier = str(column.identifier)
 
@@ -48,9 +47,13 @@ class TogaTable(NSTableView):
                 except AttributeError:
                     icon_iface = None
         except AttributeError:
-            # If the node doesn't have a property with the
-            # accessor name, assume an empty string value.
-            value = self.interface.missing_value
+            # The accessor doesn't exist in the data. Use the missing value.
+            try:
+                value = self.interface.missing_value
+            except ValueError as e:
+                # There is no explicit missing value. Warn the user.
+                message, value = e.args
+                print(message.format(row, col_identifier))
             icon_iface = None
 
         # If the value has an icon, get the _impl.
@@ -176,7 +179,7 @@ class Table(Widget):
 
         self.table.insertRowsAtIndexes(
             index_set,
-            withAnimation=NSTableViewAnimation.SlideDown
+            withAnimation=NSTableViewAnimation.EffectNone
         )
 
     def change(self, item):
@@ -201,7 +204,7 @@ class Table(Widget):
             indexes = NSIndexSet.indexSetWithIndex(index)
             self.table.removeRowsAtIndexes(
                 indexes,
-                withAnimation=NSTableViewAnimation.SlideUp
+                withAnimation=NSTableViewAnimation.EffectNone
             )
 
     def clear(self):

--- a/src/cocoa/toga_cocoa/widgets/table.py
+++ b/src/cocoa/toga_cocoa/widgets/table.py
@@ -154,10 +154,7 @@ class Table(Widget):
         # conversion from ObjC string to Python String, create the
         # ObjC string once and cache it.
         self.column_identifiers = {}
-        for i, (heading, accessor) in enumerate(zip(
-                    self.interface.headings,
-                    self.interface._accessors
-                )):
+        for heading, accessor in zip(self.interface.headings, self.interface._accessors):
             self._add_column(heading, accessor)
 
         self.table.delegate = self.table

--- a/src/cocoa/toga_cocoa/widgets/table.py
+++ b/src/cocoa/toga_cocoa/widgets/table.py
@@ -175,7 +175,7 @@ class Table(Widget):
 
         self.table.insertRowsAtIndexes(
             index_set,
-            withAnimation=NSTableViewAnimation.EffectNone
+            withAnimation=NSTableViewAnimation.SlideDown
         )
 
     def change(self, item):
@@ -200,7 +200,7 @@ class Table(Widget):
             indexes = NSIndexSet.indexSetWithIndex(index)
             self.table.removeRowsAtIndexes(
                 indexes,
-                withAnimation=NSTableViewAnimation.EffectNone
+                withAnimation=NSTableViewAnimation.SlideUp
             )
 
     def clear(self):

--- a/src/cocoa/toga_cocoa/widgets/table.py
+++ b/src/cocoa/toga_cocoa/widgets/table.py
@@ -107,6 +107,18 @@ class TogaTable(NSTableView):
         if self.interface.on_select:
             self.interface.on_select(self.interface, row=selected)
 
+    @objc_method
+    def tableView_heightOfRow_(self, table, row: int) -> float:
+
+        min_row_height = 18
+        margin = 2
+
+        # get all views in column
+        views = [self.tableView_viewForTableColumn_row_(table, col, row) for col in self.tableColumns]
+
+        max_widget_size = max(view.intrinsicContentSize().height + margin for view in views)
+        return max(min_row_height, max_widget_size)
+
 
 class Table(Widget):
     def create(self):

--- a/src/cocoa/toga_cocoa/widgets/table.py
+++ b/src/cocoa/toga_cocoa/widgets/table.py
@@ -47,7 +47,7 @@ class TogaTable(NSTableView):
         except AttributeError:
             # If the node doesn't have a property with the
             # accessor name, assume an empty string value.
-            value = ''
+            value = self.interface.missing_value
             icon_iface = None
 
         # If the value has an icon, get the _impl.

--- a/src/cocoa/toga_cocoa/widgets/table.py
+++ b/src/cocoa/toga_cocoa/widgets/table.py
@@ -13,7 +13,6 @@ from toga_cocoa.libs import (
 )
 from .base import Widget
 from .internal.cells import TogaIconView
-from .internal.data import TogaData
 
 
 class TogaTable(NSTableView):

--- a/src/cocoa/toga_cocoa/widgets/table.py
+++ b/src/cocoa/toga_cocoa/widgets/table.py
@@ -193,7 +193,8 @@ class Table(Widget):
             # We can't get the index from self.interface.data because the
             # row has already been removed. Instead we look up the index
             # from an associated view.
-            index = self.table.rowForView(self._view_for_row[item])
+            view = self._view_for_row.pop(item)
+            index = self.table.rowForView(view)
         except KeyError:
             pass
         else:
@@ -204,6 +205,7 @@ class Table(Widget):
             )
 
     def clear(self):
+        self._view_for_row.clear()
         self.table.reloadData()
 
     def set_on_select(self, handler):

--- a/src/cocoa/toga_cocoa/widgets/table.py
+++ b/src/cocoa/toga_cocoa/widgets/table.py
@@ -180,7 +180,7 @@ class Table(Widget):
         )
 
     def change(self, item):
-        row_index = self.interface.data.index(item)
+        row_index = self.table.rowForView(self._view_for_row[item])
         row_indexes = NSIndexSet.indexSetWithIndex(row_index)
         column_indexes = NSIndexSet.indexSetWithIndexesInRange(NSRange(0, len(self.columns)))
         self.table.reloadDataForRowIndexes(

--- a/src/cocoa/toga_cocoa/widgets/table.py
+++ b/src/cocoa/toga_cocoa/widgets/table.py
@@ -190,6 +190,9 @@ class Table(Widget):
 
     def remove(self, item):
         try:
+            # We can't get the index from self.interface.data because the
+            # row has already been removed. Instead we look up the index
+            # from an associated view.
             index = self.table.rowForView(self._view_for_row[item])
         except KeyError:
             pass

--- a/src/core/tests/widgets/test_table.py
+++ b/src/core/tests/widgets/test_table.py
@@ -114,7 +114,7 @@ class TableTests(TestCase):
         expecting_headings = self.headings + [new_heading]
         self.table.add_column(new_heading)
 
-        self.assertEqual(self.headings, expecting_headings)
+        self.assertEqual(self.table.headings, expecting_headings)
 
     def test_remove_column_by_accessor(self):
         remove = 'heading_2'

--- a/src/core/toga/sources/list_source.py
+++ b/src/core/toga/sources/list_source.py
@@ -30,7 +30,7 @@ class ListSource(Source):
     """
     def __init__(self, data, accessors):
         super().__init__()
-        self._accessors = accessors
+        self._accessors = accessors.copy()
         self._data = []
         for value in data:
             self._data.append(self._create_row(value))

--- a/src/core/toga/widgets/table.py
+++ b/src/core/toga/widgets/table.py
@@ -47,7 +47,7 @@ class Table(Widget):
                  multiple_select=False, on_select=None, missing_value=None,
                  factory=None):
         super().__init__(id=id, style=style, factory=factory)
-        self.headings = headings
+        self.headings = headings.copy()
         self._accessors = build_accessors(headings, accessors)
         self._multiple_select = multiple_select
         self._on_select = None

--- a/src/core/toga/widgets/table.py
+++ b/src/core/toga/widgets/table.py
@@ -47,8 +47,8 @@ class Table(Widget):
                  multiple_select=False, on_select=None, missing_value=None,
                  factory=None):
         super().__init__(id=id, style=style, factory=factory)
-        self.headings = headings.copy()
-        self._accessors = build_accessors(headings, accessors)
+        self.headings = headings[:]
+        self._accessors = build_accessors(self.headings, accessors)
         self._multiple_select = multiple_select
         self._on_select = None
         self._selection = None


### PR DESCRIPTION
Following PR #784, this PR migrates the `toga_cocoa.Table` from a cell-based to a view-based NSTableView. This has several advantages:

- Significant performance improvements, especially when resizing a window with a Table.
- Allows embedding of arbitrary widgets as table cells.
- Automatically adjusts the row height to its content.

Examples for embedding widgets are currently still missing since this feature is not yet cross-platform (see #841 for a discussion of Windows implementations).

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
