### PR TITLE
Window.on_close() on Windows

### DIFF
--- a/src/winforms/toga_winforms/window.py
+++ b/src/winforms/toga_winforms/window.py
@@ -42,6 +42,7 @@ class Window:
         self.native.ClientSize = Size(*self.interface._size)
         self.native.interface = self.interface
         self.native.Resize += self.winforms_resize
+        self.native.FormClosing += self.winforms_FormClosing
         self.toolbar_native = None
         self.toolbar_items = None
 
@@ -129,6 +130,7 @@ class Window:
         self.native.Show()
 
     def winforms_FormClosing(self, event, handler):
+        self.interface.on_close()
         if self.interface.app.on_exit:
             self.interface.app.on_exit(self.interface.app)
 


### PR DESCRIPTION
## PR description
This PR ensures that Window.on_close() is called when a window is closed.
It implements the same behaviour as on macOS.

The handler can currently not be set to a callable of the user code, but on_close() can be overridden when using a class that inherits from toga.Window
## What problem does this change solve?
The Window.on_close() handler was not called when a window closed

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
