### PR TITLE
Correct after_on_refresh handling for iOS.

### DIFF
--- a/src/iOS/toga_iOS/app.py
+++ b/src/iOS/toga_iOS/app.py
@@ -112,7 +112,24 @@ class App:
         # Main loop is a no-op on iOS; the app loop is integrated with the
         # main iOS event loop.
 
-        self.loop.run_forever(lifecycle=iOSLifecycle())
+        # The rest of this method will eventually be wrapped into
+        # rubicon as the method `run_forever_cooperatively()`.
+        # self.loop.run_forever_cooperatively(lifecycle=iOSLifecycle())
+        # ==== start run_forever_cooperatively()
+        self.loop._set_lifecycle(iOSLifecycle())
+
+        if self.loop.is_running():
+            raise RuntimeError(
+                "Recursively calling run_forever is forbidden. "
+                "To recursively run the event loop, call run().")
+
+        self.loop._running = True
+        from asyncio import events
+        if hasattr(events, "_set_running_loop"):
+            events._set_running_loop(self.loop)
+
+        self.loop._lifecycle.start()
+        # ==== end run_forever_cooperatively()
 
     def set_main_window(self, window):
         pass

--- a/src/iOS/toga_iOS/widgets/detailedlist.py
+++ b/src/iOS/toga_iOS/widgets/detailedlist.py
@@ -101,8 +101,8 @@ class DetailedList(Widget):
             self.controller.refreshControl = None
 
     def after_on_refresh(self):
-        self.refreshControl.endRefreshing()
-        self.tableView.reloadData()
+        self.controller.refreshControl.endRefreshing()
+        self.controller.tableView.reloadData()
 
     def change_source(self, source):
         self.native.reloadData()


### PR DESCRIPTION
Refresh handling on iOS incorrectly referred to the UIRefeshControl, so the refresh control would never disappear.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
