### PR TITLE
fix textinput example copy over errors

### DIFF
--- a/examples/textinput/README.rst
+++ b/examples/textinput/README.rst
@@ -1,11 +1,11 @@
-Dialogs
+Text Input
 =======
 
-Test app for the Dialog in Main Window.
+Test app for the Text Input widget.
 
 Quickstart
 ~~~~~~~~~~
 
 To run this example:
 
-    $ python -m dialogs
+    $ python -m textinput

--- a/examples/textinput/pyproject.toml
+++ b/examples/textinput/pyproject.toml
@@ -2,7 +2,7 @@
 requires = ["briefcase"]
 
 [tool.briefcase]
-project_name = "Handler Demo"
+project_name = "Text Input Demo"
 bundle = "org.beeware"
 version = "0.3.0.dev28"
 url = "https://beeware.org"
@@ -10,35 +10,35 @@ license = "BSD license"
 author = 'Tiberius Yak'
 author_email = "tiberius@beeware.org"
 
-[tool.briefcase.app.handlers]
-formal_name = "Handler Demo"
+[tool.briefcase.app.textinput]
+formal_name = "Text Input Demo"
 description = "A testing app"
-sources = ['handlers']
+sources = ['textinput']
 requires = []
 
 
-[tool.briefcase.app.handlers.macOS]
+[tool.briefcase.app.textinput.macOS]
 requires = [
     'toga-cocoa',
 ]
 
-[tool.briefcase.app.handlers.linux]
+[tool.briefcase.app.textinput.linux]
 requires = [
     'toga-gtk',
 ]
 
-[tool.briefcase.app.handlers.windows]
+[tool.briefcase.app.textinput.windows]
 requires = [
     'toga-winforms',
 ]
 
 # Mobile deployments
-[tool.briefcase.app.handlers.iOS]
+[tool.briefcase.app.textinput.iOS]
 requires = [
     'toga-iOS',
 ]
 
-[tool.briefcase.app.handlers.android]
+[tool.briefcase.app.textinput.android]
 requires = [
     'toga-android',
 ]


### PR DESCRIPTION
fix copy errors for .\examples\textinput

In .\examples\textinput, the pyproject.toml is copied from the handlers example.
This enables "briefcase dev" to work on the textinput example.
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x ] All new features have been tested (both "briefcase dev" and "py -m textinput")
- [ x ] All new features have been documented
- [ x ] I have read the **CONTRIBUTING.md** file
- [ x ] I will abide by the code of conduct
