### PR TITLE
[cocoa] Fix segfault when TogaIconView is deallocated

### DIFF
--- a/src/cocoa/toga_cocoa/widgets/table.py
+++ b/src/cocoa/toga_cocoa/widgets/table.py
@@ -74,6 +74,11 @@ class TogaTable(NSTableView):
             tcv = TogaIconView.alloc().init()
             tcv.identifier = identifier
 
+            # Prevent tcv from being deallocated prematurely when no Python references
+            # are left
+            tcv.retain()
+            tcv.autorelease()
+
         tcv.setText(str(value))
         if icon:
             tcv.setImage(icon.native)

--- a/src/cocoa/toga_cocoa/widgets/tree.py
+++ b/src/cocoa/toga_cocoa/widgets/tree.py
@@ -109,6 +109,11 @@ class TogaTree(NSOutlineView):
             tcv = TogaIconView.alloc().initWithFrame_(CGRectMake(0, 0, column.width, 16))
             tcv.identifier = identifier
 
+            # Prevent tcv from being deallocated prematurely when no Python references
+            # are left
+            tcv.retain()
+            tcv.autorelease()
+
         tcv.setText(str(value))
         if icon:
             tcv.setImage(icon.native)


### PR DESCRIPTION
Following the recent improvements to memory management in `rubicon-objc`, a few issues in toga-cocoa have become apparent which previously where hidden because Objective-C instances would live for ever.

This PR fixes an issue where the `TogaIconView` in a Tree or Table widget is deallocated before it can be used because no Python references are left after `tableView_viewForTableColumn_row_` or `outlineView_viewForTableColumn_item_` returns.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
