### PR TITLE
Correct the application of split view weights on cocoa.

### DIFF
--- a/examples/tutorial2/tutorial/app.py
+++ b/examples/tutorial2/tutorial/app.py
@@ -64,7 +64,16 @@ def build(app):
 
     split = toga.SplitContainer()
 
-    split.content = [left_container, right_container]
+    # The content of the split container can be specified as a simple list:
+    #    split.content = [left_container, right_container]
+    # but you can also specify "weight" with each content item, which will
+    # set an initial size of the columns to make a "heavy" column wider than
+    # a narrower one. In this example, the right container will be twice
+    # as wide as the left one.
+    split.content = [
+        (left_container, 1),
+        (right_container, 2)
+    ]
 
     # Create a "Things" menu group to contain some of the commands.
     # No explicit ordering is provided on the group, so it will appear

--- a/src/cocoa/toga_cocoa/widgets/splitcontainer.py
+++ b/src/cocoa/toga_cocoa/widgets/splitcontainer.py
@@ -7,20 +7,23 @@ from .base import Widget
 class TogaSplitViewDelegate(NSObject):
     @objc_method
     def splitView_resizeSubviewsWithOldSize_(self, view, size: NSSize) -> None:
-        if size.width and size.height:
-            # count = len(self.interface.content)
+        # Turn all the weights into a fraction of 1.0
+        total = sum(self.interface._weight)
+        self.interface._weight = [
+            weight / total
+            for weight in self.interface._weight
+        ]
 
-            # Turn all the weights into a fraction of 1.0
-            total = sum(self.interface._weight)
-            self.interface._weight = [
-                weight / total
-                for weight in self.interface._weight
-            ]
-
-            # Set the splitter positions based on the new weight fractions.
-            for i, weight in enumerate(self.interface._weight[:-1]):
-                view.setPosition(size.width * self.interface._weight[i], ofDividerAtIndex=i)
+        # Mark the subviews as needing adjustment
         view.adjustSubviews()
+
+        # Set the splitter positions based on the new weight fractions.
+        if self.interface.direction == self.interface.VERTICAL:
+            for i, weight in enumerate(self.interface._weight[:-1]):
+                view.setPosition(view.frame.size.width * weight, ofDividerAtIndex=i)
+        else:
+            for i, weight in enumerate(self.interface._weight[:-1]):
+                view.setPosition(view.frame.size.height * weight, ofDividerAtIndex=i)
 
     @objc_method
     def splitViewDidResizeSubviews_(self, notification) -> None:


### PR DESCRIPTION
Reported by @hoffenmerCode in #1292

The weight attributes of a SplitContainer were not being applied correctly in Cocoa. This corrects the layout.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
