### PR TITLE
Add Android font support

### DIFF
--- a/src/android/toga_android/factory.py
+++ b/src/android/toga_android/factory.py
@@ -1,4 +1,5 @@
 from .app import App, MainWindow
+from .fonts import Font
 from .icons import Icon
 from .images import Image
 from .paths import paths
@@ -24,6 +25,7 @@ __all__ = [
     "App",
     "Box",
     "Button",
+    "Font",
     "Icon",
     "Image",
     "ImageView",

--- a/src/android/toga_android/fonts.py
+++ b/src/android/toga_android/fonts.py
@@ -1,5 +1,7 @@
 from toga.fonts import (
     BOLD,
+    CURSIVE,
+    FANTASY,
     ITALIC,
     MONOSPACE,
     SANS_SERIF,
@@ -42,6 +44,13 @@ class Font:
             family = Typeface.SANS_SERIF
         elif self.interface.family is MONOSPACE:
             family = Typeface.MONOSPACE
+        elif self.interface.family is CURSIVE:
+            family = Typeface.create("cursive", Typeface.NORMAL)
+        elif self.interface.family is FANTASY:
+            # Android appears to not have a fantasy font available by default,
+            # but if it ever does, we'll start using it. Android seems to choose
+            # a serif font when asked for a fantasy font.
+            family = Typeface.create("fantasy", Typeface.NORMAL)
         else:
             family = Typeface.DEFAULT
 

--- a/src/android/toga_android/fonts.py
+++ b/src/android/toga_android/fonts.py
@@ -6,6 +6,7 @@ from toga.fonts import (
     MONOSPACE,
     SANS_SERIF,
     SERIF,
+    SYSTEM,
     SYSTEM_DEFAULT_FONT_SIZE,
 )
 
@@ -38,7 +39,9 @@ class Font:
         return Typeface.NORMAL
 
     def get_typeface(self):
-        if self.interface.family is SERIF:
+        if self.interface.family is SYSTEM:
+            family = Typeface.DEFAULT
+        elif self.interface.family is SERIF:
             family = Typeface.SERIF
         elif self.interface.family is SANS_SERIF:
             family = Typeface.SANS_SERIF
@@ -52,6 +55,6 @@ class Font:
             # a serif font when asked for a fantasy font.
             family = Typeface.create("fantasy", Typeface.NORMAL)
         else:
-            family = Typeface.DEFAULT
+            family = Typeface.create(self.interface.family, Typeface.NORMAL)
 
         return family

--- a/src/android/toga_android/fonts.py
+++ b/src/android/toga_android/fonts.py
@@ -1,0 +1,48 @@
+from toga.fonts import (
+    BOLD,
+    ITALIC,
+    MONOSPACE,
+    SANS_SERIF,
+    SERIF,
+    SYSTEM_DEFAULT_FONT_SIZE,
+)
+
+from .libs.android_widgets import (
+    Typeface,
+)
+
+
+class Font:
+    def __init__(self, interface):
+        self.interface = interface
+
+    def get_size(self):
+        # Default system font size on Android is 14sp (sp = dp, but is separately
+        # scalable in user settings). For what it's worth, Toga's default is 12pt.
+        if self.interface.size == SYSTEM_DEFAULT_FONT_SIZE:
+            font_size = 14
+        else:
+            font_size = self.interface.size
+        return float(font_size)
+
+    def get_style(self):
+        if self.interface.weight == BOLD:
+            if self.interface.style == ITALIC:
+                return Typeface.BOLD_ITALIC
+            else:
+                return Typeface.BOLD
+        if self.interface.style == ITALIC:
+            return Typeface.ITALIC
+        return Typeface.NORMAL
+
+    def get_typeface(self):
+        if self.interface.family is SERIF:
+            family = Typeface.SERIF
+        elif self.interface.family is SANS_SERIF:
+            family = Typeface.SANS_SERIF
+        elif self.interface.family is MONOSPACE:
+            family = Typeface.MONOSPACE
+        else:
+            family = Typeface.DEFAULT
+
+        return family

--- a/src/android/toga_android/libs/android_widgets.py
+++ b/src/android/toga_android/libs/android_widgets.py
@@ -23,6 +23,8 @@ Switch = JavaClass("android/widget/Switch")
 Spinner = JavaClass("android/widget/Spinner")
 TextView = JavaClass("android/widget/TextView")
 TextWatcher = JavaInterface("android/text/TextWatcher")
+TypedValue = JavaClass("android/util/TypedValue")
+Typeface = JavaClass("android/graphics/Typeface")
 ViewGroup__LayoutParams = JavaClass("android/view/ViewGroup$LayoutParams")
 View__MeasureSpec = JavaClass("android/view/View$MeasureSpec")
 

--- a/src/android/toga_android/widgets/base.py
+++ b/src/android/toga_android/widgets/base.py
@@ -14,6 +14,9 @@ class Widget:
         # can pass it as `context` when creating native Android widgets.
         self._native_activity = MainActivity.singletonThis
         self.create()
+        # Immediately re-apply styles. Some widgets may defer style application until
+        # they have been added to a container.
+        self.interface.style.reapply()
 
     def set_app(self, app):
         pass
@@ -61,6 +64,12 @@ class Widget:
     def set_background_color(self, color):
         # By default, background color can't be changed.
         pass
+
+    def set_alignment(self, alignment):
+        pass  # If appropriate, a widget subclass will implement this.
+
+    def set_color(self, color):
+        pass  # If appropriate, a widget subclass will implement this.
 
     # INTERFACE
 

--- a/src/android/toga_android/widgets/box.py
+++ b/src/android/toga_android/widgets/box.py
@@ -8,6 +8,9 @@ class Box(Widget):
         self.native = RelativeLayout(MainActivity.singletonThis)
 
     def set_child_bounds(self, widget, x, y, width, height):
+        # Avoid setting child boundaries if `create()` has not been called.
+        if not widget.native:
+            return
         # We assume `widget.native` has already been added to this `RelativeLayout`.
         #
         # We use `topMargin` and `leftMargin` to perform absolute layout. Not very

--- a/src/android/toga_android/widgets/label.py
+++ b/src/android/toga_android/widgets/label.py
@@ -12,13 +12,11 @@ class Label(Widget):
     def set_text(self, value):
         self.native.setText(value)
 
-    def set_font(self, value):
-        if not value:
-            return
-
-        value.bind(self.interface.factory)
-        self.native.setTextSize(TypedValue.COMPLEX_UNIT_SP, value._impl.get_size())
-        self.native.setTypeface(value._impl.get_typeface(), value._impl.get_style())
+    def set_font(self, font):
+        if font:
+            font_impl = font.bind(self.interface.factory)
+            self.native.setTextSize(TypedValue.COMPLEX_UNIT_SP, font_impl.get_size())
+            self.native.setTypeface(font_impl.get_typeface(), font_impl.get_style())
 
     def rehint(self):
         # Refuse to rehint an Android TextView if it has no LayoutParams yet.

--- a/src/android/toga_android/widgets/multilinetextinput.py
+++ b/src/android/toga_android/widgets/multilinetextinput.py
@@ -6,6 +6,7 @@ from ..libs.android_widgets import (
     EditText,
     Gravity,
     InputType,
+    TypedValue,
 )
 from .base import Widget, align
 
@@ -32,8 +33,11 @@ class MultilineTextInput(Widget):
     def set_alignment(self, value):
         self.native.setGravity(Gravity.TOP | align(value))
 
-    def set_font(self, value):
-        self.interface.factory.not_implemented("MutlineTextInput.set_font()")
+    def set_font(self, font):
+        if font:
+            font_impl = font.bind(self.interface.factory)
+            self.native.setTextSize(TypedValue.COMPLEX_UNIT_SP, font_impl.get_size())
+            self.native.setTypeface(font_impl.get_typeface(), font_impl.get_style())
 
     def set_value(self, value):
         self.native.setText(value)

--- a/src/android/toga_android/widgets/numberinput.py
+++ b/src/android/toga_android/widgets/numberinput.py
@@ -72,9 +72,10 @@ class NumberInput(Widget):
         self.native.setGravity(Gravity.CENTER_VERTICAL | align(value))
 
     def set_font(self, font):
-        font.bind(factory=self.interface.factory)
-        self.native.setTextSize(TypedValue.COMPLEX_UNIT_SP, font._impl.get_size())
-        self.native.setTypeface(font._impl.get_typeface(), font._impl.get_style())
+        if font:
+            font_impl = font.bind(self.interface.factory)
+            self.native.setTextSize(TypedValue.COMPLEX_UNIT_SP, font_impl.get_size())
+            self.native.setTypeface(font_impl.get_typeface(), font_impl.get_style())
 
     def set_value(self, value):
         # Store a string in the Android widget. The `afterTextChanged` method

--- a/src/android/toga_android/widgets/numberinput.py
+++ b/src/android/toga_android/widgets/numberinput.py
@@ -7,6 +7,7 @@ from ..libs.android_widgets import (
     Gravity,
     InputType,
     TextWatcher,
+    TypedValue,
     View__MeasureSpec
 )
 from .base import Widget, align
@@ -71,7 +72,9 @@ class NumberInput(Widget):
         self.native.setGravity(Gravity.CENTER_VERTICAL | align(value))
 
     def set_font(self, font):
-        self.interface.factory.not_implemented("NumberInput.set_font()")
+        font.bind(factory=self.interface.factory)
+        self.native.setTextSize(TypedValue.COMPLEX_UNIT_SP, font._impl.get_size())
+        self.native.setTypeface(font._impl.get_typeface(), font._impl.get_style())
 
     def set_value(self, value):
         # Store a string in the Android widget. The `afterTextChanged` method

--- a/src/android/toga_android/widgets/textinput.py
+++ b/src/android/toga_android/widgets/textinput.py
@@ -51,9 +51,10 @@ class TextInput(Widget):
         self.native.setGravity(Gravity.CENTER_VERTICAL | align(value))
 
     def set_font(self, font):
-        font.bind(factory=self.interface.factory)
-        self.native.setTextSize(TypedValue.COMPLEX_UNIT_SP, font._impl.get_size())
-        self.native.setTypeface(font._impl.get_typeface(), font._impl.get_style())
+        if font:
+            font_impl = font.bind(self.interface.factory)
+            self.native.setTextSize(TypedValue.COMPLEX_UNIT_SP, font_impl.get_size())
+            self.native.setTypeface(font_impl.get_typeface(), font_impl.get_style())
 
     def set_value(self, value):
         self.native.setText(value)

--- a/src/android/toga_android/widgets/textinput.py
+++ b/src/android/toga_android/widgets/textinput.py
@@ -4,7 +4,8 @@ from ..libs.android_widgets import (
     EditText,
     Gravity,
     TextWatcher,
-    View__MeasureSpec
+    TypedValue,
+    View__MeasureSpec,
 )
 from .base import Widget, align
 
@@ -42,10 +43,17 @@ class TextInput(Widget):
         self.native.setHint(value if value is not None else "")
 
     def set_alignment(self, value):
+        # Refuse to set alignment unless widget has been added to a container.
+        # This is because Android EditText requires LayoutParams before
+        # setGravity() can be called.
+        if self.native.getLayoutParams() is None:
+            return
         self.native.setGravity(Gravity.CENTER_VERTICAL | align(value))
 
     def set_font(self, font):
-        self.interface.factory.not_implemented("TextInput.set_font()")
+        font.bind(factory=self.interface.factory)
+        self.native.setTextSize(TypedValue.COMPLEX_UNIT_SP, font._impl.get_size())
+        self.native.setTypeface(font._impl.get_typeface(), font._impl.get_style())
 
     def set_value(self, value):
         self.native.setText(value)
@@ -56,6 +64,11 @@ class TextInput(Widget):
 
     def rehint(self):
         self.interface.intrinsic.width = at_least(self.interface.MIN_WIDTH)
+        # Refuse to call measure() if widget has no container, i.e., has no LayoutParams.
+        # On Android, EditText's measure() throws NullPointerException if the widget has no
+        # LayoutParams.
+        if self.native.getLayoutParams() is None:
+            return
         self.native.measure(
             View__MeasureSpec.UNSPECIFIED, View__MeasureSpec.UNSPECIFIED
         )


### PR DESCRIPTION
Add Android font support for text widgets (Label, NumberInput, TextInput) including bold & italic & font size.

This does not add fantasy or cursive support. Those are a smidge more complicated, and I'd prefer to add those in a separate pull request.

Screenshot of TravelTips now:

![image](https://user-images.githubusercontent.com/25457/88757729-8db51b00-d11b-11ea-8baf-e1f7acb6b7e5.png)

Feedback welcome.

## Implementation choices

Sometimes, calls to Android `measure()` will throw `NullPointerException`. For some widgets, they need `LayoutParams` (which are only added in Toga when a widget gets added to a container) before `measure()` can be called. This does an explicit check for `None` in those cases, which does the job fine, so I propose we roll with it.

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
