### PR TITLE
Correct packaging error.

### DIFF
--- a/nursery/curses/setup.cfg
+++ b/nursery/curses/setup.cfg
@@ -44,7 +44,9 @@ python_requires = >= 3.5
 zip_safe = False
 
 [options.packages.find]
-include = toga_curses.*
+include =
+    toga_curses
+    toga_curses.*
 
 [flake8]
 exclude=\

--- a/nursery/flask/setup.cfg
+++ b/nursery/flask/setup.cfg
@@ -43,7 +43,9 @@ python_requires = >= 3.5
 zip_safe = False
 
 [options.packages.find]
-include = toga_flask.*
+include =
+    toga_flask
+    toga_flask.*
 
 [flake8]
 exclude=\

--- a/nursery/pyramid/setup.cfg
+++ b/nursery/pyramid/setup.cfg
@@ -43,7 +43,9 @@ python_requires = >= 3.5
 zip_safe = False
 
 [options.packages.find]
-include = toga_pyramid.*
+include =
+    toga_pyramid
+    toga_pyramid.*
 
 [flake8]
 exclude=\

--- a/nursery/qt/setup.cfg
+++ b/nursery/qt/setup.cfg
@@ -43,7 +43,9 @@ python_requires = >= 3.5
 zip_safe = False
 
 [options.packages.find]
-include = toga_qt.*
+include =
+    toga_qt
+    toga_qt.*
 
 [flake8]
 exclude=\

--- a/nursery/tvOS/setup.cfg
+++ b/nursery/tvOS/setup.cfg
@@ -43,7 +43,9 @@ python_requires = >= 3.5
 zip_safe = False
 
 [options.packages.find]
-include = toga_tvOS.*
+include =
+    toga_tvOS
+    toga_tvOS.*
 
 [flake8]
 exclude=\

--- a/nursery/uwp/setup.cfg
+++ b/nursery/uwp/setup.cfg
@@ -44,7 +44,9 @@ python_requires = >= 3.5
 zip_safe = False
 
 [options.packages.find]
-include = toga_uwp.*
+include =
+    toga_uwp
+    toga_uwp.*
 
 [flake8]
 exclude=\

--- a/nursery/watchOS/setup.cfg
+++ b/nursery/watchOS/setup.cfg
@@ -42,7 +42,9 @@ python_requires = >= 3.5
 zip_safe = False
 
 [options.packages.find]
-include = toga_watchOS.*
+include =
+    toga_watchOS
+    toga_watchOS.*
 
 [flake8]
 exclude=\

--- a/nursery/web/setup.cfg
+++ b/nursery/web/setup.cfg
@@ -42,7 +42,9 @@ python_requires = >= 3.5
 zip_safe = False
 
 [options.packages.find]
-include = toga_web.*
+include =
+    toga_web
+    toga_web.*
 
 [flake8]
 exclude=\

--- a/src/android/setup.cfg
+++ b/src/android/setup.cfg
@@ -43,7 +43,9 @@ python_requires = >= 3.5
 zip_safe = False
 
 [options.packages.find]
-include = toga_android.*
+include =
+    toga_android
+    toga_android.*
 
 [flake8]
 exclude=\

--- a/src/cocoa/setup.cfg
+++ b/src/cocoa/setup.cfg
@@ -44,7 +44,9 @@ python_requires = >= 3.5
 zip_safe = False
 
 [options.packages.find]
-include = toga_cocoa.*
+include =
+    toga_cocoa
+    toga_cocoa.*
 
 [flake8]
 exclude=\

--- a/src/django/setup.cfg
+++ b/src/django/setup.cfg
@@ -43,7 +43,9 @@ python_requires = >= 3.5
 zip_safe = False
 
 [options.packages.find]
-include = toga_django.*
+include =
+    toga_django
+    toga_django.*
 
 [flake8]
 exclude=\

--- a/src/dummy/setup.cfg
+++ b/src/dummy/setup.cfg
@@ -42,7 +42,9 @@ python_requires = >= 3.5
 zip_safe = False
 
 [options.packages.find]
-include = toga_dummy.*
+include =
+    toga_dummy
+    toga_dummy.*
 
 [flake8]
 exclude=\

--- a/src/gtk/setup.cfg
+++ b/src/gtk/setup.cfg
@@ -44,7 +44,9 @@ python_requires = >= 3.5
 zip_safe = False
 
 [options.packages.find]
-include = toga_gtk.*
+include =
+    toga_gtk
+    toga_gtk.*
 
 [flake8]
 exclude=\

--- a/src/iOS/setup.cfg
+++ b/src/iOS/setup.cfg
@@ -43,7 +43,9 @@ python_requires = >= 3.5
 zip_safe = False
 
 [options.packages.find]
-include = toga_iOS.*
+include =
+    toga_iOS
+    toga_iOS.*
 
 [flake8]
 exclude=\

--- a/src/winforms/setup.cfg
+++ b/src/winforms/setup.cfg
@@ -44,7 +44,9 @@ python_requires = >= 3.5
 zip_safe = False
 
 [options.packages.find]
-include = toga_winforms.*
+include =
+    toga_winforms
+    toga_winforms.*
 
 [flake8]
 exclude=\


### PR DESCRIPTION
#943 changes the packaging metadata to be based on setup.cfg; however, due to having some stale wheels locally, I didn't notice that the root package contents of all the backends were not being included in the package.