### PR TITLE
toga_gtk: fixed bug where attempting to set multilinetextinput.value would do nothing.

### DIFF
--- a/src/gtk/toga_gtk/widgets/multilinetextinput.py
+++ b/src/gtk/toga_gtk/widgets/multilinetextinput.py
@@ -17,7 +17,7 @@ class MultilineTextInput(Widget):
         self.tag_placholder = self.buffer.create_tag("placeholder", foreground="gray")
 
     def set_value(self, value):
-        self.buffer.set_text(self.interface.value)
+        self.buffer.set_text(value)
 
     def get_value(self):
         return self.buffer.get_text(self.buffer.get_start_iter(), self.buffer.get_end_iter(), True)


### PR DESCRIPTION
This is a one-line fix for the fact that with toga_gtk, `multilinetextinput.value = 'anything'` would not do anything.

The existing implementation was accessing `self.interface.value`, which in turn called `self.get_value()`, so it would set it back to the current value regardless of the string passed in.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested (in the sense that I have run the new code and it works)
- [x] All new features have been documented—n/a, as no new features were added
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
