### PR TITLE
Mark Android icon as implemented

### DIFF
--- a/src/android/toga_android/icons.py
+++ b/src/android/toga_android/icons.py
@@ -6,4 +6,3 @@ class Icon:
         self.interface = interface
         self.interface._impl = self
         self.path = path
-        interface.factory.not_implemented("Icon")


### PR DESCRIPTION
An Android icon's `path` is already computed properly, which is the only
aspect that is meaningful on Android.

This pull request removes the meaningless "not implemented" printout when using an Android icon.

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
