### PR TITLE
Fixes #1112 -- Provide an 'all matching' option for winforms file dialogs

### DIFF
--- a/examples/dialogs/dialogs/app.py
+++ b/examples/dialogs/dialogs/app.py
@@ -43,6 +43,20 @@ class ExampledialogsApp(toga.App):
         except ValueError:
             self.label.text = "Open file dialog was canceled"
 
+    def action_open_file_filtered_dialog(self, widget):
+        try:
+            fname = self.main_window.open_file_dialog(
+                title="Open file with Toga",
+                multiselect=False,
+                file_types=['doc', 'txt'],
+            )
+            if fname is not None:
+                self.label.text = "File to open:" + fname
+            else:
+                self.label.text = "No file selected!"
+        except ValueError:
+            self.label.text = "Open file dialog was canceled"
+
     def action_open_file_dialog_multi(self, widget):
         try:
             filenames = self.main_window.open_file_dialog(
@@ -104,6 +118,11 @@ class ExampledialogsApp(toga.App):
         btn_confirm = toga.Button('Confirm', on_press=self.action_confirm_dialog, style=btn_style)
         btn_error = toga.Button('Error', on_press=self.action_error_dialog, style=btn_style)
         btn_open = toga.Button('Open File', on_press=self.action_open_file_dialog, style=btn_style)
+        btn_open_filtered = toga.Button(
+            'Open File (Filtered)',
+            on_press=self.action_open_file_filtered_dialog,
+            style=btn_style
+        )
         btn_open_multi = toga.Button(
             'Open File (Multiple)',
             on_press=self.action_open_file_dialog_multi,
@@ -127,6 +146,7 @@ class ExampledialogsApp(toga.App):
                 btn_confirm,
                 btn_error,
                 btn_open,
+                btn_open_filtered,
                 btn_save,
                 btn_select,
                 btn_select_multi,

--- a/src/winforms/tests/test_window.py
+++ b/src/winforms/tests/test_window.py
@@ -7,6 +7,20 @@ class TestWindow(TestCase):
         super().setUp()
         self.window = window.Window
 
-    def test_build_filter(self):
+    def test_build_single_filter(self):
         test_filter = self.window.build_filter(None, ["txt"])
-        self.assertEqual(test_filter, "txt files (*.txt)|*.txt|All files (*.*)|*.*")
+        self.assertEqual(
+            test_filter,
+            "|txt files (*.txt)|*.txt"
+            "|All files (*.*)|*.*",
+        )
+
+    def test_build_multiple_filter(self):
+        test_filter = self.window.build_filter(None, ["txt", "doc"])
+        self.assertEqual(
+            test_filter,
+            "All matching files (*.txt;*.doc)|*.txt;*.doc"
+            "|txt files (*.txt)|*.txt"
+            "|doc files (*.doc)|*.doc"
+            "|All files (*.*)|*.*",
+        )

--- a/src/winforms/tests/test_window.py
+++ b/src/winforms/tests/test_window.py
@@ -11,7 +11,7 @@ class TestWindow(TestCase):
         test_filter = self.window.build_filter(None, ["txt"])
         self.assertEqual(
             test_filter,
-            "|txt files (*.txt)|*.txt"
+            "txt files (*.txt)|*.txt"
             "|All files (*.*)|*.*",
         )
 

--- a/src/winforms/toga_winforms/window.py
+++ b/src/winforms/toga_winforms/window.py
@@ -210,7 +210,7 @@ class Window:
             "All files (*.*)|*.*"
         ]
 
-        if len(file_types) > 0:
+        if len(file_types) > 1:
             filters.insert(0, "All matching files ({0})|{0}".format(
                 ';'.join([
                     '*.{0}'.format(ext)

--- a/src/winforms/toga_winforms/window.py
+++ b/src/winforms/toga_winforms/window.py
@@ -203,18 +203,18 @@ class Window:
             raise ValueError("No folder provided in the select folder dialog")
 
     def build_filter(self, file_types):
-        return '|'.join(
-            [
-                "All matching files ({0})|{0}".format(
-                    ';'.join([
-                        '*.{0}'.format(ext)
-                        for ext in file_types
-                    ])
-                ),
-            ] + [
-                "{0} files (*.{0})|*.{0}".format(ext)
-                for ext in file_types
-            ] + [
-                "All files (*.*)|*.*"
-            ]
-        )
+        filters = [
+            "{0} files (*.{0})|*.{0}".format(ext)
+            for ext in file_types
+        ] + [
+            "All files (*.*)|*.*"
+        ]
+
+        if len(file_types) > 0:
+            filters.insert(0, "All matching files ({0})|{0}".format(
+                ';'.join([
+                    '*.{0}'.format(ext)
+                    for ext in file_types
+                ])
+            ))
+        return '|'.join(filters)

--- a/src/winforms/toga_winforms/window.py
+++ b/src/winforms/toga_winforms/window.py
@@ -203,6 +203,18 @@ class Window:
             raise ValueError("No folder provided in the select folder dialog")
 
     def build_filter(self, file_types):
-        file_string = "{0} files (*.{0})|*.{0}"
-        return '|'.join([file_string.format(ext) for ext in file_types]) + \
-            "|All files (*.*)|*.*"
+        return '|'.join(
+            [
+                "All matching files ({0})|{0}".format(
+                    ';'.join([
+                        '*.{0}'.format(ext)
+                        for ext in file_types
+                    ])
+                ),
+            ] + [
+                "{0} files (*.{0})|*.{0}".format(ext)
+                for ext in file_types
+            ] + [
+                "All files (*.*)|*.*"
+            ]
+        )


### PR DESCRIPTION
Under Winforms, when a file filter is used on a File dialog, only files of that type are shown. If the list of acceptable file types is long, that makes file navigation unwieldy, as you can only see files of one type at a time; and it makes selecting two files of a different type impossible under multiple selection. 

This adds an "all matching files" option as the default, which matches all valid file types. 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x]  I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
