### PR TITLE
Fixed cocoa Slider.on_press and Slider.on_release

### DIFF
--- a/src/cocoa/toga_cocoa/widgets/slider.py
+++ b/src/cocoa/toga_cocoa/widgets/slider.py
@@ -15,8 +15,7 @@ class TogaSlider(NSSlider):
         elif event_type == NSEventType.LeftMouseUp:
             if self.interface.on_release:
                 self.interface.on_release(self.interface)
-
-        if self.interface.on_change:
+        elif self.interface.on_change:
             self.interface.on_change(self.interface)
 
 


### PR DESCRIPTION
Fixed a little bug in the cocoa implementation of Slider's on_press and on_release

We want the `on_change` method to run only if `on_press` and `on_release` wasn't.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
