### PR TITLE
set font, color, bgcolor implementations for GTK

### DIFF
--- a/src/gtk/toga_gtk/widgets/base.py
+++ b/src/gtk/toga_gtk/widgets/base.py
@@ -71,16 +71,19 @@ class Widget:
         return not self.native.set_visible(not hidden)
 
     def set_font(self, font):
-        self.native.override_font(Font(font).native)
-        # Deprecated since version 3.16: Use a custom style provider and style classes instead
+        if font:
+            self.native.override_font(Font(font).native)
+            # Deprecated since version 3.16: Use a custom style provider and style classes instead
 
     def set_color(self, color):
-        self.native.override_color(Gtk.StateFlags.NORMAL, Gdk.RGBA(*color))
-        # Deprecated since version 3.16: Use a custom style provider and style classes instead
+        if color:
+            self.native.override_color(Gtk.StateFlags.NORMAL, Gdk.RGBA(*color))
+            # Deprecated since version 3.16: Use a custom style provider and style classes instead
 
     def set_background_color(self, color):
-        self.native.override_background_color(Gtk.StateFlags.NORMAL, Gdk.RGBA(*color))
-        # Deprecated since version 3.16: Use a custom style provider and style classes instead
+        if color:
+            self.native.override_background_color(Gtk.StateFlags.NORMAL, Gdk.RGBA(*color))
+            # Deprecated since version 3.16: Use a custom style provider and style classes instead
 
     ######################################################################
     # INTERFACE

--- a/src/gtk/toga_gtk/widgets/base.py
+++ b/src/gtk/toga_gtk/widgets/base.py
@@ -1,5 +1,6 @@
 from travertino.size import at_least
 from ..libs import Gtk, Gdk
+from ..fonts import Font
 
 
 class Widget:
@@ -70,7 +71,7 @@ class Widget:
         return not self.native.set_visible(not hidden)
 
     def set_font(self, font):
-        self.native.override_font(font)
+        self.native.override_font(Font(font).native)
         # Deprecated since version 3.16: Use a custom style provider and style classes instead
 
     def set_color(self, color):

--- a/src/gtk/toga_gtk/widgets/base.py
+++ b/src/gtk/toga_gtk/widgets/base.py
@@ -1,6 +1,7 @@
 from travertino.size import at_least
 from ..libs import Gtk, Gdk
 
+
 class Widget:
     def __init__(self, interface):
         self.interface = interface

--- a/src/gtk/toga_gtk/widgets/base.py
+++ b/src/gtk/toga_gtk/widgets/base.py
@@ -75,11 +75,11 @@ class Widget:
         # Deprecated since version 3.16: Use a custom style provider and style classes instead
 
     def set_color(self, color):
-        self.native.override_color(Gtk.STATE_NORMAL, Gdk.RGBA(*color))
+        self.native.override_color(Gtk.StateFlags.NORMAL, Gdk.RGBA(*color))
         # Deprecated since version 3.16: Use a custom style provider and style classes instead
 
     def set_background_color(self, color):
-        self.native.override_background_color(Gtk.STATE_NORMAL, Gdk.RGBA(*color))
+        self.native.override_background_color(Gtk.StateFlags.NORMAL, Gdk.RGBA(*color))
         # Deprecated since version 3.16: Use a custom style provider and style classes instead
 
     ######################################################################

--- a/src/gtk/toga_gtk/widgets/base.py
+++ b/src/gtk/toga_gtk/widgets/base.py
@@ -1,5 +1,5 @@
 from travertino.size import at_least
-
+from ..libs import Gtk, Gdk
 
 class Widget:
     def __init__(self, interface):
@@ -69,16 +69,16 @@ class Widget:
         return not self.native.set_visible(not hidden)
 
     def set_font(self, font):
-        # By default, font can't be changed
-        pass
+        self.native.override_font(font)
+        # Deprecated since version 3.16: Use a custom style provider and style classes instead
 
     def set_color(self, color):
-        # By default, color can't be changed
-        pass
+        self.native.override_color(Gtk.STATE_NORMAL, Gdk.RGBA(*color))
+        # Deprecated since version 3.16: Use a custom style provider and style classes instead
 
     def set_background_color(self, color):
-        # By default, background color can't be changed
-        pass
+        self.native.override_background_color(Gtk.STATE_NORMAL, Gdk.RGBA(*color))
+        # Deprecated since version 3.16: Use a custom style provider and style classes instead
 
     ######################################################################
     # INTERFACE


### PR DESCRIPTION
added
- set_font
- set_color
- set_background_color

**Docs says**
> **Deprecated since version 3.16: Use a custom style provider and style classes instead**

just added for use other widgets without errs. change in future.

## PR Checklist:
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
