### PR TITLE
Update python version badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@
 Toga
 ====
 
-.. image:: https://img.shields.io/badge/python-3.5%2C%203.6%2C%203.7-blue.svg
+.. image:: https://img.shields.io/badge/python-3.6%2C%203.7%2C3.8-blue.svg
     :target: https://pypi.python.org/pypi/toga
     :alt: Python Versions
 

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@
 Toga
 ====
 
-.. image:: https://img.shields.io/badge/python-3.6%2C%203.7%2C3.8-blue.svg
+.. image:: https://img.shields.io/badge/python-3.6%2C%203.7%2C3.9-blue.svg
     :target: https://pypi.python.org/pypi/toga
     :alt: Python Versions
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,10 +17,10 @@ classifiers =
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3 :: Only
     Topic :: Software Development
     Topic :: Software Development :: User Interfaces


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Since we have removed the support for 3.5, we can remove it from the badge as well. I've added python versions up to 3.8, but didn't add 3.9 because it's not yet supported on Windows. The last time I tried about a month ago, I have managed to install dependencies, but got an error that Briefcase doesn't have a template for Windows with Python 3.9.
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [ ] I have read the **CONTRIBUTING.md** file
- [ ] I will abide by the code of conduct
