### PR TITLE
Pin Sphinx requirement to prevent use of Sphinx 4.

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
-sphinx
+sphinx<4
 sphinxcontrib-spelling
 pyenchant
 sphinx-autobuild
 sphinx_rtd_theme
 sphinx-csv-filter
-sphinx_tabs==1.1.8
+sphinx_tabs


### PR DESCRIPTION
Sphinx 4 causes problems with some plugins; pin the Sphinx version to prevent problems.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
