### PR TITLE
An example overview making it easy run multiple examples

### DIFF
--- a/examples/examples_overview/README.rst
+++ b/examples/examples_overview/README.rst
@@ -1,0 +1,12 @@
+Examples Overview
+=================
+
+Test app for the Examples Overview widget.
+
+Quickstart
+~~~~~~~~~~
+
+To run this example:
+
+    $ pip install toga
+    $ python -m examples_overview

--- a/examples/examples_overview/README.rst
+++ b/examples/examples_overview/README.rst
@@ -1,7 +1,8 @@
 Examples Overview
 =================
 
-Test app for the Examples Overview widget.
+This example provides an overview of all other examples in a table. You can view their
+READMEs and run individual examples from the user interface.
 
 Quickstart
 ~~~~~~~~~~

--- a/examples/examples_overview/examples_overview/__init__.py
+++ b/examples/examples_overview/examples_overview/__init__.py
@@ -1,0 +1,9 @@
+# Examples of valid version strings
+# __version__ = '1.2.3.dev1'  # Development release 1
+# __version__ = '1.2.3a1'     # Alpha Release 1
+# __version__ = '1.2.3b1'     # Beta Release 1
+# __version__ = '1.2.3rc1'    # RC Release 1
+# __version__ = '1.2.3'       # Final Release
+# __version__ = '1.2.3.post1' # Post Release 1
+
+__version__ = '0.0.1'

--- a/examples/examples_overview/examples_overview/__main__.py
+++ b/examples/examples_overview/examples_overview/__main__.py
@@ -1,0 +1,4 @@
+from examples_overview.app import main
+
+if __name__ == '__main__':
+    main().main_loop()

--- a/examples/examples_overview/examples_overview/app.py
+++ b/examples/examples_overview/examples_overview/app.py
@@ -1,6 +1,7 @@
 import sys
 import os
 import subprocess
+import platform
 from pathlib import Path
 import toga
 from toga.style import Pack
@@ -24,8 +25,15 @@ class ExampleExamplesOverviewApp(toga.App):
             env=env,
         )
 
-    def reset_code(self, widget, **kwargs):
-        pass
+    def open(self, widget, **kwargs):
+        row = self.table.selection
+
+        if platform.system() == "Windows":
+            os.startfile(row.path)
+        elif platform.system() == "Darwin":
+            subprocess.run(["open", row.path])
+        else:
+            subprocess.run(["xdg-open", row.path])
 
     def on_example_selected(self, widget, row):
 
@@ -76,8 +84,14 @@ class ExampleExamplesOverviewApp(toga.App):
         )
 
         # Buttons
-        self.btn_run = toga.Button("Run Example", on_press=self.run)
-        self.btn_reset = toga.Button("Reset Code", on_press=self.reset_code)
+        self.btn_run = toga.Button(
+            "Run Example", on_press=self.run, style=Pack(flex=1, padding_right=5)
+        )
+        self.btn_open = toga.Button(
+            "Open folder", on_press=self.open, style=Pack(flex=1, padding_left=5)
+        )
+
+        button_box = toga.Box(children=[self.btn_run, self.btn_open])
 
         # ==== View of example code ====================================================
 
@@ -88,7 +102,7 @@ class ExampleExamplesOverviewApp(toga.App):
         # ==== Assemble layout =========================================================
 
         left_box = toga.Box(
-            children=[self.table, self.btn_run],
+            children=[self.table, button_box],
             style=Pack(
                 direction=COLUMN,
                 padding=1,

--- a/examples/examples_overview/examples_overview/app.py
+++ b/examples/examples_overview/examples_overview/app.py
@@ -39,11 +39,11 @@ class ExampleExamplesOverviewApp(toga.App):
 
         readme_path = row.path / "README.rst"
 
-        if readme_path.is_file():
+        try:
             with open(readme_path) as f:
                 readme_text = f.read()
-        else:
-            readme_text = "No README found"
+        except OSError:
+            readme_text = "README could not be loaded"
 
         self.info_view.value = readme_text
 

--- a/examples/examples_overview/examples_overview/app.py
+++ b/examples/examples_overview/examples_overview/app.py
@@ -1,0 +1,90 @@
+import sys
+import os
+import subprocess
+import toga
+from toga.style import Pack
+from toga.constants import COLUMN, ROW, RIGHT
+
+
+examples_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+
+
+class ExampleExamplesOverviewApp(toga.App):
+    # Button callback functions
+    def run(self, widget, **kwargs):
+
+        row = self.table.selection
+
+        env = os.environ.copy()
+        env["PYTHONPATH"] = row.path
+
+        self._process = subprocess.Popen(
+            [sys.executable, '-m', row.name],
+            env=env,
+        )
+
+    def startup(self):
+
+        self._process = None
+
+        # Set up main window
+        self.main_window = toga.MainWindow(title=self.name)
+
+        # Label for user instructions
+        self.label = toga.Label(
+            'Please select an example and press run',
+            style=Pack(padding_bottom=10),
+        )
+
+        # Table with example programs
+        self.examples = []
+
+        # search for all folders that contain modules
+        for root, dirs, files in os.walk(examples_dir):
+            # skip hidden folders
+            dirs[:] = [d for d in dirs if not d.startswith('.')]
+            if any(name == '__main__.py' for name in files):
+                example_path, example_name = os.path.split(root)
+                self.examples.append(
+                    dict(
+                        name=example_name,
+                        path=example_path
+                    )
+                )
+
+        self.examples.sort(key=lambda e: e['path'])
+
+        self.table = toga.Table(
+            headings=["Name", "Path"],
+            data=self.examples,
+            on_double_click=self.run,
+            style=Pack(padding_bottom=10, flex=1),
+        )
+
+        # Buttons
+        self.btn_run = toga.Button('Run Example', on_press=self.run)
+
+        # Outermost box
+        outer_box = toga.Box(
+            children=[self.label, self.table, self.btn_run],
+            style=Pack(
+                direction=COLUMN,
+                flex=1,
+                padding=10,
+            )
+        )
+
+        # Add the content on the main window
+        self.main_window.content = outer_box
+
+        # Show the main window
+        self.main_window.show()
+
+
+def main():
+    return ExampleExamplesOverviewApp('Examples Overview', 'org.beeware.widgets.examples_overview')
+
+
+if __name__ == '__main__':
+    app = main()
+    app.main_loop()

--- a/examples/examples_overview/examples_overview/app.py
+++ b/examples/examples_overview/examples_overview/app.py
@@ -1,9 +1,10 @@
 import sys
 import os
 import subprocess
+from pathlib import Path
 import toga
 from toga.style import Pack
-from toga.constants import COLUMN, ROW, RIGHT
+from toga.constants import COLUMN
 
 
 examples_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
@@ -19,59 +20,87 @@ class ExampleExamplesOverviewApp(toga.App):
         env["PYTHONPATH"] = row.path
 
         self._process = subprocess.Popen(
-            [sys.executable, '-m', row.name],
+            [sys.executable, "-m", row.name],
             env=env,
         )
+
+    def reset_code(self, widget, **kwargs):
+        pass
+
+    def on_example_selected(self, widget, row):
+
+        readme_path = row.path / "README.rst"
+
+        if readme_path.is_file():
+            with open(readme_path) as f:
+                readme_text = f.read()
+        else:
+            readme_text = "No README found"
+
+        self.info_view.value = readme_text
 
     def startup(self):
 
         self._process = None
 
-        # Set up main window
+        # ==== Set up main window ======================================================
+
         self.main_window = toga.MainWindow(title=self.name)
 
         # Label for user instructions
-        self.label = toga.Label(
-            'Please select an example and press run',
+        label = toga.Label(
+            "Please select an example to run",
             style=Pack(padding_bottom=10),
         )
 
-        # Table with example programs
+        # ==== Table with examples =====================================================
+
         self.examples = []
 
         # search for all folders that contain modules
         for root, dirs, files in os.walk(examples_dir):
             # skip hidden folders
-            dirs[:] = [d for d in dirs if not d.startswith('.')]
-            if any(name == '__main__.py' for name in files):
-                example_path, example_name = os.path.split(root)
-                self.examples.append(
-                    dict(
-                        name=example_name,
-                        path=example_path
-                    )
-                )
+            dirs[:] = [d for d in dirs if not d.startswith(".")]
+            if any(name == "__main__.py" for name in files):
+                path = Path(root)
+                self.examples.append(dict(name=path.name, path=path.parent))
 
-        self.examples.sort(key=lambda e: e['path'])
+        self.examples.sort(key=lambda e: e["path"])
 
         self.table = toga.Table(
             headings=["Name", "Path"],
             data=self.examples,
             on_double_click=self.run,
+            on_select=self.on_example_selected,
             style=Pack(padding_bottom=10, flex=1),
         )
 
         # Buttons
-        self.btn_run = toga.Button('Run Example', on_press=self.run)
+        self.btn_run = toga.Button("Run Example", on_press=self.run)
+        self.btn_reset = toga.Button("Reset Code", on_press=self.reset_code)
 
-        # Outermost box
-        outer_box = toga.Box(
-            children=[self.label, self.table, self.btn_run],
+        # ==== View of example code ====================================================
+
+        self.info_view = toga.MultilineTextInput(
+            placeholder="Please select example", readonly=True, style=Pack(padding=1)
+        )
+
+        # ==== Assemble layout =========================================================
+
+        left_box = toga.Box(
+            children=[self.table, self.btn_run],
             style=Pack(
                 direction=COLUMN,
+                padding=1,
                 flex=1,
-                padding=10,
-            )
+            ),
+        )
+
+        split_container = toga.SplitContainer(content=[left_box, self.info_view])
+
+        outer_box = toga.Box(
+            children=[label, split_container],
+            style=Pack(padding=10, direction=COLUMN),
         )
 
         # Add the content on the main window
@@ -82,9 +111,11 @@ class ExampleExamplesOverviewApp(toga.App):
 
 
 def main():
-    return ExampleExamplesOverviewApp('Examples Overview', 'org.beeware.widgets.examples_overview')
+    return ExampleExamplesOverviewApp(
+        "Examples Overview", "org.beeware.widgets.examples_overview"
+    )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     app = main()
     app.main_loop()

--- a/examples/examples_overview/examples_overview/app.py
+++ b/examples/examples_overview/examples_overview/app.py
@@ -20,12 +20,10 @@ class ExampleExamplesOverviewApp(toga.App):
         env = os.environ.copy()
         env["PYTHONPATH"] = row.path
 
-        self._process = subprocess.Popen(
-            [sys.executable, "-m", row.name],
-            env=env,
-        )
+        subprocess.run([sys.executable, "-m", row.name], env=env)
 
     def open(self, widget, **kwargs):
+
         row = self.table.selection
 
         if platform.system() == "Windows":
@@ -48,8 +46,6 @@ class ExampleExamplesOverviewApp(toga.App):
         self.info_view.value = readme_text
 
     def startup(self):
-
-        self._process = None
 
         # ==== Set up main window ======================================================
 

--- a/examples/examples_overview/examples_overview/app.py
+++ b/examples/examples_overview/examples_overview/app.py
@@ -93,7 +93,7 @@ class ExampleExamplesOverviewApp(toga.App):
 
         button_box = toga.Box(children=[self.btn_run, self.btn_open])
 
-        # ==== View of example code ====================================================
+        # ==== View of example README ==================================================
 
         self.info_view = toga.MultilineTextInput(
             placeholder="Please select example", readonly=True, style=Pack(padding=1)

--- a/examples/examples_overview/examples_overview/resources/README
+++ b/examples/examples_overview/examples_overview/resources/README
@@ -1,0 +1,1 @@
+Put any icons or images in this directory.

--- a/examples/examples_overview/pyproject.toml
+++ b/examples/examples_overview/pyproject.toml
@@ -1,0 +1,44 @@
+[build-system]
+requires = ["briefcase"]
+
+[tool.briefcase]
+project_name = "Examples Overview"
+bundle = "org.beeware"
+version = "0.3.0.dev24"
+url = "https://beeware.org"
+license = "BSD license"
+author = 'Tiberius Yak'
+author_email = "tiberius@beeware.org"
+
+[tool.briefcase.app.examples_overview]
+formal_name = "Examples Overview"
+description = "A testing app"
+sources = ['examples_overview']
+requires = []
+
+
+[tool.briefcase.app.examples_overview.macOS]
+requires = [
+    'toga-cocoa',
+]
+
+[tool.briefcase.app.examples_overview.linux]
+requires = [
+    'toga-gtk',
+]
+
+[tool.briefcase.app.examples_overview.windows]
+requires = [
+    'toga-winforms',
+]
+
+# Mobile deployments
+[tool.briefcase.app.examples_overview.iOS]
+requires = [
+    'toga-iOS',
+]
+
+[tool.briefcase.app.examples_overview.android]
+requires = [
+    'toga-android',
+]


### PR DESCRIPTION
This PR introduces a new example `examples_overview` which shows a table of all examples and the REAMDE of the selected example. There are buttons to run an example and to open its folder. On supported platforms, double-clicking a table row will also run the example.

Screenshot:

<img width="1208" alt="Screenshot 2020-10-20 at 12 30 01" src="https://user-images.githubusercontent.com/20974290/96580419-26e56f00-12d0-11eb-98e7-ee7c262d4d3a.png">

The aim is to simplify testing multiple examples in a user-friendly way which does not require excessive command line usage. It also makes it easier for newcomers to get an overview.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
