### PR TITLE
Number regular expression should include exponents

### DIFF
--- a/src/core/tests/test_validators.py
+++ b/src/core/tests/test_validators.py
@@ -390,14 +390,31 @@ class TestValidators(unittest.TestCase):
 
         self.validator_factory = validators.Number
         self.valid_inputs = [
-            "0", "00", "0.0", "1", "2.1", "-1", "-0.22", ".2", "88.0", "9."
+            "0",
+            "00",
+            "0.0",
+            "1",
+            "2.1",
+            "-1",
+            "-0.22",
+            ".2",
+            "88.0",
+            "9.",
+            "2e+7",
+            "9e-6",
+            "1.23e+15",
+            "-9.2E+23",
+            "1.23e-15",
+            "-9.2E-23",
         ]
         self.invalid_inputs = [
             ("a", default_error_message),
             ("ab", default_error_message),
             ("this is a not valid!", default_error_message),
             (".", default_error_message),
-            ("88.a", default_error_message)
+            ("88.a", default_error_message),
+            ("e+12", default_error_message),
+            ("E-9", default_error_message),
         ]
 
         self.check()

--- a/src/core/toga/validators.py
+++ b/src/core/toga/validators.py
@@ -344,7 +344,7 @@ class ContainsSpecial(CountValidator):
 
 class Integer(MatchRegex):
 
-    INTEGER_REGEX = r"^[0-9]+$"
+    INTEGER_REGEX = r"^\d+$"
 
     def __init__(self, error_message: Optional[str] = None, allow_empty: bool = True):
         if error_message is None:
@@ -356,7 +356,7 @@ class Integer(MatchRegex):
 
 class Number(MatchRegex):
 
-    NUMBER_REGEX = r"^[-]?(\d+|\d*\.\d+|\d+.\d*)$"
+    NUMBER_REGEX = r"^[-+]?(\d+\.|\d*\.?\d+)([eE][-+]?\d+)?$"
 
     def __init__(self, error_message: Optional[str] = None, allow_empty: bool = True):
         if error_message is None:


### PR DESCRIPTION
At the moment the numbers validator does not excpet numbers such as "1e+12" or "-9.2e-17".
Fixed that.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
