### PR TITLE
Remove "hide when stopped" functionality from ActivityIndicator

### DIFF
--- a/docs/reference/api/widgets/activityindicator.rst
+++ b/docs/reference/api/widgets/activityindicator.rst
@@ -25,9 +25,6 @@ Usage
     # make widget visible and start animation
     spinner.start()
 
-By default, the activity indicator is hidden when it is not running and will become visible when calling ``start``.
-This can be changed by setting the ``hide_when_stopped`` property to ``False`` on supported platforms.
-
 Reference
 ---------
 

--- a/src/cocoa/toga_cocoa/widgets/activityindicator.py
+++ b/src/cocoa/toga_cocoa/widgets/activityindicator.py
@@ -12,7 +12,7 @@ class ActivityIndicator(Widget):
         self.native = NSProgressIndicator.new()
         self.native.style = NSProgressIndicatorSpinningStyle
         self.native.translatesAutoresizingMaskIntoConstraints = False
-        self.native.displayedWhenStopped = not self.interface.hide_when_stopped
+        self.native.displayedWhenStopped = False
         self.native.usesThreadedAnimation = True
         self.native.indeterminate = True
         self.native.bezeled = False
@@ -21,9 +21,6 @@ class ActivityIndicator(Widget):
         # Add the layout constraints
         self.add_constraints()
         self.rehint()
-
-    def set_hide_when_stopped(self, value):
-        self.native.isDisplayedWhenStopped = not value
 
     def start(self):
         self.native.startAnimation(self.native)

--- a/src/core/tests/widgets/test_activityindicator.py
+++ b/src/core/tests/widgets/test_activityindicator.py
@@ -52,13 +52,3 @@ class ActivityIndicatorTests(TestCase):
 
         # Asserting is_running to be True
         self.assertTrue(self.activityindicator.is_running)
-
-    def test_hide_when_stopped(self):
-        # Default value is True
-        self.assertTrue(self.activityindicator.hide_when_stopped)
-
-        self.activityindicator.hide_when_stopped = False
-        self.assertFalse(self.activityindicator.hide_when_stopped)
-
-        # Asserting that hide_when_stopped value is in _sets
-        self.assertValueSet(self.activityindicator, 'hide_when_stopped', False)

--- a/src/core/toga/widgets/activityindicator.py
+++ b/src/core/toga/widgets/activityindicator.py
@@ -3,14 +3,14 @@ from .base import Widget
 
 class ActivityIndicator(Widget):
 
-    def __init__(self, id=None, style=None, running=False, hide_when_stopped=True, factory=None):
+    def __init__(self, id=None, style=None, running=False, factory=None):
         """
 
         Args:
             id (str):  An identifier for this widget.
             style (:obj:`Style`): An optional style object. If no style is provided then a
                 new one will be created for the widget.
-            running (bool):  Set the inital running mode. Defaults to False
+            running (bool):  Set the initial running mode. Defaults to False
             hide_when_stopped (bool):  Hide the indicator when not running. Defaults to
                 True.
             factory (:obj:`module`): A python module that is capable to return a
@@ -19,7 +19,6 @@ class ActivityIndicator(Widget):
         super().__init__(id=id, style=style, factory=factory)
 
         self._is_running = False
-        self._hide_when_stopped = hide_when_stopped
 
         self._impl = self.factory.ActivityIndicator(interface=self)
 
@@ -39,19 +38,9 @@ class ActivityIndicator(Widget):
         """
         return self._is_running
 
-    @property
-    def hide_when_stopped(self):
-        """Hide this activity indicator when stopped."""
-        return self._hide_when_stopped
-
-    @hide_when_stopped.setter
-    def hide_when_stopped(self, value):
-        self._hide_when_stopped = value
-        self._impl.set_hide_when_stopped(value)
-
     def start(self):
         """
-        Start this acivity indicator.
+        Start this activity indicator.
         """
         if not self.is_running:
             self._impl.start()
@@ -59,7 +48,7 @@ class ActivityIndicator(Widget):
 
     def stop(self):
         """
-        Stop this acivity indicator (if not already stopped).
+        Stop this activity indicator (if not already stopped).
         """
         if self.is_running:
             self._impl.stop()

--- a/src/dummy/toga_dummy/widgets/activityindicator.py
+++ b/src/dummy/toga_dummy/widgets/activityindicator.py
@@ -6,9 +6,6 @@ class ActivityIndicator(Widget):
     def create(self):
         self._action('create ActivityIndicator')
 
-    def set_hide_when_stopped(self, value):
-        self._set_value('hide_when_stopped', value)
-
     def start(self):
         self._action('start ActivityIndicator')
 

--- a/src/gtk/toga_gtk/widgets/activityindicator.py
+++ b/src/gtk/toga_gtk/widgets/activityindicator.py
@@ -8,9 +8,6 @@ class ActivityIndicator(Widget):
         self.native = Gtk.Spinner()
         self.native.interface = self.interface
 
-    def set_hide_when_stopped(self, value):
-        self.interface.factory.not_implemented('ActivityIndicator.set_hide_when_stopped()')
-
     def start(self):
         self.native.start()
 


### PR DESCRIPTION
As discussed in #975, this PR removes the "hide when stopped" property of the ActivityIndicator. The ActivityIndicator is now always hidden when not spinning. There are two reasons for this change:

* The functionality is rarely used. There is little benefit from showing an ActivityIndicator when not spinning.
* Some platforms such as Gtk don't support this natively.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
