### PR TITLE
Fix Android DetailedList .selection property

### DIFF
--- a/src/android/toga_android/widgets/detailedlist.py
+++ b/src/android/toga_android/widgets/detailedlist.py
@@ -13,8 +13,10 @@ class DetailedListOnClickListener(android_widgets.OnClickListener):
         self._row_number = row_number
 
     def onClick(self, _view):
+        row = self._impl.interface.data[self._row_number]
+        self._impl._selection = row
         if self._impl.interface.on_select:
-            self._impl.interface.on_select(widget=self._impl.interface, row=self._row_number)
+            self._impl.interface.on_select(widget=self._impl.interface, row=row)
 
 
 class OnRefreshListener(android_widgets.SwipeRefreshLayout__OnRefreshListener):
@@ -29,6 +31,7 @@ class OnRefreshListener(android_widgets.SwipeRefreshLayout__OnRefreshListener):
 
 class DetailedList(Widget):
     _android_swipe_refresh_layout = None
+    _selection = None
 
     def create(self):
         # DetailedList is not a specific widget on Android, so we build it out
@@ -154,7 +157,7 @@ class DetailedList(Widget):
         self.create()
 
     def get_selection(self):
-        return None
+        return self._selection
 
     def set_on_select(self, handler):
         # No special handling required.

--- a/src/core/toga/widgets/detailedlist.py
+++ b/src/core/toga/widgets/detailedlist.py
@@ -132,7 +132,7 @@ class DetailedList(Widget):
 
     @property
     def selection(self):
-        """The current selection of the table.
+        """The current selection.
 
         A value of None indicates no selection.
         """


### PR DESCRIPTION
Fix the `.selection` property on the Android `DetailedList`.

In the GIF screenshots, you can see that this also fixes the "Delete Row" button in the DetailedList demo app.

It also fixes a typo in a comment in the `core` DetailedList.


## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct


## GIF - Before

![detailedlist-click-row-click-delete-nothing-happens](https://user-images.githubusercontent.com/25457/107900459-ea302a00-6ef5-11eb-910c-6eed1bfe2bf1.gif)


## GIF - After

![detailedlist-click-row-then-click-delete-it-deletes](https://user-images.githubusercontent.com/25457/107900462-ee5c4780-6ef5-11eb-9ad1-a01dc6580bd0.gif)
