### PR TITLE
Fix resizing in multitextinput and webview widgets

### DIFF
--- a/src/gtk/toga_gtk/widgets/box.py
+++ b/src/gtk/toga_gtk/widgets/box.py
@@ -12,7 +12,8 @@ class TogaBox(Gtk.Fixed):
         # Calculate the minimum and natural width of the container.
         # print("GET PREFERRED WIDTH", self._impl.native)
         width = self._impl.interface.layout.width
-        min_width = 0 if self._impl.min_width is None else self._impl.min_width
+        min_width = self._impl.interface.style.padding_right if self._impl.min_width is None \
+                else self._impl.min_width + self._impl.interface.style.padding_right
         for widget in self.get_children():
             if (
                 min_width
@@ -32,7 +33,8 @@ class TogaBox(Gtk.Fixed):
         # Calculate the minimum and natural height of the container.
         # print("GET PREFERRED HEIGHT", self._impl.native)
         height = self._impl.interface.layout.height
-        min_height = 0 if self._impl.min_height is None else self._impl.min_height
+        min_height = self._impl.interface.style.padding_bottom if self._impl.min_height is None \
+                else self._impl.min_height + self._impl.interface.style.padding_bottom
         for widget in self.get_children():
             if (
                 min_height

--- a/src/gtk/toga_gtk/widgets/webview.py
+++ b/src/gtk/toga_gtk/widgets/webview.py
@@ -1,7 +1,7 @@
 from travertino.size import at_least
 
 from ..keys import toga_key
-from ..libs import Gtk, WebKit2
+from ..libs import WebKit2
 from .base import Widget
 
 

--- a/src/gtk/toga_gtk/window.py
+++ b/src/gtk/toga_gtk/window.py
@@ -110,13 +110,14 @@ class Window:
 
         # Now that the content is visible, we can do our initial hinting,
         # and use that as the basis for setting the minimum window size.
-        self.interface.content._impl.rehint()
         self.interface.content.style.layout(
             self.interface.content,
             GtkViewport(native=None)
         )
         self.interface.content._impl.min_width = self.interface.content.layout.width
         self.interface.content._impl.min_height = self.interface.content.layout.height
+
+        self.interface.content._impl.rehint()
 
     def gtk_on_close(self, widget, data):
         if self.interface.on_close:

--- a/src/gtk/toga_gtk/window.py
+++ b/src/gtk/toga_gtk/window.py
@@ -108,8 +108,11 @@ class Window:
     def show(self):
         self.native.show_all()
 
-        # Now that the content is visible, we can do our initial hinting,
-        # and use that as the basis for setting the minimum window size.
+        # WARNING! the our current implementation for GTK backend does not
+        # need initial hinting here because the `Box` widget implementation
+        # already calculate the minimum size for each widget when allocate it,
+        # if we do hinting here some widget will inherit its size from size
+        # window of application.
         self.interface.content.style.layout(
             self.interface.content,
             GtkViewport(native=None)

--- a/src/gtk/toga_gtk/window.py
+++ b/src/gtk/toga_gtk/window.py
@@ -108,19 +108,15 @@ class Window:
     def show(self):
         self.native.show_all()
 
-        # WARNING! the our current implementation for GTK backend does not
-        # need initial hinting here because the `Box` widget implementation
-        # already calculate the minimum size for each widget when allocate it,
-        # if we do hinting here some widget will inherit its size from size
-        # window of application.
+        # Now that the content is visible, we can do our initial hinting,
+        # and use that as the basis for setting the minimum window size.
+        self.interface.content._impl.rehint()
         self.interface.content.style.layout(
             self.interface.content,
             GtkViewport(native=None)
         )
         self.interface.content._impl.min_width = self.interface.content.layout.width
         self.interface.content._impl.min_height = self.interface.content.layout.height
-
-        self.interface.content._impl.rehint()
 
     def gtk_on_close(self, widget, data):
         if self.interface.on_close:


### PR DESCRIPTION
## Describe your changes in detail
This PR request will fix issue #1205. Also it add some enhancements in `webview` widget; since the `WebKit2.WebView()` provide us with scrollable webview there is no need to add it to `Gtk.ScrolledWindow()` widget.
  
## What problem does this change solve?
This will solve the issue of limiting resizing of window after it be big.

## This will solve
#1205

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
