### PR TITLE
Fixes #1067 - issues with adding and removing widgets at runtime from m…

### DIFF
--- a/src/iOS/toga_iOS/widgets/base.py
+++ b/src/iOS/toga_iOS/widgets/base.py
@@ -104,9 +104,6 @@ class Widget:
         else:
             child.container = self.container
 
-    def insert_child(self, index, child):
-        self.add_child(child)
-
     def remove_child(self, child):
         child.container = None
 

--- a/src/iOS/toga_iOS/widgets/base.py
+++ b/src/iOS/toga_iOS/widgets/base.py
@@ -78,6 +78,17 @@ class Widget:
         if self.container:
             child.viewport = self.root.viewport
             child.container = self.container
+        # The highest level box doesn't have a container - it is one
+        elif getattr(self, "viewport", None):
+            child.viewport = self.viewport
+            child.container = self
+
+    def remove_child(self, child):
+        # Remove the child UIView and all of its child subviews
+        child.native.removeFromSuperview()
+        for sub_child in child.interface.children:
+            if sub_child._impl:
+                child.remove_child(sub_child._impl)
 
     def add_constraints(self):
         self.native.translatesAutoresizingMaskIntoConstraints = False

--- a/src/iOS/toga_iOS/widgets/base.py
+++ b/src/iOS/toga_iOS/widgets/base.py
@@ -99,7 +99,7 @@ class Widget:
     def add_child(self, child):
 
         if self.viewport:
-            # we are the the top level NSView
+            # we are the the top level UIView
             child.container = self
         else:
             child.container = self.container


### PR DESCRIPTION
…ain_window.content on iOS

When adding a child widget to the main window content widget on iOS, the children were not being set as belonging to a container. If you attempted to add a widget to main_window.content after the content had been set, you would get an error.

The fix was to check if we are adding a child to a widget that has a viewport and pass that viewport to the child.

No remove_child was implemented for iOS, so you could not remove children at all. This method was implemented, which calls remove_child on all children as well as calling into uikit to remove all the associated views.

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
