### PR TITLE
Fix crash on adding new row to DetailedList

### DIFF
--- a/src/android/toga_android/widgets/base.py
+++ b/src/android/toga_android/widgets/base.py
@@ -1,6 +1,8 @@
 from ..libs.activity import MainActivity
 from ..libs.android_widgets import Gravity
 
+from rubicon.java.jni import java
+
 from toga.constants import CENTER, JUSTIFY, LEFT, RIGHT
 
 
@@ -10,9 +12,11 @@ class Widget:
         self.interface._impl = self
         self._container = None
         self.native = None
-        # Capture a reference to the Java `MainActivity` instance, so that subclasses
-        # can pass it as `context` when creating native Android widgets.
-        self._native_activity = MainActivity.singletonThis
+        # In Android, there is only one `app` (i.e., `Activity)`. Android widgets need a reference to
+        # the current activity to pass it as `context` when creating native Android widgets.
+        #
+        # This may happen at any time, so we need a global JNI ref.
+        self._native_activity = MainActivity(__jni__=java.NewGlobalRef(MainActivity.singletonThis))
         self.create()
         # Immediately re-apply styles. Some widgets may defer style application until
         # they have been added to a container.

--- a/src/android/toga_android/widgets/detailedlist.py
+++ b/src/android/toga_android/widgets/detailedlist.py
@@ -33,9 +33,14 @@ class DetailedList(Widget):
     def create(self):
         # DetailedList is not a specific widget on Android, so we build it out
         # of a few pieces.
-        parent = android_widgets.LinearLayout(self._native_activity)
-        parent.setOrientation(android_widgets.LinearLayout.VERTICAL)
-        self.native = parent
+
+        if self.native is None:
+            self.native = android_widgets.LinearLayout(self._native_activity)
+            self.native.setOrientation(android_widgets.LinearLayout.VERTICAL)
+        else:
+            # If create() is called a second time, clear the widget and regenerate it.
+            self.native.removeAllViews()
+
         scroll_view = android_widgets.ScrollView(self._native_activity)
         scroll_view_layout_params = android_widgets.LinearLayout__LayoutParams(
                 android_widgets.LinearLayout__LayoutParams.MATCH_PARENT,
@@ -47,7 +52,7 @@ class DetailedList(Widget):
         self._android_swipe_refresh_layout = android_widgets.SwipeRefreshLayout(
             __jni__=java.NewGlobalRef(swipe_refresh_wrapper))
         swipe_refresh_wrapper.addView(scroll_view)
-        parent.addView(swipe_refresh_wrapper, scroll_view_layout_params)
+        self.native.addView(swipe_refresh_wrapper, scroll_view_layout_params)
         dismissable_container = android_widgets.LinearLayout(self._native_activity)
         dismissable_container.setOrientation(android_widgets.LinearLayout.VERTICAL)
         dismissable_container_params = android_widgets.LinearLayout__LayoutParams(
@@ -70,9 +75,9 @@ class DetailedList(Widget):
         # Add user-provided icon to layout.
         icon_image_view = android_widgets.ImageView(self._native_activity)
         icon = self.interface.data[i].icon
-        icon.bind(self.interface.factory)
-        bitmap = android_widgets.BitmapFactory.decodeFile(str(icon._impl.path))
-        if bitmap is not None:
+        if icon is not None:
+            icon.bind(self.interface.factory)
+            bitmap = android_widgets.BitmapFactory.decodeFile(str(icon._impl.path))
             icon_image_view.setImageBitmap(bitmap)
         icon_layout_params = android_widgets.RelativeLayout__LayoutParams(
             android_widgets.RelativeLayout__LayoutParams.WRAP_CONTENT,


### PR DESCRIPTION
On Android, use a global JNI ref for `_native_activity`.

This allows the Android DetailedList demo's "Insert Row" button to be clicked without triggering a crash.

![image](https://user-images.githubusercontent.com/25457/103977856-ff63ad00-512e-11eb-97c2-38368926af6a.png)

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
