### PR TITLE
Implement DetailedList.on_select() on Android

### DIFF
--- a/src/android/toga_android/widgets/detailedlist.py
+++ b/src/android/toga_android/widgets/detailedlist.py
@@ -4,6 +4,17 @@ from ..libs import android_widgets
 from .base import Widget
 
 
+class _DetailedListOnClickListener(android_widgets.OnClickListener):
+    def __init__(self, impl, row_number):
+        super().__init__()
+        self._impl = impl
+        self._row_number = row_number
+
+    def onClick(self, _view):
+        if self._impl.interface.on_select:
+            self._impl.interface.on_select(widget=self._impl.interface, row=self._row_number)
+
+
 class DetailedList(Widget):
     def create(self):
         # DetailedList is not a specific widget on Android, so we build it out
@@ -87,6 +98,9 @@ class DetailedList(Widget):
         bottom_text_params.gravity = android_widgets.Gravity.TOP
         text_container.addView(bottom_text, bottom_text_params)
 
+        # Apply an onclick listener so that clicking anywhere on the row triggers Toga's on_select(row).
+        row_foreground.setOnClickListener(_DetailedListOnClickListener(self, i))
+
     def change_source(self, source):
         # If the source changes, re-build the widget.
         self.create()
@@ -116,8 +130,8 @@ class DetailedList(Widget):
         self.create()
 
     def set_on_select(self, handler):
-        # This widget currently does not implement any handlers for user touch.
-        self.interface.factory.not_implemented("DetailedList.set_on_select()")
+        # No special handling required.
+        pass
 
     def set_on_delete(self, handler):
         # This widget currently does not implement event handlers for data chance.

--- a/src/android/toga_android/widgets/detailedlist.py
+++ b/src/android/toga_android/widgets/detailedlist.py
@@ -4,7 +4,7 @@ from ..libs import android_widgets
 from .base import Widget
 
 
-class _DetailedListOnClickListener(android_widgets.OnClickListener):
+class DetailedListOnClickListener(android_widgets.OnClickListener):
     def __init__(self, impl, row_number):
         super().__init__()
         self._impl = impl
@@ -99,7 +99,7 @@ class DetailedList(Widget):
         text_container.addView(bottom_text, bottom_text_params)
 
         # Apply an onclick listener so that clicking anywhere on the row triggers Toga's on_select(row).
-        row_foreground.setOnClickListener(_DetailedListOnClickListener(self, i))
+        row_foreground.setOnClickListener(DetailedListOnClickListener(self, i))
 
     def change_source(self, source):
         # If the source changes, re-build the widget.


### PR DESCRIPTION
## Testing done

WIth this diff:

```
diff --git a/examples/detailedlist/detailedlist/app.py b/examples/detailedlist/detailedlist/app.py
index 59ca272d..6dbfe1c3 100644
--- a/examples/detailedlist/detailedlist/app.py
+++ b/examples/detailedlist/detailedlist/app.py
@@ -10,6 +10,7 @@ from .translations import bee_translations
 class ExampleDetailedListApp(toga.App):
     # Detailed list callback functions
     def on_select_handler(self, widget, row, **kwargs):
+        print("FYI, you selected row " + str(row))
         self.label.text = 'You selected row: {}'.format(row) if row is not None else 'No row selected'
 
     async def on_refresh_handler(self, widget, **kwargs):
@@ -47,7 +48,7 @@ class ExampleDetailedListApp(toga.App):
 
         # Outermost box
         outer_box = toga.Box(
-            children=[widget, self.label],
+            children=[self.label, widget],
             style=Pack(
                 flex=1,
                 direction=COLUMN,
diff --git a/examples/detailedlist/pyproject.toml b/examples/detailedlist/pyproject.toml
index ca61e3dd..a19cf3ac 100644
--- a/examples/detailedlist/pyproject.toml
+++ b/examples/detailedlist/pyproject.toml
@@ -35,10 +35,12 @@ requires = [
 # Mobile deployments
 [tool.briefcase.app.detailedlist.iOS]
 requires = [
-    'toga-iOS',
+'../../src/core',
+'../../src/ios',
 ]
 
 [tool.briefcase.app.detailedlist.android]
 requires = [
-    'toga-android',
+'../../src/core',
+'../../src/android',
 ]
```

I validated that if you touch the bee icon in the detailedlist demo, or the row background, or the row text, you get an update in the label.

Due to a longstanding layout bug, I had to move the label above the detailedlist in the demo app. I also added a print to be sure.

BTW, it's a weird API in Toga that means that `on_select` provides a `row` that's a number (based on testing against iOS) vs. the `on_delete` which takes a row object (e.g. object with a `subtitle` property, etc). That's fine, but it confused me while implementing this. I propose adjusting the param name to be `row_index`.

P.S. This is a short PR, but I earlier had a longer one. I figured it could be shorter. Please enjoy the laser-focused elegance of this PR. :)

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [ ] I have read the **CONTRIBUTING.md** file
- [ ] I will abide by the code of conduct
