### PR TITLE
Add recent files to document app

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -33,6 +33,7 @@ recursive-include examples *.py
 recursive-include examples *.rst
 recursive-include examples *.toml
 recursive-include examples README
+recursive-include examples *.txt
 prune examples/*/.vscode
 
 recursive-include src *.html

--- a/examples/document_app/README.rst
+++ b/examples/document_app/README.rst
@@ -1,0 +1,13 @@
+Document Apps example
+===============
+
+This is example of a document.
+When you load a txt file, it's content will be loaded to the text input.
+The app saved the last three files loaded
+
+Quickstart
+~~~~~~~~~~
+
+To run this example:
+
+    $ python -m document_app

--- a/examples/document_app/document_app/__init__.py
+++ b/examples/document_app/document_app/__init__.py
@@ -1,0 +1,9 @@
+# Examples of valid version strings
+# __version__ = '1.2.3.dev1'  # Development release 1
+# __version__ = '1.2.3a1'     # Alpha Release 1
+# __version__ = '1.2.3b1'     # Beta Release 1
+# __version__ = '1.2.3rc1'    # RC Release 1
+# __version__ = '1.2.3'       # Final Release
+# __version__ = '1.2.3.post1' # Post Release 1
+
+__version__ = '0.0.1'

--- a/examples/document_app/document_app/__main__.py
+++ b/examples/document_app/document_app/__main__.py
@@ -1,0 +1,4 @@
+from document_app.app import main
+
+if __name__ == '__main__':
+    main().main_loop()

--- a/examples/document_app/document_app/app.py
+++ b/examples/document_app/document_app/app.py
@@ -12,7 +12,7 @@ class ExampleDocumentApp(toga.DocumentApp):
             resizeable=False, minimizable=False
         )
 
-        self.text_input = toga.MultilineTextInput()
+        self.text_input = toga.MultilineTextInput(style=Pack(flex=1))
         outer_box = toga.Box(
             style=Pack(direction=COLUMN),
             children=[
@@ -38,7 +38,6 @@ def main():
     app = ExampleDocumentApp(
         'DocumentApp',
         'org.beeware.widgets.document_app',
-        recent_documents_size=3,
         load_document=load_file,
         initial_directory=str(Path(__file__).parent.parent / "resources"),
         document_types=["txt"]

--- a/examples/document_app/document_app/app.py
+++ b/examples/document_app/document_app/app.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+import toga
+from toga.constants import COLUMN
+from toga.style import Pack
+
+
+class ExampleDocumentApp(toga.DocumentApp):
+    def startup(self):
+        self.main_window = toga.MainWindow(
+            title=self.name, size=(800, 500),
+            resizeable=False, minimizable=False
+        )
+
+        self.text_input = toga.MultilineTextInput()
+        outer_box = toga.Box(
+            style=Pack(direction=COLUMN),
+            children=[
+                toga.Label("Hello!"),
+                self.text_input
+            ]
+        )
+
+        self.main_window.content = outer_box
+
+        # Show the main window
+        self.main_window.show()
+
+
+def load_file(app, file_path):
+    with open(file_path, mode="r") as file_object:
+        app.text_input.value = file_object.read()
+
+
+def main():
+    # Application class
+    #   App name and namespace
+    app = ExampleDocumentApp(
+        'DocumentApp',
+        'org.beeware.widgets.document_app',
+        recent_documents_size=3,
+        load_document=load_file,
+        initial_directory=str(Path(__file__).parent.parent / "resources"),
+        document_types=["txt"]
+    )
+    return app

--- a/examples/document_app/pyproject.toml
+++ b/examples/document_app/pyproject.toml
@@ -1,0 +1,44 @@
+[build-system]
+requires = ["briefcase"]
+
+[tool.briefcase]
+project_name = "Document App Demo"
+bundle = "org.beeware"
+version = "0.3.0.dev24"
+url = "https://beeware.org"
+license = "BSD license"
+author = 'Tiberius Yak'
+author_email = "tiberius@beeware.org"
+
+[tool.briefcase.app.document_app]
+formal_name = "Document App Demo"
+description = "A testing app"
+sources = ['document_app']
+requires = []
+
+
+[tool.briefcase.app.document_app.macOS]
+requires = [
+    'toga-cocoa',
+]
+
+[tool.briefcase.app.document_app.linux]
+requires = [
+    'toga-gtk',
+]
+
+[tool.briefcase.app.document_app.windows]
+requires = [
+    'toga-winforms',
+]
+
+# Mobile deployments
+[tool.briefcase.app.document_app.iOS]
+requires = [
+    'toga-iOS',
+]
+
+[tool.briefcase.app.document_app.android]
+requires = [
+    'toga-android',
+]

--- a/examples/document_app/resources/four.txt
+++ b/examples/document_app/resources/four.txt
@@ -1,0 +1,5 @@
+I am the forth file
+
+
+
+and I have blank lines

--- a/examples/document_app/resources/one.txt
+++ b/examples/document_app/resources/one.txt
@@ -1,0 +1,1 @@
+I am a file!

--- a/examples/document_app/resources/three.txt
+++ b/examples/document_app/resources/three.txt
@@ -1,0 +1,1 @@
+I am the third file

--- a/examples/document_app/resources/two.txt
+++ b/examples/document_app/resources/two.txt
@@ -1,0 +1,2 @@
+I am also a file
+with two lines

--- a/src/core/tests/command/test_command.py
+++ b/src/core/tests/command/test_command.py
@@ -90,7 +90,7 @@ class TestCommand(TestCase):
     def test_command_repr(self):
         self.assertEqual(
             repr(toga.Command(None, "A", group=PARENT_GROUP1, order=1, section=4)),
-            "<Command label=A group=<Group label=P order=1 parent=None> section=4 order=1>"
+            "<Command label=A>"
         )
 
     test_order_commands_by_label = order_test(

--- a/src/core/tests/command/test_commands_group.py
+++ b/src/core/tests/command/test_commands_group.py
@@ -110,11 +110,11 @@ class TestCommandsGroup(unittest.TestCase):
     def test_group_repr(self):
         parent = toga.Group("P")
         self.assertEqual(
-            repr(toga.Group("A")), "<Group label=A order=0 parent=None>"
+            repr(toga.Group("A")), "<Group label=A parent=None>"
         )
         self.assertEqual(
             repr(toga.Group("A", parent=parent)),
-            "<Group label=A order=0 parent=P>"
+            "<Group label=A parent=P>"
         )
 
     def test_set_section_without_parent(self):

--- a/src/core/tests/command/test_data_source_commands_set.py
+++ b/src/core/tests/command/test_data_source_commands_set.py
@@ -1,0 +1,127 @@
+import unittest
+from unittest import mock
+
+import toga
+import toga_dummy
+from toga.sources.list_source import ListSource
+
+
+class TestDataSourceCommandSet(unittest.TestCase):
+
+    def setUp(self):
+        self.label = "Label"
+        self.group = toga.Group("Some Label")
+        self.section = 7
+        self.order = 2
+        self.data = ListSource(data=["one", "two", "three"], accessors=["value"])
+        self.item_action = mock.Mock()
+        self.app = mock.Mock()
+        self.commands_set = toga.DataSourceCommandSet(
+            self.label,
+            self.data,
+            factory=toga_dummy.factory,
+            group=self.group,
+            section=self.section,
+            order=self.order,
+            item_to_label=lambda item: item.value,
+            item_action=self.item_action,
+            app=self.app
+        )
+
+    def test_properties(self):
+        self.assertEqual(self.commands_set.label, self.label)
+        self.assertEqual(self.commands_set.group, self.group)
+        self.assertEqual(self.commands_set.section, self.section)
+        self.assertEqual(self.commands_set.order, self.order)
+
+    def test_all_commands(self):
+        self.assert_all_commands(
+            (
+                *self.group.to_tuple(),
+                (self.section, self.order, self.label),
+                (0, 0, "one")
+            ),
+            (
+                *self.group.to_tuple(),
+                (self.section, self.order, self.label),
+                (0, 1, "two")
+            ),
+            (
+                *self.group.to_tuple(),
+                (self.section, self.order, self.label),
+                (0, 2, "three")
+            ),
+        )
+
+    def test_command_action(self):
+        widget = mock.Mock()
+        all_commands = list(self.commands_set)
+        for command in all_commands:
+            command.action(widget)
+        self.assertEqual(
+            self.item_action.call_args_list,
+            [
+                mock.call(all_commands[0], self.data[0]),
+                mock.call(all_commands[1], self.data[1]),
+                mock.call(all_commands[2], self.data[2]),
+            ]
+        )
+
+    def test_none_command_action(self):
+        commands_set = toga.DataSourceCommandSet(
+            self.label,
+            self.data,
+            item_to_label=lambda item: item.value,
+            factory=toga_dummy.factory,
+            item_action=None,
+        )
+        for command in commands_set:
+            self.assertIsNone(command.action)
+
+    def test_insert(self):
+        self.data.insert(1, "four")
+        self.assert_all_commands(
+            (
+                *self.group.to_tuple(),
+                (self.section, self.order, self.label),
+                (0, 0, "one")
+            ),
+            (
+                *self.group.to_tuple(),
+                (self.section, self.order, self.label),
+                (0, 1, "four")
+            ),
+            (
+                *self.group.to_tuple(),
+                (self.section, self.order, self.label),
+                (0, 2, "two")
+            ),
+            (
+                *self.group.to_tuple(),
+                (self.section, self.order, self.label),
+                (0, 3, "three")
+            ),
+        )
+        self.app._set_commands.assert_called_once()
+
+    def test_remove(self):
+        self.data.remove(self.data[1])
+        self.assert_all_commands(
+            (
+                *self.group.to_tuple(),
+                (self.section, self.order, self.label),
+                (0, 0, "one"),
+            ),
+            (
+                *self.group.to_tuple(),
+                (self.section, self.order, self.label),
+                (0, 1, "three"),
+            ),
+        )
+        self.app._set_commands.assert_called_once()
+
+    def assert_all_commands(self, *all_commands_tuples):
+        self.assertEqual(
+            [command.to_tuple() for command in self.commands_set],
+            list(all_commands_tuples)
+        )

--- a/src/core/tests/command/test_data_source_commands_set.py
+++ b/src/core/tests/command/test_data_source_commands_set.py
@@ -102,7 +102,6 @@ class TestDataSourceCommandSet(unittest.TestCase):
                 (0, 3, "three")
             ),
         )
-        self.app._set_commands.assert_called()
 
     def test_remove(self):
         self.data.remove(self.data[1])
@@ -118,7 +117,6 @@ class TestDataSourceCommandSet(unittest.TestCase):
                 (0, 1, "three"),
             ),
         )
-        self.app._set_commands.assert_called()
 
     def assert_all_commands(self, *all_commands_tuples):
         self.assertEqual(

--- a/src/core/tests/command/test_data_source_commands_set.py
+++ b/src/core/tests/command/test_data_source_commands_set.py
@@ -67,17 +67,6 @@ class TestDataSourceCommandSet(unittest.TestCase):
             ]
         )
 
-    def test_none_command_action(self):
-        commands_set = toga.DataSourceCommandSet(
-            self.label,
-            self.data,
-            item_to_label=lambda item: item.value,
-            factory=toga_dummy.factory,
-            item_action=None,
-        )
-        for command in commands_set:
-            self.assertIsNone(command.action)
-
     def test_insert(self):
         self.data.insert(1, "four")
         self.assert_all_commands(

--- a/src/core/tests/command/test_data_source_commands_set.py
+++ b/src/core/tests/command/test_data_source_commands_set.py
@@ -102,7 +102,7 @@ class TestDataSourceCommandSet(unittest.TestCase):
                 (0, 3, "three")
             ),
         )
-        self.app._set_commands.assert_called_once()
+        self.app._set_commands.assert_called()
 
     def test_remove(self):
         self.data.remove(self.data[1])
@@ -118,7 +118,7 @@ class TestDataSourceCommandSet(unittest.TestCase):
                 (0, 1, "three"),
             ),
         )
-        self.app._set_commands.assert_called_once()
+        self.app._set_commands.assert_called()
 
     def assert_all_commands(self, *all_commands_tuples):
         self.assertEqual(

--- a/src/core/tests/sources/test_row.py
+++ b/src/core/tests/sources/test_row.py
@@ -1,0 +1,24 @@
+from unittest import TestCase
+from unittest.mock import Mock
+
+from toga.sources.list_source import Row
+
+
+class RowTests(TestCase):
+    def setUp(self):
+        self.source = Mock()
+        self.example = Row(val1='value 1', val2=42)
+        self.example._source = self.source
+
+    def test_initial_state(self):
+        "A row holds values as expected"
+
+        self.assertEqual(self.example.val1, 'value 1')
+        self.assertEqual(self.example.val2, 42)
+
+    def test_change_value(self):
+        "If a row value changes, the source is notified"
+        self.example.val1 = 'new value'
+
+        self.assertEqual(self.example.val1, 'new value')
+        self.source._notify.assert_called_once_with('change', item=self.example)

--- a/src/core/tests/sources/test_stack_source.py
+++ b/src/core/tests/sources/test_stack_source.py
@@ -1,20 +1,21 @@
 from unittest import TestCase
 from unittest.mock import Mock
 
-from toga.sources import ListSource
+from toga.sources import StackSource
 from toga.sources.list_source import Row
 
 
-class ListSourceTests(TestCase):
+class StackSourceTests(TestCase):
     def test_init_with_tuple(self):
-        "A ListSource can be instantiated from tuples"
-        source = ListSource(
+        "A StackSource can be instantiated from tuples"
+        source = StackSource(
             data=[
                 ('first', 111),
                 ('second', 222),
                 ('third', 333),
             ],
-            accessors=['val1', 'val2']
+            accessors=['val1', 'val2'],
+            size=4,
         )
 
         self.assertEqual(len(source), 3)
@@ -39,14 +40,15 @@ class ListSourceTests(TestCase):
         listener.insert.assert_called_once_with(index=1, item=source[1])
 
     def test_init_with_list(self):
-        "A ListSource can be instantiated from lists"
-        source = ListSource(
+        "A StackSource can be instantiated from lists"
+        source = StackSource(
             data=[
                 ['first', 111],
                 ['second', 222],
                 ['third', 333],
             ],
-            accessors=['val1', 'val2']
+            accessors=['val1', 'val2'],
+            size=4,
         )
 
         self.assertEqual(len(source), 3)
@@ -71,14 +73,15 @@ class ListSourceTests(TestCase):
         listener.insert.assert_called_once_with(index=1, item=source[1])
 
     def test_init_with_dict(self):
-        "A ListSource can be instantiated from dicts"
-        source = ListSource(
+        "A StackSource can be instantiated from dicts"
+        source = StackSource(
             data=[
                 {'val1': 'first', 'val2': 111},
                 {'val1': 'second', 'val2': 222},
                 {'val1': 'third', 'val2': 333},
             ],
-            accessors=['val1', 'val2']
+            accessors=['val1', 'val2'],
+            size=4,
         )
 
         self.assertEqual(len(source), 3)
@@ -118,9 +121,9 @@ class ListSourceTests(TestCase):
             MyObject("string"),
         ]
 
-        source = ListSource(
+        source = StackSource(
             data=data,
-            accessors=['col1'],
+            accessors=['col1'], size=4
         )
 
         for i, row in enumerate(source):
@@ -135,9 +138,9 @@ class ListSourceTests(TestCase):
             -3.14,
         ]
 
-        source = ListSource(
+        source = StackSource(
             data=data,
-            accessors=['col1'],
+            accessors=['col1'], size=4
         )
 
         for i, row in enumerate(source):
@@ -152,23 +155,24 @@ class ListSourceTests(TestCase):
             "zzz",
         ]
 
-        source = ListSource(
+        source = StackSource(
             data=data,
-            accessors=['col1'],
+            accessors=['col1'], size=4
         )
 
         for i, row in enumerate(source):
             self.assertEqual(row.col1, data[i])
 
     def test_first_and_last(self):
-        "A ListSource can be instantiated from tuples"
-        source = ListSource(
+        "A StackSource can be instantiated from tuples"
+        source = StackSource(
             data=[
                 ('first', 111),
                 ('second', 222),
                 ('third', 333),
             ],
-            accessors=['val1', 'val2']
+            accessors=['val1', 'val2'],
+            size=4,
         )
 
         self.assertEqual(source.first().val1, 'first')
@@ -179,13 +183,14 @@ class ListSourceTests(TestCase):
 
     def test_iter(self):
         "A list source can be iterated over"
-        source = ListSource(
+        source = StackSource(
             data=[
                 {'val1': 'first', 'val2': 111},
                 {'val1': 'second', 'val2': 222},
                 {'val1': 'third', 'val2': 333},
             ],
-            accessors=['val1', 'val2']
+            accessors=['val1', 'val2'],
+            size=4,
         )
 
         self.assertEqual(len(source), 3)
@@ -198,13 +203,14 @@ class ListSourceTests(TestCase):
 
     def test_clear(self):
         "A list source can be cleared"
-        source = ListSource(
+        source = StackSource(
             data=[
                 {'val1': 'first', 'val2': 111},
                 {'val1': 'second', 'val2': 222},
                 {'val1': 'third', 'val2': 333},
             ],
-            accessors=['val1', 'val2']
+            accessors=['val1', 'val2'],
+            size=4,
         )
 
         self.assertEqual(len(source), 3)
@@ -220,13 +226,14 @@ class ListSourceTests(TestCase):
 
     def test_insert_kwarg(self):
         "You can insert into a list source using kwargs"
-        source = ListSource(
+        source = StackSource(
             data=[
                 {'val1': 'first', 'val2': 111},
                 {'val1': 'second', 'val2': 222},
                 {'val1': 'third', 'val2': 333},
             ],
-            accessors=['val1', 'val2']
+            accessors=['val1', 'val2'],
+            size=4,
         )
 
         self.assertEqual(len(source), 3)
@@ -246,13 +253,14 @@ class ListSourceTests(TestCase):
 
     def test_insert(self):
         "You can insert into a list source using positional args"
-        source = ListSource(
+        source = StackSource(
             data=[
                 {'val1': 'first', 'val2': 111},
                 {'val1': 'second', 'val2': 222},
                 {'val1': 'third', 'val2': 333},
             ],
-            accessors=['val1', 'val2']
+            accessors=['val1', 'val2'],
+            size=4,
         )
 
         self.assertEqual(len(source), 3)
@@ -272,13 +280,14 @@ class ListSourceTests(TestCase):
 
     def test_prepend_kwarg(self):
         "You can prepend to a list source using kwargs"
-        source = ListSource(
+        source = StackSource(
             data=[
                 {'val1': 'first', 'val2': 111},
                 {'val1': 'second', 'val2': 222},
                 {'val1': 'third', 'val2': 333},
             ],
-            accessors=['val1', 'val2']
+            accessors=['val1', 'val2'],
+            size=4,
         )
 
         self.assertEqual(len(source), 3)
@@ -296,15 +305,16 @@ class ListSourceTests(TestCase):
 
         listener.insert.assert_called_once_with(index=0, item=row)
 
-    def test_prepend(self):
+    def test_prepend_without_remove(self):
         "You can prepend to a list source using positional args"
-        source = ListSource(
+        source = StackSource(
             data=[
                 {'val1': 'first', 'val2': 111},
                 {'val1': 'second', 'val2': 222},
                 {'val1': 'third', 'val2': 333},
             ],
-            accessors=['val1', 'val2']
+            accessors=['val1', 'val2'],
+            size=4,
         )
 
         self.assertEqual(len(source), 3)
@@ -322,15 +332,47 @@ class ListSourceTests(TestCase):
 
         listener.insert.assert_called_once_with(index=0, item=row)
 
-    def test_append_kwarg(self):
-        "You can append to a list source using kwargs"
-        source = ListSource(
+    def test_prepend_with_remove(self):
+        "You can prepend to a list source using positional args"
+        source = StackSource(
             data=[
                 {'val1': 'first', 'val2': 111},
                 {'val1': 'second', 'val2': 222},
                 {'val1': 'third', 'val2': 333},
             ],
-            accessors=['val1', 'val2']
+            accessors=['val1', 'val2'],
+            size=3,
+        )
+
+        self.assertEqual(len(source), 3)
+
+        listener = Mock()
+        source.add_listener(listener)
+
+        # Prepend the new element
+        row = source.prepend('new element', 999)
+
+        self.assertEqual(len(source), 3)
+
+        self.assertEqual(source[0], row)
+        self.assertEqual(row.val1, 'new element')
+        self.assertEqual(row.val2, 999)
+
+        self.assertEqual(source[2].val1, 'second')
+        self.assertEqual(source[2].val2, 222)
+
+        listener.insert.assert_called_once_with(index=0, item=row)
+
+    def test_append_kwarg(self):
+        "You can append to a list source using kwargs"
+        source = StackSource(
+            data=[
+                {'val1': 'first', 'val2': 111},
+                {'val1': 'second', 'val2': 222},
+                {'val1': 'third', 'val2': 333},
+            ],
+            accessors=['val1', 'val2'],
+            size=4,
         )
 
         self.assertEqual(len(source), 3)
@@ -348,15 +390,16 @@ class ListSourceTests(TestCase):
 
         listener.insert.assert_called_once_with(index=3, item=row)
 
-    def test_append(self):
+    def test_append_without_exception(self):
         "You can append to a list source using positional args"
-        source = ListSource(
+        source = StackSource(
             data=[
                 {'val1': 'first', 'val2': 111},
                 {'val1': 'second', 'val2': 222},
                 {'val1': 'third', 'val2': 333},
             ],
-            accessors=['val1', 'val2']
+            accessors=['val1', 'val2'],
+            size=4,
         )
 
         self.assertEqual(len(source), 3)
@@ -374,15 +417,33 @@ class ListSourceTests(TestCase):
 
         listener.insert.assert_called_once_with(index=3, item=row)
 
-    def test_remove(self):
-        "You can remove an item from a list source"
-        source = ListSource(
+    def test_append_with_exception(self):
+        "You can append to a list source using positional args"
+        source = StackSource(
             data=[
                 {'val1': 'first', 'val2': 111},
                 {'val1': 'second', 'val2': 222},
                 {'val1': 'third', 'val2': 333},
             ],
-            accessors=['val1', 'val2']
+            accessors=['val1', 'val2'],
+            size=3,
+        )
+
+        self.assertEqual(len(source), 3)
+
+        with self.assertRaises(ValueError):
+            source.append('new element', 999)
+
+    def test_remove(self):
+        "You can remove an item from a list source"
+        source = StackSource(
+            data=[
+                {'val1': 'first', 'val2': 111},
+                {'val1': 'second', 'val2': 222},
+                {'val1': 'third', 'val2': 333},
+            ],
+            accessors=['val1', 'val2'],
+            size=4,
         )
 
         self.assertEqual(len(source), 3)
@@ -405,13 +466,14 @@ class ListSourceTests(TestCase):
     def test_get_row_index(self):
         "You can get the index of any row within a list source"
 
-        source = ListSource(
+        source = StackSource(
             data=[
                 ('first', 111),
                 ('second', 222),
                 ('third', 333),
             ],
-            accessors=['val1', 'val2']
+            accessors=['val1', 'val2'],
+            size=4,
         )
 
         for i, row in enumerate(source):

--- a/src/core/tests/test_app.py
+++ b/src/core/tests/test_app.py
@@ -123,8 +123,8 @@ class DocumentAppTests(TestCase):
         )
 
     def test_app_documents(self):
-        self.assertEqual(self.app.documents, [])
+        self.assertEqual(list(self.app.documents), [])
 
         doc = MagicMock()
         self.app._documents.append(doc)
-        self.assertEqual(self.app.documents, [doc])
+        self.assertEqual([item.path for item in self.app.documents], [doc])

--- a/src/core/toga/__init__.py
+++ b/src/core/toga/__init__.py
@@ -1,7 +1,14 @@
 from .app import App, DocumentApp, MainWindow
 # Resources
 from .colors import hsl, hsla, rgb, rgba
-from .command import GROUP_BREAK, SECTION_BREAK, Command, CommandSet, Group
+from .command import (
+    GROUP_BREAK,
+    SECTION_BREAK,
+    Command,
+    CommandSet,
+    DataSourceCommandSet,
+    Group,
+)
 from .documents import Document
 from .fonts import Font
 from .icons import Icon
@@ -39,7 +46,8 @@ __all__ = [
     # Applications
     'App', 'DocumentApp', 'MainWindow',
     # Commands
-    'Command', 'CommandSet', 'Group', 'GROUP_BREAK', 'SECTION_BREAK',
+    'Command', 'CommandSet', 'DataSourceCommandSet', 'Group', 'GROUP_BREAK',
+    'SECTION_BREAK',
     # Documents
     'Document',
     # Keys

--- a/src/core/toga/app.py
+++ b/src/core/toga/app.py
@@ -476,9 +476,6 @@ class App:
     def add_background_task(self, handler):
         self._impl.add_background_task(handler)
 
-    def _set_commands(self, group, commands):
-        self._impl._set_commands(group, commands)
-
 
 class DocumentApp(App):
     """

--- a/src/core/toga/command.py
+++ b/src/core/toga/command.py
@@ -64,7 +64,7 @@ class Group:
         return self.to_tuple() < other.to_tuple()
 
     def __gt__(self, other):
-        return other < self
+        return not self.__lt__(other)
 
     def __eq__(self, other):
         if other is None:
@@ -73,8 +73,8 @@ class Group:
 
     def __repr__(self):
         parent_string = "None" if self.parent is None else self.parent.label
-        return "<Group label={} order={} parent={}>".format(
-            self.label, self.order, parent_string
+        return "<Group label={} parent={}>".format(
+            self.label, parent_string
         )
 
     def to_tuple(self):
@@ -126,6 +126,7 @@ class Command:
         self.icon = icon
 
         self.group = group if group else Group.COMMANDS
+        self.sub_group = None
         self.section = section if section else 0
         self.order = order if order else 0
 
@@ -181,15 +182,10 @@ class Command:
         return self.to_tuple() < other.to_tuple()
 
     def __gt__(self, other):
-        return self.to_tuple() > other.to_tuple()
+        return not self.__lt__(other)
 
     def __repr__(self):
-        return "<Command label={} group={} section={} order={}>".format(
-            self.label,
-            self.group,
-            self.section,
-            self.order,
-        )
+        return "<Command label={}>".format(self.label)
 
     def to_tuple(self):
         return tuple([*self.group.to_tuple(), (self.section, self.order, self.label)])
@@ -232,6 +228,9 @@ class DataSourceCommandSet(Command):
         for index, item in enumerate(self.data):
             yield self.__build_command(index, item)
 
+    def __repr__(self):
+        return "<DataSourceCommandSet label={}>".format(self.label)
+
     @property
     def data(self):
         return self._data
@@ -258,11 +257,11 @@ class DataSourceCommandSet(Command):
 
     def insert(self, index, item):
         if self.app is not None:
-            self.app._set_commands(self.sub_group, list(self))
+            self.app._impl._update_data_menu_items(self)
 
     def remove(self, index, item):
         if self.app is not None:
-            self.app._set_commands(self.sub_group, list(self))
+            self.app._impl._update_data_menu_items(self)
 
     def __build_command(self, index, item):
         return Command(

--- a/src/core/toga/command.py
+++ b/src/core/toga/command.py
@@ -222,6 +222,10 @@ class DataSourceCommandSet(Command):
         self.item_to_label = item_to_label
         self.app = app
 
+        self.sub_group = Group(
+            label=self.label, order=self.order, section=self.section, parent=self.group
+        )
+
         self.data.add_listener(self)
 
     def __iter__(self):
@@ -254,22 +258,17 @@ class DataSourceCommandSet(Command):
 
     def insert(self, index, item):
         if self.app is not None:
-            self.app._set_commands(self.as_group(), list(self))
+            self.app._set_commands(self.sub_group, list(self))
 
     def remove(self, index, item):
         if self.app is not None:
-            self.app._set_commands(self.as_group(), list(self))
-
-    def as_group(self):
-        return Group(
-            label=self.label, order=self.order, section=self.section, parent=self.group
-        )
+            self.app._set_commands(self.sub_group, list(self))
 
     def __build_command(self, index, item):
         return Command(
             self.__get_action(item),
             self.item_to_label(item),
-            group=self.as_group(),
+            group=self.sub_group,
             order=index,
             factory=self.factory
         )

--- a/src/core/toga/sources/__init__.py
+++ b/src/core/toga/sources/__init__.py
@@ -1,5 +1,5 @@
 from .accessors import to_accessor  # noqa: F401
 from .base import Source  # noqa: F401
-from .list_source import ListSource  # noqa: F401
+from .list_source import ListSource, StackSource  # noqa: F401
 from .tree_source import TreeSource  # noqa: F401
 from .value_source import ValueSource  # noqa: F401

--- a/src/core/toga/sources/list_source.py
+++ b/src/core/toga/sources/list_source.py
@@ -105,3 +105,30 @@ class ListSource(Source):
 
     def index(self, row):
         return self._data.index(row)
+
+    def first(self):
+        return self[0]
+
+    def last(self):
+        return self[len(self) - 1]
+
+
+class StackSource(ListSource):
+
+    def __init__(self, data, accessors, size):
+        super(StackSource, self).__init__(data, accessors)
+        self.size = size
+
+    def insert(self, index, *values, **named):
+        row = super(StackSource, self).insert(index, *values, **named)
+        self.__remove_overflow()
+        return row
+
+    def append(self, *values, **named):
+        if len(self) == self.size:
+            raise ValueError("Cannot append value because of stack overflow")
+        return super(StackSource, self).append(*values, **named)
+
+    def __remove_overflow(self):
+        while len(self._data) > self.size:
+            self.remove(self.last())

--- a/src/winforms/toga_winforms/factory.py
+++ b/src/winforms/toga_winforms/factory.py
@@ -1,4 +1,4 @@
-from .app import App, MainWindow
+from .app import App, DocumentApp, MainWindow
 from .command import Command
 from .fonts import Font
 from .icons import Icon
@@ -38,6 +38,7 @@ __all__ = [
     'not_implemented',
 
     'App',
+    'DocumentApp',
     'MainWindow',
     'Command',
 


### PR DESCRIPTION
Added "Recent" submenu to DocumentApp. Did it in three steps:

1. Added a command type named DataSourceCommandSet, which is backed with a data source containing the items
2. Added a StackSource that has a max size and remove last items when overflow
3. Added the "Recent" submenu to App and made the command insertion and remove more dynamic, keeping all necessary methods private with the "_" suffix in order to not expose those to the user.

Finally, added a DocumentApp example.

![document_app](https://user-images.githubusercontent.com/19425795/95689672-0efc5400-0c1b-11eb-812f-4ac6c3bec27e.png)

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
