### PR TITLE
Fix DetailedList row background color

### DIFF
--- a/src/android/toga_android/widgets/detailedlist.py
+++ b/src/android/toga_android/widgets/detailedlist.py
@@ -68,8 +68,6 @@ class DetailedList(Widget):
     def _make_row(self, container, i):
         # Create the foreground.
         row_foreground = android_widgets.RelativeLayout(self._native_activity)
-        row_foreground.setBackgroundColor(self._native_activity.getResources().getColor(
-            android_widgets.R__color.background_light))
         container.addView(row_foreground)
 
         # Add user-provided icon to layout.


### PR DESCRIPTION
On Android, the DetailedList rows had a different background color than the rest of the widget. This fixes that. Note that it's subtle -- look carefully at the color behind "Bee" vs. the color behind "INSERT ROW".

## Before

![image](https://user-images.githubusercontent.com/25457/110252086-87e8a900-7f38-11eb-87f5-8c08e044b291.png)


## After

![image](https://user-images.githubusercontent.com/25457/110252047-5f60af00-7f38-11eb-8661-b5e720cba0f8.png)

## Other notes

The DetailedList still needs swipe-based actions to be implemented. I plan to work on that next. I saw this issue and wanted to fix it first.

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
