### PR TITLE
Fixes #690 -- corrects the scroll direction on Cocoa DetailedList.

### DIFF
--- a/src/cocoa/toga_cocoa/widgets/internal/refresh.py
+++ b/src/cocoa/toga_cocoa/widgets/internal/refresh.py
@@ -49,10 +49,6 @@ class RefreshableClipView(NSClipView):
         return constrained
 
     @objc_method
-    def isFlipped(self):
-        return True
-
-    @objc_method
     def documentRect(self) -> NSRect:
         rect = send_super(__class__, self, 'documentRect', restype=NSRect, argtypes=[])
 


### PR DESCRIPTION
The scroll direction on DetailedList on Cocoa was the opposite to what it should be.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
