### PR TITLE
Performance improvements to `toga_cocoa.Table` and `toga_cocoa.Tree`

### DIFF
--- a/src/cocoa/toga_cocoa/widgets/internal/cells.py
+++ b/src/cocoa/toga_cocoa/widgets/internal/cells.py
@@ -1,5 +1,4 @@
 from toga_cocoa.libs import (
-    CGRect,
     NSAffineTransform,
     NSBezierPath,
     NSColor,
@@ -20,27 +19,17 @@ from toga_cocoa.libs import (
     NSLayoutAttributeLeft,
     NSLayoutAttributeRight,
     NSLayoutAttributeCenterY,
+    NSLayoutAttributeWidth,
+    NSLayoutAttributeNotAnAttribute,
     NSLayoutConstraint,
     NSLayoutRelationEqual,
     NSLineBreakMode,
-    ObjCInstance,
     at,
     objc_method,
-    send_super
 )
 
 
 class TogaIconView(NSTableCellView):
-
-    @objc_method
-    def initWithFrame_(self, frame: CGRect):
-        self = ObjCInstance(send_super(__class__, self, 'initWithFrame:', frame))
-        return self.setup()
-
-    @objc_method
-    def init(self):
-        self = ObjCInstance(send_super(__class__, self, 'init'))
-        return self.setup()
 
     @objc_method
     def setup(self):
@@ -99,10 +88,12 @@ class TogaIconView(NSTableCellView):
         self.addConstraint(self.tv_left_constraint)
         self.addConstraint(self.tv_right_constraint)
 
-        return self
-
     @objc_method
-    def setImage(self, image):
+    def setImage_(self, image):
+
+        if not self.imageView:
+            self.setup()
+
         if image:
             self.imageView.image = image.resizeTo(16)
             # add padding between icon and text
@@ -113,7 +104,11 @@ class TogaIconView(NSTableCellView):
             self.tv_left_constraint.constant = 0
 
     @objc_method
-    def setText(self, text):
+    def setText_(self, text):
+
+        if not self.imageView:
+            self.setup()
+
         self.textField.stringValue = text
 
 

--- a/src/cocoa/toga_cocoa/widgets/internal/cells.py
+++ b/src/cocoa/toga_cocoa/widgets/internal/cells.py
@@ -60,6 +60,13 @@ class TogaIconView(NSTableCellView):
             self, NSLayoutAttributeLeft,
             1, 0
         )
+        # set fixed width of icon
+        self.iv_width_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # NOQA:E501
+            self.imageView, NSLayoutAttributeWidth,
+            NSLayoutRelationEqual,
+            None, NSLayoutAttributeNotAnAttribute,
+            1, 16
+        )
         # align text vertically in cell
         self.tv_vertical_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # NOQA:E501
             self.textField, NSLayoutAttributeCenterY,
@@ -84,6 +91,7 @@ class TogaIconView(NSTableCellView):
 
         self.addConstraint(self.iv_vertical_constraint)
         self.addConstraint(self.iv_left_constraint)
+        self.addConstraint(self.iv_width_constraint)
         self.addConstraint(self.tv_vertical_constraint)
         self.addConstraint(self.tv_left_constraint)
         self.addConstraint(self.tv_right_constraint)
@@ -96,10 +104,14 @@ class TogaIconView(NSTableCellView):
 
         if image:
             self.imageView.image = image.resizeTo(16)
+            # set icon width to 16
+            self.iv_width_constraint.constant = 16
             # add padding between icon and text
             self.tv_left_constraint.constant = 5
         else:
             self.imageView.image = None
+            # set icon width to 0
+            self.iv_width_constraint.constant = 0
             # remove padding between icon and text
             self.tv_left_constraint.constant = 0
 

--- a/src/cocoa/toga_cocoa/widgets/table.py
+++ b/src/cocoa/toga_cocoa/widgets/table.py
@@ -118,14 +118,25 @@ class TogaTable(NSTableView):
     @objc_method
     def tableView_heightOfRow_(self, table, row: int) -> float:
 
-        min_row_height = self.rowHeight
+        default_row_height = self.rowHeight
         margin = 2
 
         # get all views in column
-        views = [self.tableView_viewForTableColumn_row_(table, col, row) for col in self.tableColumns]
+        data_row = self.interface.data[row]
 
-        max_widget_height = max(view.intrinsicContentSize().height + margin for view in views)
-        return max(min_row_height, max_widget_height)
+        heights = [default_row_height]
+
+        for column in self.tableColumns:
+            col_identifier = str(column.identifier)
+            value = getattr(data_row, col_identifier, None)
+            if isinstance(value, toga.Widget):
+                # if the cell value is a widget, use its height
+                heights.append(value._impl.native.intrinsicContentSize().height + margin)
+            else:
+                # otherwise use default row height
+                heights.append(default_row_height)
+
+        return max(heights)
 
 
 class Table(Widget):

--- a/src/cocoa/toga_cocoa/widgets/table.py
+++ b/src/cocoa/toga_cocoa/widgets/table.py
@@ -132,9 +132,6 @@ class TogaTable(NSTableView):
             if isinstance(value, toga.Widget):
                 # if the cell value is a widget, use its height
                 heights.append(value._impl.native.intrinsicContentSize().height + margin)
-            else:
-                # otherwise use default row height
-                heights.append(default_row_height)
 
         return max(heights)
 

--- a/src/cocoa/toga_cocoa/widgets/table.py
+++ b/src/cocoa/toga_cocoa/widgets/table.py
@@ -229,6 +229,7 @@ class Table(Widget):
         column_identifier = at(accessor)
         self.column_identifiers[accessor] = column_identifier
         column = NSTableColumn.alloc().initWithIdentifier(column_identifier)
+        column.minWidth = 16
         self.table.addTableColumn(column)
         self.columns.append(column)
 

--- a/src/cocoa/toga_cocoa/widgets/tree.py
+++ b/src/cocoa/toga_cocoa/widgets/tree.py
@@ -215,7 +215,7 @@ class Tree(Widget):
             self.column_identifiers[id(column_identifier)] = accessor
             column = NSTableColumn.alloc().initWithIdentifier(column_identifier)
             # column.editable = False
-            column.midWidth = 100
+            column.minWidth = 16
             # if self.interface.sorting:
             #     sort_descriptor = NSSortDescriptor.sortDescriptorWithKey(column_identifier, ascending=True)
             #     column.sortDescriptorPrototype = sort_descriptor

--- a/src/cocoa/toga_cocoa/widgets/tree.py
+++ b/src/cocoa/toga_cocoa/widgets/tree.py
@@ -132,9 +132,6 @@ class TogaTree(NSOutlineView):
             if isinstance(value, toga.Widget):
                 # if the cell value is a widget, use its height
                 heights.append(value._impl.native.intrinsicContentSize().height)
-            else:
-                # otherwise use default row height
-                heights.append(default_row_height)
 
         return max(heights)
 


### PR DESCRIPTION
This PR provides performance improvements to `toga_cocoa.Table` and `toga_cocoa.Tree` and small layout tweaks:

* Avoid calling `tableView_viewForTableColumn_row_` from `tableView_heightOfRow_` because it leads to unnecessary initialisations of table cell views. Instead use the default row height if the cell contains only text and an icon. The same holds for `outlineView_viewForTableColumn_item_`.
* Constrain the icon width to 16 pixels in `TogaIconView`. This prevents the icon from shrinking when the column width is smaller than 16 pixels.
* Set the minimum column width to 16 pixels so that a possible icon is always visible. 

The first change leads to significant performance improvements for large tables because Cocoa will only initialise the views which are currently visible to the user.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
