### PR TITLE
Fixes #1166 - Roll back memory cleanup changes from #1109.

### DIFF
--- a/src/winforms/toga_winforms/libs/proactor.py
+++ b/src/winforms/toga_winforms/libs/proactor.py
@@ -114,9 +114,6 @@ class WinformsProactorEventLoop(asyncio.ProactorEventLoop):
         # message, it will be caught by the MessageFilter we installed on the
         # Application thread.
 
-        if self.task:
-            self.task.Dispose()
-            del self.task
         # The message is sent with:
         # * HWND 0xfff (all windows),
         # * MSG self.msg_id (a message ID in the WM_USER range)
@@ -130,8 +127,6 @@ class WinformsProactorEventLoop(asyncio.ProactorEventLoop):
         if self.app_context.MainForm:
             action = Action(self.run_once_recurring)
             self.app_context.MainForm.Invoke(action)
-            action.Dispose()
-            del action
 
     def run_once_recurring(self):
         """


### PR DESCRIPTION
#1109 made some changes to memory handling in the Winforms proactor loop to stop a slow leak.

On further investigation, it appears that this is stopping the leak by stopping the proactor :-) This meant that all asyncio handlers and background workers stopped working.

It appears that the actual problem is deeper inside Python.net (or our usage of Python.net). Even with the patch from #1109, you can see a small leak every time you click on a button. The proactor is effectively implementing "click a button every 5ms", which is why the leak is more obvious when the proactor is running.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
