### PR TITLE
Rename winforms event handler functions for consistency

### DIFF
--- a/src/winforms/toga_winforms/widgets/canvas.py
+++ b/src/winforms/toga_winforms/widgets/canvas.py
@@ -296,7 +296,7 @@ class Canvas(Box):
 
     def measure_text(self, text, font, tight=False):
         sizes = [
-            WinForms.TextRenderer.MeasureText(line, font._impl.native)
+            WinForms.TextRenderer.MeasureText(line, font.bind(self.interface.factory).native)
             for line in text.splitlines()
         ]
         width = max([size.Width for size in sizes])

--- a/src/winforms/toga_winforms/widgets/canvas.py
+++ b/src/winforms/toga_winforms/widgets/canvas.py
@@ -59,9 +59,9 @@ class Canvas(Box):
         self.native.DoubleBuffered = True
         self.native.Paint += self.winforms_paint
         self.native.Resize += self.winforms_resize
-        self.native.MouseDown += self.winforms_mouse_press
-        self.native.MouseMove += self.winforms_mouse_drag
-        self.native.MouseUp += self.winforms_mouse_release
+        self.native.MouseDown += self.winforms_mouse_down
+        self.native.MouseMove += self.winforms_mouse_move
+        self.native.MouseUp += self.winforms_mouse_up
         self.clicks = 0
 
     def set_on_resize(self, handler):
@@ -99,7 +99,7 @@ class Canvas(Box):
         if self.interface.on_resize:
             self.interface.on_resize(self.interface)
 
-    def winforms_mouse_press(self, obj, mouse_event):
+    def winforms_mouse_down(self, obj, mouse_event):
         self.clicks = mouse_event.Clicks
         if mouse_event.Button == WinForms.MouseButtons.Left and self.interface.on_press:
             self.interface.on_press(
@@ -110,7 +110,7 @@ class Canvas(Box):
                 self.interface, mouse_event.X, mouse_event.Y, mouse_event.Clicks
             )
 
-    def winforms_mouse_drag(self, obj, mouse_event):
+    def winforms_mouse_move(self, obj, mouse_event):
         if self.clicks == 0:
             return
         if mouse_event.Button == WinForms.MouseButtons.Left and self.interface.on_drag:
@@ -122,7 +122,7 @@ class Canvas(Box):
                 self.interface, mouse_event.X, mouse_event.Y, self.clicks
             )
 
-    def winforms_mouse_release(self, obj, mouse_event):
+    def winforms_mouse_up(self, obj, mouse_event):
         if mouse_event.Button == WinForms.MouseButtons.Left and self.interface.on_release:
             self.interface.on_release(
                 self.interface, mouse_event.X, mouse_event.Y, self.clicks
@@ -296,7 +296,7 @@ class Canvas(Box):
 
     def measure_text(self, text, font, tight=False):
         sizes = [
-            WinForms.TextRenderer.MeasureText(line, font.bind(self.interface.factory).native)
+            WinForms.TextRenderer.MeasureText(line, font._impl.native)
             for line in text.splitlines()
         ]
         width = max([size.Width for size in sizes])

--- a/src/winforms/toga_winforms/widgets/numberinput.py
+++ b/src/winforms/toga_winforms/widgets/numberinput.py
@@ -11,9 +11,9 @@ class NumberInput(Widget):
     def create(self):
         self.native = WinForms.NumericUpDown()
         self.native.Value = Convert.ToDecimal(0.0)
-        self.native.ValueChanged += self.winforms_number_change
+        self.native.ValueChanged += self.winforms_value_changed
 
-    def winforms_number_change(self, sender, event):
+    def winforms_value_changed(self, sender, event):
         if self.container:
             self.interface.value = Convert.ToString(sender.Value)
             if self.interface.on_change:

--- a/src/winforms/toga_winforms/widgets/optioncontainer.py
+++ b/src/winforms/toga_winforms/widgets/optioncontainer.py
@@ -7,7 +7,7 @@ from .base import Widget
 class OptionContainer(Widget):
     def create(self):
         self.native = WinForms.TabControl()
-        self.native.Selected += self.winforms_Selected
+        self.native.Selected += self.winforms_selected
 
     def add_content(self, label, widget):
         widget.viewport = WinFormsViewport(self.native, self)
@@ -50,6 +50,6 @@ class OptionContainer(Widget):
     def get_option_label(self, index):
         return self.native.TabPages[index].Text
 
-    def winforms_Selected(self, sender, event):
+    def winforms_selected(self, sender, event):
         if self.interface.on_select:
-            self.interface.on_press(self.interface)
+            self.interface.on_select(self.interface)

--- a/src/winforms/toga_winforms/widgets/selection.py
+++ b/src/winforms/toga_winforms/widgets/selection.py
@@ -10,9 +10,9 @@ class TogaComboBox(WinForms.ComboBox):
         super().__init__()
         self.interface = interface
         self.DropDownStyle = WinForms.ComboBoxStyle.DropDownList
-        self.SelectedIndexChanged += self.on_select
+        self.SelectedIndexChanged += self.winforms_selected_index_changed
 
-    def on_select(self, sender, event):
+    def winforms_selected_index_changed(self, sender, event):
         if self.interface.on_select:
             self.interface.on_select(self.interface)
 

--- a/src/winforms/toga_winforms/widgets/splitcontainer.py
+++ b/src/winforms/toga_winforms/widgets/splitcontainer.py
@@ -8,8 +8,8 @@ class SplitContainer(Widget):
     def create(self):
         self.native = WinForms.SplitContainer()
         self.native.interface = self.interface
-        self.native.Resize += self.winforms_splitter_moved
-        self.native.SplitterMoved += self.winforms_splitter_moved
+        self.native.Resize += self.winforms_resize
+        self.native.SplitterMoved += self.winforms_resize
         self.ratio = None
 
     def add_content(self, position, widget):
@@ -44,7 +44,7 @@ class SplitContainer(Widget):
         self.native.Orientation = WinForms.Orientation.Vertical if value \
             else WinForms.Orientation.Horizontal
 
-    def winforms_splitter_moved(self, sender, args):
+    def winforms_resize(self, sender, args):
         if self.interface.content:
             # Re-layout the content
             for content in self.interface.content:

--- a/src/winforms/toga_winforms/widgets/table.py
+++ b/src/winforms/toga_winforms/widgets/table.py
@@ -26,12 +26,12 @@ class Table(Widget):
         self.native.VirtualMode = True
         self.native.Columns.AddRange(dataColumn)
 
-        self.native.ItemSelectionChanged += self._native_item_selection_changed
-        self.native.RetrieveVirtualItem += self._native_retrieve_virtual_item
-        self.native.CacheVirtualItems += self._native_cache_virtual_items
-        self.native.VirtualItemsSelectionRangeChanged += self._native_virtual_item_selection_range_changed
+        self.native.ItemSelectionChanged += self.winforms_item_selection_changed
+        self.native.RetrieveVirtualItem += self.winforms_retrieve_virtual_item
+        self.native.CacheVirtualItems += self.winforms_cache_virtual_items
+        self.native.VirtualItemsSelectionRangeChanged += self.winforms_virtual_item_selection_range_changed
 
-    def _native_virtual_item_selection_range_changed(self, sender, e):
+    def winforms_virtual_item_selection_range_changed(self, sender, e):
         # update selection interface property
         self.interface._selection = self._selected_rows()
 
@@ -41,7 +41,7 @@ class Table(Widget):
             selected = self.interface.data[e.EndIndex]
             self.interface.on_select(self.interface, row=selected)
 
-    def _native_retrieve_virtual_item(self, sender, e):
+    def winforms_retrieve_virtual_item(self, sender, e):
         # Because ListView is in VirtualMode, it's necessary implement
         # VirtualItemsSelectionRangeChanged event to create ListViewItem when it's needed
         if self._cache and e.ItemIndex >= self._first_item and \
@@ -50,9 +50,9 @@ class Table(Widget):
         else:
             e.Item = WinForms.ListViewItem(self.row_data(self.interface.data[e.ItemIndex]))
 
-    def _native_cache_virtual_items(self, sender, e):
+    def winforms_cache_virtual_items(self, sender, e):
         if self._cache and e.StartIndex >= self._first_item and \
-           e.EndIndex <= self._first_item + len(self._cache):
+                e.EndIndex <= self._first_item + len(self._cache):
             # If the newly requested cache is a subset of the old cache,
             # no need to rebuild everything, so do nothing
             return
@@ -66,7 +66,7 @@ class Table(Widget):
         for i in range(new_length):
             self._cache.append(WinForms.ListViewItem(self.row_data(self.interface.data[i])))
 
-    def _native_item_selection_changed(self, sender, e):
+    def winforms_item_selection_changed(self, sender, e):
         # update selection interface property
         self.interface._selection = self._selected_rows()
 

--- a/src/winforms/toga_winforms/widgets/textinput.py
+++ b/src/winforms/toga_winforms/widgets/textinput.py
@@ -12,8 +12,8 @@ class TextInput(Widget):
     def create(self):
         self.native = WinForms.TextBox()
         self.native.Multiline = False
-        self.native.Click += self.winforms_Click
-        self.native.TextChanged += self.winforms_onTextChanged
+        self.native.Click += self.winforms_click
+        self.native.TextChanged += self.winforms_text_changed
 
     def set_readonly(self, value):
         self.native.ReadOnly = value
@@ -52,9 +52,9 @@ class TextInput(Widget):
     def set_on_change(self, handler):
         pass
 
-    def winforms_onTextChanged(self, sender, event):
+    def winforms_text_changed(self, sender, event):
         if self.interface._on_change:
             self.interface.on_change(self.interface)
 
-    def winforms_Click(self, sender, event):
+    def winforms_click(self, sender, event):
         self.native.SelectAll()


### PR DESCRIPTION
Signed-off-by: Olga <obulat@gmail.com>

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
This PR improves consistency in naming winforms event handler functions. All handlers are now named as `winforms_<native_event_name>`. For example the handler of `toga.TextInput`'s native `TextChanged` event is called `winforms_text_changed`.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
