### PR TITLE
Make changing Winforms imageview image possible

### DIFF
--- a/src/winforms/toga_winforms/widgets/imageview.py
+++ b/src/winforms/toga_winforms/widgets/imageview.py
@@ -11,7 +11,7 @@ class ImageView(Widget):
         self.native.SizeMode = WinForms.PictureBoxSizeMode.StretchImage
 
     def set_image(self, image):
-        # Dispose the image when image is set to None
+        # If an image already exists, ensure it is destroyed
         if self.native.Image is not None:
             self.native.Image.Dispose()
         if image:

--- a/src/winforms/toga_winforms/widgets/imageview.py
+++ b/src/winforms/toga_winforms/widgets/imageview.py
@@ -11,6 +11,9 @@ class ImageView(Widget):
         self.native.SizeMode = WinForms.PictureBoxSizeMode.StretchImage
 
     def set_image(self, image):
+        # Dispose the image when image is set to None
+        if self.native.Image is not None:
+            self.native.Image.Dispose()
         if image:
             # Workaround for loading image from url
             if self.interface._image._impl.url:


### PR DESCRIPTION
Currently, when we set an image to Winforms ` imageview`, it doesn't check if it already has the image. This way, when changing the image, resources are not being freed (disposed of), and we cannot delete the image that was previously used because of the Permission Error.
This PR adds a check for the existing image. If it exists, we free the resources by calling `Dispose`, and only then set the new image.

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
