### PR TITLE
Fixes an unresolved reference in Cocoa Tree

### DIFF
--- a/src/cocoa/toga_cocoa/widgets/tree.py
+++ b/src/cocoa/toga_cocoa/widgets/tree.py
@@ -294,7 +294,7 @@ class Tree(Widget):
         else:
             index = self.tree.selectedRow
             if index != -1:
-                return self.tree.itemAtRow(current_index).attrs['node']
+                return self.tree.itemAtRow(index).attrs['node']
             else:
                 return None
 


### PR DESCRIPTION
Fixes an unresolved reference `current_index` in `toga_cocoa.widgets.tee.Tree.get_selection()`.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
