### PR TITLE
Scale Android canvas properly

### DIFF
--- a/src/android/toga_android/widgets/canvas.py
+++ b/src/android/toga_android/widgets/canvas.py
@@ -2,9 +2,6 @@ from ..libs import activity
 from ..libs.android.graphics import Paint, Paint__Style, Path
 from .base import Widget
 
-# Arbitrary scale factor; to be made more specific in the future.
-SCALE_FACTOR = 5
-
 
 class DrawHandler(activity.IDrawHandler):
     def __init__(self, interface):
@@ -12,7 +9,8 @@ class DrawHandler(activity.IDrawHandler):
         super().__init__()
 
     def handleDraw(self, canvas):
-        self.interface._draw(self.interface._impl, draw_context=canvas)
+        scale_factor = self.interface._impl.viewport.dpi / self.interface._impl.viewport.baseline_dpi
+        self.interface._draw(self.interface._impl, scale_factor=scale_factor, draw_context=canvas)
 
 
 class Canvas(Widget):
@@ -53,12 +51,14 @@ class Canvas(Widget):
     def closed_path(self, x, y, draw_context, *args, **kwargs):
         pass
 
-    def move_to(self, x, y, draw_context, *args, **kwargs):
+    def move_to(self, x, y, scale_factor, *args, **kwargs):
         self._path = Path()
-        self._path.moveTo(float(x) * SCALE_FACTOR, float(y) * SCALE_FACTOR)
+        self._path.moveTo(float(x) * scale_factor,
+                          float(y) * scale_factor)
 
-    def line_to(self, x, y, draw_context, *args, **kwargs):
-        self._path.lineTo(float(x) * SCALE_FACTOR, float(y) * SCALE_FACTOR)
+    def line_to(self, x, y, scale_factor, *args, **kwargs):
+        self._path.lineTo(float(x) * scale_factor,
+                          float(y) * scale_factor)
 
     # Basic shapes
 
@@ -108,10 +108,10 @@ class Canvas(Widget):
     def fill(self, color, fill_rule, preserve, draw_context, *args, **kwargs):
         self.interface.factory.not_implemented('Canvas.fill()')
 
-    def stroke(self, color, line_width, line_dash, draw_context, *args, **kwargs):
+    def stroke(self, color, line_width, line_dash, draw_context, scale_factor, *args, **kwargs):
         self._draw_paint = Paint()
         self._draw_paint.setAntiAlias(True)
-        self._draw_paint.setStrokeWidth(float(line_width) * SCALE_FACTOR)
+        self._draw_paint.setStrokeWidth(float(line_width) * scale_factor)
         self._draw_paint.setStyle(Paint__Style.STROKE)
         if color is None:
             a, r, g, b = 255, 0, 0, 0

--- a/src/android/toga_android/widgets/canvas.py
+++ b/src/android/toga_android/widgets/canvas.py
@@ -52,12 +52,12 @@ class Canvas(Widget):
 
     def move_to(self, x, y, *args, **kwargs):
         self._path = Path()
-        self._path.moveTo(self.interface._impl.viewport.scale(x),
-                          self.interface._impl.viewport.scale(y))
+        self._path.moveTo(self.viewport.scale * x,
+                          self.viewport.scale * y)
 
     def line_to(self, x, y, *args, **kwargs):
-        self._path.lineTo(self.interface._impl.viewport.scale(x),
-                          self.interface._impl.viewport.scale(y))
+        self._path.lineTo(self.viewport.scale * x,
+                          self.viewport.scale * y)
 
     # Basic shapes
 
@@ -110,7 +110,7 @@ class Canvas(Widget):
     def stroke(self, color, line_width, line_dash, draw_context, *args, **kwargs):
         self._draw_paint = Paint()
         self._draw_paint.setAntiAlias(True)
-        self._draw_paint.setStrokeWidth(self.interface._impl.viewport.scale(line_width))
+        self._draw_paint.setStrokeWidth(self.viewport.scale * line_width)
         self._draw_paint.setStyle(Paint__Style.STROKE)
         if color is None:
             a, r, g, b = 255, 0, 0, 0

--- a/src/android/toga_android/widgets/canvas.py
+++ b/src/android/toga_android/widgets/canvas.py
@@ -9,8 +9,7 @@ class DrawHandler(activity.IDrawHandler):
         super().__init__()
 
     def handleDraw(self, canvas):
-        scale_factor = self.interface._impl.viewport.dpi / self.interface._impl.viewport.baseline_dpi
-        self.interface._draw(self.interface._impl, scale_factor=scale_factor, draw_context=canvas)
+        self.interface._draw(self.interface._impl, draw_context=canvas)
 
 
 class Canvas(Widget):
@@ -51,14 +50,14 @@ class Canvas(Widget):
     def closed_path(self, x, y, draw_context, *args, **kwargs):
         pass
 
-    def move_to(self, x, y, scale_factor, *args, **kwargs):
+    def move_to(self, x, y, *args, **kwargs):
         self._path = Path()
-        self._path.moveTo(float(x) * scale_factor,
-                          float(y) * scale_factor)
+        self._path.moveTo(self.interface._impl.viewport.scale(x),
+                          self.interface._impl.viewport.scale(y))
 
-    def line_to(self, x, y, scale_factor, *args, **kwargs):
-        self._path.lineTo(float(x) * scale_factor,
-                          float(y) * scale_factor)
+    def line_to(self, x, y, *args, **kwargs):
+        self._path.lineTo(self.interface._impl.viewport.scale(x),
+                          self.interface._impl.viewport.scale(y))
 
     # Basic shapes
 
@@ -108,10 +107,10 @@ class Canvas(Widget):
     def fill(self, color, fill_rule, preserve, draw_context, *args, **kwargs):
         self.interface.factory.not_implemented('Canvas.fill()')
 
-    def stroke(self, color, line_width, line_dash, draw_context, scale_factor, *args, **kwargs):
+    def stroke(self, color, line_width, line_dash, draw_context, *args, **kwargs):
         self._draw_paint = Paint()
         self._draw_paint.setAntiAlias(True)
-        self._draw_paint.setStrokeWidth(float(line_width) * scale_factor)
+        self._draw_paint.setStrokeWidth(self.interface._impl.viewport.scale(line_width))
         self._draw_paint.setStyle(Paint__Style.STROKE)
         if color is None:
             a, r, g, b = 255, 0, 0, 0

--- a/src/android/toga_android/window.py
+++ b/src/android/toga_android/window.py
@@ -10,10 +10,7 @@ class AndroidViewport:
         # Toga needs to know how the current DPI compares to the platform default,
         # which is 160: https://developer.android.com/training/multiscreen/screendensities
         self.baseline_dpi = 160
-        self._scale_factor = float(self.dpi / self.baseline_dpi)
-
-    def scale(self, x):
-        return self._scale_factor * x
+        self.scale = float(self.dpi / self.baseline_dpi)
 
     @property
     def width(self):

--- a/src/android/toga_android/window.py
+++ b/src/android/toga_android/window.py
@@ -10,7 +10,7 @@ class AndroidViewport:
         # Toga needs to know how the current DPI compares to the platform default,
         # which is 160: https://developer.android.com/training/multiscreen/screendensities
         self.baseline_dpi = 160
-        self.scale = float(self.dpi / self.baseline_dpi)
+        self.scale = float(self.dpi) / self.baseline_dpi
 
     @property
     def width(self):

--- a/src/android/toga_android/window.py
+++ b/src/android/toga_android/window.py
@@ -10,6 +10,10 @@ class AndroidViewport:
         # Toga needs to know how the current DPI compares to the platform default,
         # which is 160: https://developer.android.com/training/multiscreen/screendensities
         self.baseline_dpi = 160
+        self._scale_factor = float(self.dpi / self.baseline_dpi)
+
+    def scale(self, x):
+        return self._scale_factor * x
 
     @property
     def width(self):


### PR DESCRIPTION
Use Android viewport DPI (vs. baseline DPI) to compute Canvas scale factor.

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct

## Testing performed

I resized an Android virtual device to approx the same size as iOS, and I used the https://github.com/paulproteus/toganvas codebase to draw a colored "X". Here's what it looks like.

![image](https://user-images.githubusercontent.com/25457/127954676-30b15b9a-c38c-4413-9e45-f912725ca20a.png)

![image](https://user-images.githubusercontent.com/25457/127954686-717b8816-9f00-4510-9184-2e4c1194a0e6.png)

Pretty similar.

## Rationale

This is the same way we adjust pixel size for during layout:

https://github.com/beeware/toga/blob/19e89a77f1bacddc09110fd5c240ea4ecbf85b2a/src/core/toga/style/pack.py#L116-L118

I wanted to use a keyword argument for `scale_factor` and compute it only once, hence the computation within `DrawHandler#handle_draw`.