### PR TITLE
Update headline in divider.rst

### DIFF
--- a/docs/reference/api/widgets/divider.rst
+++ b/docs/reference/api/widgets/divider.rst
@@ -1,4 +1,4 @@
-Canvas
+Divider
 ======
 
 .. rst-class:: widget-support

--- a/docs/reference/api/widgets/divider.rst
+++ b/docs/reference/api/widgets/divider.rst
@@ -1,5 +1,5 @@
 Divider
-======
+=======
 
 .. rst-class:: widget-support
 .. csv-filter::


### PR DESCRIPTION
Update the headline for the divider widget in the API Reference documentation in order to correctly identify the widget.