### PR TITLE
Start the Android event loop, for the benefit of user code calling asyncio

### DIFF
--- a/src/android/setup.py
+++ b/src/android/setup.py
@@ -20,7 +20,7 @@ with open('toga_android/__init__.py', encoding='utf8') as version_file:
 setup(
     version=version,
     install_requires=[
-        'rubicon-java',
+        'rubicon-java>=0.2.2',
         'toga-core==%s' % version,
     ],
     test_suite='tests',

--- a/src/android/toga_android/app.py
+++ b/src/android/toga_android/app.py
@@ -1,3 +1,5 @@
+from rubicon.java import android_events
+
 from .libs.activity import IPythonApp, MainActivity
 from .window import Window
 
@@ -65,10 +67,13 @@ class App:
         print("Can't open document %s (yet)" % fileURL)
 
     def main_loop(self):
-        # Connect the Python code to the Java Activity.
+        # In order to support user asyncio code, start the Python/Android cooperative event loop.
+        loop = android_events.AndroidEventLoop()
+        loop.run_forever_cooperatively()
+
+        # On Android, Toga UI integrates automatically into the main Android event loop by virtue
+        # of the Android Activity system.
         self.create()
-        # The app loop is integrated with the main Android event loop,
-        # so there is no further work to do.
 
     def set_main_window(self, window):
         pass

--- a/src/android/toga_android/app.py
+++ b/src/android/toga_android/app.py
@@ -1,5 +1,7 @@
 from rubicon.java import android_events
 
+from toga.handlers import wrapped_handler
+
 from .libs.activity import IPythonApp, MainActivity
 from .window import Window
 
@@ -52,6 +54,8 @@ class App:
         self.interface._impl = self
         self._listener = None
 
+        self.loop = android_events.AndroidEventLoop()
+
     @property
     def native(self):
         return self._listener.native if self._listener else None
@@ -68,8 +72,7 @@ class App:
 
     def main_loop(self):
         # In order to support user asyncio code, start the Python/Android cooperative event loop.
-        loop = android_events.AndroidEventLoop()
-        loop.run_forever_cooperatively()
+        self.loop.run_forever_cooperatively()
 
         # On Android, Toga UI integrates automatically into the main Android event loop by virtue
         # of the Android Activity system.
@@ -85,4 +88,4 @@ class App:
         pass
 
     def add_background_task(self, handler):
-        self.interface.factory.not_implemented('App.add_background_task()')
+        self.loop.call_soon(wrapped_handler(self, handler), self)


### PR DESCRIPTION
Also bump `rubicon-java` dependency to as-yet-unreleased version containing that event loop.

See also https://github.com/beeware/rubicon-java/pull/49

I have **not** tested this, not even started it up! Once we release rubicon-java 0.2.2, I/you can test and fix if needed. I think it's OK, though. It's basically copy-pasta from my sample app. :)

## PR Checklist:
- [ ] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
