### PR TITLE
Fix bug in windows split container

### DIFF
--- a/src/winforms/toga_winforms/widgets/splitcontainer.py
+++ b/src/winforms/toga_winforms/widgets/splitcontainer.py
@@ -36,10 +36,13 @@ class SplitContainer(Widget):
             self.interface._weight = [weight/total for weight in self.interface._weight]
 
             # Set the position of splitter depending on the weight of splits.
-            self.native.SplitterDistance = int(
-                self.interface._weight[0] * self.interface.style.width
+            total_distance = (
+                self.native.Width
                 if self.interface.direction == self.interface.VERTICAL
-                else self.interface.style.height
+                else self.native.Height
+            )
+            self.native.SplitterDistance = int(
+                self.interface._weight[0] * total_distance
             )
 
     def set_app(self, app):


### PR DESCRIPTION
When trying to set a split container with a given ratio between tabs, it doesn't work as expected.

FIxed that.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
