### PR TITLE
Fix memory management issue in Cocoa TogaIconView

### DIFF
--- a/src/cocoa/toga_cocoa/widgets/internal/cells.py
+++ b/src/cocoa/toga_cocoa/widgets/internal/cells.py
@@ -33,8 +33,16 @@ class TogaIconView(NSTableCellView):
 
     @objc_method
     def setup(self):
-        self.imageView = NSImageView.alloc().init()
-        self.textField = NSTextField.alloc().init()
+        image_view = NSImageView.alloc().init()
+        text_field = NSTextField.alloc().init()
+
+        # this will retain image_view and text_field without needing to keep
+        # a Python reference
+        self.addSubview(image_view)
+        self.addSubview(text_field)
+
+        self.imageView = image_view
+        self.textField = text_field
 
         self.textField.cell.lineBreakMode = NSLineBreakMode.byTruncatingTail
         self.textField.bordered = False
@@ -42,9 +50,6 @@ class TogaIconView(NSTableCellView):
 
         self.imageView.translatesAutoresizingMaskIntoConstraints = False
         self.textField.translatesAutoresizingMaskIntoConstraints = False
-
-        self.addSubview(self.imageView)
-        self.addSubview(self.textField)
 
         # center icon vertically in cell
         self.iv_vertical_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # NOQA:E501


### PR DESCRIPTION
This PR fixes an issue with `TogaIconView` where the instances of `NSImageView` and `NSTextField` can be deallocated 
before they are added as subviews to the `TogaIconView`. This becomes a problem when we start doing proper reference management, i.e., giving up the ownership of objc instances once the corresponding Python variable is destroyed.

See https://github.com/beeware/rubicon-objc/pull/201#issuecomment-758664864 for a proper analyses of the issue.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
