### PR TITLE
Fix table example in Windows

### DIFF
--- a/src/winforms/toga_winforms/widgets/table.py
+++ b/src/winforms/toga_winforms/widgets/table.py
@@ -7,7 +7,6 @@ from .base import Widget
 
 class Table(Widget):
     def create(self):
-        self._container = self
         self.native = WinForms.ListView()
         self.native.View = WinForms.View.Details
         self._cache = []


### PR DESCRIPTION
When trying to run the table example in Windows, I get the following error:
```
File "c:\users\saroa\repos\toga\src\winforms\toga_winforms\app.py", line 144, in run_app
    self.create()
  File "c:\users\saroa\repos\toga\src\winforms\toga_winforms\app.py", line 65, in create
    self.interface.startup()
  File "C:\Users\saroa\repos\toga\examples\table\table\app.py", line 111, in startup
    self.main_window.content = outer_box
  File "c:\users\saroa\repos\toga\src\core\toga\window.py", line 132, in content
    self._impl.set_content(widget._impl)
  File "c:\users\saroa\repos\toga\src\winforms\toga_winforms\window.py", line 101, in set_content
    child._impl.container = widget
  File "c:\users\saroa\repos\toga\src\winforms\toga_winforms\widgets\base.py", line 40, in container
    child._impl.container = container
  File "c:\users\saroa\repos\toga\src\winforms\toga_winforms\widgets\base.py", line 28, in container
    raise RuntimeError('Already have a container')
RuntimeError: Already have a container
```

The reason for that is that in Windows, `Table` is set to be its own container by default. By deleting this setting, the problem was fixed. I ran the example code again, and it worked correctly.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
