### PR TITLE
Android ScrollContainer fix for flex=1

### DIFF
--- a/src/android/toga_android/widgets/scrollcontainer.py
+++ b/src/android/toga_android/widgets/scrollcontainer.py
@@ -106,4 +106,4 @@ class ScrollContainer(Widget):
             android_widgets.View__MeasureSpec.UNSPECIFIED,
         )
         self.interface.intrinsic.width = at_least(self.native.getMeasuredWidth())
-        self.interface.intrinsic.height = self.native.getMeasuredHeight()
+        self.interface.intrinsic.height = at_least(self.native.getMeasuredHeight())


### PR DESCRIPTION
This PR fixes the problem that ScrollContainer on Android did not calculate the height correctly with flex=1

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
