### PR TITLE
Revert "Fix accessing to impl layer"

### DIFF
--- a/src/android/toga_android/widgets/base.py
+++ b/src/android/toga_android/widgets/base.py
@@ -32,7 +32,6 @@ class Widget:
         self.native = None
         self._native_activity = _get_activity()
         self.create()
-        self.native._impl = self
         # Immediately re-apply styles. Some widgets may defer style application until
         # they have been added to a container.
         self.interface.style.reapply()

--- a/src/android/toga_android/widgets/scrollcontainer.py
+++ b/src/android/toga_android/widgets/scrollcontainer.py
@@ -48,11 +48,6 @@ class ScrollContainer(Widget):
         if self.interface.content is not None:
             self.set_content(self.interface.content)
 
-        # set _impl layer for other native layer versions
-        self.vScrollListener._impl = self
-        self.hScrollListener._impl = self
-        self.hScrollView._impl = self
-
     def set_content(self, widget):
         widget.viewport = AndroidViewport(widget.native)
         content_view_params = android_widgets.LinearLayout__LayoutParams(

--- a/src/android/toga_android/widgets/selection.py
+++ b/src/android/toga_android/widgets/selection.py
@@ -39,9 +39,6 @@ class Selection(Widget):
         # Create a mapping from text to numeric index to support `select_item()`.
         self._indexByItem = {}
 
-        # set _impl layer for other native layer versions
-        self.adapter._impl = self
-
     def add_item(self, item):
         new_index = self.adapter.getCount()
         self.adapter.add(str(item))

--- a/src/cocoa/toga_cocoa/documents.py
+++ b/src/cocoa/toga_cocoa/documents.py
@@ -18,6 +18,7 @@ class Document:
     def __init__(self, interface):
         self.native = TogaDocument.alloc()
         self.native.interface = interface
+        self.native._impl = self
 
         self.native.initWithContentsOfURL(
             NSURL.URLWithString('file://{}'.format(quote(interface.filename))),

--- a/src/cocoa/toga_cocoa/widgets/base.py
+++ b/src/cocoa/toga_cocoa/widgets/base.py
@@ -14,7 +14,6 @@ class Widget:
         self.constraints = None
         self.native = None
         self.create()
-        self.native._impl = self
         self.interface.style.reapply()
         self.set_enabled(self.interface.enabled)
 

--- a/src/cocoa/toga_cocoa/widgets/canvas.py
+++ b/src/cocoa/toga_cocoa/widgets/canvas.py
@@ -93,6 +93,7 @@ class Canvas(Widget):
     def create(self):
         self.native = TogaCanvas.alloc().init()
         self.native.interface = self.interface
+        self.native._impl = self
 
         NSNotificationCenter.defaultCenter.addObserver(
             self.native,

--- a/src/cocoa/toga_cocoa/widgets/multilinetextinput.py
+++ b/src/cocoa/toga_cocoa/widgets/multilinetextinput.py
@@ -34,8 +34,6 @@ class MultilineTextInput(Widget):
 
         # Create the actual text widget
         self.text = TogaTextView.alloc().init()
-        self.text.interface = self.interface
-        self.text._impl = self
         self.text.editable = True
         self.text.selectable = True
         self.text.verticallyResizable = True

--- a/src/cocoa/toga_cocoa/widgets/numberinput.py
+++ b/src/cocoa/toga_cocoa/widgets/numberinput.py
@@ -56,7 +56,6 @@ class NumberInput(Widget):
 
         self.input = NSTextField.new()
         self.input.interface = self.interface
-        self.input._impl = self
         self.input.bezeled = True
         self.input.bezelStyle = NSTextFieldSquareBezel
         self.input.translatesAutoresizingMaskIntoConstraints = False

--- a/src/gtk/toga_gtk/widgets/base.py
+++ b/src/gtk/toga_gtk/widgets/base.py
@@ -9,7 +9,6 @@ class Widget:
         self.viewport = None
         self.native = None
         self.create()
-        self.native._impl = self
         self.interface.style.reapply()
 
     def set_app(self, app):

--- a/src/gtk/toga_gtk/widgets/detailedlist.py
+++ b/src/gtk/toga_gtk/widgets/detailedlist.py
@@ -33,9 +33,6 @@ class DetailedList(Widget):
         self.native.set_min_content_width(self.interface.MIN_WIDTH)
         self.native.set_min_content_height(self.interface.MIN_HEIGHT)
 
-        # set _impl layer for other native layer versions
-        self.treeview._impl = self
-
     def change_source(self, source):
         self.treeview.set_model(None)
         self.store.change_source(source)

--- a/src/gtk/toga_gtk/widgets/multilinetextinput.py
+++ b/src/gtk/toga_gtk/widgets/multilinetextinput.py
@@ -23,10 +23,6 @@ class MultilineTextInput(Widget):
         self.textview.connect("focus-out-event", self.gtk_on_focus_out)
         self.tag_placholder = self.buffer.create_tag("placeholder", foreground="gray")
 
-        # set _impl layer for other native layer versions
-        self.textview._impl = self
-        self.buffer._impl = self
-
     def set_value(self, value):
         self.buffer.set_text(value)
 

--- a/src/gtk/toga_gtk/widgets/numberinput.py
+++ b/src/gtk/toga_gtk/widgets/numberinput.py
@@ -20,9 +20,6 @@ class NumberInput(Widget):
 
         self.rehint()
 
-        # set _impl layer for other native layer versions
-        self.adjustment._impl = self
-
     def gtk_on_change(self, widget):
         value = widget.get_text().replace(",", ".") or 0
         self.interface._value = Decimal(value).quantize(self.interface.step)

--- a/src/gtk/toga_gtk/widgets/slider.py
+++ b/src/gtk/toga_gtk/widgets/slider.py
@@ -12,9 +12,6 @@ class Slider(Widget):
         self.native.interface = self.interface
         self.native.connect("value-changed", self.gtk_on_change)
 
-        # set _impl layer for other native layer versions
-        self.adj._impl = self
-
         self.rehint()
 
     def gtk_on_change(self, widget):

--- a/src/gtk/toga_gtk/widgets/switch.py
+++ b/src/gtk/toga_gtk/widgets/switch.py
@@ -19,10 +19,6 @@ class Switch(Widget):
         self.native.pack_start(self.switch, False, False, 0)
         self.native.connect('show', lambda event: self.rehint())
 
-        # set _impl layer for other native layer versions
-        self.label._impl = self
-        self.switch._impl = self
-
     def gtk_on_toggle(self, widget, state):
         if self.interface.on_toggle:
             self.interface.on_toggle(self.interface)

--- a/src/gtk/toga_gtk/widgets/tree.py
+++ b/src/gtk/toga_gtk/widgets/tree.py
@@ -35,9 +35,6 @@ class Tree(Widget):
         self.native.set_min_content_width(200)
         self.native.set_min_content_height(200)
 
-        # set _impl layer for other native layer versions
-        self.treeview._impl = self
-
     def gtk_on_select(self, selection):
         if self.interface.on_select:
             if self.interface.multiple_select:

--- a/src/gtk/toga_gtk/widgets/webview.py
+++ b/src/gtk/toga_gtk/widgets/webview.py
@@ -17,7 +17,6 @@ class WebView(Widget):
 
         self.native = WebKit2.WebView()
         self.native.interface = self.interface
-        self.native._impl = self
 
         self.native.connect('key-press-event', self.gtk_on_key)
         self._last_key_time = 0

--- a/src/gtk/toga_gtk/window.py
+++ b/src/gtk/toga_gtk/window.py
@@ -38,6 +38,7 @@ class Window:
 
     def create(self):
         self.native = self._IMPL_CLASS()
+        self.native._impl = self
 
         self.native.connect("delete-event", self.gtk_on_close)
         self.native.set_default_size(self.interface.size[0], self.interface.size[1])

--- a/src/iOS/toga_iOS/widgets/base.py
+++ b/src/iOS/toga_iOS/widgets/base.py
@@ -10,7 +10,6 @@ class Widget:
         self.constraints = None
         self.native = None
         self.create()
-        self.native._impl = self
         self.interface.style.reapply()
         self.set_enabled(self.interface.enabled)
 

--- a/src/iOS/toga_iOS/widgets/canvas.py
+++ b/src/iOS/toga_iOS/widgets/canvas.py
@@ -41,6 +41,7 @@ class Canvas(Widget):
     def create(self):
         self.native = TogaCanvas.alloc().init()
         self.native.interface = self.interface
+        self.native._impl = self
         self.native.backgroundColor = UIColor.whiteColor
 
         # Add the layout constraints

--- a/src/iOS/toga_iOS/widgets/detailedlist.py
+++ b/src/iOS/toga_iOS/widgets/detailedlist.py
@@ -86,7 +86,6 @@ class DetailedList(Widget):
     def create(self):
         self.controller = TogaTableViewController.alloc().init()
         self.controller.interface = self.interface
-        self.controller._impl = self
         self.native = self.controller.tableView
 
         self.native.separatorStyle = UITableViewCellSeparatorStyleNone

--- a/src/iOS/toga_iOS/widgets/label.py
+++ b/src/iOS/toga_iOS/widgets/label.py
@@ -9,7 +9,8 @@ from toga_iOS.widgets.base import Widget
 class Label(Widget):
     def create(self):
         self.native = UILabel.new()
-        self.native.interface = self.interface
+        self.native.impl = self
+        self.native.interface = self
 
         self.native.lineBreakMode = NSLineBreakByWordWrapping
 

--- a/src/iOS/toga_iOS/widgets/navigationview.py
+++ b/src/iOS/toga_iOS/widgets/navigationview.py
@@ -32,7 +32,6 @@ class NavigationView(NavigationViewInterface, WidgetMixin):
         self._create()
 
     def create(self):
-        # TODO: This need to be fix to follow `Toga` architecture
         self._controller = TogaNavigationController.alloc().initWithRootViewController_(
             self._config['content']._controller
         )

--- a/src/iOS/toga_iOS/widgets/selection.py
+++ b/src/iOS/toga_iOS/widgets/selection.py
@@ -34,7 +34,6 @@ class Selection(Widget):
 
         self.picker = TogaPickerView.alloc().init()
         self.picker.interface = self.interface
-        self.picker._impl = self
         self.picker.native = self.native
         self.picker.delegate = self.picker
         self.picker.dataSource = self.picker

--- a/src/winforms/toga_winforms/widgets/box.py
+++ b/src/winforms/toga_winforms/widgets/box.py
@@ -10,7 +10,6 @@ class Box(Widget):
     def create(self):
         self.native = WinForms.Panel()
         self.native.interface = self.interface
-        self.native._impl = self
 
     def set_bounds(self, x, y, width, height):
         if self.native:

--- a/src/winforms/toga_winforms/widgets/button.py
+++ b/src/winforms/toga_winforms/widgets/button.py
@@ -10,8 +10,6 @@ from .base import Widget
 class Button(Widget):
     def create(self):
         self.native = WinForms.Button()
-        self.native.interface = self.interface
-        self.native._impl = self
         self.native.Click += self.winforms_click
         self.set_enabled(self.interface._enabled)
 

--- a/src/winforms/toga_winforms/widgets/canvas.py
+++ b/src/winforms/toga_winforms/widgets/canvas.py
@@ -57,8 +57,6 @@ class Canvas(Box):
     def create(self):
         super(Canvas, self).create()
         self.native.DoubleBuffered = True
-        self.native.interface = self.interface
-        self.native._impl = self
         self.native.Paint += self.winforms_paint
         self.native.Resize += self.winforms_resize
         self.native.MouseDown += self.winforms_mouse_down

--- a/src/winforms/toga_winforms/widgets/datepicker.py
+++ b/src/winforms/toga_winforms/widgets/datepicker.py
@@ -10,8 +10,6 @@ from .base import Widget
 class DatePicker(Widget):
     def create(self):
         self.native = WinForms.DateTimePicker()
-        self.native.interface = self.interface
-        self.native._impl = self
 
     def get_value(self):
         date = datetime.datetime.strptime(self.native.Text, '%A, %B %d, %Y').date()

--- a/src/winforms/toga_winforms/widgets/divider.py
+++ b/src/winforms/toga_winforms/widgets/divider.py
@@ -8,8 +8,6 @@ from .base import Widget
 class Divider(Widget):
     def create(self):
         self.native = WinForms.Label()
-        self.native.interface = self.interface
-        self.native._impl = self
         self.native.BorderStyle = WinForms.BorderStyle.Fixed3D
         self.native.AutoSize = False
 

--- a/src/winforms/toga_winforms/widgets/imageview.py
+++ b/src/winforms/toga_winforms/widgets/imageview.py
@@ -8,7 +8,6 @@ class ImageView(Widget):
     def create(self):
         self.native = WinForms.PictureBox()
         self.native.interface = self.interface
-        self.native._impl = self
         self.native.SizeMode = WinForms.PictureBoxSizeMode.StretchImage
 
     def set_image(self, image):

--- a/src/winforms/toga_winforms/widgets/label.py
+++ b/src/winforms/toga_winforms/widgets/label.py
@@ -10,8 +10,6 @@ from .base import Widget
 class Label(Widget):
     def create(self):
         self.native = WinForms.Label()
-        self.native.interface = self.interface
-        self.native._impl = self
 
     def set_alignment(self, value):
         self.native.TextAlign = TextAlignment(value)

--- a/src/winforms/toga_winforms/widgets/multilinetextinput.py
+++ b/src/winforms/toga_winforms/widgets/multilinetextinput.py
@@ -9,8 +9,6 @@ class MultilineTextInput(Widget):
     def create(self):
         # because https://stackoverflow.com/a/612234
         self.native = WinForms.RichTextBox()
-        self.native.interface = self.interface
-        self.native._impl = self
         self.native.Multiline = True
         self.native.TextChanged += self.winforms_text_changed
         self.native.Enter += self.winforms_enter

--- a/src/winforms/toga_winforms/widgets/numberinput.py
+++ b/src/winforms/toga_winforms/widgets/numberinput.py
@@ -10,8 +10,6 @@ from .base import Widget
 class NumberInput(Widget):
     def create(self):
         self.native = WinForms.NumericUpDown()
-        self.native.interface = self.interface
-        self.native._impl = self
         self.native.Value = Convert.ToDecimal(0.0)
         self.native.ValueChanged += self.winforms_value_changed
 

--- a/src/winforms/toga_winforms/widgets/optioncontainer.py
+++ b/src/winforms/toga_winforms/widgets/optioncontainer.py
@@ -7,8 +7,6 @@ from .base import Widget
 class OptionContainer(Widget):
     def create(self):
         self.native = WinForms.TabControl()
-        self.native.interface = self.interface
-        self.native._impl = self
         self.native.Selected += self.winforms_selected
 
     def add_content(self, label, widget):

--- a/src/winforms/toga_winforms/widgets/progressbar.py
+++ b/src/winforms/toga_winforms/widgets/progressbar.py
@@ -8,8 +8,6 @@ from .base import Widget
 class ProgressBar(Widget):
     def create(self):
         self.native = WinForms.ProgressBar()
-        self.native.interface = self.interface
-        self.native._impl = self
 
     def start(self):
         self.set_running_style()

--- a/src/winforms/toga_winforms/widgets/scrollcontainer.py
+++ b/src/winforms/toga_winforms/widgets/scrollcontainer.py
@@ -8,7 +8,6 @@ class ScrollContainer(Widget):
     def create(self):
         self.native = WinForms.Panel()
         self.native.interface = self.interface
-        self.native._impl = self
         self.native.AutoScroll = True
         self.native.Scroll += self.winforms_scroll
         self.native.MouseWheel += self.winforms_scroll

--- a/src/winforms/toga_winforms/widgets/selection.py
+++ b/src/winforms/toga_winforms/widgets/selection.py
@@ -20,8 +20,6 @@ class TogaComboBox(WinForms.ComboBox):
 class Selection(Widget):
     def create(self):
         self.native = TogaComboBox(self.interface)
-        self.native.interface = self.interface
-        self.native._impl = self
 
     def remove_all_items(self):
         self.native.Items.Clear()

--- a/src/winforms/toga_winforms/widgets/slider.py
+++ b/src/winforms/toga_winforms/widgets/slider.py
@@ -27,8 +27,6 @@ class Slider(Widget):
     """
     def create(self):
         self.native = WinForms.TrackBar()
-        self.native.interface = self.interface
-        self.native._impl = self
         self.native.Scroll += self.winforms_scroll
         self.native.MouseDown += self.winforms_mouse_down
         self.native.MouseUp += self.winforms_mouse_up

--- a/src/winforms/toga_winforms/widgets/splitcontainer.py
+++ b/src/winforms/toga_winforms/widgets/splitcontainer.py
@@ -8,7 +8,6 @@ class SplitContainer(Widget):
     def create(self):
         self.native = WinForms.SplitContainer()
         self.native.interface = self.interface
-        self.native._impl = self
         self.native.Resize += self.winforms_resize
         self.native.SplitterMoved += self.winforms_resize
         self.ratio = None

--- a/src/winforms/toga_winforms/widgets/switch.py
+++ b/src/winforms/toga_winforms/widgets/switch.py
@@ -8,8 +8,6 @@ from .base import Widget
 class Switch(Widget):
     def create(self):
         self.native = WinForms.CheckBox()
-        self.native.interface = self.interface
-        self.native._impl = self
         self.native.CheckedChanged += self.winforms_checked_changed
 
     def winforms_checked_changed(self, sender, event):

--- a/src/winforms/toga_winforms/widgets/table.py
+++ b/src/winforms/toga_winforms/widgets/table.py
@@ -8,8 +8,6 @@ from .base import Widget
 class Table(Widget):
     def create(self):
         self.native = WinForms.ListView()
-        self.native.interface = self.interface
-        self.native._impl = self
         self.native.View = WinForms.View.Details
         self._cache = []
         self._first_item = 0

--- a/src/winforms/toga_winforms/widgets/textinput.py
+++ b/src/winforms/toga_winforms/widgets/textinput.py
@@ -11,8 +11,6 @@ from .base import Widget
 class TextInput(Widget):
     def create(self):
         self.native = WinForms.TextBox()
-        self.native.interface = self.interface
-        self.native._impl = self
         self.native.Multiline = False
         self.native.DoubleClick += self.winforms_double_click
         self.native.TextChanged += self.winforms_text_changed
@@ -21,8 +19,6 @@ class TextInput(Widget):
         self.native.LostFocus += self.winforms_lost_focus
 
         self.error_provider = WinForms.ErrorProvider()
-        self.error_provider.interface = self.interface
-        self.error_provider._impl = self
         self.error_provider.SetIconAlignment(
             self.native, WinForms.ErrorIconAlignment.MiddleRight
         )

--- a/src/winforms/toga_winforms/widgets/timepicker.py
+++ b/src/winforms/toga_winforms/widgets/timepicker.py
@@ -10,8 +10,6 @@ from .base import Widget
 class TimePicker(Widget):
     def create(self):
         self.native = WinForms.DateTimePicker()
-        self.native.interface = self.interface
-        self.native._impl = self
         self.native.ValueChanged += self.winforms_value_changed
         self.native.Format = WinForms.DateTimePickerFormat.Time
         self.native.ShowUpDown = True

--- a/src/winforms/toga_winforms/widgets/tree.py
+++ b/src/winforms/toga_winforms/widgets/tree.py
@@ -6,8 +6,6 @@ from .base import Widget
 class Tree(Widget):
     def create(self):
         self.native = WinForms.TreeView()
-        self.native.interface = self.interface
-        self.native._impl = self
 
     def row_data(self, item):
         self.interface.factory.not_implemented('Tree.row_data()')

--- a/src/winforms/toga_winforms/widgets/webview.py
+++ b/src/winforms/toga_winforms/widgets/webview.py
@@ -14,8 +14,6 @@ class TogaWebBrowser(WinForms.WebBrowser):
 class WebView(Widget):
     def create(self):
         self.native = TogaWebBrowser(self)
-        self.native.interface = self.interface
-        self.native._impl = self
 
     def set_on_key_down(self, handler):
         pass


### PR DESCRIPTION
Reverts beeware/toga#1221.

This turned out to cause a bunch of problems; `_impl` objects can't be arbitrarily annotated using Rubicon-Java on Android; annotating native objects with `_impl` in this way is *legal* with Rubicon-ObjC on iOS/macOS causes circular references that can lead to memory leaks.

Since this has been done largely for symmetry, rather than due to a specific technical need, it's preferable to revert the change.