### PR TITLE
coverage: line 162 of table.py - ValueError: accessor in use

### DIFF
--- a/src/core/tests/widgets/test_table.py
+++ b/src/core/tests/widgets/test_table.py
@@ -116,7 +116,7 @@ class TableTests(TestCase):
 
         self.assertEqual(self.table.headings, expecting_headings)
 
-    def test_add_columns_accessor_in_use(self): 
+    def test_add_columns_accessor_in_use(self):
 
         new_heading = 'Heading 4'
         accessor = 'heading_2'

--- a/src/core/tests/widgets/test_table.py
+++ b/src/core/tests/widgets/test_table.py
@@ -116,6 +116,14 @@ class TableTests(TestCase):
 
         self.assertEqual(self.table.headings, expecting_headings)
 
+    def test_add_columns_accessor_in_use(self): 
+
+        new_heading = 'Heading 4'
+        accessor = 'heading_2'
+
+        with self.assertRaises(ValueError):
+            self.table.add_column(new_heading, accessor)
+
     def test_remove_column_by_accessor(self):
         remove = 'heading_2'
         dummy_data = [


### PR DESCRIPTION
Create a test if the accessor is already in use.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [ x I will abide by the code of conduct
