### PR TITLE
Support more shortcuts in windows

### DIFF
--- a/examples/canvas/canvas/app.py
+++ b/examples/canvas/canvas/app.py
@@ -1,4 +1,5 @@
 import math
+import sys
 
 from travertino.constants import (
     BLACK,
@@ -24,6 +25,8 @@ from toga.fonts import (
 from toga.style import Pack
 from toga.style.pack import COLUMN, ROW
 from toga.widgets.canvas import FillRule
+
+MOVE_STEP = 5
 
 STROKE = "Stroke"
 FILL = "Fill"
@@ -197,6 +200,80 @@ class ExampleCanvasApp(toga.App):
         self.change_shape()
         self.render_drawing()
 
+        self.commands.add(
+            toga.Command(
+                lambda widget: self.move(0, -MOVE_STEP),
+                "Move up",
+                shortcut=toga.Key.MOD_1 + toga.Key.UP,
+                group=toga.Group.COMMANDS,
+                section=1,
+                order=1,
+            ),
+            toga.Command(
+                lambda widget: self.move(0, MOVE_STEP),
+                "Move down",
+                shortcut=toga.Key.MOD_1 + toga.Key.DOWN,
+                group=toga.Group.COMMANDS,
+                section=1,
+                order=2,
+            ),
+            toga.Command(
+                lambda widget: self.move(MOVE_STEP, 0),
+                "Move right",
+                shortcut=toga.Key.MOD_1 + toga.Key.RIGHT,
+                group=toga.Group.COMMANDS,
+                section=1,
+                order=3,
+            ),
+            toga.Command(
+                lambda widget: self.move(-MOVE_STEP, 0),
+                "Move left",
+                shortcut=toga.Key.MOD_1 + toga.Key.LEFT,
+                group=toga.Group.COMMANDS,
+                section=1,
+                order=4,
+            ),
+            toga.Command(
+                lambda widget: self.scale(1, 0),
+                "Scale up x",
+                shortcut=toga.Key.MOD_1 + toga.Key.SHIFT + toga.Key.X,
+                group=toga.Group.COMMANDS,
+                section=2,
+                order=1,
+            ),
+            toga.Command(
+                lambda widget: self.scale(-1, 0),
+                "Scale down x",
+                shortcut=toga.Key.MOD_1 + toga.Key.X,
+                group=toga.Group.COMMANDS,
+                section=2,
+                order=2,
+            ),
+            toga.Command(
+                lambda widget: self.scale(0, 1),
+                "Scale up y",
+                shortcut=toga.Key.MOD_1 + toga.Key.SHIFT + toga.Key.Y,
+                group=toga.Group.COMMANDS,
+                section=2,
+                order=3,
+            ),
+            toga.Command(
+                lambda widget: self.scale(0, -1),
+                "Scale down y",
+                shortcut=toga.Key.MOD_1 + toga.Key.Y,
+                group=toga.Group.COMMANDS,
+                section=2,
+                order=4,
+            ),
+            toga.Command(
+                self.reset_transform,
+                "Reset",
+                shortcut=toga.Key.MOD_1 + toga.Key.R,
+                group=toga.Group.COMMANDS,
+                section=sys.maxsize,
+            ),
+        )
+
         # Show the main window
         self.main_window.show()
 
@@ -286,6 +363,22 @@ class ExampleCanvasApp(toga.App):
     def on_alt_release(self, widget, x, y, clicks):
         self.clicked_point = None
         self.render_drawing()
+
+    def move(self, delta_x, delta_y):
+        try:
+            self.x_translation += delta_x
+            self.y_translation += delta_y
+        except ValueError:
+            return
+        self.refresh_canvas(None)
+
+    def scale(self, delta_x, delta_y):
+        try:
+            self.scale_x_slider.tick_value += delta_x
+            self.scale_y_slider.tick_value += delta_y
+        except ValueError:
+            return
+        self.refresh_canvas(None)
 
     def get_location_vector(self, x, y):
         return x - self.x_middle, y - self.y_middle

--- a/src/core/toga/keys.py
+++ b/src/core/toga/keys.py
@@ -162,3 +162,8 @@ class Key(Enum):
             return self.value + other.value
         except AttributeError:
             return self.value + other
+
+    def __radd__(self, other):
+        """Same as add
+        """
+        return self + other

--- a/src/winforms/toga_winforms/keys.py
+++ b/src/winforms/toga_winforms/keys.py
@@ -1,5 +1,6 @@
 from toga.keys import Key
 from .libs import WinForms
+from string import ascii_uppercase
 
 
 def toga_to_winforms_key(key):
@@ -18,33 +19,16 @@ WINFORMS_MODIFIERS_MAP = {
     Key.MOD_1: WinForms.Keys.Control,
     Key.MOD_2: WinForms.Keys.Alt,
 }
+WINFORMS_MODIFIERS_MAP.update({
+    getattr(Key, modifier.upper()): getattr(WinForms.Keys, modifier.title())
+    for modifier in ["shift", "up", "down", "left", "right", "home"]
+})
+
 WINFORMS_KEYS_MAP = {
     Key.PLUS.value: WinForms.Keys.Oemplus,
     Key.MINUS.value: WinForms.Keys.OemMinus,
-    "a": WinForms.Keys.A,
-    "b": WinForms.Keys.B,
-    "c": WinForms.Keys.C,
-    "d": WinForms.Keys.D,
-    "e": WinForms.Keys.E,
-    "f": WinForms.Keys.F,
-    "g": WinForms.Keys.G,
-    "h": WinForms.Keys.H,
-    "i": WinForms.Keys.I,
-    "j": WinForms.Keys.J,
-    "k": WinForms.Keys.K,
-    "l": WinForms.Keys.L,
-    "m": WinForms.Keys.M,
-    "n": WinForms.Keys.N,
-    "o": WinForms.Keys.O,
-    "p": WinForms.Keys.P,
-    "q": WinForms.Keys.Q,
-    "r": WinForms.Keys.R,
-    "s": WinForms.Keys.S,
-    "t": WinForms.Keys.T,
-    "u": WinForms.Keys.U,
-    "v": WinForms.Keys.V,
-    "w": WinForms.Keys.W,
-    "x": WinForms.Keys.X,
-    "y": WinForms.Keys.Y,
-    "z": WinForms.Keys.Z,
 }
+WINFORMS_KEYS_MAP.update({
+    getattr(Key, letter).value: getattr(WinForms.Keys, letter)
+    for letter in ascii_uppercase
+})

--- a/src/winforms/toga_winforms/keys.py
+++ b/src/winforms/toga_winforms/keys.py
@@ -5,7 +5,7 @@ from string import ascii_uppercase
 
 def toga_to_winforms_key(key):
     code = 0
-    for modifier, modifier_code in WINFORMS_MODIFIERS_MAP.items():
+    for modifier, modifier_code in WINFORMS_NON_PRINTABLES_MAP.items():
         if modifier.value in key:
             code |= modifier_code
             key = key.replace(modifier.value, "")
@@ -15,11 +15,11 @@ def toga_to_winforms_key(key):
     return code
 
 
-WINFORMS_MODIFIERS_MAP = {
+WINFORMS_NON_PRINTABLES_MAP = {
     Key.MOD_1: WinForms.Keys.Control,
     Key.MOD_2: WinForms.Keys.Alt,
 }
-WINFORMS_MODIFIERS_MAP.update({
+WINFORMS_NON_PRINTABLES_MAP.update({
     getattr(Key, modifier.upper()): getattr(WinForms.Keys, modifier.title())
     for modifier in ["shift", "up", "down", "left", "right", "home"]
 })

--- a/src/winforms/toga_winforms/widgets/slider.py
+++ b/src/winforms/toga_winforms/widgets/slider.py
@@ -49,7 +49,7 @@ class Slider(Widget):
         minimum, maximum = self.interface.range
         span = maximum - minimum
         actual_tick_count = self.native.Maximum
-        self.native.Value = (value - minimum) / span * actual_tick_count
+        self.native.Value = round((value - minimum) / span * actual_tick_count)
 
     def set_range(self, range):
         pass


### PR DESCRIPTION
Added missing keys to Winform's keymap and added those keys to the `Canvas` example.
When doing so, found a bug in Winform's `Slider`, so fixed it.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
