### PR TITLE
Toga icon cell improvements

### DIFF
--- a/src/cocoa/toga_cocoa/libs/appkit.py
+++ b/src/cocoa/toga_cocoa/libs/appkit.py
@@ -501,6 +501,7 @@ class NSLineBreakMode(Enum):
     byTruncatingTail = 4
     byTruncatingMiddle = 5
 
+
 ######################################################################
 # NSPanel.h
 

--- a/src/cocoa/toga_cocoa/libs/appkit.py
+++ b/src/cocoa/toga_cocoa/libs/appkit.py
@@ -490,6 +490,18 @@ NSOpenPanel = ObjCClass('NSOpenPanel')
 NSOutlineView = ObjCClass('NSOutlineView')
 
 ######################################################################
+# NSParagraphStyle.h
+
+
+class NSLineBreakMode(Enum):
+    byWordWrapping = 0
+    byCharWrapping = 1
+    byClipping = 2
+    byTruncatingHead = 3
+    byTruncatingTail = 4
+    byTruncatingMiddle = 5
+
+######################################################################
 # NSPanel.h
 
 NSUtilityWindowMask = 1 << 4

--- a/src/cocoa/toga_cocoa/widgets/internal/cells.py
+++ b/src/cocoa/toga_cocoa/widgets/internal/cells.py
@@ -57,20 +57,40 @@ class TogaIconView(NSTableCellView):
         self.addSubview(self.imageView)
         self.addSubview(self.textField)
 
-        self.iv_vertical_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(
-                self.imageView, NSLayoutAttributeCenterY, NSLayoutRelationEqual, self, NSLayoutAttributeCenterY, 1, 0
+        # center icon vertically in cell
+        self.iv_vertical_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # NOQA:E501
+            self.imageView, NSLayoutAttributeCenterY,
+            NSLayoutRelationEqual,
+            self, NSLayoutAttributeCenterY,
+            1, 0
             )
-        self.iv_left_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(
-                self.imageView, NSLayoutAttributeLeft, NSLayoutRelationEqual, self, NSLayoutAttributeLeft, 1, 0
+        # align left edge of icon with left edge of cell
+        self.iv_left_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # NOQA:E501
+            self.imageView, NSLayoutAttributeLeft,
+            NSLayoutRelationEqual,
+            self, NSLayoutAttributeLeft,
+            1, 0
         )
-        self.tv_vertical_constraint =NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(
-                self.textField, NSLayoutAttributeCenterY, NSLayoutRelationEqual, self, NSLayoutAttributeCenterY, 1, 0
+        # align text vertically in cell
+        self.tv_vertical_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # NOQA:E501
+            self.textField, NSLayoutAttributeCenterY,
+            NSLayoutRelationEqual,
+            self, NSLayoutAttributeCenterY,
+            1, 0,
         )
-        self.tv_left_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(
-                self.textField, NSLayoutAttributeLeft, NSLayoutRelationEqual, self.imageView, NSLayoutAttributeRight, 1, 5
+        # align left edge of text with right edge of icon
+        self.tv_left_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # NOQA:E501
+            self.textField, NSLayoutAttributeLeft,
+            NSLayoutRelationEqual,
+            self.imageView, NSLayoutAttributeRight,
+            1, 5  # 5 pixels padding between icon and text
         )
-        self.tv_right_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(
-                self.textField, NSLayoutAttributeRight, NSLayoutRelationEqual, self, NSLayoutAttributeRight, 1, -5
+        # align right edge of text with right edge of cell
+        self.tv_right_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # NOQA:E501
+            self.textField, NSLayoutAttributeRight,
+            NSLayoutRelationEqual,
+            self, NSLayoutAttributeRight,
+            1, -5
         )
 
         self.addConstraint(self.iv_vertical_constraint)

--- a/src/cocoa/toga_cocoa/widgets/table.py
+++ b/src/cocoa/toga_cocoa/widgets/table.py
@@ -2,7 +2,6 @@ from travertino.size import at_least
 
 import toga
 from toga_cocoa.libs import (
-    CGRectMake,
     NSBezelBorder,
     NSIndexSet,
     NSRange,

--- a/src/cocoa/toga_cocoa/widgets/table.py
+++ b/src/cocoa/toga_cocoa/widgets/table.py
@@ -71,7 +71,7 @@ class TogaTable(NSTableView):
         tcv = self.makeViewWithIdentifier(identifier, owner=self)
 
         if not tcv:  # there is no existing view to reuse so create a new one
-            tcv = TogaIconView.alloc().initWithFrame_(CGRectMake(0, 0, column.width, 16))
+            tcv = TogaIconView.alloc().init()
             tcv.identifier = identifier
 
         tcv.setText(str(value))

--- a/src/cocoa/toga_cocoa/widgets/table.py
+++ b/src/cocoa/toga_cocoa/widgets/table.py
@@ -176,7 +176,7 @@ class Table(Widget):
 
         self.table.insertRowsAtIndexes(
             index_set,
-            withAnimation=NSTableViewAnimation.SlideDown
+            withAnimation=NSTableViewAnimation.EffectNone
         )
 
     def change(self, item):
@@ -201,7 +201,7 @@ class Table(Widget):
             indexes = NSIndexSet.indexSetWithIndex(index)
             self.table.removeRowsAtIndexes(
                 indexes,
-                withAnimation=NSTableViewAnimation.SlideUp
+                withAnimation=NSTableViewAnimation.EffectNone
             )
 
     def clear(self):


### PR DESCRIPTION
This PR improves the layout of the `TogaIconCell` which is used to display content in Table and Tree widgets. Specifically:

* The layout of subviews is now handled with constraints instead of an autoresizing mask. As a result, the `NSTextField` subview will now be resized properly when the column width changes.
* Set the line break mode of the `NSTextField`  to truncating the tail. Together with the above change, this means that the text is now properly truncated when the user resizes a column.
* Remove the animations when adding or removing rows. @freakboy3742, I have come to agree with you that they become really annoying when rapidly adding many rows.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
