### PR TITLE
Align tutorial installation instructions with readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ Minimum requirements
 
   * **Ubuntu 16.04 / Debian 9** ``sudo apt-get install python3-dev python3-gi python3-gi-cairo libgirepository1.0-dev libcairo2-dev libwebkitgtk-3.0-0 gir1.2-webkit2-3.0``
 
-  * **Ubuntu 18.04 / Debian 10** ``sudo apt-get install python3-dev python3-gi python3-gi-cairo libgirepository1.0-dev libcairo2-dev libwebkitgtk-4.0-37 gir1.2-webkit2-4.0``
+  * **Ubuntu 18.04 / Ubuntu 20.04 / Debian 10** ``sudo apt-get install python3-dev libgirepository1.0-dev libcairo2-dev libpango1.0-dev libwebkit2gtk-4.0-37 gir1.2-webkit2-4.0``
 
   * **Fedora** ``sudo dnf install pygobject3 python3-gobject python3-cairo-devel cairo-gobject-devel gobject-introspection-devel pywebkitgtk``
 

--- a/README.rst
+++ b/README.rst
@@ -49,9 +49,9 @@ Minimum requirements
   that ships starting with Ubuntu 14.04 and Fedora 20. You also need to install
   the Python 3 bindings and development files for GTK+.
 
-  * **Ubuntu 16.04 / Debian 9** ``sudo apt-get install python3-dev python3-gi python3-gi-cairo libgirepository1.0-dev libcairo2-dev libwebkitgtk-3.0-0 gir1.2-webkit2-3.0``
+  * **Ubuntu 16.04 / Debian 9** ``sudo apt-get install python3-dev python3-gi python3-gi-cairo libgirepository1.0-dev libcairo2-dev libpango1.0-dev libwebkitgtk-3.0-0 gir1.2-webkit2-3.0``
 
-  * **Ubuntu 18.04 / Ubuntu 20.04 / Debian 10** ``sudo apt-get install python3-dev libgirepository1.0-dev libcairo2-dev libpango1.0-dev libwebkit2gtk-4.0-37 gir1.2-webkit2-4.0``
+  * **Ubuntu 18.04, 20.04 / Debian 10, 11** ``sudo apt-get install python3-dev python3-gi python3-gi-cairo libgirepository1.0-dev libcairo2-dev libpango1.0-dev libwebkit2gtk-4.0-37 gir1.2-webkit2-4.0``
 
   * **Fedora** ``sudo dnf install pygobject3 python3-gobject python3-cairo-devel cairo-gobject-devel gobject-introspection-devel pywebkitgtk``
 

--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -66,11 +66,11 @@ Next, install Toga into your virtual environment:
       (venv) $ sudo apt-get update
       (venv) $ sudo apt-get install python3-dev libgirepository1.0-dev libcairo2-dev libpango1.0-dev libwebkitgtk-3.0-0 gir1.2-webkit-3.0
 
-      # Ubuntu 18.04 / Debian 10
+      # Ubuntu 18.04 / Ubuntu 20.04 / Debian 10
       # has webkit2-4.0
       # libwebkitgtk version seems very specific, but that is what it currently is @ 20190825
       (venv) $ sudo apt-get update
-      (venv) $ sudo apt-get install python3-dev python3-gi python3-gi-cairo libgirepository1.0-dev libcairo2-dev libwebkitgtk-4.0-37 gir1.2-webkit2-4.0
+      (venv) $ sudo apt-get install python3-dev libgirepository1.0-dev libcairo2-dev libpango1.0-dev libwebkit2gtk-4.0-37 gir1.2-webkit2-4.0
 
       # Fedora
       (venv) $ sudo dnf install pkg-config python3-devel gobject-introspection-devel cairo-devel cairo-gobject-devel pango-devel webkitgtk3

--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -62,15 +62,15 @@ Next, install Toga into your virtual environment:
 
     .. code-block:: bash
 
-      # Ubuntu, Debian 9
+      # Ubuntu 16.04 / Debian 9
       (venv) $ sudo apt-get update
-      (venv) $ sudo apt-get install python3-dev libgirepository1.0-dev libcairo2-dev libpango1.0-dev libwebkitgtk-3.0-0 gir1.2-webkit-3.0
+      (venv) $ sudo apt-get install python3-dev python3-gi python3-gi-cairo libgirepository1.0-dev libcairo2-dev libwebkitgtk-3.0-0 gir1.2-webkit2-3.0
 
-      # Debian 10
+      # Ubuntu 18.04 / Debian 10
       # has webkit2-4.0
       # libwebkitgtk version seems very specific, but that is what it currently is @ 20190825
       (venv) $ sudo apt-get update
-      (venv) $ sudo apt-get install python3-dev libgirepository1.0-dev libcairo2-dev libpango1.0-dev libwebkit2gtk-4.0-37 gir1.2-webkit2-4.0
+      (venv) $ sudo apt-get install python3-dev python3-gi python3-gi-cairo libgirepository1.0-dev libcairo2-dev libwebkitgtk-4.0-37 gir1.2-webkit2-4.0
 
       # Fedora
       (venv) $ sudo dnf install pkg-config python3-devel gobject-introspection-devel cairo-devel cairo-gobject-devel pango-devel webkitgtk3

--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -64,7 +64,7 @@ Next, install Toga into your virtual environment:
 
       # Ubuntu 16.04 / Debian 9
       (venv) $ sudo apt-get update
-      (venv) $ sudo apt-get install python3-dev python3-gi python3-gi-cairo libgirepository1.0-dev libcairo2-dev libwebkitgtk-3.0-0 gir1.2-webkit2-3.0
+      (venv) $ sudo apt-get install python3-dev libgirepository1.0-dev libcairo2-dev libpango1.0-dev libwebkitgtk-3.0-0 gir1.2-webkit-3.0
 
       # Ubuntu 18.04 / Debian 10
       # has webkit2-4.0

--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -64,16 +64,17 @@ Next, install Toga into your virtual environment:
 
       # Ubuntu 16.04 / Debian 9
       (venv) $ sudo apt-get update
-      (venv) $ sudo apt-get install python3-dev libgirepository1.0-dev libcairo2-dev libpango1.0-dev libwebkitgtk-3.0-0 gir1.2-webkit-3.0
+      (venv) $ sudo apt-get install python3-dev python3-gi python3-gi-cairo libgirepository1.0-dev libcairo2-dev libpango1.0-dev libwebkitgtk-3.0-0 gir1.2-webkit2-3.0
 
-      # Ubuntu 18.04 / Ubuntu 20.04 / Debian 10
-      # has webkit2-4.0
-      # libwebkitgtk version seems very specific, but that is what it currently is @ 20190825
+      # Ubuntu 18.04 / Ubuntu 20.04 / Debian 10 / Debian 11
       (venv) $ sudo apt-get update
-      (venv) $ sudo apt-get install python3-dev libgirepository1.0-dev libcairo2-dev libpango1.0-dev libwebkit2gtk-4.0-37 gir1.2-webkit2-4.0
+      (venv) $ sudo apt-get install python3-dev python3-gi python3-gi-cairo libgirepository1.0-dev libcairo2-dev libpango1.0-dev libwebkit2gtk-4.0-37 gir1.2-webkit2-4.0
 
       # Fedora
       (venv) $ sudo dnf install pkg-config python3-devel gobject-introspection-devel cairo-devel cairo-gobject-devel pango-devel webkitgtk3
+
+      # Arch / Manjaro
+      (venv) $ sudo pacman -Syu git pkgconf cairo python-cairo pango gobject-introspection gobject-introspection-runtime python-gobject webkit2gtk
 
     If you're not using one of these, you'll need to work out how to install
     the developer libraries for python3, cairo, pango, and


### PR DESCRIPTION
The readme distinguishes between Ubuntu versions. Further the list of
debian packages in the readme differs from the one in the tutorial.
Because the readme is more recent (see 82c94a72) it's presumably more up
to date.

Hopefully this change doesn't drop a debian package which is used only
by the tutorial but not by the readme.

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
