### PR TITLE
Android DetailedList: Implement on_select

### DIFF
--- a/src/android/toga_android/widgets/detailedlist.py
+++ b/src/android/toga_android/widgets/detailedlist.py
@@ -14,7 +14,7 @@ class DetailedListOnClickListener(android_widgets.OnClickListener):
 
     def onClick(self, _view):
         if self._impl.interface.on_select:
-            self._impl.interface.on_select(widget=self._impl.interface, row=self._row_number)
+            self._impl.interface.on_select(self._impl.interface, row=self._impl.interface.data[self._row_number])
 
 
 class OnRefreshListener(android_widgets.SwipeRefreshLayout__OnRefreshListener):


### PR DESCRIPTION
This changes the Android `DetailedList` so that it passes row data, not the row _index_. This makes it work the same as iOS & macOS (the only two that I tested). See relevant code here:

* https://github.com/beeware/toga/blob/master/src/cocoa/toga_cocoa/widgets/detailedlist.py#L89
* https://github.com/beeware/toga/blob/master/src/iOS/toga_iOS/widgets/detailedlist.py#L78

I noticed this issue in the `adb logcat` output of the DetailedList example app. When I touched a row in the app, I would get a stacktrace.

To test this, I added a `print(self.label.text)` to the `ExampleDetailedListApp` in `examples/detailedlist/detailedlist/app.py`. This proved to me that the new `self.label.text` is what it should be.

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct

