### PR TITLE
Fix minimum size in gtk backend

### DIFF
--- a/examples/examples_overview/examples_overview/app.py
+++ b/examples/examples_overview/examples_overview/app.py
@@ -106,7 +106,7 @@ class ExampleExamplesOverviewApp(toga.App):
             ),
         )
 
-        split_container = toga.SplitContainer(content=[left_box, self.info_view])
+        split_container = toga.SplitContainer(style=Pack(flex=1), content=[left_box, self.info_view])
 
         outer_box = toga.Box(
             children=[label, split_container],

--- a/examples/examples_overview/examples_overview/app.py
+++ b/examples/examples_overview/examples_overview/app.py
@@ -106,6 +106,7 @@ class ExampleExamplesOverviewApp(toga.App):
             ),
         )
 
+        # make the SplitContainer flex to occupy available pox space
         split_container = toga.SplitContainer(style=Pack(flex=1), content=[left_box, self.info_view])
 
         outer_box = toga.Box(

--- a/examples/examples_overview/examples_overview/app.py
+++ b/examples/examples_overview/examples_overview/app.py
@@ -106,7 +106,7 @@ class ExampleExamplesOverviewApp(toga.App):
             ),
         )
 
-        # make the SplitContainer flex to occupy available pox space
+        # make the SplitContainer flex to occupy available Box widget space
         split_container = toga.SplitContainer(style=Pack(flex=1), content=[left_box, self.info_view])
 
         outer_box = toga.Box(

--- a/src/core/toga/platform.py
+++ b/src/core/toga/platform.py
@@ -37,7 +37,7 @@ def get_platform_factory(factory=None):
     elif current_platform == 'ios':
         from toga_iOS import factory
         return factory
-    elif current_platform == 'linux':
+    elif current_platform == 'freebsd13':
         from toga_gtk import factory
         return factory
     elif current_platform == 'tvos':

--- a/src/core/toga/platform.py
+++ b/src/core/toga/platform.py
@@ -37,7 +37,7 @@ def get_platform_factory(factory=None):
     elif current_platform == 'ios':
         from toga_iOS import factory
         return factory
-    elif current_platform == 'freebsd13':
+    elif current_platform == 'linux':
         from toga_gtk import factory
         return factory
     elif current_platform == 'tvos':

--- a/src/gtk/toga_gtk/widgets/box.py
+++ b/src/gtk/toga_gtk/widgets/box.py
@@ -301,7 +301,7 @@ class TogaBox(Gtk.Fixed):
                                 #     widget,
                                 #     widget.children,
                                 #     min_height,
-                                )
+                                # )
         elif self.interface.style.direction == ROW:
             for widget in self.interface.children:
                 if str(type(widget)) == "<class 'toga.widgets.box.Box'>":

--- a/src/gtk/toga_gtk/widgets/box.py
+++ b/src/gtk/toga_gtk/widgets/box.py
@@ -71,7 +71,7 @@ class TogaBox(Gtk.Fixed):
         if min_width > width:
             width = min_width
 
-        # print(".... .... MIN WIDTH OF THE BOX", min_width)
+        print(".... .... MIN WIDTH OF THE BOX", min_width)
 
         return min_width, width
 

--- a/src/gtk/toga_gtk/widgets/box.py
+++ b/src/gtk/toga_gtk/widgets/box.py
@@ -46,7 +46,9 @@ class TogaBox(Gtk.Fixed):
                             else:
                                 min_width += (
                                     widget.style.padding_right
-                                    + widget.intrinsic.width.value if hasattr(widget.intrinsic.width, "value") else widget.intrinsic.width
+                                    + widget.intrinsic.width.value
+                                    if hasattr(widget.intrinsic.width, "value")
+                                    else widget.intrinsic.width
                                     + widget.style.padding_left
                                 )
                                 # print(".... NOT BOX WIDGET WITH ROW DIRECTION, FLEX AND NO HEIGHT", widget, widget.children, min_width)
@@ -63,7 +65,9 @@ class TogaBox(Gtk.Fixed):
                                 # The widget is flex and it has not width
                                 min_width += (
                                     widget.style.padding_right
-                                    + widget.intrinsic.width.value if hasattr(widget.intrinsic.width, "value") else widget.intrinsic.width
+                                    + widget.intrinsic.width.value
+                                    if hasattr(widget.intrinsic.width, "value")
+                                    else widget.intrinsic.width
                                     + widget.style.padding_left
                                 )
                                 # print(".... NOT BOX WIDGET WITH ROW DIRECTION, NOT FLEX AND NO HEIGHT", widget, widget.children, min_width)
@@ -103,12 +107,15 @@ class TogaBox(Gtk.Fixed):
                             if (
                                 min_width
                                 <= widget.style.padding_right
-                                + widget.intrinsic.width.value if hasattr(widget.intrinsic.width, "value") else widget.intrinsic.width
-                                + widget.style.padding_left
+                                + widget.intrinsic.width.value
+                                if hasattr(widget.intrinsic.width, "value")
+                                else widget.intrinsic.width + widget.style.padding_left
                             ):
                                 min_width = (
                                     widget.style.padding_right
-                                    + widget.intrinsic.width.value if hasattr(widget.intrinsic.width, "value") else widget.intrinsic.width
+                                    + widget.intrinsic.width.value
+                                    if hasattr(widget.intrinsic.width, "value")
+                                    else widget.intrinsic.width
                                     + widget.style.padding_left
                                 )
                             # print(".... NOT BOX WIDGET WITH COLUMN DIRECTION, FLEX AND NO HEIGHT", widget, widget.children, min_width)
@@ -133,17 +140,22 @@ class TogaBox(Gtk.Fixed):
                             if (
                                 min_width
                                 <= widget.style.padding_right
-                                + widget.intrinsic.width.value if hasattr(widget.intrinsic.width, "value") else widget.intrinsic.width
-                                + widget.style.padding_left
+                                + widget.intrinsic.width.value
+                                if hasattr(widget.intrinsic.width, "value")
+                                else widget.intrinsic.width + widget.style.padding_left
                             ):
                                 min_width = (
                                     widget.style.padding_right
-                                    + widget.intrinsic.width.value if hasattr(widget.intrinsic.width, "value") else widget.intrinsic.width
+                                    + widget.intrinsic.width.value
+                                    if hasattr(widget.intrinsic.width, "value")
+                                    else widget.intrinsic.width
                                     + widget.style.padding_left
                                 )
                             # print(".... NOT BOX WIDGET WITH COLUMN DIRECTION, NOT FLEX AND NO HEIGHT", widget, widget.children, min_width)
 
-        min_width += self.interface.style.padding_right + self.interface.style.padding_left
+        min_width += (
+            self.interface.style.padding_right + self.interface.style.padding_left
+        )
         if min_width > width:
             width = min_width
 
@@ -188,7 +200,9 @@ class TogaBox(Gtk.Fixed):
                             else:
                                 min_height += (
                                     widget.style.padding_top
-                                    + widget.intrinsic.height.value if hasattr(widget.intrinsic.height, "value") else widget.intrinsic.height
+                                    + widget.intrinsic.height.value
+                                    if hasattr(widget.intrinsic.height, "value")
+                                    else widget.intrinsic.height
                                     + widget.style.padding_bottom
                                 )
                                 # print(".... NOT BOX WIDGET WITH COLUMN DIRECTION, FLEX AND NO HEIGHT", widget, widget.children, min_height)
@@ -205,7 +219,9 @@ class TogaBox(Gtk.Fixed):
                                 # The widget is flex and it has not height
                                 min_height += (
                                     widget.style.padding_top
-                                    + widget.intrinsic.height.value if hasattr(widget.intrinsic.height, "value") else widget.intrinsic.height
+                                    + widget.intrinsic.height.value
+                                    if hasattr(widget.intrinsic.height, "value")
+                                    else widget.intrinsic.height
                                     + widget.style.padding_bottom
                                 )
                                 # print(".... NOT BOX WIDGET WITH COLUMN DIRECTION, NOT FLEX AND NO HEIGHT", widget, widget.children, min_height)
@@ -245,12 +261,16 @@ class TogaBox(Gtk.Fixed):
                             if (
                                 min_height
                                 <= widget.style.padding_top
-                                + widget.intrinsic.height.value if hasattr(widget.intrinsic.height, "value") else widget.intrinsic.height
+                                + widget.intrinsic.height.value
+                                if hasattr(widget.intrinsic.height, "value")
+                                else widget.intrinsic.height
                                 + widget.style.padding_bottom
                             ):
                                 min_height = (
                                     widget.style.padding_top
-                                    + widget.intrinsic.height.value if hasattr(widget.intrinsic.height, "value") else widget.intrinsic.height
+                                    + widget.intrinsic.height.value
+                                    if hasattr(widget.intrinsic.height, "value")
+                                    else widget.intrinsic.height
                                     + widget.style.padding_bottom
                                 )
                             # print(".... NOT BOX WIDGET WITH ROW DIRECTION, FLEX AND NO HEIGHT", widget, widget.children, min_height)
@@ -275,17 +295,23 @@ class TogaBox(Gtk.Fixed):
                             if (
                                 min_height
                                 <= widget.style.padding_top
-                                + widget.intrinsic.height.value if hasattr(widget.intrinsic.height, "value") else widget.intrinsic.height
+                                + widget.intrinsic.height.value
+                                if hasattr(widget.intrinsic.height, "value")
+                                else widget.intrinsic.height
                                 + widget.style.padding_bottom
                             ):
                                 min_height = (
                                     widget.style.padding_top
-                                    + widget.intrinsic.height.value if hasattr(widget.intrinsic.height, "value") else widget.intrinsic.height
+                                    + widget.intrinsic.height.value
+                                    if hasattr(widget.intrinsic.height, "value")
+                                    else widget.intrinsic.height
                                     + widget.style.padding_bottom
                                 )
                             # print(".... NOT BOX WIDGET WITH ROW DIRECTION, NOT FLEX AND NO HEIGHT", widget, widget.children, min_height)
 
-        min_height += self.interface.style.padding_bottom + self.interface.style.padding_top
+        min_height += (
+            self.interface.style.padding_bottom + self.interface.style.padding_top
+        )
         if min_height > height:
             height = min_height
 
@@ -315,8 +341,12 @@ class TogaBox(Gtk.Fixed):
                     # print("update ", widget.interface, widget.interface.layout)
                     widget.interface._impl.rehint()
                     widget_allocation = Gdk.Rectangle()
-                    widget_allocation.x = widget.interface.layout.absolute_content_left + allocation.x
-                    widget_allocation.y = widget.interface.layout.absolute_content_top + allocation.y
+                    widget_allocation.x = (
+                        widget.interface.layout.absolute_content_left + allocation.x
+                    )
+                    widget_allocation.y = (
+                        widget.interface.layout.absolute_content_top + allocation.y
+                    )
                     widget_allocation.width = widget.interface.layout.content_width
                     widget_allocation.height = widget.interface.layout.content_height
 

--- a/src/gtk/toga_gtk/widgets/box.py
+++ b/src/gtk/toga_gtk/widgets/box.py
@@ -1,3 +1,4 @@
+from travertino.constants import COLUMN, ROW
 from ..libs import Gdk, Gtk
 from .base import Widget
 
@@ -155,18 +156,140 @@ class TogaBox(Gtk.Fixed):
         # print("GET PREFERRED HEIGHT", self._impl.native)
         height = self._impl.interface.layout.height
         min_height = 0 if self._impl.min_height is None else self._impl.min_height
-        for widget in self.get_children():
-            if (
-                min_height
-                <= widget.interface.layout.absolute_content_bottom
-                + widget.interface.style.padding_bottom
-            ):
-                min_height = (
-                    widget.interface.layout.absolute_content_bottom
-                    + widget.interface.style.padding_bottom
-                )
+        # print(self.interface, "HAS", self.interface.children)
+        if self.interface.style.direction == COLUMN:
+            if min_height == 0:
+                for widget in self.interface.children:
+                    if str(type(widget)) == "<class 'toga.widgets.box.Box'>":
+                        # Use previously calculated min height from widget._impl.native.get_preferred_height()[0]
+                        if widget.style.height:
+                            min_height += (
+                                widget.style.padding_top
+                                + widget.layout.height
+                                + widget.style.padding_bottom
+                            )
+                        else:
+                            min_height += (
+                                widget.style.padding_top
+                                + widget._impl.native.get_preferred_height()[0]
+                                + widget.style.padding_bottom
+                            )
+                        # print(".... BOX WIDGET WITH COLUMN DIRECTION", widget, widget.children, min_height)
+                    else:
+                        if widget.style.flex:
+                            if widget.style.height:
+                                # The widget is flex but it has height
+                                min_height += (
+                                    widget.style.padding_top
+                                    + widget.layout.height
+                                    + widget.style.padding_bottom
+                                )
+                                # print(".... NOT BOX WIDGET WITH COLUMN DIRECTION, FLEX AND HEIGHT", widget, widget.children, min_height)
+                            else:
+                                min_height += (
+                                    widget.style.padding_top
+                                    + widget.intrinsic.height.value if hasattr(widget.intrinsic.height, "value") else widget.intrinsic.height
+                                    + widget.style.padding_bottom
+                                )
+                                # print(".... NOT BOX WIDGET WITH COLUMN DIRECTION, FLEX AND NO HEIGHT", widget, widget.children, min_height)
+                        else:
+                            if widget.style.height:
+                                # The widget is flex but it has height
+                                min_height += (
+                                    widget.style.padding_top
+                                    + widget.layout.height
+                                    + widget.style.padding_bottom
+                                )
+                                # print(".... NOT BOX WIDGET WITH COLUMN DIRECTION, NOT FLEX AND HEIGHT", widget, widget.children, min_height)
+                            else:
+                                # The widget is flex and it has not height
+                                min_height += (
+                                    widget.style.padding_top
+                                    + widget.intrinsic.height.value if hasattr(widget.intrinsic.height, "value") else widget.intrinsic.height
+                                    + widget.style.padding_bottom
+                                )
+                                # print(".... NOT BOX WIDGET WITH COLUMN DIRECTION, NOT FLEX AND NO HEIGHT", widget, widget.children, min_height)
+        elif self.interface.style.direction == ROW:
+            for widget in self.interface.children:
+                if str(type(widget)) == "<class 'toga.widgets.box.Box'>":
+                    if (
+                        min_height
+                        <= widget.style.padding_top
+                        + widget._impl.native.get_preferred_height()[0]
+                        + widget.style.padding_bottom
+                    ):
+                        min_height = (
+                            widget.style.padding_top
+                            + widget._impl.native.get_preferred_height()[0]
+                            + widget.style.padding_bottom
+                        )
+                    # print(".... BOX WIDGET WITH ROW DIRECTION", widget, widget.children, min_height)
+                else:
+                    if widget.style.flex:
+                        if widget.style.height:
+                            # The widget is flex but it has height
+                            if (
+                                min_height
+                                <= widget.style.padding_top
+                                + widget.layout.height
+                                + widget.style.padding_bottom
+                            ):
+                                min_height = (
+                                    widget.style.padding_top
+                                    + widget.layout.height
+                                    + widget.style.padding_bottom
+                                )
+                            # print(".... NOT BOX WIDGET WITH ROW DIRECTION, FLEX AND HEIGHT", widget, widget.children, min_height)
+                        else:
+                            # The widget is flex and it does not has height
+                            if (
+                                min_height
+                                <= widget.style.padding_top
+                                + widget.intrinsic.height.value if hasattr(widget.intrinsic.height, "value") else widget.intrinsic.height
+                                + widget.style.padding_bottom
+                            ):
+                                min_height = (
+                                    widget.style.padding_top
+                                    + widget.intrinsic.height.value if hasattr(widget.intrinsic.height, "value") else widget.intrinsic.height
+                                    + widget.style.padding_bottom
+                                )
+                            # print(".... NOT BOX WIDGET WITH ROW DIRECTION, FLEX AND NO HEIGHT", widget, widget.children, min_height)
+                    else:
+                        # The widget is flex but it has height
+                        if widget.style.height:
+                            # The widget is flex but it has height
+                            if (
+                                min_height
+                                <= widget.style.padding_top
+                                + widget.layout.height
+                                + widget.style.padding_bottom
+                            ):
+                                min_height = (
+                                    widget.style.padding_top
+                                    + widget.layout.height
+                                    + widget.style.padding_bottom
+                                )
+                            # print(".... NOT BOX WIDGET WITH ROW DIRECTION, NOT FLEX AND HEIGHT", widget, widget.children, min_height)
+                        else:
+                            # The widget is flex and it has not height
+                            if (
+                                min_height
+                                <= widget.style.padding_top
+                                + widget.intrinsic.height.value if hasattr(widget.intrinsic.height, "value") else widget.intrinsic.height
+                                + widget.style.padding_bottom
+                            ):
+                                min_height = (
+                                    widget.style.padding_top
+                                    + widget.intrinsic.height.value if hasattr(widget.intrinsic.height, "value") else widget.intrinsic.height
+                                    + widget.style.padding_bottom
+                                )
+                            # print(".... NOT BOX WIDGET WITH ROW DIRECTION, NOT FLEX AND NO HEIGHT", widget, widget.children, min_height)
+
+        min_height += self.interface.style.padding_bottom + self.interface.style.padding_top
         if min_height > height:
             height = min_height
+
+        # print(".... .... MIN HEIGHT OF THE BOX", min_height)
 
         return min_height, height
 

--- a/src/gtk/toga_gtk/widgets/box.py
+++ b/src/gtk/toga_gtk/widgets/box.py
@@ -13,65 +13,140 @@ class TogaBox(Gtk.Fixed):
         # print("GET PREFERRED WIDTH", self._impl.native)
         width = self._impl.interface.layout.width
         min_width = 0 if self._impl.min_width is None else self._impl.min_width
+        # print(self.interface, "HAS", self.interface.children)
         if self.interface.style.direction == ROW:
             if min_width == 0:
                 for widget in self.interface.children:
                     if str(type(widget)) == "<class 'toga.widgets.box.Box'>":
                         # Use previously calculated min width from widget._impl.native.get_preferred_width()[0]
                         if widget.style.width:
-                            pass
+                            min_width += (
+                                widget.style.padding_right
+                                + widget.layout.width
+                                + widget.style.padding_left
+                            )
                         else:
-                            pass
-                        print(".... BOX WIDGET WITH ROW DIRECTION", widget, widget.children, min_width)
+                            min_width += (
+                                widget.style.padding_right
+                                + widget._impl.native.get_preferred_width()[0]
+                                + widget.style.padding_left
+                            )
+                        # print(".... BOX WIDGET WITH ROW DIRECTION", widget, widget.children, min_width)
                     else:
                         if widget.style.flex:
                             if widget.style.width:
                                 # The widget is flex but it has width
-                                pass
-                                print(".... NOT BOX WIDGET WITH ROW DIRECTION, FLEX AND HEIGHT", widget, widget.children, min_width)
+                                min_width += (
+                                    widget.style.padding_right
+                                    + widget.layout.width
+                                    + widget.style.padding_left
+                                )
+                                # print(".... NOT BOX WIDGET WITH ROW DIRECTION, FLEX AND HEIGHT", widget, widget.children, min_width)
                             else:
-                                pass
-                                print(".... NOT BOX WIDGET WITH ROW DIRECTION, FLEX AND NO HEIGHT", widget, widget.children, min_width)
+                                min_width += (
+                                    widget.style.padding_right
+                                    + widget.intrinsic.width.value if hasattr(widget.intrinsic.width, "value") else widget.intrinsic.width
+                                    + widget.style.padding_left
+                                )
+                                # print(".... NOT BOX WIDGET WITH ROW DIRECTION, FLEX AND NO HEIGHT", widget, widget.children, min_width)
                         else:
                             if widget.style.width:
                                 # The widget is flex but it has width
-                                pass
-                                print(".... NOT BOX WIDGET WITH ROW DIRECTION, NOT FLEX AND HEIGHT", widget, widget.children, min_width)
+                                min_width += (
+                                    widget.style.padding_right
+                                    + widget.layout.width
+                                    + widget.style.padding_left
+                                )
+                                # print(".... NOT BOX WIDGET WITH ROW DIRECTION, NOT FLEX AND HEIGHT", widget, widget.children, min_width)
                             else:
                                 # The widget is flex and it has not width
-                                pass
-                                print(".... NOT BOX WIDGET WITH ROW DIRECTION, NOT FLEX AND NO HEIGHT", widget, widget.children, min_width)
+                                min_width += (
+                                    widget.style.padding_right
+                                    + widget.intrinsic.width.value if hasattr(widget.intrinsic.width, "value") else widget.intrinsic.width
+                                    + widget.style.padding_left
+                                )
+                                # print(".... NOT BOX WIDGET WITH ROW DIRECTION, NOT FLEX AND NO HEIGHT", widget, widget.children, min_width)
         elif self.interface.style.direction == COLUMN:
             for widget in self.interface.children:
                 if str(type(widget)) == "<class 'toga.widgets.box.Box'>":
-                    pass
-                    print(".... BOX WIDGET WITH COLUMN DIRECTION", widget, widget.children, min_width)
+                    if (
+                        min_width
+                        <= widget.style.padding_right
+                        + widget._impl.native.get_preferred_width()[0]
+                        + widget.style.padding_left
+                    ):
+                        min_width = (
+                            widget.style.padding_right
+                            + widget._impl.native.get_preferred_width()[0]
+                            + widget.style.padding_left
+                        )
+                    # print(".... BOX WIDGET WITH COLUMN DIRECTION", widget, widget.children, min_width)
                 else:
                     if widget.style.flex:
                         if widget.style.width:
                             # The widget is flex but it has width
-                            pass
-                            print(".... NOT BOX WIDGET WITH COLUMN DIRECTION, FLEX AND HEIGHT", widget, widget.children, min_width)
+                            if (
+                                min_width
+                                <= widget.style.padding_right
+                                + widget.layout.width
+                                + widget.style.padding_left
+                            ):
+                                min_width = (
+                                    widget.style.padding_right
+                                    + widget.layout.width
+                                    + widget.style.padding_left
+                                )
+                            # print(".... NOT BOX WIDGET WITH COLUMN DIRECTION, FLEX AND HEIGHT", widget, widget.children, min_width)
                         else:
                             # The widget is flex and it does not has width
-                            pass
-                            print(".... NOT BOX WIDGET WITH COLUMN DIRECTION, FLEX AND NO HEIGHT", widget, widget.children, min_width)
+                            if (
+                                min_width
+                                <= widget.style.padding_right
+                                + widget.intrinsic.width.value if hasattr(widget.intrinsic.width, "value") else widget.intrinsic.width
+                                + widget.style.padding_left
+                            ):
+                                min_width = (
+                                    widget.style.padding_right
+                                    + widget.intrinsic.width.value if hasattr(widget.intrinsic.width, "value") else widget.intrinsic.width
+                                    + widget.style.padding_left
+                                )
+                            # print(".... NOT BOX WIDGET WITH COLUMN DIRECTION, FLEX AND NO HEIGHT", widget, widget.children, min_width)
                     else:
                         # The widget is flex but it has width
                         if widget.style.width:
                             # The widget is flex but it has width
-                            pass
-                            print(".... NOT BOX WIDGET WITH COLUMN DIRECTION, NOT FLEX AND HEIGHT", widget, widget.children, min_width)
+                            if (
+                                min_width
+                                <= widget.style.padding_right
+                                + widget.layout.width
+                                + widget.style.padding_left
+                            ):
+                                min_width = (
+                                    widget.style.padding_right
+                                    + widget.layout.width
+                                    + widget.style.padding_left
+                                )
+                            # print(".... NOT BOX WIDGET WITH COLUMN DIRECTION, NOT FLEX AND HEIGHT", widget, widget.children, min_width)
                         else:
                             # The widget is flex and it has not width
-                            pass
-                            print(".... NOT BOX WIDGET WITH COLUMN DIRECTION, NOT FLEX AND NO HEIGHT", widget, widget.children, min_width)
+                            if (
+                                min_width
+                                <= widget.style.padding_right
+                                + widget.intrinsic.width.value if hasattr(widget.intrinsic.width, "value") else widget.intrinsic.width
+                                + widget.style.padding_left
+                            ):
+                                min_width = (
+                                    widget.style.padding_right
+                                    + widget.intrinsic.width.value if hasattr(widget.intrinsic.width, "value") else widget.intrinsic.width
+                                    + widget.style.padding_left
+                                )
+                            # print(".... NOT BOX WIDGET WITH COLUMN DIRECTION, NOT FLEX AND NO HEIGHT", widget, widget.children, min_width)
 
         min_width += self.interface.style.padding_right + self.interface.style.padding_left
         if min_width > width:
             width = min_width
 
-        print(".... .... MIN WIDTH OF THE BOX", min_width)
+        # print(".... .... MIN WIDTH OF THE BOX", min_width)
 
         return min_width, width
 

--- a/src/gtk/toga_gtk/widgets/box.py
+++ b/src/gtk/toga_gtk/widgets/box.py
@@ -54,12 +54,19 @@ class TogaBox(Gtk.Fixed):
                             #     min_width,
                             # )
                         else:
-                            min_width += (
-                                widget.style.padding_right
-                                + widget.intrinsic.width.value
-                                if hasattr(widget.intrinsic.width, "value")
-                                else widget.intrinsic.width
-                                + widget.style.padding_left
+                            try:
+                                min_width += (
+                                    widget.style.padding_right
+                                    + widget.intrinsic.width.value
+                                    if hasattr(widget.intrinsic.width, "value")
+                                    else widget.intrinsic.width
+                                    + widget.style.padding_left
+                                )
+                            except:
+                                min_width += (
+                                    widget.style.padding_right
+                                    + widget._impl.native.get_preferred_width()[0]
+                                    + widget.style.padding_left
                             )
                             # print(
                             #     ".... NOT BOX WIDGET WITH ROW DIRECTION AND NO HEIGHT",
@@ -109,20 +116,33 @@ class TogaBox(Gtk.Fixed):
                         # )
                     else:
                         # The widget does not has width
-                        if (
-                            min_width
-                            <= widget.style.padding_right
-                            + widget.intrinsic.width.value
-                            if hasattr(widget.intrinsic.width, "value")
-                            else widget.intrinsic.width + widget.style.padding_left
-                        ):
-                            min_width = (
-                                widget.style.padding_right
+                        try:
+                            if (
+                                min_width
+                                <= widget.style.padding_right
                                 + widget.intrinsic.width.value
                                 if hasattr(widget.intrinsic.width, "value")
-                                else widget.intrinsic.width
+                                else widget.intrinsic.width + widget.style.padding_left
+                            ):
+                                min_width = (
+                                    widget.style.padding_right
+                                    + widget.intrinsic.width.value
+                                    if hasattr(widget.intrinsic.width, "value")
+                                    else widget.intrinsic.width
+                                    + widget.style.padding_left
+                                )
+                        except:
+                            if (
+                                min_width
+                                <= widget.style.padding_right
+                                + widget._impl.native.get_preferred_width()[0]
                                 + widget.style.padding_left
-                            )
+                            ):
+                                min_width = (
+                                    widget.style.padding_right
+                                    + widget._impl.native.get_preferred_width()[0]
+                                    + widget.style.padding_left
+                                )
                         # print(
                         #     ".... NOT BOX WIDGET WITH COLUMN DIRECTION AND NO HEIGHT",
                         #     widget,
@@ -185,13 +205,20 @@ class TogaBox(Gtk.Fixed):
                             #     min_height,
                             # )
                         else:
-                            min_height += (
-                                widget.style.padding_top
-                                + widget.intrinsic.height.value
-                                if hasattr(widget.intrinsic.height, "value")
-                                else widget.intrinsic.height
-                                + widget.style.padding_bottom
-                            )
+                            try:
+                                min_height += (
+                                    widget.style.padding_top
+                                    + widget.intrinsic.height.value
+                                    if hasattr(widget.intrinsic.height, "value")
+                                    else widget.intrinsic.height
+                                    + widget.style.padding_bottom
+                                )
+                            except:
+                                min_height += (
+                                    widget.style.padding_top
+                                    + widget._impl.native.get_preferred_height()[0]
+                                    + widget.style.padding_bottom
+                                )
                             # print(
                             #     ".... NOT BOX WIDGET WITH COLUMN DIRECTION AND NO HEIGHT",
                             #     widget,
@@ -240,21 +267,34 @@ class TogaBox(Gtk.Fixed):
                         # )
                     else:
                         # The widget does not has height
-                        if (
-                            min_height
-                            <= widget.style.padding_top
-                            + widget.intrinsic.height.value
-                            if hasattr(widget.intrinsic.height, "value")
-                            else widget.intrinsic.height
-                            + widget.style.padding_bottom
-                        ):
-                            min_height = (
-                                widget.style.padding_top
+                        try:
+                            if (
+                                min_height
+                                <= widget.style.padding_top
                                 + widget.intrinsic.height.value
                                 if hasattr(widget.intrinsic.height, "value")
                                 else widget.intrinsic.height
                                 + widget.style.padding_bottom
-                            )
+                            ):
+                                min_height = (
+                                    widget.style.padding_top
+                                    + widget.intrinsic.height.value
+                                    if hasattr(widget.intrinsic.height, "value")
+                                    else widget.intrinsic.height
+                                    + widget.style.padding_bottom
+                                )
+                        except:
+                            if (
+                                min_height
+                                <= widget.style.padding_top
+                                + widget._impl.native.get_preferred_height()[0]
+                                + widget.style.padding_bottom
+                            ):
+                                min_height = (
+                                    widget.style.padding_top
+                                    + widget._impl.native.get_preferred_height()[0]
+                                    + widget.style.padding_bottom
+                                )
                         # print(
                         #     ".... NOT BOX WIDGET WITH ROW DIRECTION AND NO HEIGHT",
                         #     widget,

--- a/src/gtk/toga_gtk/widgets/box.py
+++ b/src/gtk/toga_gtk/widgets/box.py
@@ -62,7 +62,7 @@ class TogaBox(Gtk.Fixed):
                                     else widget.intrinsic.width
                                     + widget.style.padding_left
                                 )
-                            except:
+                            except TypeError:
                                 min_width += (
                                     widget.style.padding_right
                                     + widget._impl.native.get_preferred_width()[0]
@@ -131,7 +131,7 @@ class TogaBox(Gtk.Fixed):
                                     else widget.intrinsic.width
                                     + widget.style.padding_left
                                 )
-                        except:
+                        except TypeError:
                             if (
                                 min_width
                                 <= widget.style.padding_right
@@ -213,7 +213,7 @@ class TogaBox(Gtk.Fixed):
                                     else widget.intrinsic.height
                                     + widget.style.padding_bottom
                                 )
-                            except:
+                            except TypeError:
                                 min_height += (
                                     widget.style.padding_top
                                     + widget._impl.native.get_preferred_height()[0]
@@ -283,7 +283,7 @@ class TogaBox(Gtk.Fixed):
                                     else widget.intrinsic.height
                                     + widget.style.padding_bottom
                                 )
-                        except:
+                        except TypeError:
                             if (
                                 min_height
                                 <= widget.style.padding_top

--- a/src/gtk/toga_gtk/widgets/box.py
+++ b/src/gtk/toga_gtk/widgets/box.py
@@ -81,23 +81,41 @@ class TogaBox(Gtk.Fixed):
             for widget in self.interface.children:
                 widget._impl.rehint()
                 if str(type(widget)) == "<class 'toga.widgets.box.Box'>":
-                    if (
-                        min_width
-                        <= widget.style.padding_right
-                        + widget._impl.native.get_preferred_width()[0]
-                        + widget.style.padding_left
-                    ):
-                        min_width = (
-                            widget.style.padding_right
+                    if widget.style.width:
+                        if min_width <= (
+                                widget.style.padding_right
+                                + widget.layout.width
+                                + widget.style.padding_left
+                            ):
+                            min_width = (
+                                widget.style.padding_right
+                                + widget.layout.width
+                                + widget.style.padding_left
+                            )
+                        # print(
+                        #     ".... BOX WIDGET WITH COLUMN DIRECTION AND WIDTH",
+                        #     widget,
+                        #     widget.children,
+                        #     min_width,
+                        # )
+                    else:
+                        if (
+                            min_width
+                            <= widget.style.padding_right
                             + widget._impl.native.get_preferred_width()[0]
                             + widget.style.padding_left
-                        )
-                    # print(
-                    #     ".... BOX WIDGET WITH COLUMN DIRECTION",
-                    #     widget,
-                    #     widget.children,
-                    #     min_width,
-                    # )
+                        ):
+                            min_width = (
+                                widget.style.padding_right
+                                + widget._impl.native.get_preferred_width()[0]
+                                + widget.style.padding_left
+                            )
+                        # print(
+                        #     ".... BOX WIDGET WITH COLUMN DIRECTION AND NO WIDTH",
+                        #     widget,
+                        #     widget.children,
+                        #     min_width,
+                        # )
                 else:
                     if widget.style.width:
                         # The widget has width
@@ -241,23 +259,41 @@ class TogaBox(Gtk.Fixed):
             for widget in self.interface.children:
                 widget._impl.rehint()
                 if str(type(widget)) == "<class 'toga.widgets.box.Box'>":
-                    if (
-                        min_height
-                        <= widget.style.padding_top
-                        + widget._impl.native.get_preferred_height()[0]
-                        + widget.style.padding_bottom
-                    ):
-                        min_height = (
-                            widget.style.padding_top
+                    if widget.style.width:
+                        if min_height <= (
+                                widget.style.padding_top
+                                + widget.layout.height
+                                + widget.style.padding_bottom
+                            ):
+                            min_height = (
+                                widget.style.padding_top
+                                + widget.layout.height
+                                + widget.style.padding_bottom
+                            )
+                        # print(
+                        #     ".... BOX WIDGET WITH COLUMN DIRECTION AND HEIGHT",
+                        #     widget,
+                        #     widget.children,
+                        #     min_height,
+                        # )
+                    else:
+                        if (
+                            min_height
+                            <= widget.style.padding_top
                             + widget._impl.native.get_preferred_height()[0]
                             + widget.style.padding_bottom
-                        )
-                    # print(
-                    #     ".... BOX WIDGET WITH ROW DIRECTION",
-                    #     widget,
-                    #     widget.children,
-                    #     min_height,
-                    # )
+                        ):
+                            min_height = (
+                                widget.style.padding_top
+                                + widget._impl.native.get_preferred_height()[0]
+                                + widget.style.padding_bottom
+                            )
+                        # print(
+                        #     ".... BOX WIDGET WITH ROW DIRECTION",
+                        #     widget,
+                        #     widget.children,
+                        #     min_height,
+                        # )
                 else:
                     if widget.style.height:
                         # The widget has height

--- a/src/gtk/toga_gtk/widgets/box.py
+++ b/src/gtk/toga_gtk/widgets/box.py
@@ -11,9 +11,9 @@ class TogaBox(Gtk.Fixed):
 
     def do_get_preferred_width(self):
         # Calculate the minimum and natural width of the container.
-        # print("GET PREFERRED WIDTH", self._impl.native)
         width = self._impl.interface.layout.width
         min_width = 0 if self._impl.min_width is None else self._impl.min_width
+
         # print(self.interface, "HAS", self.interface.children)
         if self.interface.style.direction == ROW:
             if min_width == 0:
@@ -48,7 +48,7 @@ class TogaBox(Gtk.Fixed):
                                 + widget.style.padding_left
                             )
                             # print(
-                            #     ".... NOT BOX WIDGET WITH ROW DIRECTION AND HEIGHT",
+                            #     ".... NOT BOX WIDGET WITH ROW DIRECTION AND WIDTH",
                             #     widget,
                             #     widget.children,
                             #     min_width,
@@ -69,7 +69,7 @@ class TogaBox(Gtk.Fixed):
                                     + widget.style.padding_left
                                 )
                             # print(
-                            #     ".... NOT BOX WIDGET WITH ROW DIRECTION AND NO HEIGHT",
+                            #     ".... NOT BOX WIDGET WITH ROW DIRECTION AND NO WIDTH",
                             #     widget,
                             #     widget.children,
                             #     min_width,
@@ -109,7 +109,7 @@ class TogaBox(Gtk.Fixed):
                                 + widget.style.padding_left
                             )
                         # print(
-                        #     ".... NOT BOX WIDGET WITH COLUMN DIRECTION AND HEIGHT",
+                        #     ".... NOT BOX WIDGET WITH COLUMN DIRECTION AND WIDTH",
                         #     widget,
                         #     widget.children,
                         #     min_width,
@@ -144,7 +144,7 @@ class TogaBox(Gtk.Fixed):
                                     + widget.style.padding_left
                                 )
                         # print(
-                        #     ".... NOT BOX WIDGET WITH COLUMN DIRECTION AND NO HEIGHT",
+                        #     ".... NOT BOX WIDGET WITH COLUMN DIRECTION AND NO WIDTH",
                         #     widget,
                         #     widget.children,
                         #     min_width,
@@ -162,9 +162,9 @@ class TogaBox(Gtk.Fixed):
 
     def do_get_preferred_height(self):
         # Calculate the minimum and natural height of the container.
-        # print("GET PREFERRED HEIGHT", self._impl.native)
         height = self._impl.interface.layout.height
         min_height = 0 if self._impl.min_height is None else self._impl.min_height
+
         # print(self.interface, "HAS", self.interface.children)
         if self.interface.style.direction == COLUMN:
             if min_height == 0:

--- a/src/gtk/toga_gtk/widgets/box.py
+++ b/src/gtk/toga_gtk/widgets/box.py
@@ -83,10 +83,10 @@ class TogaBox(Gtk.Fixed):
                 if str(type(widget)) == "<class 'toga.widgets.box.Box'>":
                     if widget.style.width:
                         if min_width <= (
-                                widget.style.padding_right
-                                + widget.layout.width
-                                + widget.style.padding_left
-                            ):
+                            widget.style.padding_right
+                            + widget.layout.width
+                            + widget.style.padding_left
+                        ):
                             min_width = (
                                 widget.style.padding_right
                                 + widget.layout.width
@@ -261,10 +261,10 @@ class TogaBox(Gtk.Fixed):
                 if str(type(widget)) == "<class 'toga.widgets.box.Box'>":
                     if widget.style.width:
                         if min_height <= (
-                                widget.style.padding_top
-                                + widget.layout.height
-                                + widget.style.padding_bottom
-                            ):
+                            widget.style.padding_top
+                            + widget.layout.height
+                            + widget.style.padding_bottom
+                        ):
                             min_height = (
                                 widget.style.padding_top
                                 + widget.layout.height

--- a/src/gtk/toga_gtk/widgets/box.py
+++ b/src/gtk/toga_gtk/widgets/box.py
@@ -13,18 +13,54 @@ class TogaBox(Gtk.Fixed):
         # print("GET PREFERRED WIDTH", self._impl.native)
         width = self._impl.interface.layout.width
         min_width = 0 if self._impl.min_width is None else self._impl.min_width
-        for widget in self.get_children():
-            if (
-                min_width
-                <= widget.interface.layout.absolute_content_right
-                + widget.interface.style.padding_right
-            ):
-                min_width = (
-                    widget.interface.layout.absolute_content_right
-                    + widget.interface.style.padding_right
-                )
+        if self.interface.style.direction == ROW:
+            if min_width == 0:
+                for widget in self.interface.children:
+                    if str(type(widget)) == "<class 'toga.widgets.box.Box'>":
+                        if widget.style.width:
+                            pass
+                        else:
+                            pass
+                    else:
+                        if widget.style.flex:
+                            if widget.style.width:
+                                # The widget is flex but it has width
+                                pass
+                            else:
+                                pass
+                        else:
+                            if widget.style.width:
+                                # The widget is flex but it has width
+                                pass
+                            else:
+                                # The widget is flex and it has not width
+                                pass
+        elif self.interface.style.direction == COLUMN:
+            for widget in self.interface.children:
+                if str(type(widget)) == "<class 'toga.widgets.box.Box'>":
+                    pass
+                else:
+                    if widget.style.flex:
+                        if widget.style.width:
+                            # The widget is flex but it has width
+                            pass
+                        else:
+                            # The widget is flex and it does not has width
+                            pass
+                    else:
+                        # The widget is flex but it has width
+                        if widget.style.width:
+                            # The widget is flex but it has width
+                            pass
+                        else:
+                            # The widget is flex and it has not width
+                            pass
+
+        min_width += self.interface.style.padding_right + self.interface.style.padding_left
         if min_width > width:
             width = min_width
+
+        # print(".... .... MIN WIDTH OF THE BOX", min_width)
 
         return min_width, width
 

--- a/src/gtk/toga_gtk/widgets/box.py
+++ b/src/gtk/toga_gtk/widgets/box.py
@@ -17,44 +17,55 @@ class TogaBox(Gtk.Fixed):
             if min_width == 0:
                 for widget in self.interface.children:
                     if str(type(widget)) == "<class 'toga.widgets.box.Box'>":
+                        # Use previously calculated min width from widget._impl.native.get_preferred_width()[0]
                         if widget.style.width:
                             pass
                         else:
                             pass
+                        print(".... BOX WIDGET WITH ROW DIRECTION", widget, widget.children, min_width)
                     else:
                         if widget.style.flex:
                             if widget.style.width:
                                 # The widget is flex but it has width
                                 pass
+                                print(".... NOT BOX WIDGET WITH ROW DIRECTION, FLEX AND HEIGHT", widget, widget.children, min_width)
                             else:
                                 pass
+                                print(".... NOT BOX WIDGET WITH ROW DIRECTION, FLEX AND NO HEIGHT", widget, widget.children, min_width)
                         else:
                             if widget.style.width:
                                 # The widget is flex but it has width
                                 pass
+                                print(".... NOT BOX WIDGET WITH ROW DIRECTION, NOT FLEX AND HEIGHT", widget, widget.children, min_width)
                             else:
                                 # The widget is flex and it has not width
                                 pass
+                                print(".... NOT BOX WIDGET WITH ROW DIRECTION, NOT FLEX AND NO HEIGHT", widget, widget.children, min_width)
         elif self.interface.style.direction == COLUMN:
             for widget in self.interface.children:
                 if str(type(widget)) == "<class 'toga.widgets.box.Box'>":
                     pass
+                    print(".... BOX WIDGET WITH COLUMN DIRECTION", widget, widget.children, min_width)
                 else:
                     if widget.style.flex:
                         if widget.style.width:
                             # The widget is flex but it has width
                             pass
+                            print(".... NOT BOX WIDGET WITH COLUMN DIRECTION, FLEX AND HEIGHT", widget, widget.children, min_width)
                         else:
                             # The widget is flex and it does not has width
                             pass
+                            print(".... NOT BOX WIDGET WITH COLUMN DIRECTION, FLEX AND NO HEIGHT", widget, widget.children, min_width)
                     else:
                         # The widget is flex but it has width
                         if widget.style.width:
                             # The widget is flex but it has width
                             pass
+                            print(".... NOT BOX WIDGET WITH COLUMN DIRECTION, NOT FLEX AND HEIGHT", widget, widget.children, min_width)
                         else:
                             # The widget is flex and it has not width
                             pass
+                            print(".... NOT BOX WIDGET WITH COLUMN DIRECTION, NOT FLEX AND NO HEIGHT", widget, widget.children, min_width)
 
         min_width += self.interface.style.padding_right + self.interface.style.padding_left
         if min_width > width:

--- a/src/gtk/toga_gtk/widgets/box.py
+++ b/src/gtk/toga_gtk/widgets/box.py
@@ -67,7 +67,7 @@ class TogaBox(Gtk.Fixed):
                                     widget.style.padding_right
                                     + widget._impl.native.get_preferred_width()[0]
                                     + widget.style.padding_left
-                            )
+                                )
                             # print(
                             #     ".... NOT BOX WIDGET WITH ROW DIRECTION AND NO HEIGHT",
                             #     widget,

--- a/src/gtk/toga_gtk/widgets/box.py
+++ b/src/gtk/toga_gtk/widgets/box.py
@@ -57,9 +57,9 @@ class TogaBox(Gtk.Fixed):
                             try:
                                 min_width += (
                                     widget.style.padding_right
-                                    + widget.intrinsic.width.value
+                                    + (widget.intrinsic.width.value
                                     if hasattr(widget.intrinsic.width, "value")
-                                    else widget.intrinsic.width
+                                    else widget.intrinsic.width)
                                     + widget.style.padding_left
                                 )
                             except TypeError:
@@ -120,15 +120,15 @@ class TogaBox(Gtk.Fixed):
                             if (
                                 min_width
                                 <= widget.style.padding_right
-                                + widget.intrinsic.width.value
+                                + (widget.intrinsic.width.value
                                 if hasattr(widget.intrinsic.width, "value")
-                                else widget.intrinsic.width + widget.style.padding_left
+                                else widget.intrinsic.width) + widget.style.padding_left
                             ):
                                 min_width = (
                                     widget.style.padding_right
-                                    + widget.intrinsic.width.value
+                                    + (widget.intrinsic.width.value
                                     if hasattr(widget.intrinsic.width, "value")
-                                    else widget.intrinsic.width
+                                    else widget.intrinsic.width)
                                     + widget.style.padding_left
                                 )
                         except TypeError:
@@ -208,9 +208,9 @@ class TogaBox(Gtk.Fixed):
                             try:
                                 min_height += (
                                     widget.style.padding_top
-                                    + widget.intrinsic.height.value
+                                    + (widget.intrinsic.height.value
                                     if hasattr(widget.intrinsic.height, "value")
-                                    else widget.intrinsic.height
+                                    else widget.intrinsic.height)
                                     + widget.style.padding_bottom
                                 )
                             except TypeError:
@@ -271,16 +271,16 @@ class TogaBox(Gtk.Fixed):
                             if (
                                 min_height
                                 <= widget.style.padding_top
-                                + widget.intrinsic.height.value
+                                + (widget.intrinsic.height.value
                                 if hasattr(widget.intrinsic.height, "value")
-                                else widget.intrinsic.height
+                                else widget.intrinsic.height)
                                 + widget.style.padding_bottom
                             ):
                                 min_height = (
                                     widget.style.padding_top
-                                    + widget.intrinsic.height.value
+                                    + (widget.intrinsic.height.value
                                     if hasattr(widget.intrinsic.height, "value")
-                                    else widget.intrinsic.height
+                                    else widget.intrinsic.height)
                                     + widget.style.padding_bottom
                                 )
                         except TypeError:

--- a/src/gtk/toga_gtk/widgets/box.py
+++ b/src/gtk/toga_gtk/widgets/box.py
@@ -18,6 +18,7 @@ class TogaBox(Gtk.Fixed):
         if self.interface.style.direction == ROW:
             if min_width == 0:
                 for widget in self.interface.children:
+                    widget._impl.rehint()
                     if str(type(widget)) == "<class 'toga.widgets.box.Box'>":
                         # Use previously calculated min width from
                         # widget._impl.native.get_preferred_width()[0]
@@ -78,6 +79,7 @@ class TogaBox(Gtk.Fixed):
                             # )
         elif self.interface.style.direction == COLUMN:
             for widget in self.interface.children:
+                widget._impl.rehint()
                 if str(type(widget)) == "<class 'toga.widgets.box.Box'>":
                     if (
                         min_width
@@ -176,6 +178,7 @@ class TogaBox(Gtk.Fixed):
         if self.interface.style.direction == COLUMN:
             if min_height == 0:
                 for widget in self.interface.children:
+                    widget._impl.rehint()
                     if str(type(widget)) == "<class 'toga.widgets.box.Box'>":
                         # Use previously calculated min height from
                         # widget._impl.native.get_preferred_height()[0]
@@ -236,6 +239,7 @@ class TogaBox(Gtk.Fixed):
                             # )
         elif self.interface.style.direction == ROW:
             for widget in self.interface.children:
+                widget._impl.rehint()
                 if str(type(widget)) == "<class 'toga.widgets.box.Box'>":
                     if (
                         min_height

--- a/src/gtk/toga_gtk/widgets/box.py
+++ b/src/gtk/toga_gtk/widgets/box.py
@@ -57,9 +57,11 @@ class TogaBox(Gtk.Fixed):
                             try:
                                 min_width += (
                                     widget.style.padding_right
-                                    + (widget.intrinsic.width.value
-                                    if hasattr(widget.intrinsic.width, "value")
-                                    else widget.intrinsic.width)
+                                    + (
+                                        widget.intrinsic.width.value
+                                        if hasattr(widget.intrinsic.width, "value")
+                                        else widget.intrinsic.width
+                                    )
                                     + widget.style.padding_left
                                 )
                             except TypeError:
@@ -120,15 +122,20 @@ class TogaBox(Gtk.Fixed):
                             if (
                                 min_width
                                 <= widget.style.padding_right
-                                + (widget.intrinsic.width.value
-                                if hasattr(widget.intrinsic.width, "value")
-                                else widget.intrinsic.width) + widget.style.padding_left
+                                + (
+                                    widget.intrinsic.width.value
+                                    if hasattr(widget.intrinsic.width, "value")
+                                    else widget.intrinsic.width
+                                )
+                                + widget.style.padding_left
                             ):
                                 min_width = (
                                     widget.style.padding_right
-                                    + (widget.intrinsic.width.value
-                                    if hasattr(widget.intrinsic.width, "value")
-                                    else widget.intrinsic.width)
+                                    + (
+                                        widget.intrinsic.width.value
+                                        if hasattr(widget.intrinsic.width, "value")
+                                        else widget.intrinsic.width
+                                    )
                                     + widget.style.padding_left
                                 )
                         except TypeError:
@@ -208,9 +215,11 @@ class TogaBox(Gtk.Fixed):
                             try:
                                 min_height += (
                                     widget.style.padding_top
-                                    + (widget.intrinsic.height.value
-                                    if hasattr(widget.intrinsic.height, "value")
-                                    else widget.intrinsic.height)
+                                    + (
+                                        widget.intrinsic.height.value
+                                        if hasattr(widget.intrinsic.height, "value")
+                                        else widget.intrinsic.height
+                                    )
                                     + widget.style.padding_bottom
                                 )
                             except TypeError:
@@ -271,16 +280,20 @@ class TogaBox(Gtk.Fixed):
                             if (
                                 min_height
                                 <= widget.style.padding_top
-                                + (widget.intrinsic.height.value
-                                if hasattr(widget.intrinsic.height, "value")
-                                else widget.intrinsic.height)
+                                + (
+                                    widget.intrinsic.height.value
+                                    if hasattr(widget.intrinsic.height, "value")
+                                    else widget.intrinsic.height
+                                )
                                 + widget.style.padding_bottom
                             ):
                                 min_height = (
                                     widget.style.padding_top
-                                    + (widget.intrinsic.height.value
-                                    if hasattr(widget.intrinsic.height, "value")
-                                    else widget.intrinsic.height)
+                                    + (
+                                        widget.intrinsic.height.value
+                                        if hasattr(widget.intrinsic.height, "value")
+                                        else widget.intrinsic.height
+                                    )
                                     + widget.style.padding_bottom
                                 )
                         except TypeError:

--- a/src/gtk/toga_gtk/widgets/box.py
+++ b/src/gtk/toga_gtk/widgets/box.py
@@ -19,7 +19,8 @@ class TogaBox(Gtk.Fixed):
             if min_width == 0:
                 for widget in self.interface.children:
                     if str(type(widget)) == "<class 'toga.widgets.box.Box'>":
-                        # Use previously calculated min width from widget._impl.native.get_preferred_width()[0]
+                        # Use previously calculated min width from
+                        # widget._impl.native.get_preferred_width()[0]
                         if widget.style.width:
                             min_width += (
                                 widget.style.padding_right
@@ -32,7 +33,12 @@ class TogaBox(Gtk.Fixed):
                                 + widget._impl.native.get_preferred_width()[0]
                                 + widget.style.padding_left
                             )
-                        # print(".... BOX WIDGET WITH ROW DIRECTION", widget, widget.children, min_width)
+                        # print(
+                        #     ".... BOX WIDGET WITH ROW DIRECTION",
+                        #     widget,
+                        #     widget.children,
+                        #     min_width,
+                        # )
                     else:
                         if widget.style.flex:
                             if widget.style.width:
@@ -42,7 +48,12 @@ class TogaBox(Gtk.Fixed):
                                     + widget.layout.width
                                     + widget.style.padding_left
                                 )
-                                # print(".... NOT BOX WIDGET WITH ROW DIRECTION, FLEX AND HEIGHT", widget, widget.children, min_width)
+                                # print(
+                                #     ".... NOT BOX WIDGET WITH ROW DIRECTION, FLEX AND HEIGHT",
+                                #     widget,
+                                #     widget.children,
+                                #     min_width,
+                                # )
                             else:
                                 min_width += (
                                     widget.style.padding_right
@@ -51,7 +62,12 @@ class TogaBox(Gtk.Fixed):
                                     else widget.intrinsic.width
                                     + widget.style.padding_left
                                 )
-                                # print(".... NOT BOX WIDGET WITH ROW DIRECTION, FLEX AND NO HEIGHT", widget, widget.children, min_width)
+                                # print(
+                                #     ".... NOT BOX WIDGET WITH ROW DIRECTION, FLEX AND NO HEIGHT",
+                                #     widget,
+                                #     widget.children,
+                                #     min_width,
+                                # )
                         else:
                             if widget.style.width:
                                 # The widget is flex but it has width
@@ -60,7 +76,12 @@ class TogaBox(Gtk.Fixed):
                                     + widget.layout.width
                                     + widget.style.padding_left
                                 )
-                                # print(".... NOT BOX WIDGET WITH ROW DIRECTION, NOT FLEX AND HEIGHT", widget, widget.children, min_width)
+                                # print(
+                                #     ".... NOT BOX WIDGET WITH ROW DIRECTION, NOT FLEX AND HEIGHT",
+                                #     widget,
+                                #     widget.children,
+                                #     min_width,
+                                # )
                             else:
                                 # The widget is flex and it has not width
                                 min_width += (
@@ -70,7 +91,12 @@ class TogaBox(Gtk.Fixed):
                                     else widget.intrinsic.width
                                     + widget.style.padding_left
                                 )
-                                # print(".... NOT BOX WIDGET WITH ROW DIRECTION, NOT FLEX AND NO HEIGHT", widget, widget.children, min_width)
+                                # print(
+                                #     ".... NOT BOX WIDGET WITH ROW DIRECTION, NOT FLEX AND NO HEIGHT",
+                                #     widget,
+                                #     widget.children,
+                                #     min_width,
+                                # )
         elif self.interface.style.direction == COLUMN:
             for widget in self.interface.children:
                 if str(type(widget)) == "<class 'toga.widgets.box.Box'>":
@@ -85,7 +111,12 @@ class TogaBox(Gtk.Fixed):
                             + widget._impl.native.get_preferred_width()[0]
                             + widget.style.padding_left
                         )
-                    # print(".... BOX WIDGET WITH COLUMN DIRECTION", widget, widget.children, min_width)
+                    # print(
+                    #     ".... BOX WIDGET WITH COLUMN DIRECTION",
+                    #     widget,
+                    #     widget.children,
+                    #     min_width,
+                    # )
                 else:
                     if widget.style.flex:
                         if widget.style.width:
@@ -101,7 +132,12 @@ class TogaBox(Gtk.Fixed):
                                     + widget.layout.width
                                     + widget.style.padding_left
                                 )
-                            # print(".... NOT BOX WIDGET WITH COLUMN DIRECTION, FLEX AND HEIGHT", widget, widget.children, min_width)
+                            # print(
+                            #     ".... NOT BOX WIDGET WITH COLUMN DIRECTION, FLEX AND HEIGHT",
+                            #     widget,
+                            #     widget.children,
+                            #     min_width,
+                            # )
                         else:
                             # The widget is flex and it does not has width
                             if (
@@ -118,7 +154,12 @@ class TogaBox(Gtk.Fixed):
                                     else widget.intrinsic.width
                                     + widget.style.padding_left
                                 )
-                            # print(".... NOT BOX WIDGET WITH COLUMN DIRECTION, FLEX AND NO HEIGHT", widget, widget.children, min_width)
+                            # print(
+                            #     ".... NOT BOX WIDGET WITH COLUMN DIRECTION, FLEX AND NO HEIGHT",
+                            #     widget,
+                            #     widget.children,
+                            #     min_width,
+                            # )
                     else:
                         # The widget is flex but it has width
                         if widget.style.width:
@@ -134,7 +175,12 @@ class TogaBox(Gtk.Fixed):
                                     + widget.layout.width
                                     + widget.style.padding_left
                                 )
-                            # print(".... NOT BOX WIDGET WITH COLUMN DIRECTION, NOT FLEX AND HEIGHT", widget, widget.children, min_width)
+                            # print(
+                            #     ".... NOT BOX WIDGET WITH COLUMN DIRECTION, NOT FLEX AND HEIGHT",
+                            #     widget,
+                            #     widget.children,
+                            #     min_width,
+                            # )
                         else:
                             # The widget is flex and it has not width
                             if (
@@ -151,7 +197,12 @@ class TogaBox(Gtk.Fixed):
                                     else widget.intrinsic.width
                                     + widget.style.padding_left
                                 )
-                            # print(".... NOT BOX WIDGET WITH COLUMN DIRECTION, NOT FLEX AND NO HEIGHT", widget, widget.children, min_width)
+                            # print(
+                            #     ".... NOT BOX WIDGET WITH COLUMN DIRECTION, NOT FLEX AND NO HEIGHT",
+                            #     widget,
+                            #     widget.children,
+                            #     min_width,
+                            # )
 
         min_width += (
             self.interface.style.padding_right + self.interface.style.padding_left
@@ -173,7 +224,8 @@ class TogaBox(Gtk.Fixed):
             if min_height == 0:
                 for widget in self.interface.children:
                     if str(type(widget)) == "<class 'toga.widgets.box.Box'>":
-                        # Use previously calculated min height from widget._impl.native.get_preferred_height()[0]
+                        # Use previously calculated min height from
+                        # widget._impl.native.get_preferred_height()[0]
                         if widget.style.height:
                             min_height += (
                                 widget.style.padding_top
@@ -186,7 +238,12 @@ class TogaBox(Gtk.Fixed):
                                 + widget._impl.native.get_preferred_height()[0]
                                 + widget.style.padding_bottom
                             )
-                        # print(".... BOX WIDGET WITH COLUMN DIRECTION", widget, widget.children, min_height)
+                        # print(
+                        #     ".... BOX WIDGET WITH COLUMN DIRECTION",
+                        #     widget,
+                        #     widget.children,
+                        #     min_height,
+                        # )
                     else:
                         if widget.style.flex:
                             if widget.style.height:
@@ -196,7 +253,12 @@ class TogaBox(Gtk.Fixed):
                                     + widget.layout.height
                                     + widget.style.padding_bottom
                                 )
-                                # print(".... NOT BOX WIDGET WITH COLUMN DIRECTION, FLEX AND HEIGHT", widget, widget.children, min_height)
+                                # print(
+                                #     ".... NOT BOX WIDGET WITH COLUMN DIRECTION, FLEX AND HEIGHT",
+                                #     widget,
+                                #     widget.children,
+                                #     min_height,
+                                # )
                             else:
                                 min_height += (
                                     widget.style.padding_top
@@ -205,7 +267,12 @@ class TogaBox(Gtk.Fixed):
                                     else widget.intrinsic.height
                                     + widget.style.padding_bottom
                                 )
-                                # print(".... NOT BOX WIDGET WITH COLUMN DIRECTION, FLEX AND NO HEIGHT", widget, widget.children, min_height)
+                                # print(
+                                #     ".... NOT BOX WIDGET WITH COLUMN DIRECTION, FLEX AND NO HEIGHT",
+                                #     widget,
+                                #     widget.children,
+                                #     min_height,
+                                # )
                         else:
                             if widget.style.height:
                                 # The widget is flex but it has height
@@ -214,7 +281,12 @@ class TogaBox(Gtk.Fixed):
                                     + widget.layout.height
                                     + widget.style.padding_bottom
                                 )
-                                # print(".... NOT BOX WIDGET WITH COLUMN DIRECTION, NOT FLEX AND HEIGHT", widget, widget.children, min_height)
+                                # print(
+                                #     ".... NOT BOX WIDGET WITH COLUMN DIRECTION, NOT FLEX AND HEIGHT",
+                                #     widget,
+                                #     widget.children,
+                                #     min_height,
+                                # )
                             else:
                                 # The widget is flex and it has not height
                                 min_height += (
@@ -224,7 +296,12 @@ class TogaBox(Gtk.Fixed):
                                     else widget.intrinsic.height
                                     + widget.style.padding_bottom
                                 )
-                                # print(".... NOT BOX WIDGET WITH COLUMN DIRECTION, NOT FLEX AND NO HEIGHT", widget, widget.children, min_height)
+                                # print(
+                                #     ".... NOT BOX WIDGET WITH COLUMN DIRECTION, NOT FLEX AND NO HEIGHT",
+                                #     widget,
+                                #     widget.children,
+                                #     min_height,
+                                )
         elif self.interface.style.direction == ROW:
             for widget in self.interface.children:
                 if str(type(widget)) == "<class 'toga.widgets.box.Box'>":
@@ -239,7 +316,12 @@ class TogaBox(Gtk.Fixed):
                             + widget._impl.native.get_preferred_height()[0]
                             + widget.style.padding_bottom
                         )
-                    # print(".... BOX WIDGET WITH ROW DIRECTION", widget, widget.children, min_height)
+                    # print(
+                    #     ".... BOX WIDGET WITH ROW DIRECTION",
+                    #     widget,
+                    #     widget.children,
+                    #     min_height,
+                    # )
                 else:
                     if widget.style.flex:
                         if widget.style.height:
@@ -255,7 +337,12 @@ class TogaBox(Gtk.Fixed):
                                     + widget.layout.height
                                     + widget.style.padding_bottom
                                 )
-                            # print(".... NOT BOX WIDGET WITH ROW DIRECTION, FLEX AND HEIGHT", widget, widget.children, min_height)
+                            # print(
+                            #     ".... NOT BOX WIDGET WITH ROW DIRECTION, FLEX AND HEIGHT",
+                            #     widget,
+                            #     widget.children,
+                            #     min_height,
+                            # )
                         else:
                             # The widget is flex and it does not has height
                             if (
@@ -273,7 +360,12 @@ class TogaBox(Gtk.Fixed):
                                     else widget.intrinsic.height
                                     + widget.style.padding_bottom
                                 )
-                            # print(".... NOT BOX WIDGET WITH ROW DIRECTION, FLEX AND NO HEIGHT", widget, widget.children, min_height)
+                            # print(
+                            #     ".... NOT BOX WIDGET WITH ROW DIRECTION, FLEX AND NO HEIGHT",
+                            #     widget,
+                            #     widget.children,
+                            #     min_height,
+                            # )
                     else:
                         # The widget is flex but it has height
                         if widget.style.height:
@@ -289,7 +381,12 @@ class TogaBox(Gtk.Fixed):
                                     + widget.layout.height
                                     + widget.style.padding_bottom
                                 )
-                            # print(".... NOT BOX WIDGET WITH ROW DIRECTION, NOT FLEX AND HEIGHT", widget, widget.children, min_height)
+                            # print(
+                            #     ".... NOT BOX WIDGET WITH ROW DIRECTION, NOT FLEX AND HEIGHT",
+                            #     widget,
+                            #     widget.children,
+                            #     min_height,
+                            # )
                         else:
                             # The widget is flex and it has not height
                             if (
@@ -307,7 +404,12 @@ class TogaBox(Gtk.Fixed):
                                     else widget.intrinsic.height
                                     + widget.style.padding_bottom
                                 )
-                            # print(".... NOT BOX WIDGET WITH ROW DIRECTION, NOT FLEX AND NO HEIGHT", widget, widget.children, min_height)
+                            # print(
+                            #     ".... NOT BOX WIDGET WITH ROW DIRECTION, NOT FLEX AND NO HEIGHT",
+                            #     widget,
+                            #     widget.children,
+                            #     min_height,
+                            # )
 
         min_height += (
             self.interface.style.padding_bottom + self.interface.style.padding_top

--- a/src/gtk/toga_gtk/widgets/box.py
+++ b/src/gtk/toga_gtk/widgets/box.py
@@ -40,63 +40,33 @@ class TogaBox(Gtk.Fixed):
                         #     min_width,
                         # )
                     else:
-                        if widget.style.flex:
-                            if widget.style.width:
-                                # The widget is flex but it has width
-                                min_width += (
-                                    widget.style.padding_right
-                                    + widget.layout.width
-                                    + widget.style.padding_left
-                                )
-                                # print(
-                                #     ".... NOT BOX WIDGET WITH ROW DIRECTION, FLEX AND HEIGHT",
-                                #     widget,
-                                #     widget.children,
-                                #     min_width,
-                                # )
-                            else:
-                                min_width += (
-                                    widget.style.padding_right
-                                    + widget.intrinsic.width.value
-                                    if hasattr(widget.intrinsic.width, "value")
-                                    else widget.intrinsic.width
-                                    + widget.style.padding_left
-                                )
-                                # print(
-                                #     ".... NOT BOX WIDGET WITH ROW DIRECTION, FLEX AND NO HEIGHT",
-                                #     widget,
-                                #     widget.children,
-                                #     min_width,
-                                # )
+                        if widget.style.width:
+                            # The widget has width
+                            min_width += (
+                                widget.style.padding_right
+                                + widget.layout.width
+                                + widget.style.padding_left
+                            )
+                            # print(
+                            #     ".... NOT BOX WIDGET WITH ROW DIRECTION AND HEIGHT",
+                            #     widget,
+                            #     widget.children,
+                            #     min_width,
+                            # )
                         else:
-                            if widget.style.width:
-                                # The widget is flex but it has width
-                                min_width += (
-                                    widget.style.padding_right
-                                    + widget.layout.width
-                                    + widget.style.padding_left
-                                )
-                                # print(
-                                #     ".... NOT BOX WIDGET WITH ROW DIRECTION, NOT FLEX AND HEIGHT",
-                                #     widget,
-                                #     widget.children,
-                                #     min_width,
-                                # )
-                            else:
-                                # The widget is flex and it has not width
-                                min_width += (
-                                    widget.style.padding_right
-                                    + widget.intrinsic.width.value
-                                    if hasattr(widget.intrinsic.width, "value")
-                                    else widget.intrinsic.width
-                                    + widget.style.padding_left
-                                )
-                                # print(
-                                #     ".... NOT BOX WIDGET WITH ROW DIRECTION, NOT FLEX AND NO HEIGHT",
-                                #     widget,
-                                #     widget.children,
-                                #     min_width,
-                                # )
+                            min_width += (
+                                widget.style.padding_right
+                                + widget.intrinsic.width.value
+                                if hasattr(widget.intrinsic.width, "value")
+                                else widget.intrinsic.width
+                                + widget.style.padding_left
+                            )
+                            # print(
+                            #     ".... NOT BOX WIDGET WITH ROW DIRECTION AND NO HEIGHT",
+                            #     widget,
+                            #     widget.children,
+                            #     min_width,
+                            # )
         elif self.interface.style.direction == COLUMN:
             for widget in self.interface.children:
                 if str(type(widget)) == "<class 'toga.widgets.box.Box'>":
@@ -118,91 +88,47 @@ class TogaBox(Gtk.Fixed):
                     #     min_width,
                     # )
                 else:
-                    if widget.style.flex:
-                        if widget.style.width:
-                            # The widget is flex but it has width
-                            if (
-                                min_width
-                                <= widget.style.padding_right
+                    if widget.style.width:
+                        # The widget has width
+                        if (
+                            min_width
+                            <= widget.style.padding_right
+                            + widget.layout.width
+                            + widget.style.padding_left
+                        ):
+                            min_width = (
+                                widget.style.padding_right
                                 + widget.layout.width
                                 + widget.style.padding_left
-                            ):
-                                min_width = (
-                                    widget.style.padding_right
-                                    + widget.layout.width
-                                    + widget.style.padding_left
-                                )
-                            # print(
-                            #     ".... NOT BOX WIDGET WITH COLUMN DIRECTION, FLEX AND HEIGHT",
-                            #     widget,
-                            #     widget.children,
-                            #     min_width,
-                            # )
-                        else:
-                            # The widget is flex and it does not has width
-                            if (
-                                min_width
-                                <= widget.style.padding_right
-                                + widget.intrinsic.width.value
-                                if hasattr(widget.intrinsic.width, "value")
-                                else widget.intrinsic.width + widget.style.padding_left
-                            ):
-                                min_width = (
-                                    widget.style.padding_right
-                                    + widget.intrinsic.width.value
-                                    if hasattr(widget.intrinsic.width, "value")
-                                    else widget.intrinsic.width
-                                    + widget.style.padding_left
-                                )
-                            # print(
-                            #     ".... NOT BOX WIDGET WITH COLUMN DIRECTION, FLEX AND NO HEIGHT",
-                            #     widget,
-                            #     widget.children,
-                            #     min_width,
-                            # )
+                            )
+                        # print(
+                        #     ".... NOT BOX WIDGET WITH COLUMN DIRECTION AND HEIGHT",
+                        #     widget,
+                        #     widget.children,
+                        #     min_width,
+                        # )
                     else:
-                        # The widget is flex but it has width
-                        if widget.style.width:
-                            # The widget is flex but it has width
-                            if (
-                                min_width
-                                <= widget.style.padding_right
-                                + widget.layout.width
-                                + widget.style.padding_left
-                            ):
-                                min_width = (
-                                    widget.style.padding_right
-                                    + widget.layout.width
-                                    + widget.style.padding_left
-                                )
-                            # print(
-                            #     ".... NOT BOX WIDGET WITH COLUMN DIRECTION, NOT FLEX AND HEIGHT",
-                            #     widget,
-                            #     widget.children,
-                            #     min_width,
-                            # )
-                        else:
-                            # The widget is flex and it has not width
-                            if (
-                                min_width
-                                <= widget.style.padding_right
+                        # The widget does not has width
+                        if (
+                            min_width
+                            <= widget.style.padding_right
+                            + widget.intrinsic.width.value
+                            if hasattr(widget.intrinsic.width, "value")
+                            else widget.intrinsic.width + widget.style.padding_left
+                        ):
+                            min_width = (
+                                widget.style.padding_right
                                 + widget.intrinsic.width.value
                                 if hasattr(widget.intrinsic.width, "value")
-                                else widget.intrinsic.width + widget.style.padding_left
-                            ):
-                                min_width = (
-                                    widget.style.padding_right
-                                    + widget.intrinsic.width.value
-                                    if hasattr(widget.intrinsic.width, "value")
-                                    else widget.intrinsic.width
-                                    + widget.style.padding_left
-                                )
-                            # print(
-                            #     ".... NOT BOX WIDGET WITH COLUMN DIRECTION, NOT FLEX AND NO HEIGHT",
-                            #     widget,
-                            #     widget.children,
-                            #     min_width,
-                            # )
+                                else widget.intrinsic.width
+                                + widget.style.padding_left
+                            )
+                        # print(
+                        #     ".... NOT BOX WIDGET WITH COLUMN DIRECTION AND NO HEIGHT",
+                        #     widget,
+                        #     widget.children,
+                        #     min_width,
+                        # )
 
         min_width += (
             self.interface.style.padding_right + self.interface.style.padding_left
@@ -245,63 +171,33 @@ class TogaBox(Gtk.Fixed):
                         #     min_height,
                         # )
                     else:
-                        if widget.style.flex:
-                            if widget.style.height:
-                                # The widget is flex but it has height
-                                min_height += (
-                                    widget.style.padding_top
-                                    + widget.layout.height
-                                    + widget.style.padding_bottom
-                                )
-                                # print(
-                                #     ".... NOT BOX WIDGET WITH COLUMN DIRECTION, FLEX AND HEIGHT",
-                                #     widget,
-                                #     widget.children,
-                                #     min_height,
-                                # )
-                            else:
-                                min_height += (
-                                    widget.style.padding_top
-                                    + widget.intrinsic.height.value
-                                    if hasattr(widget.intrinsic.height, "value")
-                                    else widget.intrinsic.height
-                                    + widget.style.padding_bottom
-                                )
-                                # print(
-                                #     ".... NOT BOX WIDGET WITH COLUMN DIRECTION, FLEX AND NO HEIGHT",
-                                #     widget,
-                                #     widget.children,
-                                #     min_height,
-                                # )
+                        if widget.style.height:
+                            # The widget has height
+                            min_height += (
+                                widget.style.padding_top
+                                + widget.layout.height
+                                + widget.style.padding_bottom
+                            )
+                            # print(
+                            #     ".... NOT BOX WIDGET WITH COLUMN DIRECTION AND HEIGHT",
+                            #     widget,
+                            #     widget.children,
+                            #     min_height,
+                            # )
                         else:
-                            if widget.style.height:
-                                # The widget is flex but it has height
-                                min_height += (
-                                    widget.style.padding_top
-                                    + widget.layout.height
-                                    + widget.style.padding_bottom
-                                )
-                                # print(
-                                #     ".... NOT BOX WIDGET WITH COLUMN DIRECTION, NOT FLEX AND HEIGHT",
-                                #     widget,
-                                #     widget.children,
-                                #     min_height,
-                                # )
-                            else:
-                                # The widget is flex and it has not height
-                                min_height += (
-                                    widget.style.padding_top
-                                    + widget.intrinsic.height.value
-                                    if hasattr(widget.intrinsic.height, "value")
-                                    else widget.intrinsic.height
-                                    + widget.style.padding_bottom
-                                )
-                                # print(
-                                #     ".... NOT BOX WIDGET WITH COLUMN DIRECTION, NOT FLEX AND NO HEIGHT",
-                                #     widget,
-                                #     widget.children,
-                                #     min_height,
-                                # )
+                            min_height += (
+                                widget.style.padding_top
+                                + widget.intrinsic.height.value
+                                if hasattr(widget.intrinsic.height, "value")
+                                else widget.intrinsic.height
+                                + widget.style.padding_bottom
+                            )
+                            # print(
+                            #     ".... NOT BOX WIDGET WITH COLUMN DIRECTION AND NO HEIGHT",
+                            #     widget,
+                            #     widget.children,
+                            #     min_height,
+                            # )
         elif self.interface.style.direction == ROW:
             for widget in self.interface.children:
                 if str(type(widget)) == "<class 'toga.widgets.box.Box'>":
@@ -323,93 +219,48 @@ class TogaBox(Gtk.Fixed):
                     #     min_height,
                     # )
                 else:
-                    if widget.style.flex:
-                        if widget.style.height:
-                            # The widget is flex but it has height
-                            if (
-                                min_height
-                                <= widget.style.padding_top
+                    if widget.style.height:
+                        # The widget has height
+                        if (
+                            min_height
+                            <= widget.style.padding_top
+                            + widget.layout.height
+                            + widget.style.padding_bottom
+                        ):
+                            min_height = (
+                                widget.style.padding_top
                                 + widget.layout.height
                                 + widget.style.padding_bottom
-                            ):
-                                min_height = (
-                                    widget.style.padding_top
-                                    + widget.layout.height
-                                    + widget.style.padding_bottom
-                                )
-                            # print(
-                            #     ".... NOT BOX WIDGET WITH ROW DIRECTION, FLEX AND HEIGHT",
-                            #     widget,
-                            #     widget.children,
-                            #     min_height,
-                            # )
-                        else:
-                            # The widget is flex and it does not has height
-                            if (
-                                min_height
-                                <= widget.style.padding_top
-                                + widget.intrinsic.height.value
-                                if hasattr(widget.intrinsic.height, "value")
-                                else widget.intrinsic.height
-                                + widget.style.padding_bottom
-                            ):
-                                min_height = (
-                                    widget.style.padding_top
-                                    + widget.intrinsic.height.value
-                                    if hasattr(widget.intrinsic.height, "value")
-                                    else widget.intrinsic.height
-                                    + widget.style.padding_bottom
-                                )
-                            # print(
-                            #     ".... NOT BOX WIDGET WITH ROW DIRECTION, FLEX AND NO HEIGHT",
-                            #     widget,
-                            #     widget.children,
-                            #     min_height,
-                            # )
+                            )
+                        # print(
+                        #     ".... NOT BOX WIDGET WITH ROW DIRECTION AND HEIGHT",
+                        #     widget,
+                        #     widget.children,
+                        #     min_height,
+                        # )
                     else:
-                        # The widget is flex but it has height
-                        if widget.style.height:
-                            # The widget is flex but it has height
-                            if (
-                                min_height
-                                <= widget.style.padding_top
-                                + widget.layout.height
-                                + widget.style.padding_bottom
-                            ):
-                                min_height = (
-                                    widget.style.padding_top
-                                    + widget.layout.height
-                                    + widget.style.padding_bottom
-                                )
-                            # print(
-                            #     ".... NOT BOX WIDGET WITH ROW DIRECTION, NOT FLEX AND HEIGHT",
-                            #     widget,
-                            #     widget.children,
-                            #     min_height,
-                            # )
-                        else:
-                            # The widget is flex and it has not height
-                            if (
-                                min_height
-                                <= widget.style.padding_top
+                        # The widget does not has height
+                        if (
+                            min_height
+                            <= widget.style.padding_top
+                            + widget.intrinsic.height.value
+                            if hasattr(widget.intrinsic.height, "value")
+                            else widget.intrinsic.height
+                            + widget.style.padding_bottom
+                        ):
+                            min_height = (
+                                widget.style.padding_top
                                 + widget.intrinsic.height.value
                                 if hasattr(widget.intrinsic.height, "value")
                                 else widget.intrinsic.height
                                 + widget.style.padding_bottom
-                            ):
-                                min_height = (
-                                    widget.style.padding_top
-                                    + widget.intrinsic.height.value
-                                    if hasattr(widget.intrinsic.height, "value")
-                                    else widget.intrinsic.height
-                                    + widget.style.padding_bottom
-                                )
-                            # print(
-                            #     ".... NOT BOX WIDGET WITH ROW DIRECTION, NOT FLEX AND NO HEIGHT",
-                            #     widget,
-                            #     widget.children,
-                            #     min_height,
-                            # )
+                            )
+                        # print(
+                        #     ".... NOT BOX WIDGET WITH ROW DIRECTION AND NO HEIGHT",
+                        #     widget,
+                        #     widget.children,
+                        #     min_height,
+                        # )
 
         min_height += (
             self.interface.style.padding_bottom + self.interface.style.padding_top

--- a/src/gtk/toga_gtk/widgets/canvas.py
+++ b/src/gtk/toga_gtk/widgets/canvas.py
@@ -1,3 +1,5 @@
+from travertino.size import at_least
+
 from ..colors import native_color
 from ..libs import Gtk, Pango, cairo
 from .base import Widget
@@ -171,6 +173,8 @@ class Canvas(Widget):
 
     def rehint(self):
         # print("REHINT", self, self.native.get_preferred_width(), self.native.get_preferred_height())
-        # width = self.native.get_preferred_width()
-        # height = self.native.get_preferred_height()
-        pass
+        width = self.native.get_preferred_width()
+        height = self.native.get_preferred_height()
+
+        self.interface.intrinsic.width = at_least(width[1])
+        self.interface.intrinsic.height = at_least(height[1])

--- a/src/gtk/toga_gtk/widgets/numberinput.py
+++ b/src/gtk/toga_gtk/widgets/numberinput.py
@@ -61,10 +61,13 @@ class NumberInput(Widget):
         self.interface.factory.not_implemented('NumberInput.set_font()')
 
     def rehint(self):
+        # Does not use self.interface.MIN_WIDTH as a minimum width; because
+        # the min width of the widget will fail when number input width be
+        # larger than self.interface.MIN_WIDTH
         width = self.native.get_preferred_width()
         height = self.native.get_preferred_height()
         if width and height:
-            self.interface.intrinsic.width = at_least(self.interface.MIN_WIDTH)
+            self.interface.intrinsic.width = at_least(width[0])
             self.interface.intrinsic.height = height[1]
 
     def set_on_change(self, handler):

--- a/src/gtk/toga_gtk/widgets/selection.py
+++ b/src/gtk/toga_gtk/widgets/selection.py
@@ -33,10 +33,13 @@ class Selection(Widget):
         return self.native.get_active_text()
 
     def rehint(self):
-        # width = self.native.get_preferred_width()
+        # Does not use self.interface.MIN_WIDTH as a minimum width;
+        # because the min width of the widget will fail when item width
+        # be larger than self.interface.MIN_WIDTH
+        width = self.native.get_preferred_width()
         height = self.native.get_preferred_height()
 
-        self.interface.intrinsic.width = at_least(self.interface.MIN_WIDTH)
+        self.interface.intrinsic.width = at_least(width[0])
         self.interface.intrinsic.height = height[1]
 
     def set_on_select(self, handler):

--- a/src/gtk/toga_gtk/window.py
+++ b/src/gtk/toga_gtk/window.py
@@ -106,10 +106,8 @@ class Window:
             child._impl.container = widget
 
     def show(self):
-        self.native.show_all()
-
-        # Now that the content is visible, we can do our initial hinting,
-        # and use that as the basis for setting the minimum window size.
+        # Now we will do our initial hinting, and use that as the basis
+        # for setting the minimum window size.
         self.interface.content._impl.rehint()
         self.interface.content.style.layout(
             self.interface.content,
@@ -117,6 +115,11 @@ class Window:
         )
         self.interface.content._impl.min_width = self.interface.content.layout.width
         self.interface.content._impl.min_height = self.interface.content.layout.height
+
+        # Because we modify gtk backend do_get_preferred_width and
+        # do_get_preferred_height methods, showing the window must be
+        # do after setting our layout.
+        self.native.show_all()
 
     def gtk_delete_event(self, widget, data):
         if self.interface.on_close:


### PR DESCRIPTION
## Describe your changes in detail
As discuss in #1263 PR, this PR addressing the bug of window resizing and widgets size in `gtk` backend and fix them by recalculating the `min_width` and `min_height` using layout provided by the style engine. 

## What problem does this change solve?
This Will fix issue #1205.

## If this PR relates to an issue:
#1205

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
