### PR TITLE
Adding frame to the split container to be visually distinguish.

### DIFF
--- a/src/gtk/toga_gtk/widgets/splitcontainer.py
+++ b/src/gtk/toga_gtk/widgets/splitcontainer.py
@@ -29,10 +29,14 @@ class SplitContainer(Widget):
 
         if position == 0:
             self.native.set_wide_handle(True)
-            self.native.pack1(widget.native, flex, False)
+            widget_frame = Gtk.Frame()
+            widget_frame.add(widget.native)
+            self.native.pack1(widget_frame, flex, False)
         elif position == 1:
             self.native.set_wide_handle(True)
-            self.native.pack2(widget.native, flex, False)
+            widget_frame = Gtk.Frame()
+            widget_frame.add(widget.native)
+            self.native.pack2(widget_frame, flex, False)
 
     def set_app(self, app):
         if self.interface.content:


### PR DESCRIPTION
This PR will add frame to the splits of the splitcontainer to be visually distinguish from other contents.
* Before add frame:
![splitcontainer_without_frame](https://user-images.githubusercontent.com/50509521/94132461-e15b9080-fe4e-11ea-8b21-043322a92944.png)

* After add frame:
![after](https://user-images.githubusercontent.com/50509521/94134539-aa3aae80-fe51-11ea-9886-70e48f7f84bd.png)

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
