### PR TITLE
Migrate WebView -> WKWebView

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ Minimum requirements
 
 * Toga requires **Python 3**. Python 2 is not supported.
 
-* If you're on macOS, you need to be on 10.7 (Lion) or newer.
+* If you're on macOS, you need to be on 10.10 (Yosemite) or newer.
 
 * If you're on Linux, you need to have GTK+ 3.10 or later. This is the version
   that ships starting with Ubuntu 14.04 and Fedora 20. You also need to install

--- a/docs/reference/api/widgets/webview.rst
+++ b/docs/reference/api/widgets/webview.rst
@@ -11,7 +11,12 @@ WebView
 .. |y| image:: /_static/yes.png
     :width: 16
 
-The Web View widget is used for displaying an embedded browser window within an application
+The Web View widget is used for displaying an embedded browser window within an application.
+
+Both sites served by a web server and local content can be displayed. Due to security
+restrictions in the macOS backend WKWebView, local content on macOS can only be loaded
+from a single directory, relative to the base URL, and not from an absolute "file://" URL.
+As a workaround, it is possible to use a lightweight webserver instead.
 
 .. figure:: /reference/images/WebView.jpeg
     :align: center

--- a/docs/reference/platforms.rst
+++ b/docs/reference/platforms.rst
@@ -13,7 +13,7 @@ macOS
 
 .. image:: /reference/screenshots/cocoa.png
 
-The backend for macOS is named `toga-cocoa`_. It supports macOS 10.7 (Lion)
+The backend for macOS is named `toga-cocoa`_. It supports macOS 10.10 (Yosemite)
 and later. It is installed automatically on macOS machines (machines that
 report ``sys.platform == 'darwin'``), or can be manually installed by invoking::
 

--- a/src/cocoa/README.rst
+++ b/src/cocoa/README.rst
@@ -12,7 +12,7 @@ For more details, see the `Toga project on Github`_.
 Prerequisites
 ~~~~~~~~~~~~~
 
-This backend requires OS X 10.7 (Lion).
+This backend requires OS X 10.10 (Yosemite).
 
 Community
 ---------

--- a/src/cocoa/toga_cocoa/widgets/webview.py
+++ b/src/cocoa/toga_cocoa/widgets/webview.py
@@ -2,6 +2,7 @@ from travertino.size import at_least
 
 from toga_cocoa.keys import toga_key
 from toga_cocoa.libs import NSURL, NSURLRequest, WKWebView
+from rubicon.objc import objc_method
 
 from .base import Widget
 

--- a/src/cocoa/toga_cocoa/widgets/webview.py
+++ b/src/cocoa/toga_cocoa/widgets/webview.py
@@ -1,11 +1,11 @@
 from asyncio import get_event_loop
-from ctypes import c_void_p
 
 from travertino.size import at_least
 
 from toga_cocoa.keys import toga_key
 from toga_cocoa.libs import NSURL, NSURLRequest, WKWebView
-from rubicon.objc import objc_method
+from rubicon.objc import objc_method, py_from_ns
+from rubicon.objc.runtime import objc_id
 
 from .base import Widget
 
@@ -84,13 +84,14 @@ class WebView(Widget):
         loop = get_event_loop()
         future = loop.create_future()
 
-        def completion_handler(res: int, error: c_void_p) -> None:
+        def completion_handler(res: objc_id, error: objc_id) -> None:
 
             if error:
-                exc = RuntimeError('Error evaluating JavaScript: {}'.format(error))
+                error = py_from_ns(error)
+                exc = RuntimeError(str(error))
                 future.set_exception(exc)
             else:
-                future.set_result(res)
+                future.set_result(py_from_ns(res))
 
         self.native.evaluateJavaScript(javascript, completionHandler=completion_handler)
 

--- a/src/cocoa/toga_cocoa/widgets/webview.py
+++ b/src/cocoa/toga_cocoa/widgets/webview.py
@@ -1,14 +1,14 @@
 from travertino.size import at_least
 
 from toga_cocoa.keys import toga_key
-from toga_cocoa.libs import NSURL, NSURLRequest, WebView, objc_method
+from toga_cocoa.libs import NSURL, NSURLRequest, WKWebView
 
 from .base import Widget
 
 
-class TogaWebView(WebView):
+class TogaWebView(WKWebView):
     @objc_method
-    def webView_didFinishLoadForFrame_(self, sender, frame) -> None:
+    def webView_didFinish_navigation_(self, sender, wkNavigation) -> None:
         if self.interface.on_webview_load:
             self.interface.on_webview_load(self.interface)
 
@@ -57,14 +57,14 @@ class WebView(Widget):
     def set_url(self, value):
         if value:
             request = NSURLRequest.requestWithURL(NSURL.URLWithString(self.interface.url))
-            self.native.mainFrame.loadRequest(request)
+            self.native.loadRequest(request)
 
     def set_content(self, root_url, content):
-        self.native.mainFrame.loadHTMLString(content, baseURL=NSURL.URLWithString(root_url))
+        self.native.loadHTMLString(content, baseURL=NSURL.URLWithString(root_url))
 
     def set_user_agent(self, value):
         user_agent = value if value else "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/603.3.8 (KHTML, like Gecko) Version/10.1.2 Safari/603.3.8"  # NOQA
-        self.native.customUserAgent = user_agent
+        # self.native.customUserAgent = user_agent
 
     async def evaluate_javascript(self, javascript):
         """
@@ -75,7 +75,7 @@ class WebView(Widget):
         :param javascript: The javascript expression to evaluate
         :type  javascript: ``str``
         """
-        return self.native.stringByEvaluatingJavaScriptFromString(javascript)
+        return self.native.evaluateJavaScript(javascript, completionHandler=None)
 
     def invoke_javascript(self, javascript):
         """
@@ -83,7 +83,7 @@ class WebView(Widget):
 
         :param javascript: The javascript e
         """
-        self.native.stringByEvaluatingJavaScriptFromString(javascript)
+        self.native.evaluateJavaScript(javascript, completionHandler=None)
 
     def rehint(self):
         self.interface.intrinsic.width = at_least(self.interface.MIN_WIDTH)

--- a/src/cocoa/toga_cocoa/widgets/webview.py
+++ b/src/cocoa/toga_cocoa/widgets/webview.py
@@ -101,7 +101,7 @@ class WebView(Widget):
         """
         Invoke a block of javascript.
 
-        :param javascript: The javascript expression to evoke
+        :param javascript: The javascript expression to invoke
         """
         self.native.evaluateJavaScript(javascript, completionHandler=None)
 

--- a/src/core/README.rst
+++ b/src/core/README.rst
@@ -18,7 +18,7 @@ Prerequisites
 
 Toga has some minimum requirements:
 
-* If you're on OS X, you need to be on 10.7 (Lion) or newer.
+* If you're on OS X, you need to be on 10.10 (Yosemite) or newer.
 
 * If you're on Linux, you need to have GTK+ 3.4 or later. This is the version
   that ships starting with Ubuntu 12.04 and Fedora 17.


### PR DESCRIPTION
This PR migrates the WebView implementation in Cocoa from WebView (deprecated in macOS 10.10) to WKWebView.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
