### PR TITLE
Use rubicon-objc `load_library` to load system libraries

### DIFF
--- a/src/cocoa/toga_cocoa/libs/appkit.py
+++ b/src/cocoa/toga_cocoa/libs/appkit.py
@@ -1,11 +1,12 @@
 ##########################################################################
 # System/Library/Frameworks/AppKit.framework
 ##########################################################################
-from ctypes import Structure, c_void_p, cdll, util
+from ctypes import Structure, c_void_p
 from enum import Enum
 
 from rubicon.objc import CGFloat, ObjCClass, objc_const
 from rubicon.objc.api import NSString
+from rubicon.objc.runtime import load_library
 
 from travertino.colors import (
     BLACK,
@@ -27,7 +28,7 @@ from travertino.colors import (
 from toga.constants import CENTER, JUSTIFY, LEFT, RIGHT
 
 ######################################################################
-appkit = cdll.LoadLibrary(util.find_library('AppKit'))
+appkit = load_library('AppKit')
 ######################################################################
 
 ######################################################################

--- a/src/cocoa/toga_cocoa/libs/core_graphics.py
+++ b/src/cocoa/toga_cocoa/libs/core_graphics.py
@@ -10,15 +10,14 @@ from ctypes import (
     c_uint32,
     c_void_p,
     c_wchar_p,
-    cdll,
-    util
 )
 
 from rubicon.objc import CGFloat, CGRect
 from rubicon.objc.types import register_preferred_encoding
+from rubicon.objc.runtime import load_library
 
 ######################################################################
-core_graphics = cdll.LoadLibrary(util.find_library('CoreGraphics'))
+core_graphics = load_library('CoreGraphics')
 ######################################################################
 
 ######################################################################

--- a/src/cocoa/toga_cocoa/libs/foundation.py
+++ b/src/cocoa/toga_cocoa/libs/foundation.py
@@ -1,12 +1,13 @@
 ##########################################################################
 # System/Library/Frameworks/Foundation.framework
 ##########################################################################
-from ctypes import c_bool, cdll, util
+from ctypes import c_bool
 
 from rubicon.objc import NSPoint, NSRect, ObjCClass
+from rubicon.objc.runtime import load_library
 
 ######################################################################
-foundation = cdll.LoadLibrary(util.find_library('Foundation'))
+foundation = load_library('Foundation')
 ######################################################################
 
 foundation.NSMouseInRect.restype = c_bool

--- a/src/cocoa/toga_cocoa/libs/webkit.py
+++ b/src/cocoa/toga_cocoa/libs/webkit.py
@@ -1,7 +1,6 @@
 ##########################################################################
 # System/Library/Frameworks/WebKit.framework
 ##########################################################################
-from ctypes import cdll, util
 
 from rubicon.objc import ObjCClass
 from rubicon.objc.runtime import load_library

--- a/src/cocoa/toga_cocoa/libs/webkit.py
+++ b/src/cocoa/toga_cocoa/libs/webkit.py
@@ -4,9 +4,10 @@
 from ctypes import cdll, util
 
 from rubicon.objc import ObjCClass
+from rubicon.objc.runtime import load_library
 
 ######################################################################
-webkit = cdll.LoadLibrary(util.find_library('WebKit'))
+webkit = load_library('WebKit')
 ######################################################################
 
 ######################################################################


### PR DESCRIPTION
From macOS 11 onward, system libraries are no longer present on the filesystem. From Apple's release notes:

> New in macOS Big Sur 11 beta, the system ships with a built-in dynamic linker cache of all system-provided libraries. As part of this change, copies of dynamic libraries are no longer present on the filesystem. Code that attempts to check for dynamic library presence by looking for a file at a path or enumerating a directory will fail. Instead, check for library presence by attempting to dlopen() the path, which will correctly check for the library in the cache.

As a result, using `cdll.LoadLibrary(util.find_library('lib'))` fails to load the libraries on macOS 11. This will likely be fixed when PR https://github.com/python/cpython/pull/21241 is merged. I believe the fix will be backported to Python 3.8 but not to 3.7 and lower. Since toga supports older version of Python as well, this PR proposes to use rubicon-objc's `load_library` to load system libraries. This has been designed to work on iOS as well where libraries are also inaccessible in the file system.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
