### PR TITLE
Fix Winforms font family lookup

### DIFF
--- a/src/winforms/toga_winforms/libs/fonts.py
+++ b/src/winforms/toga_winforms/libs/fonts.py
@@ -16,7 +16,8 @@ from .winforms import (
     FontStyle,
     SystemFonts,
     Text,
-    WinForms
+    WinForms,
+    ArgumentException
 )
 
 
@@ -51,14 +52,14 @@ def win_font_family(value):
             MONOSPACE: FontFamily.GenericMonospace,
         }[value]
     except KeyError:
-        if value in Text.InstalledFontCollection().Families:
+        try:
             return FontFamily(value)
-    else:
-        print(
-            "Unable to load font-family '{}', loading {} instead".format(
-                value, SystemFonts.DefaultFont.FontFamily)
-        )
-        return SystemFonts.DefaultFont.FontFamily
+        except ArgumentException:
+            print(
+                "Unable to load font-family '{}', loading '{}' instead".format(
+                    value, SystemFonts.DefaultFont.FontFamily.Name)
+            )
+            return SystemFonts.DefaultFont.FontFamily
 
 
 def win_font_style(weight, style, font_family):

--- a/src/winforms/toga_winforms/libs/fonts.py
+++ b/src/winforms/toga_winforms/libs/fonts.py
@@ -15,7 +15,6 @@ from .winforms import (
     FontFamily,
     FontStyle,
     SystemFonts,
-    Text,
     WinForms,
     ArgumentException
 )

--- a/src/winforms/toga_winforms/libs/winforms.py
+++ b/src/winforms/toga_winforms/libs/winforms.py
@@ -14,6 +14,7 @@ from System import (  # noqa: F401, E402
     Single,
     Threading,
     Uri,
+    ArgumentException,
 )
 
 from System.Drawing import (  # noqa: F401, E402


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Refs #1210
This PR fixes a bug where the Windows backend could not set a custom font.
The `win_font_family` function was looking up the string value of the font name in a list of FontFamily objects, and, therefore, could not find it. Since Winforms doesn't provide an easy way to get a list of installed font family names as strings, this PR simply tries to get the FontFamily from the value string and uses the fallback in case of pythonnet's ArgumentException.

I tested it the tutorial1 because there is no specific example app for fonts, and managed to set the label font to 'Comic Sans MS'.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
