### PR TITLE
Add labels toml

### DIFF
--- a/.github/labels.toml
+++ b/.github/labels.toml
@@ -1,47 +1,47 @@
 [GSoC]
 color = "fbca04"
 name = "GSoC"
-#description = null  # To use: uncomment and replace null with value
+description = "Tickets describing GSoC projects"
 
 [bug]
 color = "fc2929"
 name = "bug"
-#description = null  # To use: uncomment and replace null with value
+description = "Something isn't working"
+
+[documentation]
+color = "8125dd"
+name = "documentation"
+description = "The issue relates to documentation."
 
 [duplicate]
 color = "cccccc"
 name = "duplicate"
-#description = null  # To use: uncomment and replace null with value
+description = "This issue or pull request already exists"
 
 [enhancement]
 color = "84b6eb"
 name = "enhancement"
-#description = null  # To use: uncomment and replace null with value
+description = "New feature or request"
 
 [first-timers-only]
 color = "f9d0c4"
 name = "first-timers-only"
-#description = null  # To use: uncomment and replace null with value
+description = "Is this your first time contributing? This could be a good place to start!"
 
 [invalid]
 color = "e6e6e6"
 name = "invalid"
-#description = null  # To use: uncomment and replace null with value
+description = "This doesn't seem right"
 
 [not-quite-right]
 color = "d4c5f9"
 name = "not-quite-right"
-#description = null  # To use: uncomment and replace null with value
-
-[on-hold]
-color = "e08fc2"
-name = "on-hold"
-description = ""
+description = "The idea or PR has been reviewed, but more work is needed."
 
 [question]
 color = "cc317c"
 name = "question"
-#description = null  # To use: uncomment and replace null with value
+description = "Further information is requested"
 
 [ready-for-review]
 color = "006b75"
@@ -61,14 +61,44 @@ description = ""
 [up-for-grabs]
 color = "0e8a16"
 name = "up-for-grabs"
-#description = null  # To use: uncomment and replace null with value
+description = "Help wanted!"
 
 [wontfix]
 color = "ffffff"
 name = "wontfix"
-#description = null  # To use: uncomment and replace null with value
+description = "This will not be worked on"
 
 [work-in-progress]
 color = "fef2c0"
 name = "work-in-progress"
-#description = null  # To use: uncomment and replace null with value
+description = "The PR is a work in progress"
+
+[android]
+color = "25d4dd"
+name = "android"
+description = "The issue relates to Android mobile support."
+
+[iOS]
+color = "25d4dd"
+name = "iOS"
+description = "The issue relates to Apple iOS mobile support."
+
+[linux]
+color = "25d4dd"
+name = "linux"
+description = "The issue relates Linux support."
+
+[macOS]
+color = "25d4dd"
+name = "macOS"
+description = "The issue relates to Apple macOS support."
+
+[web]
+color = "25d4dd"
+name = "web"
+description = "The issue relates to supporting the web as a platform."
+
+[windows]
+color = "25d4dd"
+name = "windows"
+description = "The issue relates to Microsoft Windows support."

--- a/.github/labels.toml
+++ b/.github/labels.toml
@@ -1,0 +1,74 @@
+[GSoC]
+color = "fbca04"
+name = "GSoC"
+#description = null  # To use: uncomment and replace null with value
+
+[bug]
+color = "fc2929"
+name = "bug"
+#description = null  # To use: uncomment and replace null with value
+
+[duplicate]
+color = "cccccc"
+name = "duplicate"
+#description = null  # To use: uncomment and replace null with value
+
+[enhancement]
+color = "84b6eb"
+name = "enhancement"
+#description = null  # To use: uncomment and replace null with value
+
+[first-timers-only]
+color = "f9d0c4"
+name = "first-timers-only"
+#description = null  # To use: uncomment and replace null with value
+
+[invalid]
+color = "e6e6e6"
+name = "invalid"
+#description = null  # To use: uncomment and replace null with value
+
+[not-quite-right]
+color = "d4c5f9"
+name = "not-quite-right"
+#description = null  # To use: uncomment and replace null with value
+
+[on-hold]
+color = "e08fc2"
+name = "on-hold"
+description = ""
+
+[question]
+color = "cc317c"
+name = "question"
+#description = null  # To use: uncomment and replace null with value
+
+[ready-for-review]
+color = "006b75"
+name = "ready-for-review"
+#description = null  # To use: uncomment and replace null with value
+
+[rebase-required]
+color = "888888"
+name = "rebase-required"
+#description = null  # To use: uncomment and replace null with value
+
+[tutorial-bugs]
+color = "bfdadc"
+name = "tutorial-bugs"
+description = ""
+
+[up-for-grabs]
+color = "0e8a16"
+name = "up-for-grabs"
+#description = null  # To use: uncomment and replace null with value
+
+[wontfix]
+color = "ffffff"
+name = "wontfix"
+#description = null  # To use: uncomment and replace null with value
+
+[work-in-progress]
+color = "fef2c0"
+name = "work-in-progress"
+#description = null  # To use: uncomment and replace null with value

--- a/.github/labels.toml
+++ b/.github/labels.toml
@@ -58,6 +58,11 @@ color = "f975e6"
 name = "not-quite-right"
 description = "The idea or PR has been reviewed, but more work is needed."
 
+[more-details]
+color = "f975e6"
+name = "more-details"
+description = "More details are needed before the question can be answered."
+
 [question]
 color = "cc317c"
 name = "question"

--- a/.github/labels.toml
+++ b/.github/labels.toml
@@ -1,12 +1,17 @@
 [GSoC]
-color = "fbca04"
+color = "fef2c0"
 name = "GSoC"
 description = "Tickets describing GSoC projects"
 
+[android]
+color = "25d4dd"
+name = "android"
+description = "The issue relates to Android mobile support."
+
 [bug]
-color = "fc2929"
+color = "dd2525"
 name = "bug"
-description = "Something isn't working"
+description = "A confirmed crash or error in behavior."
 
 [documentation]
 color = "8125dd"
@@ -14,74 +19,29 @@ name = "documentation"
 description = "The issue relates to documentation."
 
 [duplicate]
-color = "cccccc"
+color = "333333"
 name = "duplicate"
-description = "This issue or pull request already exists"
+description = "A duplicate of an existing ticket."
 
 [enhancement]
-color = "84b6eb"
+color = "2525dd"
 name = "enhancement"
-description = "New feature or request"
+description = "New features, or improvements on existing features."
 
 [first-timers-only]
-color = "f9d0c4"
+color = "25dd25"
 name = "first-timers-only"
 description = "Is this your first time contributing? This could be a good place to start!"
-
-[invalid]
-color = "e6e6e6"
-name = "invalid"
-description = "This doesn't seem right"
-
-[not-quite-right]
-color = "d4c5f9"
-name = "not-quite-right"
-description = "The idea or PR has been reviewed, but more work is needed."
-
-[question]
-color = "cc317c"
-name = "question"
-description = "Further information is requested"
-
-[ready-for-review]
-color = "006b75"
-name = "ready-for-review"
-#description = null  # To use: uncomment and replace null with value
-
-[rebase-required]
-color = "888888"
-name = "rebase-required"
-#description = null  # To use: uncomment and replace null with value
-
-[tutorial-bugs]
-color = "bfdadc"
-name = "tutorial-bugs"
-description = ""
-
-[up-for-grabs]
-color = "0e8a16"
-name = "up-for-grabs"
-description = "Help wanted!"
-
-[wontfix]
-color = "ffffff"
-name = "wontfix"
-description = "This will not be worked on"
-
-[work-in-progress]
-color = "fef2c0"
-name = "work-in-progress"
-description = "The PR is a work in progress"
-
-[android]
-color = "25d4dd"
-name = "android"
-description = "The issue relates to Android mobile support."
 
 [iOS]
 color = "25d4dd"
 name = "iOS"
 description = "The issue relates to Apple iOS mobile support."
+
+[invalid]
+color = "333333"
+name = "invalid"
+description = "The issue is mistaken or incorrect in some way."
 
 [linux]
 color = "25d4dd"
@@ -93,6 +53,21 @@ color = "25d4dd"
 name = "macOS"
 description = "The issue relates to Apple macOS support."
 
+[not-quite-right]
+color = "f975e6"
+name = "not-quite-right"
+description = "The idea or PR has been reviewed, but more work is needed."
+
+[question]
+color = "cc317c"
+name = "question"
+description = "Requests for information."
+
+[up-for-grabs]
+color = "25dd25"
+name = "up-for-grabs"
+description = "Help wanted!"
+
 [web]
 color = "25d4dd"
 name = "web"
@@ -102,3 +77,13 @@ description = "The issue relates to supporting the web as a platform."
 color = "25d4dd"
 name = "windows"
 description = "The issue relates to Microsoft Windows support."
+
+[wontfix]
+color = "333333"
+name = "wontfix"
+description = "The problem described is real, but we've decided against fixing it."
+
+[work-in-progress]
+color = "f975e6"
+name = "work-in-progress"
+description = "The PR is a work in progress"

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ src/gtk/cairo
 pip-selfcheck.json
 pyvenv.cfg
 .vscode
+.envrc
 bin/
 lib/
 


### PR DESCRIPTION
This PR adds a *labels.toml* file. This file can be used to sync the Github labels of the *Toga* project, making it easy to add, edit, and delete labels. look [here](https://raphael.codes/blog/announcing-python-3.6-cli-labels/) for for details.

It is worth noting that I kept the color-coding of existing labels as they were but used the new labels colors taken from the *Briefcase* project for unification purposes. In the future, it is worth changing all the colors to be the same in both projects.

Once this PR will be approved and merged, I will run the `labels sync` command in order to sync the labels with the repository.

## Edit
After a little bit of thought, simply copied the *labels.toml* file from *Briefcase*. If any changes are needed, let me know.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
