### PR TITLE
Add solid lines on Android canvas

### DIFF
--- a/src/android/toga_android/factory.py
+++ b/src/android/toga_android/factory.py
@@ -5,6 +5,7 @@ from .images import Image
 from .paths import paths
 from .widgets.box import Box
 from .widgets.button import Button
+from .widgets.canvas import Canvas
 from .widgets.detailedlist import DetailedList
 from .widgets.imageview import ImageView
 from .widgets.label import Label
@@ -29,6 +30,7 @@ __all__ = [
     "App",
     "Box",
     "Button",
+    "Canvas",
     "Font",
     "Icon",
     "Image",

--- a/src/android/toga_android/libs/activity.py
+++ b/src/android/toga_android/libs/activity.py
@@ -8,3 +8,8 @@ MainActivity = JavaClass('org/beeware/android/MainActivity')
 # The `IPythonApp` interface in Java allows Python code to
 # run on Android activity lifecycle hooks such as `onCreate()`.
 IPythonApp = JavaInterface('org/beeware/android/IPythonApp')
+
+# The `CustomView` Java class allows Python code to implement a View's
+# `onDraw()` method, when given a Python implementation of `IView`.
+CustomView = JavaClass('org/beeware/android/CustomView')
+IView = JavaInterface('org/beeware/android/IView')

--- a/src/android/toga_android/libs/activity.py
+++ b/src/android/toga_android/libs/activity.py
@@ -9,7 +9,12 @@ MainActivity = JavaClass('org/beeware/android/MainActivity')
 # run on Android activity lifecycle hooks such as `onCreate()`.
 IPythonApp = JavaInterface('org/beeware/android/IPythonApp')
 
-# The `CustomView` Java class allows Python code to implement a View's
-# `onDraw()` method, when given a Python implementation of `IView`.
-CustomView = JavaClass('org/beeware/android/CustomView')
-IView = JavaInterface('org/beeware/android/IView')
+# The `DrawHandlerView` Java class is an `android.view.View`. It allows user
+# code to draw on its canvas.
+#
+# After a `DrawHandlerView` is constructed, you must provide a draw handler
+# with `setDrawHandler()`. Whenever Android calls the `DrawHandlerView`'s `onDraw()`,
+# the draw handler view will call the draw handler's `handleDraw()` with the
+# `android.graphics.Canvas`.
+DrawHandlerView = JavaClass('org/beeware/android/DrawHandlerView')
+IDrawHandler = JavaInterface('org/beeware/android/IDrawHandler')

--- a/src/android/toga_android/libs/android/graphics.py
+++ b/src/android/toga_android/libs/android/graphics.py
@@ -2,6 +2,9 @@ from rubicon.java import JavaClass
 
 BitmapFactory = JavaClass("android/graphics/BitmapFactory")
 Color = JavaClass("android/graphics/Color")
+Paint = JavaClass("android/graphics/Paint")
+Path = JavaClass("android/graphics/Path")
+Paint__Style = JavaClass("android/graphics/Paint$Style")
 PorterDuff__Mode = JavaClass("android/graphics/PorterDuff$Mode")
 Rect = JavaClass("android/graphics/Rect")
 Typeface = JavaClass("android/graphics/Typeface")

--- a/src/android/toga_android/widgets/canvas.py
+++ b/src/android/toga_android/widgets/canvas.py
@@ -117,3 +117,9 @@ class Canvas(Widget):
 
     def reset_transform(self, draw_context, *args, **kwargs):
         self.interface.factory.not_implemented('Canvas.reset_transform')
+
+    def rect(self, x, y, width, height, draw_context, *args, **kwargs):
+        self.interface.factory.not_implemented('Canvas.rect')
+
+    def measure_text(self, text, font, tight=False):
+        self.interface.factory.not_implemented('Canvas.measure_text')

--- a/src/android/toga_android/widgets/canvas.py
+++ b/src/android/toga_android/widgets/canvas.py
@@ -82,6 +82,25 @@ class Canvas(Widget):
     ):
         self.interface.factory.not_implemented('Canvas.arc()')
 
+    def ellipse(
+        self,
+        x,
+        y,
+        radiusx,
+        radiusy,
+        rotation,
+        startangle,
+        endangle,
+        anticlockwise,
+        draw_context,
+        *args,
+        **kwargs
+    ):
+        self.interface.factory.not_implemented('Canvas.ellipse')
+
+    def rect(self, x, y, width, height, draw_context, *args, **kwargs):
+        self.interface.factory.not_implemented('Canvas.rect')
+
     # Drawing Paths
 
     def fill(self, color, fill_rule, preserve, draw_context, *args, **kwargs):
@@ -100,26 +119,29 @@ class Canvas(Widget):
 
         draw_context.drawPath(self._path, self._draw_paint)
 
-    def set_on_resize(self, handler):
-        self.interface.factory.not_implemented('Canvas.on_resize')
-
-    def write_text(self, text, x, y, font, *args, **kwargs):
-        self.interface.factory.not_implemented('Canvas.write_text')
-
-    def translate(self, tx, ty, draw_context, *args, **kwargs):
-        self.interface.factory.not_implemented('Canvas.translate')
-
-    def scale(self, sx, sy, draw_context, *args, **kwargs):
-        self.interface.factory.not_implemented('Canvas.scale')
+    # Transformations
 
     def rotate(self, radians, draw_context, *args, **kwargs):
         self.interface.factory.not_implemented('Canvas.rotate')
 
+    def scale(self, sx, sy, draw_context, *args, **kwargs):
+        self.interface.factory.not_implemented('Canvas.scale')
+
+    def translate(self, tx, ty, draw_context, *args, **kwargs):
+        self.interface.factory.not_implemented('Canvas.translate')
+
     def reset_transform(self, draw_context, *args, **kwargs):
         self.interface.factory.not_implemented('Canvas.reset_transform')
 
-    def rect(self, x, y, width, height, draw_context, *args, **kwargs):
-        self.interface.factory.not_implemented('Canvas.rect')
+    # Text
 
     def measure_text(self, text, font, tight=False):
         self.interface.factory.not_implemented('Canvas.measure_text')
+
+    def write_text(self, text, x, y, font, *args, **kwargs):
+        self.interface.factory.not_implemented('Canvas.write_text')
+
+    # Rehint
+
+    def set_on_resize(self, handler):
+        self.interface.factory.not_implemented('Canvas.on_resize')

--- a/src/android/toga_android/widgets/canvas.py
+++ b/src/android/toga_android/widgets/canvas.py
@@ -1,0 +1,104 @@
+from ..libs import activity
+from ..libs.android.graphics import Paint, Paint__Style, Path
+from .base import Widget
+
+# Arbitrary scale factor; to be made more specific in the future.
+SCALE_FACTOR = 5
+
+
+class CanvasView(activity.IView):
+    def __init__(self, interface):
+        self.interface = interface
+        super().__init__()
+
+    def onDraw(self, canvas):
+        self.interface._draw(self.interface._impl, draw_context=canvas)
+
+
+class Canvas(Widget):
+    def create(self):
+        self.native = activity.CustomView(self._native_activity.getApplicationContext())
+        self._path = None
+        self._draw_paint = None
+        self.native.setView(CanvasView(self.interface))
+
+    def redraw(self):
+        pass
+
+    def set_on_press(self, handler):
+        self.interface.factory.not_implemented('Canvas.set_on_press()')
+
+    def set_on_release(self, handler):
+        self.interface.factory.not_implemented('Canvas.set_on_release()')
+
+    def set_on_drag(self, handler):
+        self.interface.factory.not_implemented('Canvas.set_on_drag()')
+
+    def set_on_alt_press(self, handler):
+        self.interface.factory.not_implemented('Canvas.set_on_alt_press()')
+
+    def set_on_alt_release(self, handler):
+        self.interface.factory.not_implemented('Canvas.set_on_alt_release()')
+
+    def set_on_alt_drag(self, handler):
+        self.interface.factory.not_implemented('Canvas.set_on_alt_drag()')
+
+    # Basic paths
+
+    def new_path(self, draw_context, *args, **kwargs):
+        self.interface.factory.not_implemented('Canvas.new_path()')
+
+    def closed_path(self, x, y, draw_context, *args, **kwargs):
+        pass
+
+    def move_to(self, x, y, draw_context, *args, **kwargs):
+        self._path = Path()
+        self._path.moveTo(float(x) * SCALE_FACTOR, float(y) * SCALE_FACTOR)
+
+    def line_to(self, x, y, draw_context, *args, **kwargs):
+        self._path.lineTo(float(x) * SCALE_FACTOR, float(y) * SCALE_FACTOR)
+
+    # Basic shapes
+
+    def bezier_curve_to(
+            self, cp1x, cp1y, cp2x, cp2y, x, y, draw_context, *args, **kwargs
+    ):
+        self.interface.factory.not_implemented('Canvas.bezier_curve_to()')
+
+    def quadratic_curve_to(self, cpx, cpy, x, y, draw_context, *args, **kwargs):
+        self.interface.factory.not_implemented('Canvas.quadratic_curve_to()')
+
+    def arc(
+            self,
+            x,
+            y,
+            radius,
+            startangle,
+            endangle,
+            anticlockwise,
+            draw_context,
+            *args,
+            **kwargs
+    ):
+        self.interface.factory.not_implemented('Canvas.arc()')
+
+    # Drawing Paths
+
+    def fill(self, color, fill_rule, preserve, draw_context, *args, **kwargs):
+        self.interface.factory.not_implemented('Canvas.fill()')
+
+    def stroke(self, color, line_width, line_dash, draw_context, *args, **kwargs):
+        self._draw_paint = Paint()
+        self._draw_paint.setAntiAlias(True)
+        self._draw_paint.setStrokeWidth(float(line_width) * SCALE_FACTOR)
+        self._draw_paint.setStyle(Paint__Style.STROKE)
+        if color is None:
+            a, r, g, b = 255, 0, 0, 0
+        else:
+            a, r, g, b = round(color.a * 255), int(color.r), int(color.g), int(color.b)
+        self._draw_paint.setARGB(a, r, g, b)
+
+        draw_context.drawPath(self._path, self._draw_paint)
+
+    def set_on_resize(self, handler):
+        self.interface.factory.not_implemented('Canvas.on_resize')

--- a/src/android/toga_android/widgets/canvas.py
+++ b/src/android/toga_android/widgets/canvas.py
@@ -6,21 +6,23 @@ from .base import Widget
 SCALE_FACTOR = 5
 
 
-class CanvasView(activity.IView):
+class DrawHandler(activity.IDrawHandler):
     def __init__(self, interface):
         self.interface = interface
         super().__init__()
 
-    def onDraw(self, canvas):
+    def handleDraw(self, canvas):
         self.interface._draw(self.interface._impl, draw_context=canvas)
 
 
 class Canvas(Widget):
     def create(self):
-        self.native = activity.CustomView(self._native_activity.getApplicationContext())
+        # Our native widget is a DrawHandlerView, which delegates drawing to DrawHandler,
+        # so we can pass the `android.graphics.Canvas` around as `draw_context`.
+        self.native = activity.DrawHandlerView(self._native_activity.getApplicationContext())
+        self.native.setDrawHandler(DrawHandler(self.interface))
         self._path = None
         self._draw_paint = None
-        self.native.setView(CanvasView(self.interface))
 
     def redraw(self):
         pass

--- a/src/android/toga_android/widgets/canvas.py
+++ b/src/android/toga_android/widgets/canvas.py
@@ -102,3 +102,18 @@ class Canvas(Widget):
 
     def set_on_resize(self, handler):
         self.interface.factory.not_implemented('Canvas.on_resize')
+
+    def write_text(self, text, x, y, font, *args, **kwargs):
+        self.interface.factory.not_implemented('Canvas.write_text')
+
+    def translate(self, tx, ty, draw_context, *args, **kwargs):
+        self.interface.factory.not_implemented('Canvas.translate')
+
+    def scale(self, sx, sy, draw_context, *args, **kwargs):
+        self.interface.factory.not_implemented('Canvas.scale')
+
+    def rotate(self, radians, draw_context, *args, **kwargs):
+        self.interface.factory.not_implemented('Canvas.rotate')
+
+    def reset_transform(self, draw_context, *args, **kwargs):
+        self.interface.factory.not_implemented('Canvas.reset_transform')


### PR DESCRIPTION
Add drawing solid lines on Android canvas.

This makes progress toward implementing the Canvas widget on Android generally.

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct

## Testing done

I made a sample app here: https://github.com/paulproteus/toganvas/blob/main/toganvas/src/toganvas/app.py / https://github.com/paulproteus/toganvas

On iOS and on Android, it looks as follows.

![image](https://user-images.githubusercontent.com/25457/126588810-5a7e2f8a-ad58-4273-9334-9fb01af190a3.png)

![image](https://user-images.githubusercontent.com/25457/126588817-0f237386-6124-4aca-aba4-76c24303ef0b.png)

There's lots more work to do, but I thought it would be nice for my motivation to submit some progress via this pull request.
