### PR TITLE
Fix defaulting to windowBackgroundColor

### DIFF
--- a/src/cocoa/toga_cocoa/colors.py
+++ b/src/cocoa/toga_cocoa/colors.py
@@ -4,6 +4,10 @@ CACHE = {}
 
 
 def native_color(c):
+
+    if not c:
+        return None
+
     try:
         color = CACHE[c]
     except KeyError:

--- a/src/cocoa/toga_cocoa/widgets/base.py
+++ b/src/cocoa/toga_cocoa/widgets/base.py
@@ -83,7 +83,7 @@ class Widget:
 
     def set_background_color(self, color):
         if color is None:
-            self.native.backgroundColor = NSColor.windowBackgroundColor
+            self.native.backgroundColor = None
             self.native.drawsBackground = True
         elif color is TRANSPARENT:
             self.native.backgroundColor = NSColor.clearColor

--- a/src/cocoa/toga_cocoa/widgets/base.py
+++ b/src/cocoa/toga_cocoa/widgets/base.py
@@ -82,10 +82,7 @@ class Widget:
         pass
 
     def set_background_color(self, color):
-        if color is None:
-            self.native.backgroundColor = None
-            self.native.drawsBackground = True
-        elif color is TRANSPARENT:
+        if color is TRANSPARENT:
             self.native.backgroundColor = NSColor.clearColor
             self.native.drawsBackground = False
         else:


### PR DESCRIPTION
This fixes an issue introduced by #1002 where the background color of all Cocoa views would default to `windowBackgroundColor`. This does not make sense for some widgets such as text fields (white background). The background color now defaults to `None` instead. As far as I can see, this gives the correct behaviour for all widgets. But maybe there are corner cases which I missed?

There is also a subtle difference in macOS Big Sur between explicitly setting the background color to `windowBackgroundColor` and not setting it at all. Not setting the background color gives a slightly brighter background which seems to be the default for built-in apps.

Apologies for not testing the previous PR sufficiently. 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
