### PR TITLE
Make input validators a list.

### DIFF
--- a/examples/textinput/textinput/app.py
+++ b/examples/textinput/textinput/app.py
@@ -72,18 +72,18 @@ class TextInputApp(toga.App):
             placeholder='Password...',
             style=Pack(padding=10),
             on_change=self.on_password_change,
-            validator=validators.Combine(
+            validators=[
                 validators.MinLength(10),
                 validators.ContainsUppercase(),
                 validators.ContainsLowercase(),
                 validators.ContainsSpecial(),
                 validators.ContainsDigit()
-            )
+            ]
         )
         self.email_input = toga.TextInput(
             placeholder='Email...',
             style=Pack(padding=10),
-            validator=validators.Email()
+            validators=[validators.Email()]
         )
         self.number_input = toga.NumberInput(style=Pack(padding=10))
         btn_extract = toga.Button(

--- a/src/core/tests/test_validators.py
+++ b/src/core/tests/test_validators.py
@@ -87,18 +87,17 @@ class TestValidators(unittest.TestCase):
         self.check()
 
     def test_validate_length_between(self):
-        too_short_error_message = "Input is too short (length should be at least 5)"
-        too_long_error_message = "Input is too long (length should be at most 10)"
+        default_error_message = "Input should be between 5 and 10 characters"
 
         self.args = [5, 10]
         self.validator_factory = validators.LengthBetween
         self.valid_inputs = ["I am good", "right", "123456789"]
         self.invalid_inputs = [
-            ("I", too_short_error_message),
-            ("am", too_short_error_message),
-            ("tiny", too_short_error_message),
-            ("I am way too long", too_long_error_message),
-            ("are you serious now?", too_long_error_message),
+            ("I", default_error_message),
+            ("am", default_error_message),
+            ("tiny", default_error_message),
+            ("I am way too long", default_error_message),
+            ("are you serious now?", default_error_message),
         ]
 
         self.check()

--- a/src/core/tests/widgets/test_textinput.py
+++ b/src/core/tests/widgets/test_textinput.py
@@ -108,18 +108,18 @@ class ValidatedTextInputTests(TestCase):
             initial=self.initial,
             factory=toga_dummy.factory
         )
-        self.assertTrue(text_input.is_valid())
+        self.assertTrue(text_input.validate())
 
-    def test_is_valid_returns_true(self):
+    def test_validate_true_when_valid(self):
         validator = Mock(return_value=None)
         text_input = toga.TextInput(
             initial=self.initial,
             validators=[validator],
             factory=toga_dummy.factory
         )
-        self.assertTrue(text_input.is_valid())
+        self.assertTrue(text_input.validate())
 
-    def test_is_valid_returns_false(self):
+    def test_validate_false_when_invalid(self):
         message = "This is an error message"
         validator = Mock(return_value=message)
         text_input = toga.TextInput(
@@ -127,7 +127,7 @@ class ValidatedTextInputTests(TestCase):
             validators=[validator],
             factory=toga_dummy.factory
         )
-        self.assertFalse(text_input.is_valid())
+        self.assertFalse(text_input.validate())
 
     def test_validate_passes(self):
         validator = Mock(side_effect=[None, None])

--- a/src/core/tests/widgets/test_textinput.py
+++ b/src/core/tests/widgets/test_textinput.py
@@ -81,7 +81,7 @@ class ValidatedTextInputTests(TestCase):
         validator = Mock(return_value=None)
         text_input = toga.TextInput(
             initial=self.initial,
-            validator=validator,
+            validators=[validator],
             factory=toga_dummy.factory
         )
         self.assertValueNotSet(text_input, "error")
@@ -98,7 +98,7 @@ class ValidatedTextInputTests(TestCase):
 
         self.assertValueNotSet(text_input, "error")
 
-        text_input.validator = validator
+        text_input.validators = [validator]
 
         self.assertValueSet(text_input, "error", message)
         validator.assert_called_once_with(self.initial)
@@ -114,7 +114,7 @@ class ValidatedTextInputTests(TestCase):
         validator = Mock(return_value=None)
         text_input = toga.TextInput(
             initial=self.initial,
-            validator=validator,
+            validators=[validator],
             factory=toga_dummy.factory
         )
         self.assertTrue(text_input.is_valid())
@@ -124,7 +124,7 @@ class ValidatedTextInputTests(TestCase):
         validator = Mock(return_value=message)
         text_input = toga.TextInput(
             initial=self.initial,
-            validator=validator,
+            validators=[validator],
             factory=toga_dummy.factory
         )
         self.assertFalse(text_input.is_valid())
@@ -133,7 +133,7 @@ class ValidatedTextInputTests(TestCase):
         validator = Mock(side_effect=[None, None])
         text_input = toga.TextInput(
             initial=self.initial,
-            validator=validator,
+            validators=[validator],
             factory=toga_dummy.factory
         )
         self.assertValueNotSet(text_input, "error")
@@ -149,7 +149,7 @@ class ValidatedTextInputTests(TestCase):
         validator = Mock(side_effect=[None, message])
         text_input = toga.TextInput(
             initial=self.initial,
-            validator=validator,
+            validators=[validator],
             factory=toga_dummy.factory
         )
         self.assertValueNotSet(text_input, "error")

--- a/src/core/toga/validators.py
+++ b/src/core/toga/validators.py
@@ -3,19 +3,6 @@ from typing import Optional, Union, List
 from string import ascii_uppercase, ascii_lowercase, digits
 
 
-class Combine:
-    def __init__(self, *validators):
-        """Use this method to combine multiple validators."""
-        self.validators = validators
-
-    def __call__(self, input_string):
-        for validator in self.validators:
-            error_message = validator(input_string)
-            if error_message is not None:
-                return error_message
-        return None
-
-
 class BooleanValidator:
     def __init__(self, error_message: str, allow_empty: bool = True):
         self.error_message = error_message
@@ -65,37 +52,7 @@ class CountValidator:
         )
 
 
-class MinLength(BooleanValidator):
-    def __init__(
-        self, length: int, error_message: Optional[str] = None, allow_empty: bool = True
-    ):
-        if error_message is None:
-            error_message = "Input is too short (length should be at least {})".format(
-                length
-            )
-        super().__init__(error_message=error_message, allow_empty=allow_empty)
-        self.length = length
-
-    def is_valid(self, input_string: str):
-        return len(input_string) >= self.length
-
-
-class MaxLength(BooleanValidator):
-    def __init__(
-        self, length: int, error_message: Optional[str] = None, allow_empty: bool = True
-    ):
-        if error_message is None:
-            error_message = "Input is too long (length should be at most {})".format(
-                length
-            )
-        super().__init__(error_message=error_message, allow_empty=allow_empty)
-        self.length = length
-
-    def is_valid(self, input_string: str):
-        return len(input_string) <= self.length
-
-
-class LengthBetween(Combine):
+class LengthBetween(BooleanValidator):
     def __init__(
         self,
         min_value: int,
@@ -103,9 +60,59 @@ class LengthBetween(Combine):
         error_message: Optional[str] = None,
         allow_empty: bool = True,
     ):
+        if error_message is None:
+            error_message = "Input should be between {} and {} characters".format(
+                min_value, max_value
+            )
+        super().__init__(error_message=error_message, allow_empty=allow_empty)
+        self.min_value = min_value
+        self.max_value = max_value
+
+    def is_valid(self, input_string: str):
+        if self.min_value:
+            if len(input_string) < self.min_value:
+                return False
+        if self.max_value:
+            if len(input_string) > self.max_value:
+                return False
+        return True
+
+
+class MinLength(LengthBetween):
+    def __init__(
+        self,
+        length: int,
+        error_message: Optional[str] = None,
+        allow_empty: bool = True
+    ):
+        if error_message is None:
+            error_message = "Input is too short (length should be at least {})".format(
+                length
+            )
         super().__init__(
-            MinLength(min_value, error_message=error_message, allow_empty=allow_empty),
-            MaxLength(max_value, error_message=error_message, allow_empty=allow_empty),
+            min_value=length,
+            max_value=None,
+            error_message=error_message,
+            allow_empty=allow_empty
+        )
+
+
+class MaxLength(LengthBetween):
+    def __init__(
+        self,
+        length: int,
+        error_message: Optional[str] = None,
+        allow_empty: bool = True
+    ):
+        if error_message is None:
+            error_message = "Input is too long (length should be at most {})".format(
+                length
+            )
+        super().__init__(
+            min_value=None,
+            max_value=length,
+            error_message=error_message,
+            allow_empty=allow_empty
         )
 
 

--- a/src/core/toga/widgets/textinput.py
+++ b/src/core/toga/widgets/textinput.py
@@ -16,7 +16,7 @@ class TextInput(Widget):
         placeholder (str): If no input is present this text is shown.
         readonly (bool):  Whether a user can write into the text input, defaults to `False`.
         on_change (Callable): Method to be called when text is changed in text box
-        validator (Callable): Validator to run on the value of the text box. Should
+        validators (list): list of validators to run on the value of the text box. Should
             return None is value is valid and an error message if not.
         on_change (``callable``): The handler to invoke when the text changes.
         on_gain_focus (:obj:`callable`): Function to execute when get focused.
@@ -25,17 +25,17 @@ class TextInput(Widget):
     MIN_WIDTH = 100
 
     def __init__(
-            self,
-            id=None,
-            style=None,
-            factory=None,
-            initial=None,
-            placeholder=None,
-            readonly=False,
-            on_change=None,
-            on_gain_focus=None,
-            on_lose_focus=None,
-            validator=None
+        self,
+        id=None,
+        style=None,
+        factory=None,
+        initial=None,
+        placeholder=None,
+        readonly=False,
+        on_change=None,
+        on_gain_focus=None,
+        on_lose_focus=None,
+        validators=None
     ):
         super().__init__(id=id, style=style, factory=factory)
 
@@ -48,7 +48,7 @@ class TextInput(Widget):
 
         # Set the actual value after on_change, as it may trigger change events, etc.
         self.value = initial
-        self.validator = validator
+        self.validators = validators
         self.on_lose_focus = on_lose_focus
         self.on_gain_focus = on_gain_focus
 
@@ -128,12 +128,15 @@ class TextInput(Widget):
         self._impl.set_on_change(self._on_change)
 
     @property
-    def validator(self):
-        return self._validator
+    def validators(self):
+        return self._validators
 
-    @validator.setter
-    def validator(self, validator):
-        self._validator = validator
+    @validators.setter
+    def validators(self, validators):
+        if validators is None:
+            self._validators = []
+        else:
+            self._validators = validators
         self.validate()
 
     @property
@@ -165,10 +168,10 @@ class TextInput(Widget):
         self._impl.set_on_lose_focus(self._on_lose_focus)
 
     def validate(self):
-        if self.validator is None:
-            error_message = None
-        else:
-            error_message = self.validator(self.value)
+        error_message = None
+        for validator in self.validators:
+            if error_message is None:
+                error_message = validator(self.value)
 
         if error_message is None:
             self._impl.clear_error()
@@ -178,6 +181,4 @@ class TextInput(Widget):
             return False
 
     def is_valid(self):
-        if self.validator is None:
-            return True
-        return self.validator(self.value) is None
+        return self.validate()

--- a/src/core/toga/widgets/textinput.py
+++ b/src/core/toga/widgets/textinput.py
@@ -179,6 +179,3 @@ class TextInput(Widget):
         else:
             self._impl.set_error(error_message)
             return False
-
-    def is_valid(self):
-        return self.validate()


### PR DESCRIPTION
This alters the API for TextInput validators so that `validators` is a list, rather than a single object. This means there is no need for a `Combine` operator, as combination of validators is the default behaviour.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
