### PR TITLE
Compute Android Toga window height properly

### DIFF
--- a/src/android/toga_android/window.py
+++ b/src/android/toga_android/window.py
@@ -28,7 +28,8 @@ class AndroidViewport:
         if not has_action_bar_size:
             return 0
 
-        return TypedValue.complexToDimensionPixelSize(tv.data, self.native.getContext().getResources().getDisplayMetrics())
+        return TypedValue.complexToDimensionPixelSize(
+            tv.data, self.native.getContext().getResources().getDisplayMetrics())
 
     def _status_bar_height(self):
         """

--- a/src/android/toga_android/window.py
+++ b/src/android/toga_android/window.py
@@ -1,4 +1,5 @@
 from . import dialogs
+from .libs.android_widgets import R__attr, TypedValue
 
 
 class AndroidViewport:
@@ -15,7 +16,30 @@ class AndroidViewport:
 
     @property
     def height(self):
-        return self.native.getContext().getResources().getDisplayMetrics().heightPixels
+        screen_height = self.native.getContext().getResources().getDisplayMetrics().heightPixels
+        return screen_height - self._status_bar_height() - self._action_bar_height()
+
+    def _action_bar_height(self):
+        """
+        Get the size of the action bar. The action bar shows the app name and can provide some app actions.
+        """
+        tv = TypedValue()
+        has_action_bar_size = self.native.getContext().getTheme().resolveAttribute(R__attr.actionBarSize, tv, True)
+        if not has_action_bar_size:
+            return 0
+
+        return TypedValue.complexToDimensionPixelSize(tv.data, self.native.getContext().getResources().getDisplayMetrics())
+
+    def _status_bar_height(self):
+        """
+        Get the size of the status bar. The status bar is typically rendered above the app,
+        showing the current time, battery level, etc.
+        """
+        resource_id = self.native.getContext().getResources().getIdentifier("status_bar_height", "dimen", "android")
+        if resource_id <= 0:
+            return 0
+
+        return self.native.getContext().getResources().getDimensionPixelSize(resource_id)
 
 
 class Window:


### PR DESCRIPTION
On Android, compute the Toga viewport size such that the full app can display.

To do that, we subtract the app action bar (app name header) plus status bar (platform clock widget).

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct

## Screenshots

With this change, here's the DetailedList demo:

![image](https://user-images.githubusercontent.com/25457/114811076-4979b180-9d62-11eb-84ed-412ecd8aa13b.png)

Note that the bottom status text now actually displays!

This is very similar to the iOS layout.

![image](https://user-images.githubusercontent.com/25457/114811183-82b22180-9d62-11eb-8dd8-8bb1a2b3544d.png)
