### PR TITLE
Fixes for WinForms webview

### DIFF
--- a/src/winforms/toga_winforms/widgets/webview.py
+++ b/src/winforms/toga_winforms/widgets/webview.py
@@ -1,9 +1,10 @@
+import sys
+
 from travertino.size import at_least
 
 from toga_winforms.libs import Uri, WinForms
 
 from .base import Widget
-
 
 ie_updated = False
 
@@ -31,7 +32,8 @@ def _set_ie_mode():
         Get the installed version of IE
         :return:
         """
-        ie_key = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, r"Software\Microsoft\Internet Explorer")
+        ie_key = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE,
+                                r"Software\Microsoft\Internet Explorer")
         try:
             version, type = winreg.QueryValueEx(ie_key, "svcVersion")
         except:
@@ -53,26 +55,31 @@ def _set_ie_mode():
         return value
 
     try:
-        browser_emulation = winreg.OpenKey(winreg.HKEY_CURRENT_USER,
-                                           r"Software\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_BROWSER_EMULATION",
-                                           0, winreg.KEY_ALL_ACCESS)
+        browser_emulation = winreg.OpenKey(
+            winreg.HKEY_CURRENT_USER,
+            r"Software\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_BROWSER_EMULATION",
+            0, winreg.KEY_ALL_ACCESS)
     except WindowsError:
-        browser_emulation = winreg.CreateKeyEx(winreg.HKEY_CURRENT_USER,
-                                               r"Software\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_BROWSER_EMULATION",
-                                               0, winreg.KEY_ALL_ACCESS)
+        browser_emulation = winreg.CreateKeyEx(
+            winreg.HKEY_CURRENT_USER,
+            r"Software\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_BROWSER_EMULATION",
+            0, winreg.KEY_ALL_ACCESS)
 
     try:
-        dpi_support = winreg.OpenKey(winreg.HKEY_CURRENT_USER,
-                                     r"Software\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_96DPI_PIXEL",
-                                     0, winreg.KEY_ALL_ACCESS)
+        dpi_support = winreg.OpenKey(
+            winreg.HKEY_CURRENT_USER,
+            r"Software\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_96DPI_PIXEL",
+            0, winreg.KEY_ALL_ACCESS)
     except WindowsError:
-        dpi_support = winreg.CreateKeyEx(winreg.HKEY_CURRENT_USER,
-                                               r"Software\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_96DPI_PIXEL",
-                                               0, winreg.KEY_ALL_ACCESS)
+        dpi_support = winreg.CreateKeyEx(
+            winreg.HKEY_CURRENT_USER,
+            r"Software\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_96DPI_PIXEL",
+            0, winreg.KEY_ALL_ACCESS)
 
     mode = get_ie_mode()
     executable_name = sys.executable.split("\\")[-1]
-    winreg.SetValueEx(browser_emulation, executable_name, 0, winreg.REG_DWORD, mode)
+    winreg.SetValueEx(browser_emulation, executable_name, 0, winreg.REG_DWORD,
+                      mode)
     winreg.CloseKey(browser_emulation)
 
     winreg.SetValueEx(dpi_support, executable_name, 0, winreg.REG_DWORD, 1)
@@ -101,7 +108,8 @@ class WebView(Widget):
 
     def set_url(self, value):
         if value:
-            self.native.Navigate(Uri(self.interface.url), "_self", None, "User-Agent: %s" % self.interface.user_agent)
+            self.native.Navigate(Uri(self.interface.url), "_self", None,
+                                 "User-Agent: %s" % self.interface.user_agent)
 
     def set_content(self, root_url, content):
         self.native.Url = Uri(root_url)

--- a/src/winforms/toga_winforms/widgets/webview.py
+++ b/src/winforms/toga_winforms/widgets/webview.py
@@ -84,6 +84,8 @@ class TogaWebBrowser(WinForms.WebBrowser):
     def __init__(self, interface):
         _set_ie_mode()
         super().__init__()
+        self.ScriptErrorsSuppressed = True
+        self.DpiAware = True
         self.interface = interface
 
 

--- a/src/winforms/toga_winforms/widgets/webview.py
+++ b/src/winforms/toga_winforms/widgets/webview.py
@@ -5,8 +5,84 @@ from toga_winforms.libs import Uri, WinForms
 from .base import Widget
 
 
+ie_updated = False
+
+
+def _set_ie_mode():
+    """
+    By default hosted IE control emulates IE7 regardless which version of IE is installed. To fix this, a proper value
+    must be set for the executable.
+    See http://msdn.microsoft.com/en-us/library/ee330730%28v=vs.85%29.aspx#browser_emulation for details on this
+    behaviour.
+    """
+
+    global ie_updated
+
+    if ie_updated:
+        return
+
+    try:
+        import _winreg as winreg  # Python 2
+    except ImportError:
+        import winreg  # Python 3
+
+    def get_ie_mode():
+        """
+        Get the installed version of IE
+        :return:
+        """
+        ie_key = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, r"Software\Microsoft\Internet Explorer")
+        try:
+            version, type = winreg.QueryValueEx(ie_key, "svcVersion")
+        except:
+            version, type = winreg.QueryValueEx(ie_key, "Version")
+
+        winreg.CloseKey(ie_key)
+
+        if version.startswith("11"):
+            value = 0x2AF9
+        elif version.startswith("10"):
+            value = 0x2711
+        elif version.startswith("9"):
+            value = 0x270F
+        elif version.startswith("8"):
+            value = 0x22B8
+        else:
+            value = 0x2AF9  # Set IE11 as default
+
+        return value
+
+    try:
+        browser_emulation = winreg.OpenKey(winreg.HKEY_CURRENT_USER,
+                                           r"Software\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_BROWSER_EMULATION",
+                                           0, winreg.KEY_ALL_ACCESS)
+    except WindowsError:
+        browser_emulation = winreg.CreateKeyEx(winreg.HKEY_CURRENT_USER,
+                                               r"Software\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_BROWSER_EMULATION",
+                                               0, winreg.KEY_ALL_ACCESS)
+
+    try:
+        dpi_support = winreg.OpenKey(winreg.HKEY_CURRENT_USER,
+                                     r"Software\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_96DPI_PIXEL",
+                                     0, winreg.KEY_ALL_ACCESS)
+    except WindowsError:
+        dpi_support = winreg.CreateKeyEx(winreg.HKEY_CURRENT_USER,
+                                               r"Software\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_96DPI_PIXEL",
+                                               0, winreg.KEY_ALL_ACCESS)
+
+    mode = get_ie_mode()
+    executable_name = sys.executable.split("\\")[-1]
+    winreg.SetValueEx(browser_emulation, executable_name, 0, winreg.REG_DWORD, mode)
+    winreg.CloseKey(browser_emulation)
+
+    winreg.SetValueEx(dpi_support, executable_name, 0, winreg.REG_DWORD, 1)
+    winreg.CloseKey(dpi_support)
+    ie_updated = True
+
+
 class TogaWebBrowser(WinForms.WebBrowser):
     def __init__(self, interface):
+        _set_ie_mode()
         super().__init__()
         self.interface = interface
 

--- a/src/winforms/toga_winforms/widgets/webview.py
+++ b/src/winforms/toga_winforms/widgets/webview.py
@@ -35,10 +35,6 @@ def _set_ie_mode():
         winreg.SetValueEx(key, executable_name, 0, winreg.REG_DWORD, mode)
         winreg.CloseKey(key)
 
-    browser_emulation = open_key()
-    dpi_support = open_key(
-        r"Software\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_96DPI_PIXEL"
-    )
     # Get the installed version of IE
     ie_key = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE,
                             r"Software\Microsoft\Internet Explorer")

--- a/src/winforms/toga_winforms/widgets/webview.py
+++ b/src/winforms/toga_winforms/widgets/webview.py
@@ -36,7 +36,7 @@ def _set_ie_mode():
                                 r"Software\Microsoft\Internet Explorer")
         try:
             version, type = winreg.QueryValueEx(ie_key, "svcVersion")
-        except:
+        except Exception:
             version, type = winreg.QueryValueEx(ie_key, "Version")
 
         winreg.CloseKey(ie_key)


### PR DESCRIPTION
## fix for use latest IE as WinForms webview
By default hosted IE control emulates IE7 regardless which version of IE is installed. To fix this, a proper value must be set for the executable.
See http://msdn.microsoft.com/en-us/library/ee330730%28v=vs.85%29.aspx#browser_emulation for details on this behaviour.

## hide script errors (`ScriptErrorsSuppressed`)
## set DpiAware to `True`

Want to do more tests on different computers.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
