### PR TITLE
Don't use `NSImage.resizeTo`

### DIFF
--- a/src/cocoa/toga_cocoa/widgets/internal/cells.py
+++ b/src/cocoa/toga_cocoa/widgets/internal/cells.py
@@ -103,7 +103,7 @@ class TogaIconView(NSTableCellView):
             self.setup()
 
         if image:
-            self.imageView.image = image.resizeTo(16)
+            self.imageView.image = image
             # set icon width to 16
             self.iv_width_constraint.constant = 16
             # add padding between icon and text


### PR DESCRIPTION
As reported in #1115, the call to `NSImage.resizeTo` in `TogaIconView` is sketchy: rubicon-objc recognises the method but it is not documented anywhere. This PR removes this call and uses the image as-is. Any resizing is already handled properly by the `NSImageView` because of the enforced constraints.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
