### PR TITLE
cocoa: disable 'Show All' menu item when all windows are shown

### DIFF
--- a/src/cocoa/toga_cocoa/app.py
+++ b/src/cocoa/toga_cocoa/app.py
@@ -7,7 +7,7 @@ from urllib.parse import unquote, urlparse
 from rubicon.objc.eventloop import CocoaLifecycle, EventLoopPolicy
 
 import toga
-from toga.handlers import wrapped_handler
+from toga.handlers import wrapped_handler, NativeHandler
 
 from .keys import cocoa_key
 from .libs import (
@@ -144,30 +144,27 @@ class App:
                 section=20,
             ),
             toga.Command(
-                SEL('hide:'),
+                NativeHandler(SEL('hide:')),
                 'Hide ' + formal_name,
                 shortcut=toga.Key.MOD_1 + 'h',
                 group=toga.Group.APP,
                 order=0,
                 section=sys.maxsize - 1,
-                _action_is_raw=True,
             ),
             toga.Command(
-                SEL('hideOtherApplications:'),
+                NativeHandler(SEL('hideOtherApplications:')),
                 'Hide Others',
                 shortcut=toga.Key.MOD_1 + toga.Key.MOD_2 + 'h',
                 group=toga.Group.APP,
                 order=1,
                 section=sys.maxsize - 1,
-                _action_is_raw=True,
             ),
             toga.Command(
-                SEL('unhideAllApplications:'),
+                NativeHandler(SEL('unhideAllApplications:')),
                 'Show All',
                 group=toga.Group.APP,
                 order=2,
                 section=sys.maxsize - 1,
-                _action_is_raw=True,
             ),
             # Quit should always be the last item, in a section on its own
             toga.Command(
@@ -218,10 +215,13 @@ class App:
                     key = ''
                     modifier = None
 
-                if cmd._action_is_raw:
-                    action = cmd.action
-                else:
+                # Native handlers can be invoked directly as menu actions.
+                # Standard wrapped menu items have a `_raw` attribute,
+                # and are invoked using the selectMenuItem:
+                if hasattr(cmd.action, '_raw'):
                     action = SEL('selectMenuItem:')
+                else:
+                    action = cmd.action
 
                 item = NSMenuItem.alloc().initWithTitle(
                     cmd.label,

--- a/src/cocoa/toga_cocoa/command.py
+++ b/src/cocoa/toga_cocoa/command.py
@@ -1,9 +1,7 @@
 
 class Command:
     def __init__(self, interface):
-        self.interface = interface
-        self.native = []
+        pass
 
     def set_enabled(self, value):
-        for widget in self.native:
-            widget.enabled = value
+        pass

--- a/src/cocoa/toga_cocoa/command.py
+++ b/src/cocoa/toga_cocoa/command.py
@@ -1,7 +1,8 @@
 
 class Command:
     def __init__(self, interface):
-        pass
+        self.interface = interface
+        self.native = []
 
     def set_enabled(self, value):
         pass

--- a/src/cocoa/toga_cocoa/window.py
+++ b/src/cocoa/toga_cocoa/window.py
@@ -109,6 +109,11 @@ class WindowDelegate(NSObject):
             native.setAction_(SEL('onToolbarButtonPress:'))
         except KeyError:
             pass
+
+        # Prevent the toolbar item from being deallocated when
+        # no Python references remain
+        native.retain()
+        native.autorelease()
         return native
 
     @objc_method

--- a/src/core/toga/command.py
+++ b/src/core/toga/command.py
@@ -113,14 +113,14 @@ class Command:
             alphabetically by label within its section.
         enabled: whether to enable the command or not.
     """
-    def __init__(self, action, label,
-                 shortcut=None, tooltip=None, icon=None,
-                 group=None, section=None, order=None, enabled=True, factory=None,
-                 _action_is_raw=False):
+    def __init__(
+        self, action, label,
+        shortcut=None, tooltip=None, icon=None,
+        group=None, section=None, order=None, enabled=True, factory=None,
+    ):
         self.factory = factory
 
-        self._action_is_raw = _action_is_raw
-        self.action = action if _action_is_raw else wrapped_handler(self, action)
+        self.action = wrapped_handler(self, action)
         self.label = label
 
         self.shortcut = shortcut

--- a/src/core/toga/command.py
+++ b/src/core/toga/command.py
@@ -115,10 +115,12 @@ class Command:
     """
     def __init__(self, action, label,
                  shortcut=None, tooltip=None, icon=None,
-                 group=None, section=None, order=None, enabled=True, factory=None):
+                 group=None, section=None, order=None, enabled=True, factory=None,
+                 _action_is_raw=False):
         self.factory = factory
 
-        self.action = wrapped_handler(self, action)
+        self._action_is_raw = _action_is_raw
+        self.action = action if _action_is_raw else wrapped_handler(self, action)
         self.label = label
 
         self.shortcut = shortcut


### PR DESCRIPTION
This passes `unhideAllApplications:` as a selector to `NSMenuItem`
and turns `autoenablesItems` back on, for `validateMenuItem:`
to be invoked for built-in selectors.
With `autoenablesItems` being true
flipping the value of `NSMenuItem.enabled` does not trigger an update
and we must implement `validateMenuItem:` on the delegate
to disable custom commands.

Signed-off-by: layday <layday@protonmail.com>

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
