### PR TITLE
Fix TypeError when no on_select callback is specified

### DIFF
--- a/src/winforms/toga_winforms/widgets/table.py
+++ b/src/winforms/toga_winforms/widgets/table.py
@@ -71,7 +71,7 @@ class Table(Widget):
         self.interface._selection = self._selected_rows()
 
         if e.IsSelected and self.interface.on_select:
-                self.interface.on_select(self.interface, row=self.interface.data[e.ItemIndex])
+            self.interface.on_select(self.interface, row=self.interface.data[e.ItemIndex])
 
     def _selected_rows(self):
         if not self.native.SelectedIndices.Count:

--- a/src/winforms/toga_winforms/widgets/table.py
+++ b/src/winforms/toga_winforms/widgets/table.py
@@ -70,8 +70,8 @@ class Table(Widget):
         # update selection interface property
         self.interface._selection = self._selected_rows()
 
-        if e.IsSelected:
-            self.interface.on_select(self.interface, row=self.interface.data[e.ItemIndex])
+        if e.IsSelected and self.interface.on_select:
+                self.interface.on_select(self.interface, row=self.interface.data[e.ItemIndex])
 
     def _selected_rows(self):
         if not self.native.SelectedIndices.Count:


### PR DESCRIPTION
Signed-off-by: Olga <obulat@gmail.com>

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Fixes #994.
Added a check for interface `on_select` callback before calling winforms `on_select`.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
