### PR TITLE
Handle transparent background color in Cocoa

### DIFF
--- a/src/cocoa/toga_cocoa/widgets/base.py
+++ b/src/cocoa/toga_cocoa/widgets/base.py
@@ -1,4 +1,8 @@
+from travertino.constants import TRANSPARENT
+
 from toga_cocoa.constraints import Constraints
+from toga_cocoa.libs import NSColor
+from toga_cocoa.colors import native_color
 
 
 class Widget:
@@ -78,7 +82,13 @@ class Widget:
         pass
 
     def set_background_color(self, color):
-        pass
+        if color is None:
+            self.native.backgroundColor = NSColor.windowBackgroundColor
+        elif color is TRANSPARENT:
+            self.native.backgroundColor = NSColor.clearColor
+            self.native.drawsBackground = False
+        else:
+            self.native.backgroundColor = native_color(color)
 
     # INTERFACE
 

--- a/src/cocoa/toga_cocoa/widgets/base.py
+++ b/src/cocoa/toga_cocoa/widgets/base.py
@@ -84,11 +84,13 @@ class Widget:
     def set_background_color(self, color):
         if color is None:
             self.native.backgroundColor = NSColor.windowBackgroundColor
+            self.native.drawsBackground = True
         elif color is TRANSPARENT:
             self.native.backgroundColor = NSColor.clearColor
             self.native.drawsBackground = False
         else:
             self.native.backgroundColor = native_color(color)
+            self.native.drawsBackground = True
 
     # INTERFACE
 

--- a/src/cocoa/toga_cocoa/widgets/box.py
+++ b/src/cocoa/toga_cocoa/widgets/box.py
@@ -1,7 +1,6 @@
 from travertino.size import at_least
 
-from toga_cocoa.colors import native_color
-from toga_cocoa.libs import NSColor, NSView, objc_method
+from toga_cocoa.libs import NSView, objc_method
 
 from .base import Widget
 
@@ -25,12 +24,6 @@ class Box(Widget):
 
         # Add the layout constraints
         self.add_constraints()
-
-    def set_background_color(self, color):
-        if color is None:
-            self.native.backgroundColor = NSColor.windowBackgroundColor
-        else:
-            self.native.backgroundColor = native_color(color)
 
     def rehint(self):
         content_size = self.native.intrinsicContentSize()


### PR DESCRIPTION
As described in #976, setting the background color for a Box with the Cocoa backend raises AttributeError. This PR aims to fix this with the following changes:

* A TRANSPARENT background color is handled in the Cocoa backend by setting `self.native.drawsBackground = False`.
* The implementation of `set_background_color` is moved from the Box widget to the base Widget because all Cocoa Views have a background color attribute.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
