### PR TITLE
Add None viewport by default to Windows widget.

### DIFF
--- a/src/core/toga/widgets/base.py
+++ b/src/core/toga/widgets/base.py
@@ -201,8 +201,7 @@ class Widget(Node):
             self._root.refresh()
         else:
             self.refresh_sublayouts()
-            if self._impl.viewport is not None:
-                super().refresh(self._impl.viewport)
+            super().refresh(self._impl.viewport)
 
     def refresh_sublayouts(self):
         for child in self.children:

--- a/src/core/toga/widgets/base.py
+++ b/src/core/toga/widgets/base.py
@@ -201,7 +201,8 @@ class Widget(Node):
             self._root.refresh()
         else:
             self.refresh_sublayouts()
-            super().refresh(self._impl.viewport)
+            if self._impl.viewport is not None:
+                super().refresh(self._impl.viewport)
 
     def refresh_sublayouts(self):
         for child in self.children:

--- a/src/winforms/toga_winforms/widgets/base.py
+++ b/src/winforms/toga_winforms/widgets/base.py
@@ -8,6 +8,7 @@ class Widget:
 
         self._container = None
         self.native = None
+        self.viewport = None
         self.create()
         self.interface.style.reapply()
 
@@ -42,6 +43,14 @@ class Widget:
             child._impl.container = container
 
         self.rehint()
+
+    @property
+    def viewport(self):
+        return self._viewport
+
+    @viewport.setter
+    def viewport(self, viewport):
+        self._viewport = viewport
 
     def set_enabled(self, value):
         if self.native:


### PR DESCRIPTION
When trying to refresh an App in windows, sometimes an `AttributeError` is raised that _impl doesn't have a `viewport` attribute.
Fixed that by default, viewport is `None`.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
