### PR TITLE
Fixes #1282 - Use different enum constants on M1 Macs

### DIFF
--- a/src/cocoa/toga_cocoa/libs/appkit.py
+++ b/src/cocoa/toga_cocoa/libs/appkit.py
@@ -1,6 +1,7 @@
 ##########################################################################
 # System/Library/Frameworks/AppKit.framework
 ##########################################################################
+import platform
 from ctypes import Structure, c_void_p
 from enum import Enum, IntEnum
 
@@ -371,6 +372,19 @@ NSImageScaleAxesIndependently = 1
 NSImageScaleNone = 2
 NSImageScaleProportionallyUpOrDown = 3
 
+if platform == 'arm64':
+    NSImageResizingModeTile = 1
+    NSImageResizingModeStretch = 0
+else:
+    NSImageResizingModeTile = 0
+    NSImageResizingModeStretch = 1
+
+
+class NSImageResizingMode(Enum):
+    Tile = NSImageResizingModeTile
+    Stretch = NSImageResizingModeStretch
+
+
 ######################################################################
 # NSImageCell.h
 
@@ -639,8 +653,13 @@ NSTabViewItem = ObjCClass('NSTabViewItem')
 ######################################################################
 # NSText.h
 NSLeftTextAlignment = 0
-NSRightTextAlignment = 1
-NSCenterTextAlignment = 2
+if platform.machine() == 'arm64':
+    NSRightTextAlignment = 2
+    NSCenterTextAlignment = 1
+else:
+    NSRightTextAlignment = 1
+    NSCenterTextAlignment = 2
+
 NSJustifiedTextAlignment = 3
 NSNaturalTextAlignment = 4
 


### PR DESCRIPTION

macOS on M1 adopts the iOS values for some constants. See

https://developer.apple.com/documentation/apple-silicon/addressing-architectural-differences-in-your-macos-code

for details. 

This PR uses platform.architecture() to differentiate arm from x86 macOS builds.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
