### PR TITLE
TextInput select_all on double click instead of click

### DIFF
--- a/src/winforms/toga_winforms/widgets/textinput.py
+++ b/src/winforms/toga_winforms/widgets/textinput.py
@@ -12,7 +12,7 @@ class TextInput(Widget):
     def create(self):
         self.native = WinForms.TextBox()
         self.native.Multiline = False
-        self.native.Click += self.winforms_click
+        self.native.DoubleClick += self.winforms_select_all_text
         self.native.TextChanged += self.winforms_text_changed
 
     def set_readonly(self, value):
@@ -56,5 +56,5 @@ class TextInput(Widget):
         if self.interface._on_change:
             self.interface.on_change(self.interface)
 
-    def winforms_click(self, sender, event):
+    def winforms_select_all_text(self, sender, event):
         self.native.SelectAll()

--- a/src/winforms/toga_winforms/widgets/textinput.py
+++ b/src/winforms/toga_winforms/widgets/textinput.py
@@ -12,7 +12,7 @@ class TextInput(Widget):
     def create(self):
         self.native = WinForms.TextBox()
         self.native.Multiline = False
-        self.native.DoubleClick += self.winforms_select_all_text
+        self.native.DoubleClick += self.winforms_double_click
         self.native.TextChanged += self.winforms_text_changed
 
     def set_readonly(self, value):
@@ -56,5 +56,5 @@ class TextInput(Widget):
         if self.interface._on_change:
             self.interface.on_change(self.interface)
 
-    def winforms_select_all_text(self, sender, event):
+    def winforms_double_click(self, sender, event):
         self.native.SelectAll()


### PR DESCRIPTION
When using TextInput widget in windows, every click selects all text. This should be happening only when clicking twice. Changed that.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
