### PR TITLE
Simplify Discord links.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,8 +84,7 @@ Toga is part of the `BeeWare suite`_. You can talk to the community through:
 
 * `@pybeeware on Twitter <https://twitter.com/pybeeware>`__
 
-* `Discord <https://discord.com/channels/836455665257021440/836455665257021443>`__ 
-  (`Click here for an invitation to the server <https://beeware.org/bee/chat/>`__)
+* `Discord <https://beeware.org/bee/chat/>`__
 
 * The Toga `Github Discussions forum <https://github.com/beeware/toga/discussions>`__
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -89,8 +89,7 @@ Toga is part of the `BeeWare suite`_. You can talk to the community through:
 
  * `@pybeeware on Twitter <https://twitter.com/pybeeware>`__
 
- * `Discord <https://discord.com/channels/836455665257021440/836455665257021443>`__ 
-   (`Click here for an invitation to the server <https://beeware.org/bee/chat/>`__)
+ * `Discord <https://beeware.org/bee/chat/>`__
 
  * The Toga `Github Discussions forum <https://github.com/beeware/toga/discussions>`__
 

--- a/docs/reference/platforms.rst
+++ b/docs/reference/platforms.rst
@@ -130,11 +130,8 @@ Eventually, the Toga project would like to provide support for the following pla
  * Curses (for console)
 
 If you are interested in these platforms and would like to contribute, please
-get in touch on Twitter_ or Discord_ (`Click here for an invitation to the
-Discord server <https://beeware.org/bee/chat/>`__).
-
-.. _Twitter: https://twitter.com/pybeeware
-.. _Discord: https://discord.com/channels/836455665257021440/836455665257021443
+get in touch on `Twitter <https://twitter.com/pybeeware>`__ or
+`Discord <https://beeware.org/bee/chat/>`__).
 
 
 Unofficial platform support

--- a/nursery/curses/README.rst
+++ b/nursery/curses/README.rst
@@ -20,8 +20,7 @@ Toga is part of the `BeeWare suite`_. You can talk to the community through:
 
 * `@pybeeware on Twitter <https://twitter.com/pybeeware>`__
 
-* `Discord <https://discord.com/channels/836455665257021440/836455665257021443>`__ 
-  (`Click here for an invitation to the server <https://beeware.org/bee/chat/>`__)
+* `Discord <https://beeware.org/bee/chat/>`__
 
 * The Toga `Github Discussions forum <https://github.com/beeware/toga/discussions>`__
 

--- a/nursery/falcon/README.rst
+++ b/nursery/falcon/README.rst
@@ -20,8 +20,7 @@ Toga is part of the `BeeWare suite`_. You can talk to the community through:
 
 * `@pybeeware on Twitter <https://twitter.com/pybeeware>`__
 
-* `Discord <https://discord.com/channels/836455665257021440/836455665257021443>`__ 
-  (`Click here for an invitation to the server <https://beeware.org/bee/chat/>`__)
+* `Discord <https://beeware.org/bee/chat/>`__
 
 * The Toga `Github Discussions forum <https://github.com/beeware/toga/discussions>`__
 

--- a/nursery/pyramid/README.rst
+++ b/nursery/pyramid/README.rst
@@ -18,8 +18,7 @@ Toga is part of the `BeeWare suite`_. You can talk to the community through:
 
 * `@pybeeware on Twitter <https://twitter.com/pybeeware>`__
 
-* `Discord <https://discord.com/channels/836455665257021440/836455665257021443>`__ 
-  (`Click here for an invitation to the server <https://beeware.org/bee/chat/>`__)
+* `Discord <https://beeware.org/bee/chat/>`__
 
 * The Toga `Github Discussions forum <https://github.com/beeware/toga/discussions>`__
 

--- a/nursery/qt/README.rst
+++ b/nursery/qt/README.rst
@@ -20,8 +20,7 @@ Toga is part of the `BeeWare suite`_. You can talk to the community through:
 
 * `@pybeeware on Twitter <https://twitter.com/pybeeware>`__
 
-* `Discord <https://discord.com/channels/836455665257021440/836455665257021443>`__ 
-  (`Click here for an invitation to the server <https://beeware.org/bee/chat/>`__)
+* `Discord <https://beeware.org/bee/chat/>`__
 
 * The Toga `Github Discussions forum <https://github.com/beeware/toga/discussions>`__
 

--- a/nursery/starlette/README.rst
+++ b/nursery/starlette/README.rst
@@ -20,8 +20,7 @@ Toga is part of the `BeeWare suite`_. You can talk to the community through:
 
 * `@pybeeware on Twitter <https://twitter.com/pybeeware>`__
 
-* `Discord <https://discord.com/channels/836455665257021440/836455665257021443>`__ 
-  (`Click here for an invitation to the server <https://beeware.org/bee/chat/>`__)
+* `Discord <https://beeware.org/bee/chat/>`__
 
 * The Toga `Github Discussions forum <https://github.com/beeware/toga/discussions>`__
 

--- a/nursery/tornado/README.rst
+++ b/nursery/tornado/README.rst
@@ -20,8 +20,7 @@ Toga is part of the `BeeWare suite`_. You can talk to the community through:
 
 * `@pybeeware on Twitter <https://twitter.com/pybeeware>`__
 
-* `Discord <https://discord.com/channels/836455665257021440/836455665257021443>`__ 
-  (`Click here for an invitation to the server <https://beeware.org/bee/chat/>`__)
+* `Discord <https://beeware.org/bee/chat/>`__
 
 * The Toga `Github Discussions forum <https://github.com/beeware/toga/discussions>`__
 

--- a/nursery/tvOS/README.rst
+++ b/nursery/tvOS/README.rst
@@ -20,8 +20,7 @@ Toga is part of the `BeeWare suite`_. You can talk to the community through:
 
 * `@pybeeware on Twitter <https://twitter.com/pybeeware>`__
 
-* `Discord <https://discord.com/channels/836455665257021440/836455665257021443>`__ 
-  (`Click here for an invitation to the server <https://beeware.org/bee/chat/>`__)
+* `Discord <https://beeware.org/bee/chat/>`__
 
 * The Toga `Github Discussions forum <https://github.com/beeware/toga/discussions>`__
 

--- a/nursery/uwp/README.rst
+++ b/nursery/uwp/README.rst
@@ -20,8 +20,7 @@ Toga is part of the `BeeWare suite`_. You can talk to the community through:
 
 * `@pybeeware on Twitter <https://twitter.com/pybeeware>`__
 
-* `Discord <https://discord.com/channels/836455665257021440/836455665257021443>`__ 
-  (`Click here for an invitation to the server <https://beeware.org/bee/chat/>`__)
+* `Discord <https://beeware.org/bee/chat/>`__
 
 * The Toga `Github Discussions forum <https://github.com/beeware/toga/discussions>`__
 

--- a/nursery/watchOS/README.rst
+++ b/nursery/watchOS/README.rst
@@ -20,8 +20,7 @@ Toga is part of the `BeeWare suite`_. You can talk to the community through:
 
 * `@pybeeware on Twitter <https://twitter.com/pybeeware>`__
 
-* `Discord <https://discord.com/channels/836455665257021440/836455665257021443>`__ 
-  (`Click here for an invitation to the server <https://beeware.org/bee/chat/>`__)
+* `Discord <https://beeware.org/bee/chat/>`__
 
 * The Toga `Github Discussions forum <https://github.com/beeware/toga/discussions>`__
 

--- a/src/android/README.rst
+++ b/src/android/README.rst
@@ -16,8 +16,7 @@ Toga is part of the `BeeWare suite`_. You can talk to the community through:
 
 * `@pybeeware on Twitter <https://twitter.com/pybeeware>`__
 
-* `Discord <https://discord.com/channels/836455665257021440/836455665257021443>`__ 
-  (`Click here for an invitation to the server <https://beeware.org/bee/chat/>`__)
+* `Discord <https://beeware.org/bee/chat/>`__
 
 * The Toga `Github Discussions forum <https://github.com/beeware/toga/discussions>`__
 

--- a/src/cocoa/README.rst
+++ b/src/cocoa/README.rst
@@ -21,8 +21,7 @@ Toga is part of the `BeeWare suite`_. You can talk to the community through:
 
 * `@pybeeware on Twitter <https://twitter.com/pybeeware>`__
 
-* `Discord <https://discord.com/channels/836455665257021440/836455665257021443>`__ 
-  (`Click here for an invitation to the server <https://beeware.org/bee/chat/>`__)
+* `Discord <https://beeware.org/bee/chat/>`__
 
 * The Toga `Github Discussions forum <https://github.com/beeware/toga/discussions>`__
 

--- a/src/core/README.rst
+++ b/src/core/README.rst
@@ -98,8 +98,7 @@ Toga is part of the `BeeWare suite`_. You can talk to the community through:
 
 * `@pybeeware on Twitter <https://twitter.com/pybeeware>`__
 
-* `Discord <https://discord.com/channels/836455665257021440/836455665257021443>`__ 
-  (`Click here for an invitation to the server <https://beeware.org/bee/chat/>`__)
+* `Discord <https://beeware.org/bee/chat/>`__
 
 * The Toga `Github Discussions forum <https://github.com/beeware/toga/discussions>`__
 

--- a/src/django/README.rst
+++ b/src/django/README.rst
@@ -57,8 +57,7 @@ community through:
 
 * `@pybeeware on Twitter <https://twitter.com/pybeeware>`__
 
-* `Discord <https://discord.com/channels/836455665257021440/836455665257021443>`__ 
-  (`Click here for an invitation to the server <https://beeware.org/bee/chat/>`__)
+* `Discord <https://beeware.org/bee/chat/>`__
 
 * The Toga `Github Discussions forum <https://github.com/beeware/toga/discussions>`__
 

--- a/src/dummy/README.rst
+++ b/src/dummy/README.rst
@@ -17,8 +17,7 @@ Toga is part of the `BeeWare suite`_. You can talk to the community through:
 
 * `@pybeeware on Twitter <https://twitter.com/pybeeware>`__
 
-* `Discord <https://discord.com/channels/836455665257021440/836455665257021443>`__ 
-  (`Click here for an invitation to the server <https://beeware.org/bee/chat/>`__)
+* `Discord <https://beeware.org/bee/chat/>`__
 
 * The Toga `Github Discussions forum <https://github.com/beeware/toga/discussions>`__
 

--- a/src/flask/README.rst
+++ b/src/flask/README.rst
@@ -50,8 +50,7 @@ community through:
 
 * `@pybeeware on Twitter <https://twitter.com/pybeeware>`__
 
-* `Discord <https://discord.com/channels/836455665257021440/836455665257021443>`__ 
-  (`Click here for an invitation to the server <https://beeware.org/bee/chat/>`__)
+* `Discord <https://beeware.org/bee/chat/>`__
 
 * The Toga `Github Discussions forum <https://github.com/beeware/toga/discussions>`__
 

--- a/src/gtk/README.rst
+++ b/src/gtk/README.rst
@@ -22,11 +22,11 @@ to install the following:
 
 * **Ubuntu 16.04 / Debian 8** ``apt-get install python3-gi gir1.2-webkit2-4.0``
   or ``apt-get install python3-gi gir1.2-webkit-3.0``
-  
+
 * **Fedora** ``dnf install python3-gobject pywebkitgtk``
-  or ``yum install python3-gobject pywebkitgtk`` 
-  
-* **Arch Linux** ``pacman -S python-gobject webkit2gtk`` 
+  or ``yum install python3-gobject pywebkitgtk``
+
+* **Arch Linux** ``pacman -S python-gobject webkit2gtk``
 
 Community
 ---------
@@ -35,8 +35,7 @@ Toga is part of the `BeeWare suite`_. You can talk to the community through:
 
 * `@pybeeware on Twitter <https://twitter.com/pybeeware>`__
 
-* `Discord <https://discord.com/channels/836455665257021440/836455665257021443>`__ 
-  (`Click here for an invitation to the server <https://beeware.org/bee/chat/>`__)
+* `Discord <https://beeware.org/bee/chat/>`__
 
 * The Toga `Github Discussions forum <https://github.com/beeware/toga/discussions>`__
 

--- a/src/iOS/README.rst
+++ b/src/iOS/README.rst
@@ -16,8 +16,7 @@ Toga is part of the `BeeWare suite`_. You can talk to the community through:
 
 * `@pybeeware on Twitter <https://twitter.com/pybeeware>`__
 
-* `Discord <https://discord.com/channels/836455665257021440/836455665257021443>`__ 
-  (`Click here for an invitation to the server <https://beeware.org/bee/chat/>`__)
+* `Discord <https://beeware.org/bee/chat/>`__
 
 * The Toga `Github Discussions forum <https://github.com/beeware/toga/discussions>`__
 

--- a/src/web/README.rst
+++ b/src/web/README.rst
@@ -18,8 +18,7 @@ Toga is part of the `BeeWare suite`_. You can talk to the community through:
 
 * `@pybeeware on Twitter <https://twitter.com/pybeeware>`__
 
-* `Discord <https://discord.com/channels/836455665257021440/836455665257021443>`__ 
-  (`Click here for an invitation to the server <https://beeware.org/bee/chat/>`__)
+* `Discord <https://beeware.org/bee/chat/>`__
 
 * The Toga `Github Discussions forum <https://github.com/beeware/toga/discussions>`__
 

--- a/src/winforms/README.rst
+++ b/src/winforms/README.rst
@@ -16,8 +16,7 @@ Toga is part of the `BeeWare suite`_. You can talk to the community through:
 
 * `@pybeeware on Twitter <https://twitter.com/pybeeware>`__
 
-* `Discord <https://discord.com/channels/836455665257021440/836455665257021443>`__ 
-  (`Click here for an invitation to the server <https://beeware.org/bee/chat/>`__)
+* `Discord <https://beeware.org/bee/chat/>`__
 
 * The Toga `Github Discussions forum <https://github.com/beeware/toga/discussions>`__
 


### PR DESCRIPTION
Turns out direct Discord links aren't a good idea; replace them with a simpler link to the invite.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
