### PR TITLE
Add Divider implementation in Windows

### DIFF
--- a/examples/divider/divider/app.py
+++ b/examples/divider/divider/app.py
@@ -11,7 +11,7 @@ class DividerApp(toga.App):
         self.main_window = toga.MainWindow(title=self.name, size=(300, 150))
 
         style = Pack(padding_top=24)
-        substyle = Pack(padding_right=24, flex=1)
+        substyle = Pack(padding_right=12, padding_left=12, flex=1)
 
         # Add the content on the main window
         self.main_window.content = toga.Box(
@@ -23,9 +23,9 @@ class DividerApp(toga.App):
                 toga.Label('Section 3', style=style),
                 toga.Box(
                     children=[
-                        toga.DetailedList(['List 1'], style=substyle),
+                        toga.TextInput(placeholder="First textbox"),
                         toga.Divider(direction=toga.Divider.VERTICAL, style=substyle),
-                        toga.DetailedList(['List 2'], style=substyle),
+                        toga.TextInput(placeholder="Second textbox"),
                     ],
                     style=Pack(direction=ROW, padding=24, flex=1),
                 ),

--- a/src/winforms/toga_winforms/factory.py
+++ b/src/winforms/toga_winforms/factory.py
@@ -9,6 +9,7 @@ from .widgets.button import Button
 from .widgets.canvas import Canvas
 from .widgets.datepicker import DatePicker
 # from .widgets.detailedlist import DetailedList
+from .widgets.divider import Divider
 from .widgets.imageview import ImageView
 from .widgets.label import Label
 from .widgets.multilinetextinput import MultilineTextInput
@@ -50,6 +51,7 @@ __all__ = [
     'Box',
     'Button',
     'Canvas',
+    'Divider',
     # 'DetailedList',
     'ImageView',
     'DatePicker',

--- a/src/winforms/toga_winforms/widgets/divider.py
+++ b/src/winforms/toga_winforms/widgets/divider.py
@@ -11,8 +11,8 @@ class Divider(Widget):
         self.native.BorderStyle = WinForms.BorderStyle.Fixed3D
         self.native.AutoSize = False
 
-    def set_direction(self, direction):
-        if direction == toga.Divider.HORIZONTAL:
+    def set_direction(self, value):
+        if value == toga.Divider.HORIZONTAL:
             self.native.Height = 2
         else:
             self.native.Width = 2

--- a/src/winforms/toga_winforms/widgets/divider.py
+++ b/src/winforms/toga_winforms/widgets/divider.py
@@ -1,0 +1,26 @@
+import toga
+from toga_winforms.libs import WinForms
+from travertino.size import at_least
+
+from .base import Widget
+
+
+class Divider(Widget):
+    def create(self):
+        self.native = WinForms.Label()
+        self.native.BorderStyle = WinForms.BorderStyle.Fixed3D
+        self.native.AutoSize = False
+
+    def set_direction(self, direction):
+        if direction == toga.Divider.HORIZONTAL:
+            self.native.Height = 2
+        else:
+            self.native.Width = 2
+
+    def rehint(self):
+        if self.interface.direction == toga.Divider.HORIZONTAL:
+            self.interface.intrinsic.width = at_least(self.native.Width)
+            self.interface.intrinsic.height = self.native.Height
+        else:
+            self.interface.intrinsic.width = self.native.Width
+            self.interface.intrinsic.height = at_least(self.native.Height)


### PR DESCRIPTION
This is an initial implementation of the `toga.Divider` widget in Windows, based on [this](https://stackoverflow.com/questions/3296110/draw-horizontal-divider-in-winforms) suggestion.

![dividers](https://user-images.githubusercontent.com/19425795/94429020-5ce47700-019a-11eb-86c9-be54e8491f5f.png)

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
