### PR TITLE
Ensure textinput content persists on loss of focus.

### DIFF
--- a/src/cocoa/toga_cocoa/widgets/textinput.py
+++ b/src/cocoa/toga_cocoa/widgets/textinput.py
@@ -42,6 +42,8 @@ class TogaTextField(NSTextField):
         else:
             self._configured = True
 
+        send_super(__class__, self, 'textDidEndEditing:', textObject)
+
 
 class TextInput(Widget):
     def create(self):


### PR DESCRIPTION
Cocoa's textInputs cleared themselves on loss of focus; this was due to not completing the internal `textDidEndEditing:` action.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
