### PR TITLE
Add transparent color to windows color map

### DIFF
--- a/examples/box/box/app.py
+++ b/examples/box/box/app.py
@@ -1,6 +1,15 @@
 import toga
-from toga.colors import BLUE, RED
-from toga.constants import CENTER, COLUMN, GREEN, ROW, WHITE, YELLOW
+from toga.constants import (
+    CENTER,
+    COLUMN,
+    GREEN,
+    ROW,
+    WHITE,
+    YELLOW,
+    BLUE,
+    RED,
+    TRANSPARENT,
+)
 from toga.style import Pack
 
 
@@ -10,13 +19,12 @@ class ExampleBoxApp(toga.App):
         #   Main window of the application with title and size
         #   Also make the window non-resizable and non-minimizable.
         self.main_window = toga.MainWindow(
-            title=self.name, size=(800, 500),
-            resizeable=False, minimizable=False
+            title=self.name, size=(800, 500), resizeable=False, minimizable=False
         )
         self.yellow_button = toga.Button(
             label="Set yellow color",
             on_press=self.set_yellow_color,
-            style=Pack(background_color=YELLOW)
+            style=Pack(background_color=YELLOW),
         )
         self.inner_box = toga.Box(
             style=Pack(direction=ROW),
@@ -24,25 +32,25 @@ class ExampleBoxApp(toga.App):
                 toga.Button(
                     label="Set red color",
                     on_press=self.set_red_color,
-                    style=Pack(background_color=RED)
+                    style=Pack(background_color=RED),
                 ),
                 self.yellow_button,
                 toga.Button(
                     label="Set blue color",
                     on_press=self.set_blue_color,
-                    style=Pack(background_color=BLUE)
+                    style=Pack(background_color=BLUE),
                 ),
                 toga.Button(
                     label="Set green color",
                     on_press=self.set_green_color,
-                    style=Pack(background_color=GREEN)
+                    style=Pack(background_color=GREEN),
                 ),
                 toga.Button(
                     label="Reset color",
                     on_press=self.reset_color,
-                    style=Pack(background_color=WHITE)
-                )
-            ]
+                    style=Pack(background_color=WHITE),
+                ),
+            ],
         )
         #  Create the outer box with 2 rows
         self.outer_box = toga.Box(
@@ -50,8 +58,10 @@ class ExampleBoxApp(toga.App):
             children=[
                 self.inner_box,
                 toga.Label(text="Hello to my world!", style=Pack(text_align=CENTER)),
-                toga.Switch("Enable yellow", is_on=True, on_toggle=self.toggle_yellow_button)
-            ]
+                toga.Switch(
+                    "Enable yellow", is_on=True, on_toggle=self.toggle_yellow_button
+                ),
+            ],
         )
 
         # Add the content on the main window
@@ -72,6 +82,9 @@ class ExampleBoxApp(toga.App):
     def set_green_color(self, widget):
         self.outer_box.style.background_color = GREEN
 
+    def set_transparent_color(self, widget):
+        self.outer_box.style.background_color = TRANSPARENT
+
     def reset_color(self, widget):
         self.outer_box.style.background_color = None
 
@@ -85,5 +98,5 @@ class ExampleBoxApp(toga.App):
 def main():
     # Application class
     #   App name and namespace
-    app = ExampleBoxApp('Box', 'org.beeware.widgets.boxes')
+    app = ExampleBoxApp("Box", "org.beeware.widgets.boxes")
     return app

--- a/examples/box/box/app.py
+++ b/examples/box/box/app.py
@@ -82,9 +82,6 @@ class ExampleBoxApp(toga.App):
     def set_green_color(self, widget):
         self.outer_box.style.background_color = GREEN
 
-    def set_transparent_color(self, widget):
-        self.outer_box.style.background_color = TRANSPARENT
-
     def reset_color(self, widget):
         self.outer_box.style.background_color = None
 

--- a/examples/box/box/app.py
+++ b/examples/box/box/app.py
@@ -8,7 +8,6 @@ from toga.constants import (
     YELLOW,
     BLUE,
     RED,
-    TRANSPARENT,
 )
 from toga.style import Pack
 

--- a/src/winforms/toga_winforms/colors.py
+++ b/src/winforms/toga_winforms/colors.py
@@ -1,8 +1,10 @@
-from travertino.colors import NAMED_COLOR
+from travertino.colors import NAMED_COLOR, TRANSPARENT
 
 from .libs import Color
 
-CACHE = {None: Color.Empty}
+CACHE = {
+    TRANSPARENT: Color.Empty
+}
 
 
 def native_color(c):

--- a/src/winforms/toga_winforms/widgets/box.py
+++ b/src/winforms/toga_winforms/widgets/box.py
@@ -1,3 +1,5 @@
+from travertino.constants import TRANSPARENT
+
 from toga_winforms.colors import native_color
 from toga_winforms.libs import Point, Size, WinForms
 
@@ -26,3 +28,5 @@ class Box(Widget):
     def set_background_color(self, value):
         if value:
             self.native.BackColor = native_color(value)
+        else:
+            self.native.BackColor = native_color(TRANSPARENT)

--- a/src/winforms/toga_winforms/widgets/button.py
+++ b/src/winforms/toga_winforms/widgets/button.py
@@ -1,3 +1,4 @@
+from travertino.constants import TRANSPARENT
 from travertino.size import at_least
 
 from toga_winforms.colors import native_color
@@ -31,10 +32,11 @@ class Button(Widget):
     def set_color(self, value):
         if value:
             self.native.ForeColor = native_color(value)
+        else:
+            self.native.ForeColor = native_color(TRANSPARENT)
 
     def set_background_color(self, value):
-        if value:
-            self.native.BackColor = native_color(value)
+        self.native.BackColor = native_color(value)
 
     def rehint(self):
         # self.native.Size = Size(0, 0)

--- a/src/winforms/toga_winforms/widgets/button.py
+++ b/src/winforms/toga_winforms/widgets/button.py
@@ -36,7 +36,10 @@ class Button(Widget):
             self.native.ForeColor = native_color(TRANSPARENT)
 
     def set_background_color(self, value):
-        self.native.BackColor = native_color(value)
+        if value:
+            self.native.BackColor = native_color(value)
+        else:
+            self.native.BackColor = native_color(TRANSPARENT)
 
     def rehint(self):
         # self.native.Size = Size(0, 0)

--- a/src/winforms/toga_winforms/widgets/label.py
+++ b/src/winforms/toga_winforms/widgets/label.py
@@ -1,3 +1,4 @@
+from travertino.constants import TRANSPARENT
 from travertino.size import at_least
 
 from toga_winforms.libs import TextAlignment, WinForms
@@ -23,10 +24,14 @@ class Label(Widget):
     def set_color(self, value):
         if value:
             self.native.ForeColor = native_color(value)
+        else:
+            self.native.ForeColor = native_color(TRANSPARENT)
 
     def set_background_color(self, value):
         if value:
             self.native.BackColor = native_color(value)
+        else:
+            self.native.BackColor = native_color(TRANSPARENT)
 
     def rehint(self):
         # Width & height of a label is known and fixed.


### PR DESCRIPTION
This fixes a bug when trying to set the background color of a widget in Windows with  `TRANSPARENT` it raises an error.

## PR Checklist:
- [X] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
