### PR TITLE
Add default implementation of the "About" command

### DIFF
--- a/examples/tutorial0/tutorial/app.py
+++ b/examples/tutorial0/tutorial/app.py
@@ -1,4 +1,5 @@
 import toga
+from tutorial import __version__
 
 
 def button_handler(widget):
@@ -17,7 +18,13 @@ def build(app):
 
 
 def main():
-    return toga.App('First App', 'org.beeware.helloworld', startup=build)
+    return toga.App(
+        'First App',
+        app_id='org.beeware.helloworld',
+        author='Tiberius Yak',
+        version=__version__,
+        startup=build,
+    )
 
 
 if __name__ == '__main__':

--- a/src/android/toga_android/app.py
+++ b/src/android/toga_android/app.py
@@ -1,5 +1,9 @@
+import sys
+
 from rubicon.java import android_events
 
+import toga
+from toga import Command, Key
 from toga.handlers import wrapped_handler
 
 from .libs.activity import IPythonApp, MainActivity
@@ -89,3 +93,21 @@ class App:
 
     def add_background_task(self, handler):
         self.loop.call_soon(wrapped_handler(self, handler), self)
+
+    def about_command(self):
+        return Command(None, "About")
+
+    def preferences_command(self):
+        return Command(None, "Preferences")
+
+    def home_page_command(self):
+        return Command(None, "Visit homepage", group=toga.Group.HELP)
+
+    def quit_command(self):
+        return Command(
+            lambda s: self.exit(),
+            'Exit ' + self.interface.name,
+            shortcut=Key.MOD_1 + 'q',
+            group=toga.Group.FILE,
+            section=sys.maxsize
+        )

--- a/src/android/toga_android/app.py
+++ b/src/android/toga_android/app.py
@@ -1,9 +1,5 @@
-import sys
-
 from rubicon.java import android_events
 
-import toga
-from toga import Command, Key
 from toga.handlers import wrapped_handler
 
 from .libs.activity import IPythonApp, MainActivity
@@ -93,21 +89,3 @@ class App:
 
     def add_background_task(self, handler):
         self.loop.call_soon(wrapped_handler(self, handler), self)
-
-    def about_command(self):
-        return Command(None, "About")
-
-    def preferences_command(self):
-        return Command(None, "Preferences")
-
-    def home_page_command(self):
-        return Command(None, "Visit homepage", group=toga.Group.HELP)
-
-    def quit_command(self):
-        return Command(
-            lambda s: self.exit(),
-            'Exit ' + self.interface.name,
-            shortcut=Key.MOD_1 + 'q',
-            group=toga.Group.FILE,
-            section=sys.maxsize
-        )

--- a/src/cocoa/toga_cocoa/app.py
+++ b/src/cocoa/toga_cocoa/app.py
@@ -123,7 +123,6 @@ class App:
         formal_name = self.interface.formal_name
 
         self.interface.commands.add(
-            toga.Command(None, 'About ' + formal_name, group=toga.Group.APP),
             toga.Command(None, 'Preferences', group=toga.Group.APP),
             # Quit should always be the last item, in a section on it's own
             toga.Command(

--- a/src/cocoa/toga_cocoa/app.py
+++ b/src/cocoa/toga_cocoa/app.py
@@ -120,20 +120,6 @@ class App:
         self.appDelegate.native = self.native
         self.native.setDelegate_(self.appDelegate)
 
-        formal_name = self.interface.formal_name
-
-        self.interface.commands.add(
-            toga.Command(None, 'Preferences', group=toga.Group.APP),
-            # Quit should always be the last item, in a section on it's own
-            toga.Command(
-                lambda s: self.exit(), 'Quit ' + formal_name,
-                shortcut=toga.Key.MOD_1 + 'q',
-                group=toga.Group.APP,
-                section=sys.maxsize
-            ),
-
-            toga.Command(None, 'Visit homepage', group=toga.Group.HELP)
-        )
         self._create_app_commands()
 
         # Call user code to populate the main window
@@ -143,6 +129,24 @@ class App:
         # then force the creation of the menus.
         self._menu_items = {}
         self.create_menus()
+
+    def about_command(self):
+        return toga.AboutCommand(self.interface, group=toga.Group.APP)
+
+    def home_page_command(self):
+        return toga.Command(None, 'Visit homepage', group=toga.Group.HELP)
+
+    def preferences_command(self):
+        return toga.Command(None, 'Preferences', group=toga.Group.APP)
+
+    def quit_command(self):
+        return toga.Command(
+            lambda s: self.exit(),
+            'Quit',
+            shortcut=toga.Key.MOD_1 + 'q',
+            group=toga.Group.APP,
+            section=sys.maxsize
+        )
 
     def _create_app_commands(self):
         # No extra commands

--- a/src/core/tests/test_app.py
+++ b/src/core/tests/test_app.py
@@ -17,17 +17,7 @@ class AppTests(TestCase):
 
         self.started = False
 
-        def test_startup_function(app):
-            self.started = True
-            return self.content
-
-        self.app = toga.App(
-            formal_name=self.name,
-            app_id=self.app_id,
-            startup=test_startup_function,
-            factory=toga_dummy.factory,
-            id=self.id
-        )
+        self.app = self.create_app()
 
     def test_app_name(self):
         self.assertEqual(self.app.name, self.name)
@@ -103,6 +93,42 @@ class AppTests(TestCase):
         self.assertTrue(self.app.is_full_screen)
         self.app.set_full_screen()
         self.assertFalse(self.app.is_full_screen)
+
+    def test_default_commands(self):
+        self.assertValueSet(self.app, "about command", "about")
+        self.assertValueSet(self.app, "preferences command", "preferences")
+        self.assertValueSet(self.app, "homepage command", "homepage")
+        self.assertValueSet(self.app, "quit command", "quit")
+
+    def test_no_about_command(self):
+        app = self.create_app(about_command=False)
+        self.assertNoValueSet(app, "about command")
+
+    def test_no_preferences_command(self):
+        app = self.create_app(preferences_command=False)
+        self.assertNoValueSet(app, "preferences command")
+
+    def test_no_home_page_command(self):
+        app = self.create_app(home_page_command=False)
+        self.assertNoValueSet(app, "homepage command")
+
+    def test_no_quit_command(self):
+        app = self.create_app(quit_command=False)
+        self.assertNoValueSet(app, "quit command")
+
+    def create_app(self, **kwargs):
+        def test_startup_function(app):
+            self.started = True
+            return self.content
+
+        return toga.App(
+            factory=toga_dummy.factory,
+            formal_name=self.name,
+            id=self.id,
+            app_id=self.app_id,
+            startup=test_startup_function,
+            **kwargs,
+        )
 
 
 class DocumentAppTests(TestCase):

--- a/src/core/toga/__init__.py
+++ b/src/core/toga/__init__.py
@@ -46,7 +46,7 @@ __all__ = [
     # Applications
     'App', 'DocumentApp', 'MainWindow',
     # Commands
-    'Command', 'CommandSet', 'Group', 'GROUP_BREAK', 'SECTION_BREAK',
+    'Command', 'CommandSet', 'Group', 'GROUP_BREAK', 'SECTION_BREAK', "AboutCommand",
     # Documents
     'Document',
     # Keys

--- a/src/core/toga/__init__.py
+++ b/src/core/toga/__init__.py
@@ -1,7 +1,14 @@
 from .app import App, DocumentApp, MainWindow
 # Resources
 from .colors import hsl, hsla, rgb, rgba
-from .command import GROUP_BREAK, SECTION_BREAK, Command, CommandSet, Group
+from .command import (
+    GROUP_BREAK,
+    SECTION_BREAK,
+    Command,
+    CommandSet,
+    Group,
+    AboutCommand,
+)
 from .documents import Document
 from .fonts import Font
 from .icons import Icon

--- a/src/core/toga/app.py
+++ b/src/core/toga/app.py
@@ -3,7 +3,7 @@ import sys
 from builtins import id as identifier
 from email.message import Message
 
-from toga.command import CommandSet
+from toga.command import CommandSet, AboutCommand
 from toga.handlers import wrapped_handler
 from toga.icons import Icon
 from toga.platform import get_platform_factory
@@ -79,6 +79,8 @@ class App:
         argument of :class:`toga.App`.
     :param factory: A python module that is capable to return a implementation
         of this class with the same name. (optional & normally not needed)
+    :param default_about_command: Create default implementation of the About command.
+        For more information, go to :class:`toga.AboutCommand`
     """
     app = None
 
@@ -96,6 +98,7 @@ class App:
         startup=None,
         on_exit=None,
         factory=None,
+        default_about_command=True,
     ):
         # Keep an accessible copy of the app instance
         App.app = self
@@ -168,7 +171,7 @@ class App:
         if app_id:
             self._app_id = app_id
         else:
-            self._app_id = self.metadata['App-ID']
+            self._app_id = self.metadata.get('App-ID', None)
 
         if self._app_id is None:
             raise RuntimeError('Toga application must have an App ID')
@@ -177,29 +180,29 @@ class App:
         # the module metadata.
         if author:
             self._author = author
-        elif self.metadata['Author']:
-            self._author = self.metadata['Author']
+        else:
+            self._author = self.metadata.get('Author', None)
 
         # If a version has been provided, use it; otherwise, look to
         # the module metadata.
         if version:
             self._version = version
-        elif self.metadata['Version']:
-            self._version = self.metadata['Version']
+        else:
+            self._version = self.metadata.get('Version', None)
 
         # If a home_page has been provided, use it; otherwise, look to
         # the module metadata.
         if home_page:
             self._home_page = home_page
-        elif self.metadata['Home-page']:
-            self._home_page = self.metadata['home_page']
+        else:
+            self._home_page = self.metadata.get('home_page', None)
 
         # If a description has been provided, use it; otherwise, look to
         # the module metadata.
         if description:
             self._description = description
-        elif self.metadata['description']:
-            self._description = self.metadata['Summary']
+        else:
+            self._description = self.metadata.get('Summary', None)
 
         # Set the application DOM ID; create an ID if one hasn't been provided.
         self._id = id if id else identifier(self)
@@ -226,6 +229,9 @@ class App:
 
         self._impl = self._create_impl()
         self.on_exit = on_exit
+
+        if default_about_command:
+            self.commands.add(AboutCommand(self))
 
     def _create_impl(self):
         return self.factory.App(interface=self)

--- a/src/core/toga/app.py
+++ b/src/core/toga/app.py
@@ -3,7 +3,7 @@ import sys
 from builtins import id as identifier
 from email.message import Message
 
-from toga.command import CommandSet, AboutCommand
+from toga.command import CommandSet
 from toga.handlers import wrapped_handler
 from toga.icons import Icon
 from toga.platform import get_platform_factory

--- a/src/core/toga/app.py
+++ b/src/core/toga/app.py
@@ -79,8 +79,13 @@ class App:
         argument of :class:`toga.App`.
     :param factory: A python module that is capable to return a implementation
         of this class with the same name. (optional & normally not needed)
-    :param default_about_command: Create default implementation of the About command.
+    :param about_command: Add "About" command as implemented in the "about" method.
         For more information, go to :class:`toga.AboutCommand`
+    :param quit_command: Add "Quit" command as implemented in the "quit" method.
+    :param home_page_command: Add "Homepage" command as implemented in the "home_page"
+        method.
+    :param preferences_command: Add "Preferences" command as implemented in the
+        "preferences" method.
     """
     app = None
 
@@ -98,7 +103,10 @@ class App:
         startup=None,
         on_exit=None,
         factory=None,
-        default_about_command=True,
+        about_command=True,
+        preferences_command=True,
+        home_page_command=True,
+        quit_command=True,
     ):
         # Keep an accessible copy of the app instance
         App.app = self
@@ -230,8 +238,14 @@ class App:
         self._impl = self._create_impl()
         self.on_exit = on_exit
 
-        if default_about_command:
-            self.commands.add(AboutCommand(self))
+        if about_command:
+            self.commands.add(self.about_command())
+        if preferences_command:
+            self.commands.add(self.preferences_command())
+        if home_page_command:
+            self.commands.add(self.home_page_command())
+        if quit_command:
+            self.commands.add(self.quit_command())
 
     def _create_impl(self):
         return self.factory.App(interface=self)
@@ -410,6 +424,38 @@ class App:
     def hide_cursor(self):
         """Hide cursor from view."""
         self._impl.hide_cursor()
+
+    def about_command(self):
+        """
+        Returns the "About" command.
+
+        This method can be override if you you wish to implement your own command.
+        """
+        return self._impl.about_command()
+
+    def quit_command(self):
+        """
+        Returns the "Quit" command.
+
+        This method can be override if you you wish to implement your own command.
+        """
+        return self._impl.quit_command()
+
+    def home_page_command(self):
+        """
+        Returns the "Homepage" command.
+
+        This method can be override if you you wish to implement your own command.
+        """
+        return self._impl.home_page_command()
+
+    def preferences_command(self):
+        """
+        Returns the "Preferences" command.
+
+        This method can be override if you you wish to implement your own command.
+        """
+        return self._impl.preferences_command()
 
     def startup(self):
         """ Create and show the main window for the application

--- a/src/core/toga/command.py
+++ b/src/core/toga/command.py
@@ -161,7 +161,7 @@ class CommandSet:
 
 class AboutCommand(Command):
 
-    def __init__(self, app, group=Group.HELP, label="About", **kwargs):
+    def __init__(self, app, group, label="About", **kwargs):
         super(AboutCommand, self).__init__(
             action=self.about_action,
             label=label,

--- a/src/core/toga/command.py
+++ b/src/core/toga/command.py
@@ -157,3 +157,28 @@ class CommandSet:
 
             yield cmd
             prev_cmd = cmd
+
+
+class AboutCommand(Command):
+
+    def __init__(self, app, group=Group.HELP, label="About", **kwargs):
+        super(AboutCommand, self).__init__(
+            action=self.about_action,
+            label=label,
+            group=group,
+            **kwargs)
+        self._app = app
+
+    @property
+    def app(self):
+        return self._app
+
+    def about_action(self, widget):
+        message_parts = []
+        if self.app.name is not None:
+            message_parts.append("Name: {name}".format(name=self.app.name))
+        if self.app.author is not None:
+            message_parts.append("Author: {author}".format(author=self.app.author))
+        if self.app.version is not None:
+            message_parts.append("Version: {version}".format(version=self.app.version))
+        self._app.main_window.info_dialog("About", "\n".join(message_parts))

--- a/src/dummy/toga_dummy/app.py
+++ b/src/dummy/toga_dummy/app.py
@@ -9,6 +9,11 @@ class MainWindow(Window):
         self.action('handle MainWindow on_close')
 
 
+def dummy_command(app, name):
+    app._set_value("{name} command".format(name=name), name)
+    return Command(None, name)
+
+
 class App(LoggedObject):
     def __init__(self, interface):
         super().__init__()
@@ -57,20 +62,16 @@ class App(LoggedObject):
         self._action('add_background_task', handler=handler)
 
     def about_command(self):
-        return self.__dummy_command("about")
+        return dummy_command(self, "about")
 
     def preferences_command(self):
-        return self.__dummy_command("preferences")
+        return dummy_command(self, "preferences")
 
     def home_page_command(self):
-        return self.__dummy_command("homepage")
+        return dummy_command(self, "homepage")
 
     def quit_command(self):
-        return self.__dummy_command("quit")
-
-    def __dummy_command(self, name):
-        self._set_value("{name} command".format(name=name), name)
-        return Command(None, name)
+        return dummy_command(self, "quit")
 
 
 @not_required_on('mobile', 'web')

--- a/src/dummy/toga_dummy/app.py
+++ b/src/dummy/toga_dummy/app.py
@@ -61,19 +61,15 @@ class App(LoggedObject):
     def add_background_task(self, handler):
         self._action('add_background_task', handler=handler)
 
-    @not_required_on('mobile')
     def about_command(self):
         return dummy_command(self, "about")
 
-    @not_required_on('mobile')
     def preferences_command(self):
         return dummy_command(self, "preferences")
 
-    @not_required_on('mobile')
     def home_page_command(self):
         return dummy_command(self, "homepage")
 
-    @not_required_on('mobile', 'web')
     def quit_command(self):
         return dummy_command(self, "quit")
 

--- a/src/dummy/toga_dummy/app.py
+++ b/src/dummy/toga_dummy/app.py
@@ -1,3 +1,4 @@
+from toga import Command
 from .utils import LoggedObject, not_required_on
 from .window import Window
 
@@ -54,6 +55,22 @@ class App(LoggedObject):
 
     def add_background_task(self, handler):
         self._action('add_background_task', handler=handler)
+
+    def about_command(self):
+        return self.__dummy_command("about")
+
+    def preferences_command(self):
+        return self.__dummy_command("preferences")
+
+    def home_page_command(self):
+        return self.__dummy_command("homepage")
+
+    def quit_command(self):
+        return self.__dummy_command("quit")
+
+    def __dummy_command(self, name):
+        self._set_value("{name} command".format(name=name), name)
+        return Command(None, name)
 
 
 @not_required_on('mobile', 'web')

--- a/src/dummy/toga_dummy/app.py
+++ b/src/dummy/toga_dummy/app.py
@@ -61,15 +61,19 @@ class App(LoggedObject):
     def add_background_task(self, handler):
         self._action('add_background_task', handler=handler)
 
+    @not_required_on('mobile')
     def about_command(self):
         return dummy_command(self, "about")
 
+    @not_required_on('mobile')
     def preferences_command(self):
         return dummy_command(self, "preferences")
 
+    @not_required_on('mobile')
     def home_page_command(self):
         return dummy_command(self, "homepage")
 
+    @not_required_on('mobile', 'web')
     def quit_command(self):
         return dummy_command(self, "quit")
 

--- a/src/dummy/toga_dummy/utils.py
+++ b/src/dummy/toga_dummy/utils.py
@@ -338,6 +338,12 @@ class TestCase(unittest.TestCase):
         except AttributeError:
             self.fail('Widget {} is not a logged object'.format(_widget))
 
+    def assertNoValueSet(self, _widget, attr):
+        self.assertFalse(
+            attr in _widget._impl._sets,
+            "Widget {} should not have set attribute {}".format(_widget, attr)
+        )
+
     def assertValueGet(self, _widget, attr):
         """Assert that the widget implementation attempted to retrieve an attribute
 

--- a/src/gtk/toga_gtk/app.py
+++ b/src/gtk/toga_gtk/app.py
@@ -75,19 +75,6 @@ class App:
 
     def gtk_startup(self, data=None):
         # Set up the default commands for the interface.
-        self.interface.commands.add(
-            Command(None, 'About ' + self.interface.name, group=toga.Group.HELP),
-            Command(None, 'Preferences', group=toga.Group.APP),
-            # Quit should always be the last item, in a section on it's own
-            Command(
-                lambda widget: self.exit(),
-                'Quit ' + self.interface.name,
-                shortcut=toga.Key.MOD_1 + 'q',
-                group=toga.Group.APP,
-                section=sys.maxsize
-            ),
-            Command(None, 'Visit homepage', group=toga.Group.HELP)
-        )
         self._create_app_commands()
 
         self.interface.startup()
@@ -104,6 +91,24 @@ class App:
         # see #872 for details.
         settings = Gtk.Settings.get_default()
         settings.set_property("gtk-shell-shows-menubar", False)
+
+    def home_page_command(self):
+        return Command(None, 'Visit homepage', group=toga.Group.HELP)
+
+    def preferences_command(self):
+        return Command(None, 'Preferences', group=toga.Group.APP)
+
+    def about_command(self):
+        return toga.AboutCommand(self.interface, group=toga.Group.HELP)
+
+    def quit_command(self):
+        return Command(
+            lambda widget: self.exit(),
+            'Quit ' + self.interface.name,
+            shortcut=toga.Key.MOD_1 + 'q',
+            group=toga.Group.APP,
+            section=sys.maxsize
+        )
 
     def _create_app_commands(self):
         # No extra menus

--- a/src/iOS/toga_iOS/app.py
+++ b/src/iOS/toga_iOS/app.py
@@ -1,8 +1,11 @@
 import asyncio
+import sys
 
 from rubicon.objc import SEL, objc_method
 from rubicon.objc.eventloop import EventLoopPolicy, iOSLifecycle
 
+import toga
+from toga import Command, Key
 from toga.handlers import wrapped_handler
 from toga_iOS.libs import (
     NSNotificationCenter,
@@ -142,3 +145,21 @@ class App:
 
     def add_background_task(self, handler):
         self.loop.call_soon(wrapped_handler(self, handler), self)
+
+    def about_command(self):
+        return Command(None, "About")
+
+    def preferences_command(self):
+        return Command(None, "Preferences")
+
+    def home_page_command(self):
+        return Command(None, "Visit homepage", group=toga.Group.HELP)
+
+    def quit_command(self):
+        return Command(
+            lambda s: self.exit(),
+            'Exit ' + self.interface.name,
+            shortcut=Key.MOD_1 + 'q',
+            group=toga.Group.FILE,
+            section=sys.maxsize
+        )

--- a/src/iOS/toga_iOS/app.py
+++ b/src/iOS/toga_iOS/app.py
@@ -1,11 +1,8 @@
 import asyncio
-import sys
 
 from rubicon.objc import SEL, objc_method
 from rubicon.objc.eventloop import EventLoopPolicy, iOSLifecycle
 
-import toga
-from toga import Command, Key
 from toga.handlers import wrapped_handler
 from toga_iOS.libs import (
     NSNotificationCenter,
@@ -145,21 +142,3 @@ class App:
 
     def add_background_task(self, handler):
         self.loop.call_soon(wrapped_handler(self, handler), self)
-
-    def about_command(self):
-        return Command(None, "About")
-
-    def preferences_command(self):
-        return Command(None, "Preferences")
-
-    def home_page_command(self):
-        return Command(None, "Visit homepage", group=toga.Group.HELP)
-
-    def quit_command(self):
-        return Command(
-            lambda s: self.exit(),
-            'Exit ' + self.interface.name,
-            shortcut=Key.MOD_1 + 'q',
-            group=toga.Group.FILE,
-            section=sys.maxsize
-        )

--- a/src/web/toga_web/app.py
+++ b/src/web/toga_web/app.py
@@ -21,11 +21,14 @@ class App:
         self.interface.icon.bind(self.interface.factory)
         # self.resource_path = os.path.dirname(os.path.dirname(NSBundle.mainBundle.bundlePath))
 
-        formal_name = self.interface.formal_name
-        self.interface.commands.add(
-            toga.Command(None, 'About ' + formal_name, group=toga.Group.APP),
-            toga.Command(None, 'Preferences', group=toga.Group.APP),
-        )
+    def about_command(self):
+        return toga.AboutCommand(self.interface, group=toga.Group.APP)
+
+    def preferences_command(self):
+        return toga.Command(None, 'Preferences', group=toga.Group.APP)
+
+    def home_page_command(self):
+        return toga.Command(None, 'Visit homepage', group=toga.Group.HELP)
 
     def main_loop(self):
         # Main loop is a no-op

--- a/src/web/toga_web/app.py
+++ b/src/web/toga_web/app.py
@@ -1,4 +1,7 @@
+import sys
+
 import toga
+from toga import Key
 
 from .window import Window
 
@@ -29,6 +32,15 @@ class App:
 
     def home_page_command(self):
         return toga.Command(None, 'Visit homepage', group=toga.Group.HELP)
+
+    def quit_command(self):
+        return toga.Command(
+            lambda s: self.exit(),
+            'Exit',
+            shortcut=Key.MOD_1 + 'q',
+            group=toga.Group.FILE,
+            section=sys.maxsize
+        )
 
     def main_loop(self):
         # Main loop is a no-op

--- a/src/winforms/toga_winforms/app.py
+++ b/src/winforms/toga_winforms/app.py
@@ -54,7 +54,6 @@ class App:
         self.native.SetCompatibleTextRenderingDefault(False)
 
         self.interface.commands.add(
-            toga.Command(None, 'About ' + self.interface.name, group=toga.Group.HELP),
             toga.Command(None, 'Preferences', group=toga.Group.FILE),
             # Quit should always be the last item, in a section on it's own
             toga.Command(

--- a/src/winforms/toga_winforms/app.py
+++ b/src/winforms/toga_winforms/app.py
@@ -52,19 +52,6 @@ class App:
 
         self.native.EnableVisualStyles()
         self.native.SetCompatibleTextRenderingDefault(False)
-
-        self.interface.commands.add(
-            toga.Command(None, 'Preferences', group=toga.Group.FILE),
-            # Quit should always be the last item, in a section on it's own
-            toga.Command(
-                lambda s: self.exit(),
-                'Exit ' + self.interface.name,
-                shortcut=Key.MOD_1 + 'q',
-                group=toga.Group.FILE,
-                section=sys.maxsize
-            ),
-            toga.Command(None, 'Visit homepage', group=toga.Group.HELP)
-        )
         self._create_app_commands()
 
         # Call user code to populate the main window
@@ -73,6 +60,24 @@ class App:
         self.create_menus()
         self.interface.icon.bind(self.interface.factory)
         self.interface.main_window._impl.set_app(self)
+
+    def about_command(self):
+        return toga.AboutCommand(self.interface, group=toga.Group.HELP)
+
+    def home_page_command(self):
+        return toga.Command(None, 'Visit homepage', group=toga.Group.HELP)
+
+    def preferences_command(self):
+        return toga.Command(None, 'Preferences', group=toga.Group.FILE)
+
+    def quit_command(self):
+        return toga.Command(
+            lambda s: self.exit(),
+            'Exit ' + self.interface.name,
+            shortcut=Key.MOD_1 + 'q',
+            group=toga.Group.FILE,
+            section=sys.maxsize
+        )
 
     def create_menus(self):
         toga.Group.FILE.order = 0


### PR DESCRIPTION
Added a default implementation of the "About" command. This command should work absolutely fine in any of the supported platforms, as long as `info_dialog` is implemented correctly.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
