### PR TITLE
Add TextInput validator

### DIFF
--- a/examples/textinput/textinput/app.py
+++ b/examples/textinput/textinput/app.py
@@ -1,3 +1,4 @@
+import re
 from string import ascii_lowercase, ascii_uppercase, digits
 
 import toga
@@ -72,6 +73,11 @@ class TextInputApp(toga.App):
             style=Pack(padding=10),
             on_change=self.on_password_change
         )
+        self.email_input = toga.TextInput(
+            placeholder='Email...',
+            style=Pack(padding=10),
+            validator=self.validate_email
+        )
         self.number_input = toga.NumberInput(style=Pack(padding=10))
         btn_extract = toga.Button(
             'Extract values',
@@ -86,6 +92,7 @@ class TextInputApp(toga.App):
                 self.text_input,
                 self.password_input,
                 self.password_content_label,
+                self.email_input,
                 self.number_input,
                 self.text_label,
                 self.password_label,
@@ -123,6 +130,23 @@ class TextInputApp(toga.App):
             else:
                 contains.add("special characters")
         return "Password contains: {}".format(', '.join(contains))
+
+    @classmethod
+    def validate_email(cls, value):
+        if value == "":
+            return
+        split_email = value.split("@")
+        email_parts = len(split_email)
+        if email_parts == 1:
+            return 'No "@" in address'
+        if email_parts >= 3:
+            return 'Too many "@" symbols in address'
+        name, domain = split_email
+        if not re.match(r"[A-Za-z][A-Za-z0-9\-.]*", name):
+            return 'Email name is invalid'
+        if not re.match(r"[A-Za-z][A-Za-z0-9\-.]*", domain):
+            return 'Email domain is invalid'
+        return
 
 
 def main():

--- a/src/android/toga_android/widgets/textinput.py
+++ b/src/android/toga_android/widgets/textinput.py
@@ -63,6 +63,12 @@ class TextInput(Widget):
         # No special handling required.
         pass
 
+    def set_error(self, error_message):
+        self.interface.factory.not_implemented("TextInput.set_error()")
+
+    def unset_error(self):
+        self.interface.factory.not_implemented("TextInput.unset_error()")
+
     def rehint(self):
         self.interface.intrinsic.width = at_least(self.interface.MIN_WIDTH)
         # Refuse to call measure() if widget has no container, i.e., has no LayoutParams.

--- a/src/android/toga_android/widgets/textinput.py
+++ b/src/android/toga_android/widgets/textinput.py
@@ -66,8 +66,8 @@ class TextInput(Widget):
     def set_error(self, error_message):
         self.interface.factory.not_implemented("TextInput.set_error()")
 
-    def unset_error(self):
-        self.interface.factory.not_implemented("TextInput.unset_error()")
+    def clear_error(self):
+        self.interface.factory.not_implemented("TextInput.clear_error()")
 
     def rehint(self):
         self.interface.intrinsic.width = at_least(self.interface.MIN_WIDTH)

--- a/src/cocoa/toga_cocoa/widgets/passwordinput.py
+++ b/src/cocoa/toga_cocoa/widgets/passwordinput.py
@@ -1,16 +1,20 @@
-from toga_cocoa.libs import NSSecureTextField, NSTextFieldSquareBezel
+from toga_cocoa.libs import NSSecureTextField, NSTextFieldSquareBezel, objc_method
 
-from .textinput import TextInput, TogaTextFieldDelegate
+
+from .textinput import TextInput
+
+
+class TogaSecureTextField(NSSecureTextField):
+    @objc_method
+    def textDidChange_(self, notification) -> None:
+        if self.interface.on_change:
+            self.interface.on_change(self.interface)
 
 
 class PasswordInput(TextInput):
     def create(self):
-        self.native = NSSecureTextField.new()
+        self.native = TogaSecureTextField.new()
         self.native.interface = self.interface
-
-        delegate = TogaTextFieldDelegate.new()
-        delegate.interface = self.interface
-        self.native.delegate = delegate
 
         self.native.bezeled = True
         self.native.bezelStyle = NSTextFieldSquareBezel

--- a/src/cocoa/toga_cocoa/widgets/textinput.py
+++ b/src/cocoa/toga_cocoa/widgets/textinput.py
@@ -76,5 +76,5 @@ class TextInput(Widget):
         if self.interface.window is not None:
             self.interface.window.error_dialog("Validation Error", error_message)
 
-    def unset_error(self):
+    def clear_error(self):
         self.last_valid_value = self.interface.value

--- a/src/cocoa/toga_cocoa/widgets/textinput.py
+++ b/src/cocoa/toga_cocoa/widgets/textinput.py
@@ -11,25 +11,25 @@ from toga_cocoa.libs import (
 from .base import Widget
 
 
-class TogaTextFieldDelegate(NSObject):
+class TogaTextField(NSTextField):
     @objc_method
-    def controlTextDidChange_(self, notification) -> None:
+    def textDidChange_(self, notification) -> None:
         if self.interface.on_change:
             self.interface.on_change(self.interface)
 
     @objc_method
-    def controlTextDidEndEditing_(self) -> None:
-        self.interface.validate()
+    def textShouldEndEditing_(self, textObject) -> bool:
+        return self.interface.validate()
 
 
 class TextInput(Widget):
     def create(self):
-        self.native = NSTextField.new()
+        self.native = TogaTextField.new()
         self.native.interface = self.interface
 
-        delegate = TogaTextFieldDelegate.new()
-        delegate.interface = self.interface
-        self.native.delegate = delegate
+        # delegate = TogaTextFieldDelegate.new()
+        # delegate.interface = self.interface
+        # self.native.delegate = delegate
 
         self.native.bezeled = True
         self.native.bezelStyle = NSTextFieldSquareBezel
@@ -72,9 +72,9 @@ class TextInput(Widget):
         pass
 
     def set_error(self, error_message):
-        self.interface.value = self.last_valid_value
         if self.interface.window is not None:
             self.interface.window.error_dialog("Validation Error", error_message)
 
     def clear_error(self):
-        self.last_valid_value = self.interface.value
+        # Cocoa TextInput can't ever be in an invalid state, so clear is a no-op
+        pass

--- a/src/cocoa/toga_cocoa/widgets/textinput.py
+++ b/src/cocoa/toga_cocoa/widgets/textinput.py
@@ -65,3 +65,9 @@ class TextInput(Widget):
 
     def set_on_change(self, handler):
         pass
+
+    def set_error(self, error_message):
+        self.interface.factory.not_implemented("TextInput.set_error()")
+
+    def unset_error(self):
+        self.interface.factory.not_implemented("TextInput.unset_error()")

--- a/src/cocoa/toga_cocoa/widgets/textinput.py
+++ b/src/cocoa/toga_cocoa/widgets/textinput.py
@@ -1,7 +1,6 @@
 from travertino.size import at_least
 
 from toga_cocoa.libs import (
-    NSObject,
     NSTextAlignment,
     NSTextField,
     NSTextFieldSquareBezel,
@@ -27,16 +26,11 @@ class TextInput(Widget):
         self.native = TogaTextField.new()
         self.native.interface = self.interface
 
-        # delegate = TogaTextFieldDelegate.new()
-        # delegate.interface = self.interface
-        # self.native.delegate = delegate
-
         self.native.bezeled = True
         self.native.bezelStyle = NSTextFieldSquareBezel
 
         # Add the layout constraints
         self.add_constraints()
-        self.last_valid_value = None
 
     def set_readonly(self, value):
         # Even if it's not editable, it's still selectable.

--- a/src/cocoa/toga_cocoa/widgets/textinput.py
+++ b/src/cocoa/toga_cocoa/widgets/textinput.py
@@ -32,6 +32,8 @@ class TextInput(Widget):
         self.native.bezeled = True
         self.native.bezelStyle = NSTextFieldSquareBezel
 
+        self.native.wantsLayer = True
+
         # Add the layout constraints
         self.add_constraints()
 
@@ -69,7 +71,6 @@ class TextInput(Widget):
         pass
 
     def set_error(self, error_message):
-        self.native.wantsLayer = True
         self.native.layer.borderColor = NSColor.redColor.CGColor
         self.native.layer.borderWidth = 1.0
         self.native.layer.cornerRadius = 0.0
@@ -79,5 +80,4 @@ class TextInput(Widget):
         self.set_background_color(None)
         self.native.toolTip = ""
         if self.native.layer is not None:
-            self.native.layer.borderColor = None
-        self.native.wantsLayer = False
+            self.native.layer = None

--- a/src/cocoa/toga_cocoa/widgets/textinput.py
+++ b/src/cocoa/toga_cocoa/widgets/textinput.py
@@ -5,7 +5,8 @@ from toga_cocoa.libs import (
     NSTextAlignment,
     NSTextField,
     NSTextFieldSquareBezel,
-    objc_method
+    objc_method,
+    NSColor,
 )
 
 from .base import Widget
@@ -16,6 +17,7 @@ class TogaTextFieldDelegate(NSObject):
     def controlTextDidChange_(self, notification) -> None:
         if self.interface.on_change:
             self.interface.on_change(self.interface)
+        self.interface.validate()
 
 
 class TextInput(Widget):
@@ -67,7 +69,15 @@ class TextInput(Widget):
         pass
 
     def set_error(self, error_message):
-        self.interface.factory.not_implemented("TextInput.set_error()")
+        self.native.wantsLayer = True
+        self.native.layer.borderColor = NSColor.redColor.CGColor
+        self.native.layer.borderWidth = 1.0
+        self.native.layer.cornerRadius = 0.0
+        self.native.toolTip = error_message
 
     def unset_error(self):
-        self.interface.factory.not_implemented("TextInput.unset_error()")
+        self.set_background_color(None)
+        self.native.toolTip = ""
+        if self.native.layer is not None:
+            self.native.layer.borderColor = None
+        self.native.wantsLayer = False

--- a/src/core/tests/widgets/test_textinput.py
+++ b/src/core/tests/widgets/test_textinput.py
@@ -1,6 +1,7 @@
 import toga
 import toga_dummy
 from toga_dummy.utils import TestCase
+from unittest.mock import Mock, call
 
 
 class TextInputTests(TestCase):
@@ -10,10 +11,12 @@ class TextInputTests(TestCase):
         self.initial = 'Initial Text'
         self.placeholder = 'Placeholder Text'
         self.readonly = False
-        self.text_input = toga.TextInput(initial=self.initial,
-                                         placeholder=self.placeholder,
-                                         readonly=self.readonly,
-                                         factory=toga_dummy.factory)
+        self.text_input = toga.TextInput(
+            initial=self.initial,
+            placeholder=self.placeholder,
+            readonly=self.readonly,
+            factory=toga_dummy.factory
+        )
 
     def test_widget_created(self):
         self.assertEqual(self.text_input._impl.interface, self.text_input)
@@ -54,3 +57,93 @@ class TextInputTests(TestCase):
     def test_focus(self):
         self.text_input.focus()
         self.assertActionPerformed(self.text_input, "focus")
+
+
+class ValidatedTextInputTests(TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.initial = 'Initial Text'
+
+    def test_validator_run_in_constructor(self):
+        validator = Mock(return_value=None)
+        text_input = toga.TextInput(
+            initial=self.initial,
+            validator=validator,
+            factory=toga_dummy.factory
+        )
+        self.assertValueNotSet(text_input, "error")
+        self.assertActionPerformed(text_input, "unset_error")
+        validator.assert_called_once_with(self.initial)
+
+    def test_validator_run_after_set(self):
+        message = "This is an error message"
+        validator = Mock(return_value=message)
+        text_input = toga.TextInput(
+            initial=self.initial,
+            factory=toga_dummy.factory
+        )
+
+        self.assertValueNotSet(text_input, "error")
+
+        text_input.validator = validator
+
+        self.assertValueSet(text_input, "error", message)
+        validator.assert_called_once_with(self.initial)
+
+    def test_text_input_with_no_validator_is_valid(self):
+        text_input = toga.TextInput(
+            initial=self.initial,
+            factory=toga_dummy.factory
+        )
+        self.assertTrue(text_input.is_valid())
+
+    def test_is_valid_returns_true(self):
+        validator = Mock(return_value=None)
+        text_input = toga.TextInput(
+            initial=self.initial,
+            validator=validator,
+            factory=toga_dummy.factory
+        )
+        self.assertTrue(text_input.is_valid())
+
+    def test_is_valid_returns_false(self):
+        message = "This is an error message"
+        validator = Mock(return_value=message)
+        text_input = toga.TextInput(
+            initial=self.initial,
+            validator=validator,
+            factory=toga_dummy.factory
+        )
+        self.assertFalse(text_input.is_valid())
+
+    def test_validate_passes(self):
+        validator = Mock(side_effect=[None, None])
+        text_input = toga.TextInput(
+            initial=self.initial,
+            validator=validator,
+            factory=toga_dummy.factory
+        )
+        self.assertValueNotSet(text_input, "error")
+
+        text_input.validate()
+        self.assertValueNotSet(text_input, "error")
+        self.assertEqual(
+            validator.call_args_list, [call(self.initial), call(self.initial)]
+        )
+
+    def test_validate_fails(self):
+        message = "This is an error message"
+        validator = Mock(side_effect=[None, message])
+        text_input = toga.TextInput(
+            initial=self.initial,
+            validator=validator,
+            factory=toga_dummy.factory
+        )
+        self.assertValueNotSet(text_input, "error")
+
+        text_input.validate()
+        self.assertValueSet(text_input, "error", message)
+        self.assertEqual(
+            validator.call_args_list, [call(self.initial), call(self.initial)]
+        )

--- a/src/core/tests/widgets/test_textinput.py
+++ b/src/core/tests/widgets/test_textinput.py
@@ -73,7 +73,7 @@ class ValidatedTextInputTests(TestCase):
             factory=toga_dummy.factory
         )
         self.assertValueNotSet(text_input, "error")
-        self.assertActionPerformed(text_input, "unset_error")
+        self.assertActionPerformed(text_input, "clear_error")
         validator.assert_called_once_with(self.initial)
 
     def test_validator_run_after_set(self):

--- a/src/core/toga/widgets/textinput.py
+++ b/src/core/toga/widgets/textinput.py
@@ -129,17 +129,11 @@ class TextInput(Widget):
         else:
             error_message = self.validator(self.value)
         if error_message is None:
-            self.clear_error()
+            self._impl.clear_error()
         else:
-            self.set_error(error_message)
+            self._impl.set_error(error_message)
 
     def is_valid(self):
         if self.validator is None:
             return True
         return self.validator(self.value) is None
-
-    def set_error(self, error_message):
-        self._impl.set_error(error_message)
-
-    def clear_error(self):
-        self._impl.clear_error()

--- a/src/core/toga/widgets/textinput.py
+++ b/src/core/toga/widgets/textinput.py
@@ -128,10 +128,13 @@ class TextInput(Widget):
             error_message = None
         else:
             error_message = self.validator(self.value)
+
         if error_message is None:
             self._impl.clear_error()
+            return True
         else:
             self._impl.set_error(error_message)
+            return False
 
     def is_valid(self):
         if self.validator is None:

--- a/src/core/toga/widgets/textinput.py
+++ b/src/core/toga/widgets/textinput.py
@@ -20,7 +20,9 @@ class TextInput(Widget):
 
     def __init__(
             self, id=None, style=None, factory=None,
-            initial=None, placeholder=None, readonly=False, on_change=None):
+            initial=None, placeholder=None, readonly=False, on_change=None,
+            validator=None
+    ):
         super().__init__(id=id, style=style, factory=factory)
 
         # Create a platform specific implementation of the widget
@@ -29,6 +31,7 @@ class TextInput(Widget):
         self.on_change = on_change
         self.placeholder = placeholder
         self.readonly = readonly
+        self.validator = validator
 
         # Set the actual value last, as it may trigger change events, etc.
         self.value = initial
@@ -100,10 +103,28 @@ class TextInput(Widget):
 
     @on_change.setter
     def on_change(self, handler):
-        """Set the handler to invoke when the value is changeed.
+        """Set the handler to invoke when the value is changed.
 
         Args:
-            handler (:obj:`callable`): The handler to invoke when the value is changeed.
+            handler (:obj:`callable`): The handler to invoke when the value is changed.
         """
         self._on_change = wrapped_handler(self, handler)
         self._impl.set_on_change(self._on_change)
+
+    def validate(self):
+        error_message = None if self.validator is None else self.validator(self.value)
+        if error_message is None:
+            self.unset_error()
+        else:
+            self.set_error(error_message)
+
+    def is_valid(self):
+        if self.validator is None:
+            return True
+        return self.validator(self.value) is None
+
+    def set_error(self, error_message):
+        self._impl.set_error(error_message)
+
+    def unset_error(self):
+        self._impl.unset_error()

--- a/src/core/toga/widgets/textinput.py
+++ b/src/core/toga/widgets/textinput.py
@@ -15,6 +15,9 @@ class TextInput(Widget):
         initial (str): The initial text for the input.
         placeholder (str): If no input is present this text is shown.
         readonly (bool):  Whether a user can write into the text input, defaults to `False`.
+        on_change (Callable): Method to be called when text is changed in text box
+        validator (Callable): Validator to run on the value of the text box. Should
+            return None is value is valid and an error message if not.
     """
     MIN_WIDTH = 100
 

--- a/src/core/toga/widgets/textinput.py
+++ b/src/core/toga/widgets/textinput.py
@@ -31,10 +31,10 @@ class TextInput(Widget):
         self.on_change = on_change
         self.placeholder = placeholder
         self.readonly = readonly
-        self.validator = validator
 
-        # Set the actual value last, as it may trigger change events, etc.
+        # Set the actual value after on_change, as it may trigger change events, etc.
         self.value = initial
+        self.validator = validator
 
     def _create(self):
         self._impl = self.factory.TextInput(interface=self)
@@ -111,8 +111,20 @@ class TextInput(Widget):
         self._on_change = wrapped_handler(self, handler)
         self._impl.set_on_change(self._on_change)
 
+    @property
+    def validator(self):
+        return self._validator
+
+    @validator.setter
+    def validator(self, validator):
+        self._validator = validator
+        self.validate()
+
     def validate(self):
-        error_message = None if self.validator is None else self.validator(self.value)
+        if self.validator is None:
+            error_message = None
+        else:
+            error_message = self.validator(self.value)
         if error_message is None:
             self.unset_error()
         else:

--- a/src/core/toga/widgets/textinput.py
+++ b/src/core/toga/widgets/textinput.py
@@ -129,7 +129,7 @@ class TextInput(Widget):
         else:
             error_message = self.validator(self.value)
         if error_message is None:
-            self.unset_error()
+            self.clear_error()
         else:
             self.set_error(error_message)
 
@@ -141,5 +141,5 @@ class TextInput(Widget):
     def set_error(self, error_message):
         self._impl.set_error(error_message)
 
-    def unset_error(self):
-        self._impl.unset_error()
+    def clear_error(self):
+        self._impl.clear_error()

--- a/src/dummy/toga_dummy/utils.py
+++ b/src/dummy/toga_dummy/utils.py
@@ -363,7 +363,7 @@ class TestCase(unittest.TestCase):
     def assertValueNotSet(self, _widget, attr):
         self.assertTrue(
             attr not in _widget._impl._sets,
-            msg=f"Expected {attr} not to be set, but it was."
+            msg="Expected {attr} not to be set, but it was.".format(attr=attr)
         )
 
     def assertActionNotPerformed(self, _widget, action):

--- a/src/dummy/toga_dummy/utils.py
+++ b/src/dummy/toga_dummy/utils.py
@@ -360,6 +360,12 @@ class TestCase(unittest.TestCase):
         except AttributeError:
             self.fail('Widget {} is not a logged object'.format(_widget))
 
+    def assertValueNotSet(self, _widget, attr):
+        self.assertTrue(
+            attr not in _widget._impl._sets,
+            msg=f"Expected {attr} not to be set, but it was."
+        )
+
     def assertActionNotPerformed(self, _widget, action):
         """Assert that the named action was *not* performed by a widget.
 

--- a/src/dummy/toga_dummy/widgets/textinput.py
+++ b/src/dummy/toga_dummy/widgets/textinput.py
@@ -32,5 +32,5 @@ class TextInput(Widget):
     def set_error(self, error_message):
         self._set_value('error', error_message)
 
-    def unset_error(self):
-        self._action('unset_error')
+    def clear_error(self):
+        self._action('clear_error')

--- a/src/dummy/toga_dummy/widgets/textinput.py
+++ b/src/dummy/toga_dummy/widgets/textinput.py
@@ -28,3 +28,9 @@ class TextInput(Widget):
 
     def set_on_change(self, handler):
         self._set_value('on_change', handler)
+
+    def set_error(self, error_message):
+        self._set_value('error', error_message)
+
+    def unset_error(self):
+        self._action('unset_error')

--- a/src/gtk/toga_gtk/widgets/textinput.py
+++ b/src/gtk/toga_gtk/widgets/textinput.py
@@ -47,3 +47,9 @@ class TextInput(Widget):
     def set_on_change(self, handler):
         # No special handling required
         pass
+
+    def set_error(self, error_message):
+        self.interface.factory.not_implemented("TextInput.set_error()")
+
+    def unset_error(self):
+        self.interface.factory.not_implemented("TextInput.unset_error()")

--- a/src/gtk/toga_gtk/widgets/textinput.py
+++ b/src/gtk/toga_gtk/widgets/textinput.py
@@ -51,5 +51,5 @@ class TextInput(Widget):
     def set_error(self, error_message):
         self.interface.factory.not_implemented("TextInput.set_error()")
 
-    def unset_error(self):
-        self.interface.factory.not_implemented("TextInput.unset_error()")
+    def clear_error(self):
+        self.interface.factory.not_implemented("TextInput.clear_error()")

--- a/src/iOS/toga_iOS/widgets/textinput.py
+++ b/src/iOS/toga_iOS/widgets/textinput.py
@@ -66,5 +66,5 @@ class TextInput(Widget):
     def set_error(self, error_message):
         self.interface.factory.not_implemented("TextInput.set_error()")
 
-    def unset_error(self):
-        self.interface.factory.not_implemented("TextInput.unset_error()")
+    def clear_error(self):
+        self.interface.factory.not_implemented("TextInput.clear_error()")

--- a/src/iOS/toga_iOS/widgets/textinput.py
+++ b/src/iOS/toga_iOS/widgets/textinput.py
@@ -62,3 +62,9 @@ class TextInput(Widget):
     def set_on_change(self, handler):
         # No special handling required
         pass
+
+    def set_error(self, error_message):
+        self.interface.factory.not_implemented("TextInput.set_error()")
+
+    def unset_error(self):
+        self.interface.factory.not_implemented("TextInput.unset_error()")

--- a/src/winforms/toga_winforms/widgets/textinput.py
+++ b/src/winforms/toga_winforms/widgets/textinput.py
@@ -66,7 +66,7 @@ class TextInput(Widget):
     def winforms_validated(self, sender, event):
         self.interface.validate()
 
-    def unset_error(self):
+    def clear_error(self):
         self.error_provider.SetError(self.native, "")
 
     def set_error(self, error_message):

--- a/src/winforms/toga_winforms/widgets/textinput.py
+++ b/src/winforms/toga_winforms/widgets/textinput.py
@@ -14,6 +14,12 @@ class TextInput(Widget):
         self.native.Multiline = False
         self.native.DoubleClick += self.winforms_double_click
         self.native.TextChanged += self.winforms_text_changed
+        self.native.Validated += self.winforms_validated
+        self.error_provider = WinForms.ErrorProvider()
+        self.error_provider.SetIconAlignment(
+            self.native, WinForms.ErrorIconAlignment.BottomRight
+        )
+        self.error_provider.BlinkStyle = WinForms.ErrorBlinkStyle.NeverBlink
 
     def set_readonly(self, value):
         self.native.ReadOnly = value
@@ -55,6 +61,15 @@ class TextInput(Widget):
     def winforms_text_changed(self, sender, event):
         if self.interface._on_change:
             self.interface.on_change(self.interface)
+
+    def winforms_validated(self, sender, event):
+        self.interface.validate()
+
+    def unset_error(self):
+        self.error_provider.SetError(self.native, "")
+
+    def set_error(self, error_message):
+        self.error_provider.SetError(self.native, error_message)
 
     def winforms_double_click(self, sender, event):
         self.native.SelectAll()

--- a/src/winforms/toga_winforms/widgets/textinput.py
+++ b/src/winforms/toga_winforms/widgets/textinput.py
@@ -17,8 +17,9 @@ class TextInput(Widget):
         self.native.Validated += self.winforms_validated
         self.error_provider = WinForms.ErrorProvider()
         self.error_provider.SetIconAlignment(
-            self.native, WinForms.ErrorIconAlignment.BottomRight
+            self.native, WinForms.ErrorIconAlignment.MiddleRight
         )
+        self.error_provider.SetIconPadding(self.native, -20)
         self.error_provider.BlinkStyle = WinForms.ErrorBlinkStyle.NeverBlink
 
     def set_readonly(self, value):


### PR DESCRIPTION
Initial implementation of a validator in `toga.TextInput` in Windows. One can add a `validator` parameter to the `toga.TextInput` constructor in order to validate the value. the `validator` callable should return `None` if the value is valid and an error message if it is not.

![validator](https://user-images.githubusercontent.com/19425795/94454041-130b8900-01ba-11eb-99a3-155164820d87.png)

closes #909

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
