### PR TITLE
Async Cocoa dialogs

### DIFF
--- a/src/cocoa/toga_cocoa/dialogs.py
+++ b/src/cocoa/toga_cocoa/dialogs.py
@@ -172,7 +172,8 @@ async def open_file(window, title, file_types, multiselect):
         file_types: Ignored for now.
         multiselect: Flag to allow multiple file selection.
     Returns:
-        (list) A list of file paths (may be empty).
+        A list of absolute paths(str) if multiselect is True, a single path(str)
+        otherwise. Returns None if no file is selected.
     """
 
     # Initialize and configure the panel.
@@ -191,13 +192,13 @@ async def open_file(window, title, file_types, multiselect):
     def completion_handler(r: int) -> None:
         if r == NSFileHandlingPanelOKButton:
             if multiselect:
-                paths = [str(url.path) for url in panel.URLs]
+                res = [str(url.path) for url in panel.URLs]
             else:
-                paths = [str(panel.URL.path)]
+                res = str(panel.URL.path)
         else:
-            paths = []
+            res = None
 
-        future.set_result(paths)
+        future.set_result(res)
 
     panel.beginSheetModalForWindow(window._impl.native, completionHandler=completion_handler)
 
@@ -212,7 +213,8 @@ async def select_folder(window, title, multiselect):
         title: Title of the dialog.
         multiselect: Flag to allow multiple folder selection.
     Returns:
-        (list) A list of folder paths (may be empty).
+        A list of absolute paths(str) if multiselect is True, a single path(str)
+        otherwise. Returns None if no folder is selected.
     """
     panel = NSOpenPanel.alloc().init()
     panel.title = title
@@ -234,13 +236,13 @@ async def select_folder(window, title, multiselect):
 
         if r == NSFileHandlingPanelOKButton:
             if multiselect:
-                paths = [str(url.path) for url in panel.URLs]
+                res = [str(url.path) for url in panel.URLs]
             else:
-                paths = [str(panel.URL.path)]
+                res = str(panel.URL.path)
         else:
-            paths = []
+            res = None
 
-        future.set_result(paths)
+        future.set_result(res)
 
     panel.beginSheetModalForWindow(window._impl.native, completionHandler=completion_handler)
 

--- a/src/cocoa/toga_cocoa/window.py
+++ b/src/cocoa/toga_cocoa/window.py
@@ -252,26 +252,26 @@ class Window:
     def close(self):
         self.native.close()
 
-    def info_dialog(self, title, message):
-        return dialogs.info(self.interface, title, message)
+    async def info_dialog(self, title, message):
+        return await dialogs.info(self.interface, title, message)
 
-    def question_dialog(self, title, message):
-        return dialogs.question(self.interface, title, message)
+    async def question_dialog(self, title, message):
+        return await dialogs.question(self.interface, title, message)
 
-    def confirm_dialog(self, title, message):
-        return dialogs.confirm(self.interface, title, message)
+    async def confirm_dialog(self, title, message):
+        return await dialogs.confirm(self.interface, title, message)
 
-    def error_dialog(self, title, message):
-        return dialogs.error(self.interface, title, message)
+    async def error_dialog(self, title, message):
+        return await dialogs.error(self.interface, title, message)
 
-    def stack_trace_dialog(self, title, message, content, retry=False):
-        return dialogs.stack_trace(self.interface, title, message, content, retry)
+    async def stack_trace_dialog(self, title, message, content, retry=False):
+        return await dialogs.stack_trace(self.interface, title, message, content, retry)
 
-    def save_file_dialog(self, title, suggested_filename, file_types):
-        return dialogs.save_file(self.interface, title, suggested_filename, file_types)
+    async def save_file_dialog(self, title, suggested_filename, file_types):
+        return await dialogs.save_file(self.interface, title, suggested_filename, file_types)
 
-    def open_file_dialog(self, title, initial_directory, file_types, multiselect):
-        return dialogs.open_file(self.interface, title, file_types, multiselect)
+    async def open_file_dialog(self, title, initial_directory, file_types, multiselect):
+        return await dialogs.open_file(self.interface, title, file_types, multiselect)
 
-    def select_folder_dialog(self, title, initial_directory, multiselect):
-        return dialogs.select_folder(self.interface, title, multiselect)
+    async def select_folder_dialog(self, title, initial_directory, multiselect):
+        return await dialogs.select_folder(self.interface, title, multiselect)

--- a/src/core/toga/window.py
+++ b/src/core/toga/window.py
@@ -262,7 +262,7 @@ class Window:
             file_types: A list of strings with the allowed file extensions.
 
         Returns:
-            The absolute path(str) to the selected location.
+            The absolute path(str) to the selected location. May be None.
         """
         return self._impl.save_file_dialog(title, suggested_filename, file_types)
 
@@ -277,7 +277,8 @@ class Window:
             multiselect: Value showing whether a user can select multiple files.
 
         Returns:
-            The absolute path(str) to the selected file or a list(str) if multiselect
+            A list of absolute paths(str) if multiselect is True, a single path(str)
+            otherwise. Returns None if no file is selected.
         """
         return self._impl.open_file_dialog(title, initial_directory, file_types, multiselect)
 
@@ -291,6 +292,7 @@ class Window:
             multiselect (bool): Value showing whether a user can select multiple files.
 
         Returns:
-            The absolute path(str) to the selected file or None.
+            A list of absolute paths(str) if multiselect is True, a single path(str)
+            otherwise. Returns None if no folder is selected.
         """
         return self._impl.select_folder_dialog(title, initial_directory, multiselect)


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

This PR makes all Cocoa dialogs async and can be considered a followup to #987 for Android. Async dialogs on macOS are only possible when they are attached to a window as a sheet. This is not a problem for toga at the moment since it associates all dialogs with a window. Introducing application-wide dialogs will however be more difficult because the Cocoa API for this is _synchronous_.

This PR also cleans up the doc strings describing the dialog return types and introduces uniform return types for `select_folder` and `select_file`. Previously, `select_folder` would always return a list which could be empty (no folder selected), contain a single string (single file selected) or contain multiple strings (multiple folders selected). `select_folder` returns `None` (no file selected) a string (a single file selected) or a list of strings (multiple files selected). `open_file` similarly returns `None` or a string. For more uniform behaviour, `select_folder` has been adapted to follow the convention of the other dialogs.

Moving to async dialogs also fixes issue #1006.

This PR is marked as a draft because it requires awaiting the implementation methods in the interface layer. This will break other currently synchronous implementations.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
