### PR TITLE
Implement insert and remove api for toga_gtk.Widget

### DIFF
--- a/src/gtk/toga_gtk/widgets/base.py
+++ b/src/gtk/toga_gtk/widgets/base.py
@@ -39,6 +39,7 @@ class Widget:
             # setting container, adding self to container.native
             self._container = container
             self._container.native.add(self.native)
+            self.native.show_all()
 
         for child in self.interface.children:
             child._impl.container = container
@@ -84,8 +85,14 @@ class Widget:
     ######################################################################
 
     def add_child(self, child):
-        if self.container:
+        if self.viewport:
+            # we are the the top level container
+            child.container = self
+        else:
             child.container = self.container
+
+    def insert_child(self, index, child):
+        self.add_child(child)
 
     def remove_child(self, child):
         child.container = None


### PR DESCRIPTION
This PR implements the API to insert and remove widgets in the Gtk backend, similar to existing implementations for Cocoa and Winforms.

The example to test this is `layout`. However, there remains a small issue with this example in particular and the implementation of `toga_gtk.ImageView`: the example involves adding and reparenting an ImageView. However, the `toga_gtk.ImageView.rehint` produces incorrect dimensions in the first run after ImageView added to the new container (`native.get_allocated_width()` and `native.get_allocated_height()` both return 1). We only get correct values and an appearing image in the second run, for instance when resizing the window.

To me, this looks like an issue with `toga_gtk.ImageView` itself and should be fixed there instead of in this PR.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
