### PR TITLE
iOS supports dark mode

### DIFF
--- a/src/iOS/toga_iOS/widgets/box.py
+++ b/src/iOS/toga_iOS/widgets/box.py
@@ -25,7 +25,10 @@ class Box(Widget):
         self.add_constraints()
 
     def set_background_color(self, value):
-        if value is None:
-            self.native.backgroundColor = UIColor.whiteColor
-        else:
+        if value:
             self.native.backgroundColor = native_color(value)
+        else:
+            try:
+                self.native.backgroundColor = UIColor.systemBackgroundColor()  # iOS 13+
+            except AttributeError:
+                self.native.backgroundColor = UIColor.whiteColor


### PR DESCRIPTION
Signed-off-by: Isaiah Hewitt <isaiah@hewitts.us>

<!--- Describe your changes in detail -->
Added dark mode for iOS 13+.  For earlier versions without dark mode, the background color is white by default.
<!--- What problem does this change solve? -->
In dark mode, the background color defaults to black, and text defaults to white.
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
#856

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
