### PR TITLE
Bug fix for Divider

### DIFF
--- a/src/core/toga/widgets/divider.py
+++ b/src/core/toga/widgets/divider.py
@@ -19,6 +19,8 @@ class Divider(Widget):
     def __init__(self, id=None, style=None, direction=HORIZONTAL, factory=None):
         super().__init__(id=id, style=style, factory=factory)
 
+        self._direction = direction
+
         # Create a platform specific implementation of a Divider
         self._impl = self.factory.Divider(interface=self)
         self.direction = direction


### PR DESCRIPTION
This PR fixes and issue when instantiating a Divider widget. This issue was introduced by #974 which calls `rehint` while applying a style. This is called when the implementation instance is created and causes an AttributeError because `toga_cocoa.Divider.rehint` accesses the `toga.Divider._direction` attribute of the interface before it has been set.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
