### PR TITLE
Determine tree/table selection directly by API, rather than using a shadow

### DIFF
--- a/examples/table/table/app.py
+++ b/examples/table/table/app.py
@@ -30,7 +30,9 @@ class ExampleTableApp(toga.App):
         self.table1.data.insert(0, *choice(bee_movies))
 
     def delete_handler(self, widget, **kwargs):
-        if len(self.table1.data) > 0:
+        if self.table1.selection:
+            self.table1.data.remove(self.table1.selection)
+        elif len(self.table1.data) > 0:
             self.table1.data.remove(self.table1.data[0])
         else:
             print('Table is empty!')

--- a/src/cocoa/toga_cocoa/widgets/table.py
+++ b/src/cocoa/toga_cocoa/widgets/table.py
@@ -99,20 +99,6 @@ class TogaTable(NSTableView):
 
     @objc_method
     def tableViewSelectionDidChange_(self, notification) -> None:
-        selection = []
-        current_index = self.selectedRowIndexes.firstIndex
-        for i in range(self.selectedRowIndexes.count):
-            selection.append(self.interface.data[current_index])
-            current_index = self.selectedRowIndexes.indexGreaterThanIndex(current_index)
-
-        if not self.interface.multiple_select:
-            try:
-                self.interface._selection = selection[0]
-            except IndexError:
-                self.interface._selection = None
-        else:
-            self.interface._selection = selection
-
         if notification.object.selectedRow == -1:
             selected = None
         else:
@@ -224,6 +210,23 @@ class Table(Widget):
     def clear(self):
         self._view_for_row.clear()
         self.table.reloadData()
+
+    def get_selection(self):
+        if self.interface.multiple_select:
+            selection = []
+
+            current_index = self.table.selectedRowIndexes.firstIndex
+            for i in range(self.table.selectedRowIndexes.count):
+                selection.append(self.interface.data[current_index])
+                current_index = self.table.selectedRowIndexes.indexGreaterThanIndex(current_index)
+
+            return selection
+        else:
+            index = self.table.selectedRow
+            if index != -1:
+                return self.interface.data[index]
+            else:
+                return None
 
     def set_on_select(self, handler):
         pass

--- a/src/cocoa/toga_cocoa/widgets/tree.py
+++ b/src/cocoa/toga_cocoa/widgets/tree.py
@@ -168,20 +168,6 @@ class TogaTree(NSOutlineView):
     # OutlineViewDelegate methods
     @objc_method
     def outlineViewSelectionDidChange_(self, notification) -> None:
-        selection = []
-        current_index = self.selectedRowIndexes.firstIndex
-        for i in range(self.selectedRowIndexes.count):
-            selection.append(self.itemAtRow(current_index).attrs['node'])
-            current_index = self.selectedRowIndexes.indexGreaterThanIndex(current_index)
-
-        if not self.interface.multiple_select:
-            try:
-                self.interface._selection = selection[0]
-            except IndexError:
-                self.interface._selection = None
-        else:
-            self.interface._selection = selection
-
         if notification.object.selectedRow == -1:
             selected = None
         else:
@@ -294,6 +280,23 @@ class Tree(Widget):
 
     def clear(self):
         self.tree.reloadData()
+
+    def get_selection(self):
+        if self.interface.multiple_select:
+            selection = []
+
+            current_index = self.tree.selectedRowIndexes.firstIndex
+            for i in range(self.tree.selectedRowIndexes.count):
+                selection.append(self.tree.itemAtRow(current_index).attrs['node'])
+                current_index = self.tree.selectedRowIndexes.indexGreaterThanIndex(current_index)
+
+            return selection
+        else:
+            index = self.tree.selectedRow
+            if index != -1:
+                return self.tree.itemAtRow(current_index).attrs['node']
+            else:
+                return None
 
     def set_on_select(self, handler):
         pass

--- a/src/core/toga/widgets/table.py
+++ b/src/core/toga/widgets/table.py
@@ -57,7 +57,6 @@ class Table(Widget):
         self._multiple_select = multiple_select
         self._on_select = None
         self._on_double_click = None
-        self._selection = None
         self._data = None
         if missing_value is None:
             print("WARNING: Using empty string for missing value in data. "
@@ -102,10 +101,10 @@ class Table(Widget):
         """The current selection of the table.
 
         A value of None indicates no selection.
-        If the table allows multiple selection, returns a list of
+        If the tree allows multiple selection, returns a list of
         selected data nodes. Otherwise, returns a single data node.
         """
-        return self._selection
+        return self._impl.get_selection()
 
     def scroll_to_top(self):
         """Scroll the view so that the top of the list (first row) is visible

--- a/src/core/toga/widgets/tree.py
+++ b/src/core/toga/widgets/tree.py
@@ -44,7 +44,6 @@ class Tree(Widget):
         self.headings = headings
         self._accessors = build_accessors(headings, accessors)
         self._multiple_select = multiple_select
-        self._selection = None
         self._data = None
         self._on_select = None
         self._on_double_click = None
@@ -91,10 +90,10 @@ class Tree(Widget):
         """The current selection of the table.
 
         A value of None indicates no selection.
-        If the table allows multiple selection, returns a list of
+        If the tree allows multiple selection, returns a list of
         selected data nodes. Otherwise, returns a single data node.
         """
-        return self._selection
+        return self._impl.get_selection()
 
     @property
     def on_select(self):

--- a/src/dummy/toga_dummy/widgets/table.py
+++ b/src/dummy/toga_dummy/widgets/table.py
@@ -20,6 +20,10 @@ class Table(Widget):
     def clear(self):
         self._action('clear')
 
+    def get_selection(self):
+        self._action('get selection')
+        return None
+
     def set_on_select(self, handler):
         self._set_value('on_select', handler)
 

--- a/src/dummy/toga_dummy/widgets/tree.py
+++ b/src/dummy/toga_dummy/widgets/tree.py
@@ -20,6 +20,10 @@ class Tree(Widget):
     def clear(self):
         self._action('clear')
 
+    def get_selection(self):
+        self._action('get selection')
+        return None
+
     def set_on_select(self, handler):
         self._set_value('on_select', handler)
 

--- a/src/gtk/toga_gtk/widgets/table.py
+++ b/src/gtk/toga_gtk/widgets/table.py
@@ -5,7 +5,16 @@ class Table(Tree):
 
     def gtk_on_select(self, selection):
         if self.interface.on_select:
-            tree_model, tree_iter = selection.get_selected()
+            if self.interface.multiple_select:
+                tree_model, tree_path = selection.get_selected_rows()
+                if tree_path:
+                    tree_iter = tree_model.get_iter(tree_path[-1])
+                else:
+                    tree_iter = None
+            else:
+                tree_model, tree_iter = selection.get_selected()
+
+            # Covert the tree iter into the actual row.
             if tree_iter:
                 row = tree_model.get(tree_iter, 0)[0]
             else:
@@ -52,6 +61,9 @@ class Table(Tree):
 
     def clear(self):
         super().clear()
+
+    def get_selection(self):
+        return super().get_selection()
 
     def set_on_select(self, handler):
         super().set_on_select(handler)

--- a/src/winforms/toga_winforms/widgets/table.py
+++ b/src/winforms/toga_winforms/widgets/table.py
@@ -31,11 +31,8 @@ class Table(Widget):
         self.native.VirtualItemsSelectionRangeChanged += self.winforms_virtual_item_selection_range_changed
 
     def winforms_virtual_item_selection_range_changed(self, sender, e):
-        # update selection interface property
-        self.interface._selection = self._selected_rows()
-
         # `Shift` key or Range selection handler
-        if e.IsSelected and self.interface.multiple_select and self.interface.on_select:
+        if self.interface.multiple_select and self.interface.on_select:
             # call on select with the last row of the multi selection
             selected = self.interface.data[e.EndIndex]
             self.interface.on_select(self.interface, row=selected)
@@ -66,21 +63,8 @@ class Table(Widget):
             self._cache.append(WinForms.ListViewItem(self.row_data(self.interface.data[i])))
 
     def winforms_item_selection_changed(self, sender, e):
-        # update selection interface property
-        self.interface._selection = self._selected_rows()
-
-        if e.IsSelected and self.interface.on_select:
+        if self.interface.on_select:
             self.interface.on_select(self.interface, row=self.interface.data[e.ItemIndex])
-
-    def _selected_rows(self):
-        if not self.native.SelectedIndices.Count:
-            return None
-
-        if self.interface.multiple_select:
-            selected = [row for i, row in enumerate(self.interface.data) if i in self.native.SelectedIndices]
-            return selected
-        else:
-            return self.interface.data[self.native.SelectedIndices[0]]
 
     def _create_column(self, heading, accessor):
         col = WinForms.ColumnHeader()
@@ -121,6 +105,19 @@ class Table(Widget):
 
     def clear(self):
         self.native.Items.Clear()
+
+    def get_selection(self):
+        if self.interface.multiple_select:
+            selected = [
+                row
+                for i, row in enumerate(self.interface.data)
+                if i in self.native.SelectedIndices
+            ]
+            return selected
+        elif not self.native.SelectedIndices.Count:
+            return None
+        else:
+            return self.interface.data[self.native.SelectedIndices[0]]
 
     def set_on_select(self, handler):
         pass

--- a/src/winforms/toga_winforms/widgets/tree.py
+++ b/src/winforms/toga_winforms/widgets/tree.py
@@ -28,6 +28,9 @@ class Tree(Widget):
     def clear(self):
         self.interface.factory.not_implemented('Tree.clear()')
 
+    def get_selection(self):
+        self.interface.factory.not_implemented('Tree.get_selection()')
+
     def set_on_select(self, handler):
         self.interface.factory.not_implemented('Tree.set_on_select()')
 


### PR DESCRIPTION
Historically, we've used a shadow attribute to track selection on trees and tables. This replaces that mechanism with a native API call to extract the selection.

Also implements multi-select for trees and tables on GTK.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
