### PR TITLE
Add toggle method to toga.Switch

### DIFF
--- a/src/core/tests/widgets/test_switch.py
+++ b/src/core/tests/widgets/test_switch.py
@@ -53,3 +53,17 @@ class SwitchTests(TestCase):
     def test_focus(self):
         self.switch.focus()
         self.assertActionPerformed(self.switch, "focus")
+
+    def test_toggle_from_true_to_false(self):
+        self.switch.is_on = True
+        self.switch.toggle()
+        self.assertValueSet(self.switch, 'is_on', False)
+
+    def test_toggle_from_false_to_true(self):
+        self.switch.is_on = False
+        self.switch.toggle()
+        self.assertValueSet(self.switch, 'is_on', True)
+
+    def test_set_is_on_with_non_boolean(self):
+        with self.assertRaises(ValueError):
+            self.switch.is_on = "on"

--- a/src/core/toga/widgets/switch.py
+++ b/src/core/toga/widgets/switch.py
@@ -71,7 +71,12 @@ class Switch(Widget):
 
     @is_on.setter
     def is_on(self, value):
-        if value is True:
-            self._impl.set_is_on(True)
-        elif value is False:
-            self._impl.set_is_on(False)
+        if not isinstance(value, bool):
+            raise ValueError("Switch.is_on can only be set to true or false")
+        self._impl.set_is_on(value)
+
+    def toggle(self):
+        """Reverse the value of `Slider.is_on` property from true to false and
+        vice versa.
+        """
+        self.is_on = not self.is_on


### PR DESCRIPTION
Added a toggle method to `toga.Slider` to invert `Slider.is_on` property.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
