### PR TITLE
Tableview style improvements

### DIFF
--- a/src/cocoa/toga_cocoa/widgets/table.py
+++ b/src/cocoa/toga_cocoa/widgets/table.py
@@ -146,7 +146,7 @@ class Table(Widget):
         self.table.interface = self.interface
         self.table._impl = self
         self.table.columnAutoresizingStyle = NSTableViewColumnAutoresizingStyle.Uniform
-
+        self.table.usesAlternatingRowBackgroundColors = True
         self.table.allowsMultipleSelection = self.interface.multiple_select
 
         # Create columns for the table

--- a/src/cocoa/toga_cocoa/widgets/table.py
+++ b/src/cocoa/toga_cocoa/widgets/table.py
@@ -119,14 +119,14 @@ class TogaTable(NSTableView):
     @objc_method
     def tableView_heightOfRow_(self, table, row: int) -> float:
 
-        min_row_height = 18
+        min_row_height = self.rowHeight
         margin = 2
 
         # get all views in column
         views = [self.tableView_viewForTableColumn_row_(table, col, row) for col in self.tableColumns]
 
-        max_widget_size = max(view.intrinsicContentSize().height + margin for view in views)
-        return max(min_row_height, max_widget_size)
+        max_widget_height = max(view.intrinsicContentSize().height + margin for view in views)
+        return max(min_row_height, max_widget_height)
 
 
 class Table(Widget):

--- a/src/cocoa/toga_cocoa/widgets/tree.py
+++ b/src/cocoa/toga_cocoa/widgets/tree.py
@@ -118,16 +118,16 @@ class TogaTree(NSOutlineView):
     @objc_method
     def outlineView_heightOfRowByItem_(self, tree, item) -> float:
 
-        min_row_size = 18
+        min_row_height = self.rowHeight
 
         if item is self:
-            return min_row_size
+            return min_row_height
 
         # get all views in column
         views = [self.outlineView_viewForTableColumn_item_(tree, col, item) for col in self.tableColumns]
 
-        max_widget_size = max(view.intrinsicContentSize().height for view in views)
-        return max(min_row_size, max_widget_size)
+        max_widget_height = max(view.intrinsicContentSize().height for view in views)
+        return max(min_row_height, max_widget_height)
 
     # @objc_method
     # def outlineView_sortDescriptorsDidChange_(self, tableView, oldDescriptors) -> None:
@@ -195,7 +195,6 @@ class Tree(Widget):
         self.tree._impl = self
         self.tree.columnAutoresizingStyle = NSTableViewColumnAutoresizingStyle.Uniform
         self.tree.usesAlternatingRowBackgroundColors = True
-
         self.tree.allowsMultipleSelection = self.interface.multiple_select
 
         # Create columns for the tree


### PR DESCRIPTION
This PR improves the appearance of Table and Tree widgets in Cocoa. In particular:

* Minimum row heights are no longer hard-coded but taken from the platform default. This is also in preparation for macOS Big Sur where the NSOutlineView and NSTableView have a new `style` attribute to change their appearance, including the row height, depending on the context they are shown in.
* The Table widget now has alternating row colors.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
