### PR TITLE
Cocoa ScrollContainer: confine content in non-scrolling direction

### DIFF
--- a/examples/scrollcontainer/scrollcontainer/app.py
+++ b/examples/scrollcontainer/scrollcontainer/app.py
@@ -1,21 +1,36 @@
 import toga
-from toga.constants import COLUMN, LEFT
+from toga.constants import COLUMN
 from toga.style import Pack
+
+
+class Item(toga.Box):
+    def __init__(self, text):
+        super().__init__(style=Pack(direction=COLUMN))
+
+        label = toga.Label(text)
+
+        hline = toga.Divider()
+        hline.style.padding_top = 5
+        hline.style.padding_bottom = 5
+
+        self.add(label, hline)
 
 
 class ScrollContainerApp(toga.App):
     def startup(self):
-        self.main_window = toga.MainWindow(self.name)
+
         box = toga.Box()
         box.style.direction = COLUMN
+        box.style.padding = 10
 
         for x in range(100):
-            label_text = 'Label %d' % (x)
-            box.add(toga.Label(label_text, style=Pack(text_align=LEFT)))
+            label_text = 'Label {}'.format(x)
+            box.add(Item(label_text))
 
-        scroller = toga.ScrollContainer()
+        scroller = toga.ScrollContainer(horizontal=False)
         scroller.content = box
 
+        self.main_window = toga.MainWindow(self.name)
         self.main_window.content = scroller
         self.main_window.show()
 

--- a/src/cocoa/toga_cocoa/widgets/scrollcontainer.py
+++ b/src/cocoa/toga_cocoa/widgets/scrollcontainer.py
@@ -29,21 +29,14 @@ class ScrollContainer(Widget):
 
     def set_bounds(self, x, y, width, height):
         super().set_bounds(x, y, width, height)
-        if not self.interface.horizontal:
-            self.interface.content._impl.native.frame = NSMakeRect(
-                0, 0, width, self.interface.content.layout.height
-            )
-        elif not self.interface.vertical:
-            self.interface.content._impl.native.frame = NSMakeRect(
-                0, 0, self.interface.content.layout.width, height
-            )
-        else:
-            self.interface.content._impl.native.frame = NSMakeRect(
-                0,
-                0,
-                self.interface.content.layout.width,
-                self.interface.content.layout.height,
-            )
+
+        if self.interface.horizontal:
+            width = self.interface.content.layout.width
+
+        if self.interface.vertical:
+            height = self.interface.content.layout.height
+
+        self.interface.content._impl.native.frame = NSMakeRect(0, 0, width, height)
 
     def set_vertical(self, value):
         self.native.hasVerticalScroller = value

--- a/src/cocoa/toga_cocoa/widgets/scrollcontainer.py
+++ b/src/cocoa/toga_cocoa/widgets/scrollcontainer.py
@@ -30,6 +30,10 @@ class ScrollContainer(Widget):
     def set_bounds(self, x, y, width, height):
         super().set_bounds(x, y, width, height)
 
+        # Restrict dimensions of content to dimensions of ScrollContainer
+        # along any non-scrolling directions. Set dimensions of content
+        # to its layout dimensions along the scrolling directions.
+
         if self.interface.horizontal:
             width = self.interface.content.layout.width
 

--- a/src/cocoa/toga_cocoa/widgets/scrollcontainer.py
+++ b/src/cocoa/toga_cocoa/widgets/scrollcontainer.py
@@ -29,10 +29,21 @@ class ScrollContainer(Widget):
 
     def set_bounds(self, x, y, width, height):
         super().set_bounds(x, y, width, height)
-        self.interface.content._impl.native.frame = NSMakeRect(
-            0, 0,
-            self.interface.content.layout.width, self.interface.content.layout.height
-        )
+        if not self.interface.horizontal:
+            self.interface.content._impl.native.frame = NSMakeRect(
+                0, 0, width, self.interface.content.layout.height
+            )
+        elif not self.interface.vertical:
+            self.interface.content._impl.native.frame = NSMakeRect(
+                0, 0, self.interface.content.layout.width, height
+            )
+        else:
+            self.interface.content._impl.native.frame = NSMakeRect(
+                0,
+                0,
+                self.interface.content.layout.width,
+                self.interface.content.layout.height,
+            )
 
     def set_vertical(self, value):
         self.native.hasVerticalScroller = value


### PR DESCRIPTION
This confines the content of a ScrollContainer to its width or height along any non-scrolling direction. This means that for a ScrollContainer without a horizontal scroll bar (`horizontal = False`), the content will be confined to the width of the ScrollContainer. For a ScrollContainer without a vertical scroll bar (`vertical = False`), the content will be confined to the height of the ScrollContainer.

This change prevents content from unexpectedly becoming invisible when it's outside of the visible area along a non-scrolling direction.

I am not sure if this is the intended effect of disabling a scrollbar but it makes sense to me. A common use case would be a vertical stack of widgets to scroll through, similar to DetailedList, where the width of the widgets is fixed by the available space / window size.

@freakboy3742, what do you think?

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
