### PR TITLE
Fix crash in Android button

### DIFF
--- a/src/android/toga_android/widgets/button.py
+++ b/src/android/toga_android/widgets/button.py
@@ -33,6 +33,10 @@ class Button(Widget):
         pass
 
     def rehint(self):
+        # Like other text-viewing widgets, Android crashes when rendering
+        # `Button` unless it has its layout params set. Guard for that case.
+        if self.native.getLayoutParams() is None:
+            return
         self.native.measure(
             android_widgets.View__MeasureSpec.UNSPECIFIED,
             android_widgets.View__MeasureSpec.UNSPECIFIED,


### PR DESCRIPTION
Android's `Button` is a `TextView` subclass. This pull request gives its `rehint()` method the same treatment as toga `Label` (i.e., android `TextView`).

The recent font work (#1005) fiddled with layout under Toga's Android backend, which is why this is only needed now.

Happy to discuss more!

## PR Checklist:
- [x] All new features have been tested -- yes -- I can repro the crash with `tutorial3` and validate that this fixes the crash
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
