### PR TITLE
Add child to top level container in Winforms

### DIFF
--- a/src/winforms/toga_winforms/widgets/base.py
+++ b/src/winforms/toga_winforms/widgets/base.py
@@ -101,7 +101,10 @@ class Widget:
     # INTERFACE
 
     def add_child(self, child):
-        if self.container:
+        if self.viewport:
+            # we are the the top level container
+            child.container = self
+        else:
             child.container = self.container
 
     def insert_child(self, index, child):


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Refs #1284 

When adding a child widget to another widget in Winforms, we only checked if the parent had a `container` property, and set the child's `container` property to that. A top-level container does not have a `container` property, so it was impossible to add a child to any top-level container.

This PR uses the Cocoa implementation: it checks for the parent widget's `viewport`. If the parent has `viewport` property, it is the top-level widget, so we set the child's container to the widget itself.
This was actually a change that was added to make widget addition/removal possible, but the Winforms backend was not updated at the time.
## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
