### PR TITLE
Table row double click action

### DIFF
--- a/examples/tree_source/tree_source/app.py
+++ b/examples/tree_source/tree_source/app.py
@@ -1,3 +1,6 @@
+import os
+import subprocess
+import platform
 from datetime import datetime
 from pathlib import Path
 
@@ -120,6 +123,16 @@ class ExampleTreeSourceApp(toga.App):
         else:
             self.label.text = 'You selected {0} items'.format(files)
 
+    def double_click_handler(self, widget, node):
+        # open the file or folder in the platform's default app
+        print('clicked ', node)
+        if platform.system() == 'Darwin':
+            subprocess.call(('open', node.path))
+        elif platform.system() == 'Windows':
+            os.startfile(node.path)
+        else:
+            subprocess.call(('xdg-open', node.path))
+
     def startup(self):
         # Set up main window
         self.main_window = toga.MainWindow(title=self.name)
@@ -132,6 +145,7 @@ class ExampleTreeSourceApp(toga.App):
             style=Pack(flex=1),
             multiple_select=True,
             on_select=self.selection_handler,
+            on_double_click=self.double_click_handler
         )
         self.label = toga.Label('A view of the current directory!', style=Pack(padding=10))
 

--- a/examples/tree_source/tree_source/app.py
+++ b/examples/tree_source/tree_source/app.py
@@ -125,7 +125,7 @@ class ExampleTreeSourceApp(toga.App):
 
     def double_click_handler(self, widget, node):
         # open the file or folder in the platform's default app
-        print('clicked ', node)
+        self.label.text = 'You started {0}'.format(node.path)
         if platform.system() == 'Darwin':
             subprocess.call(('open', node.path))
         elif platform.system() == 'Windows':

--- a/src/cocoa/toga_cocoa/widgets/table.py
+++ b/src/cocoa/toga_cocoa/widgets/table.py
@@ -85,6 +85,11 @@ class TogaTable(NSTableView):
 
         return tcv
 
+    @objc_method
+    def tableView_pasteboardWriterForRow_(self, table, row) -> None:
+        # this seems to be required to prevent issue 21562075 in AppKit
+        return None
+
     # TableDelegate methods
     @objc_method
     def selectionShouldChangeInTableView_(self, table) -> bool:
@@ -128,6 +133,7 @@ class TogaTable(NSTableView):
         max_widget_height = max(view.intrinsicContentSize().height + margin for view in views)
         return max(min_row_height, max_widget_height)
 
+    # target methods
     @objc_method
     def onDoubleClick_(self, sender) -> None:
         if self.clickedRow == -1:

--- a/src/cocoa/toga_cocoa/widgets/table.py
+++ b/src/cocoa/toga_cocoa/widgets/table.py
@@ -11,7 +11,8 @@ from toga_cocoa.libs import (
     NSTableViewAnimation,
     NSTableViewColumnAutoresizingStyle,
     at,
-    objc_method
+    objc_method,
+    SEL
 )
 
 from .base import Widget
@@ -127,6 +128,16 @@ class TogaTable(NSTableView):
         max_widget_height = max(view.intrinsicContentSize().height + margin for view in views)
         return max(min_row_height, max_widget_height)
 
+    @objc_method
+    def onDoubleClick_(self, sender) -> None:
+        if self.clickedRow == -1:
+            clicked = None
+        else:
+            clicked = self.interface.data[self.clickedRow]
+
+        if self.interface.on_double_click:
+            self.interface.on_double_click(self.interface, row=clicked)
+
 
 class Table(Widget):
     def create(self):
@@ -159,6 +170,8 @@ class Table(Widget):
 
         self.table.delegate = self.table
         self.table.dataSource = self.table
+        self.table.target = self.table
+        self.table.doubleAction = SEL('onDoubleClick:')
 
         # Embed the table view in the scroll view
         self.native.documentView = self.table
@@ -208,6 +221,9 @@ class Table(Widget):
         self.table.reloadData()
 
     def set_on_select(self, handler):
+        pass
+
+    def set_on_double_click(self, handler):
         pass
 
     def scroll_to_row(self, row):

--- a/src/cocoa/toga_cocoa/widgets/tree.py
+++ b/src/cocoa/toga_cocoa/widgets/tree.py
@@ -14,7 +14,8 @@ from toga_cocoa.libs import (  # NSSortDescriptor,
     NSTableViewColumnAutoresizingStyle,
     at,
     objc_method,
-    send_super
+    send_super,
+    SEL
 )
 from toga_cocoa.widgets.base import Widget
 from toga_cocoa.widgets.internal.cells import TogaIconView
@@ -129,6 +130,11 @@ class TogaTree(NSOutlineView):
         max_widget_height = max(view.intrinsicContentSize().height for view in views)
         return max(min_row_height, max_widget_height)
 
+    @objc_method
+    def outlineView_pasteboardWriterForItem_(self, tree, item) -> None:
+        # this seems to be required to prevent issue 21562075 in AppKit
+        return None
+
     # @objc_method
     # def outlineView_sortDescriptorsDidChange_(self, tableView, oldDescriptors) -> None:
     #
@@ -150,7 +156,7 @@ class TogaTree(NSOutlineView):
             if self.interface.multiple_select:
                 self.selectAll(self)
         else:
-            # forawrd call to super
+            # forward call to super
             send_super(__class__, self, 'keyDown:', event)
 
     # OutlineViewDelegate methods
@@ -177,6 +183,17 @@ class TogaTree(NSOutlineView):
 
         if self.interface.on_select:
             self.interface.on_select(self.interface, node=selected)
+
+    # target methods
+    @objc_method
+    def onDoubleClick_(self, sender) -> None:
+        if self.clickedRow == -1:
+            node = None
+        else:
+            node = self.itemAtRow(self.clickedRow).attrs['node']
+
+        if self.interface.on_select:
+            self.interface.on_double_click(self.interface, node=node)
 
 
 class Tree(Widget):
@@ -223,6 +240,8 @@ class Tree(Widget):
 
         self.tree.delegate = self.tree
         self.tree.dataSource = self.tree
+        self.tree.target = self.tree
+        self.tree.doubleAction = SEL('onDoubleClick:')
 
         # Embed the tree view in the scroll view
         self.native.documentView = self.tree
@@ -272,6 +291,9 @@ class Tree(Widget):
         self.tree.reloadData()
 
     def set_on_select(self, handler):
+        pass
+
+    def set_on_double_click(self, handler):
         pass
 
     def rehint(self):

--- a/src/core/tests/widgets/test_table.py
+++ b/src/core/tests/widgets/test_table.py
@@ -17,11 +17,16 @@ class TableTests(TestCase):
         def select_handler(widget, row):
             pass
 
+        def double_click_handler(widget, row):
+            pass
+
         self.on_select = select_handler
+        self.on_double_click = double_click_handler
 
         self.table = toga.Table(
             self.headings,
             on_select=self.on_select,
+            on_double_click=self.on_double_click,
             factory=toga_dummy.factory
         )
 
@@ -94,12 +99,26 @@ class TableTests(TestCase):
 
         self.assertValueSet(self.table, "on_select", self.table.on_select)
 
-        on_sele = self.table.on_select
-        self.assertEqual(on_sele._raw, self.on_select)
+        on_select = self.table.on_select
+        self.assertEqual(on_select._raw, self.on_select)
 
         self.table.on_select = dummy_handler
-        on_sele = self.table.on_select
-        self.assertEqual(on_sele._raw, dummy_handler)
+        on_select = self.table.on_select
+        self.assertEqual(on_select._raw, dummy_handler)
+
+    def test_on_double_click(self):
+
+        def dummy_handler(widget, row):
+            pass
+
+        self.assertValueSet(self.table, "on_double_click", self.table.on_double_click)
+
+        on_double_click = self.table.on_double_click
+        self.assertEqual(on_double_click._raw, self.on_double_click)
+
+        self.table.on_double_click = dummy_handler
+        on_double_click = self.table.on_double_click
+        self.assertEqual(on_double_click._raw, dummy_handler)
 
     def test_add_column(self):
         new_heading = 'Heading 4'

--- a/src/core/toga/widgets/table.py
+++ b/src/core/toga/widgets/table.py
@@ -17,6 +17,8 @@ class Table(Widget):
         style (:obj:`Style`): An optional style object.
             If no style is provided` then a new one will be created for the widget.
         on_select (``callable``): A function to be invoked on selecting a row of the table.
+        on_double_click (``callable``): A function to be invoked on double clicking a row of
+            the table.
         missing_value (``str`` or ``None``): value for replacing a missing value
             in the data source. (Default: None). When 'None', a warning message
             will be shown.
@@ -44,13 +46,14 @@ class Table(Widget):
     MIN_HEIGHT = 100
 
     def __init__(self, headings, id=None, style=None, data=None, accessors=None,
-                 multiple_select=False, on_select=None, missing_value=None,
-                 factory=None):
+                 multiple_select=False, on_select=None, on_double_click=None,
+                 missing_value=None, factory=None):
         super().__init__(id=id, style=style, factory=factory)
         self.headings = headings[:]
         self._accessors = build_accessors(self.headings, accessors)
         self._multiple_select = multiple_select
         self._on_select = None
+        self._on_double_click = None
         self._selection = None
         self._data = None
         if missing_value is None:
@@ -62,6 +65,7 @@ class Table(Widget):
         self.data = data
 
         self.on_select = on_select
+        self.on_double_click = on_double_click
 
     @property
     def data(self):
@@ -126,8 +130,8 @@ class Table(Widget):
     @property
     def on_select(self):
         """ The callback function that is invoked when a row of the table is selected.
-        The provided callback function has to accept two arguments table (``:obj:Table`)
-        and row (``int`` or ``None``).
+        The provided callback function has to accept two arguments table (:obj:`Table`)
+        and row (``Row`` or ``None``).
 
         Returns:
             (``callable``) The callback function.
@@ -144,6 +148,28 @@ class Table(Widget):
         """
         self._on_select = wrapped_handler(self, handler)
         self._impl.set_on_select(self._on_select)
+
+    @property
+    def on_double_click(self):
+        """ The callback function that is invoked when a row of the table is double clicked.
+        The provided callback function has to accept two arguments table (:obj:`Table`)
+        and row (``Row`` or ``None``).
+
+        Returns:
+            (``callable``) The callback function.
+        """
+        return self._on_double_click
+
+    @on_double_click.setter
+    def on_double_click(self, handler):
+        """
+        Set the function to be executed on node double click
+
+        :param handler: callback function
+        :type handler: ``callable``
+        """
+        self._on_double_click = wrapped_handler(self, handler)
+        self._impl.set_on_double_click(self._on_double_click)
 
     def add_column(self, heading, accessor=None):
         """

--- a/src/core/toga/widgets/tree.py
+++ b/src/core/toga/widgets/tree.py
@@ -31,6 +31,7 @@ class Tree(Widget):
         multiple rows. Defaults to ``False``.
     :param on_select: A handler to be invoked when the user selects one or
         multiple rows.
+    :param on_double_click: A handler to be invoked when the user double clicks a row.
     :param factory:: A python module that is capable to return a implementation
         of this class with the same name. (optional; used only for testing)
     """
@@ -38,7 +39,7 @@ class Tree(Widget):
     MIN_HEIGHT = 100
 
     def __init__(self, headings, id=None, style=None, data=None, accessors=None,
-                 multiple_select=False, on_select=None, factory=None):
+                 multiple_select=False, on_select=None, on_double_click=None, factory=None):
         super().__init__(id=id, style=style, factory=factory)
         self.headings = headings
         self._accessors = build_accessors(headings, accessors)
@@ -46,11 +47,13 @@ class Tree(Widget):
         self._selection = None
         self._data = None
         self._on_select = None
+        self._on_double_click = None
 
         self._impl = self.factory.Tree(interface=self)
         self.data = data
 
         self.on_select = on_select
+        self.on_double_click = on_double_click
 
     @property
     def data(self):
@@ -96,7 +99,9 @@ class Tree(Widget):
     @property
     def on_select(self):
         """
-        The callable function for when a node on the Tree is selected
+        The callable function for when a node on the Tree is selected. The provided
+        callback function has to accept two arguments tree (:obj:`Tree`) and node
+        (``Node`` or ``None``).
 
         :rtype: ``callable``
         """
@@ -112,3 +117,25 @@ class Tree(Widget):
         """
         self._on_select = wrapped_handler(self, handler)
         self._impl.set_on_select(self._on_select)
+
+    @property
+    def on_double_click(self):
+        """
+        The callable function for when a node on the Tree is selected. The provided
+        callback function has to accept two arguments tree (:obj:`Tree`) and node
+        (``Node`` or ``None``).
+
+        :rtype: ``callable``
+        """
+        return self._on_double_click
+
+    @on_double_click.setter
+    def on_double_click(self, handler):
+        """
+        Set the function to be executed on node double click
+
+        :param handler:     callback function
+        :type handler:      ``callable``
+        """
+        self._on_double_click = wrapped_handler(self, handler)
+        self._impl.set_on_double_click(self._on_double_click)

--- a/src/dummy/toga_dummy/widgets/table.py
+++ b/src/dummy/toga_dummy/widgets/table.py
@@ -23,6 +23,9 @@ class Table(Widget):
     def set_on_select(self, handler):
         self._set_value('on_select', handler)
 
+    def set_on_double_click(self, handler):
+        self._set_value('on_double_click', handler)
+
     def scroll_to_row(self, row):
         self._set_value('scroll to', row)
 

--- a/src/dummy/toga_dummy/widgets/tree.py
+++ b/src/dummy/toga_dummy/widgets/tree.py
@@ -22,3 +22,6 @@ class Tree(Widget):
 
     def set_on_select(self, handler):
         self._set_value('on_select', handler)
+
+    def set_on_double_click(self, handler):
+        self._set_value('on_double_click', handler)

--- a/src/gtk/toga_gtk/widgets/table.py
+++ b/src/gtk/toga_gtk/widgets/table.py
@@ -55,3 +55,6 @@ class Table(Tree):
 
     def set_on_select(self, handler):
         super().set_on_select(handler)
+
+    def set_on_double_click(self, handler):
+        self.interface.factory.not_implemented('Table.set_on_double_click()')

--- a/src/gtk/toga_gtk/widgets/tree.py
+++ b/src/gtk/toga_gtk/widgets/tree.py
@@ -91,5 +91,8 @@ class Tree(Widget):
         # No special handling required
         pass
 
+    def set_on_double_click(self, handler):
+        self.interface.factory.not_implemented('Tree.set_on_double_click()')
+
     def scroll_to_node(self, node):
         raise NotImplementedError

--- a/src/winforms/toga_winforms/widgets/table.py
+++ b/src/winforms/toga_winforms/widgets/table.py
@@ -126,6 +126,9 @@ class Table(Widget):
     def set_on_select(self, handler):
         pass
 
+    def set_on_double_click(self, handler):
+        self.interface.factory.not_implemented('Table.set_on_double_click()')
+
     def scroll_to_row(self, row):
         self.native.EnsureVisible(row)
 

--- a/src/winforms/toga_winforms/widgets/tree.py
+++ b/src/winforms/toga_winforms/widgets/tree.py
@@ -31,5 +31,8 @@ class Tree(Widget):
     def set_on_select(self, handler):
         self.interface.factory.not_implemented('Tree.set_on_select()')
 
+    def set_on_double_click(self, handler):
+        self.interface.factory.not_implemented('Table.set_on_double_click()')
+
     def scroll_to_node(self, node):
         self.interface.factory.not_implemented('Tree.scroll_to_node()')


### PR DESCRIPTION
Added a handler `on_double_click` to Tree and Table widgets to handle when a user double-clicks a row or node. This has multiple use cases, for instance to "open" a clicked item if it represents a file or folder, or to open a window with detailed information on the represented item. This PR only includes an implementation for the Cocoa backend.

In addition, the `tree_source` example, which demonstrates how to implement a file browser with a Tree widget, now responds to double-clicking a node with opening the file or folder in the platform's default app.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
