### PR TITLE
Fix bug in windows selection

### DIFF
--- a/src/winforms/toga_winforms/widgets/selection.py
+++ b/src/winforms/toga_winforms/widgets/selection.py
@@ -32,8 +32,7 @@ class Selection(Widget):
             self.native.SelectedIndex = 0
 
     def select_item(self, item):
-        index = self.native.FindString(item)
-        self.native.SelectedIndex = index
+        self.native.SelectedItem = item
 
     def get_selected_item(self):
         return self.native.SelectedItem


### PR DESCRIPTION
There is a bug in the `select_item` method in Winforms.
It seems like the method "native.FindItem"  returns the wrong index.

In order to fix the problem altogether, setting `SelectedItem` instead of `SelectedIndex`.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
