### PR TITLE
cast str on cocoa open_file dialog single file selection

### DIFF
--- a/src/cocoa/toga_cocoa/dialogs.py
+++ b/src/cocoa/toga_cocoa/dialogs.py
@@ -142,7 +142,7 @@ def open_file(window, title, file_types, multiselect):
     if result == NSFileHandlingPanelOKButton:
         paths = [str(url.path) for url in panel.URLs]
         filename_or_filenames = (paths if multiselect else
-                                 panel.URL.path)
+                                 str(panel.URL.path))
         return filename_or_filenames
 
 


### PR DESCRIPTION
<!--- Describe your changes in detail -->
`open_file_dialog` in cocoa is not casting the NSString into a python string for single files. I cast it to a python string if just one file is selected.


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
