### PR TITLE
Android dashed line canvas

### DIFF
--- a/src/android/toga_android/libs/android/graphics.py
+++ b/src/android/toga_android/libs/android/graphics.py
@@ -2,6 +2,7 @@ from rubicon.java import JavaClass
 
 BitmapFactory = JavaClass("android/graphics/BitmapFactory")
 Color = JavaClass("android/graphics/Color")
+DashPathEffect = JavaClass("android/graphics/DashPathEffect")
 Paint = JavaClass("android/graphics/Paint")
 Path = JavaClass("android/graphics/Path")
 Paint__Style = JavaClass("android/graphics/Paint$Style")

--- a/src/android/toga_android/widgets/canvas.py
+++ b/src/android/toga_android/widgets/canvas.py
@@ -2,9 +2,6 @@ from ..libs import activity
 from ..libs.android.graphics import Paint, Paint__Style, Path
 from .base import Widget
 
-# Arbitrary scale factor; to be made more specific in the future.
-SCALE_FACTOR = 5
-
 
 class DrawHandler(activity.IDrawHandler):
     def __init__(self, interface):
@@ -12,7 +9,8 @@ class DrawHandler(activity.IDrawHandler):
         super().__init__()
 
     def handleDraw(self, canvas):
-        self.interface._draw(self.interface._impl, draw_context=canvas)
+        scale_factor = self.interface._impl.viewport.dpi / self.interface._impl.viewport.baseline_dpi
+        self.interface._draw(self.interface._impl, scale_factor=scale_factor, draw_context=canvas)
 
 
 class Canvas(Widget):
@@ -53,12 +51,14 @@ class Canvas(Widget):
     def closed_path(self, x, y, draw_context, *args, **kwargs):
         pass
 
-    def move_to(self, x, y, draw_context, *args, **kwargs):
+    def move_to(self, x, y, scale_factor, *args, **kwargs):
         self._path = Path()
-        self._path.moveTo(float(x) * SCALE_FACTOR, float(y) * SCALE_FACTOR)
+        self._path.moveTo(float(x) * scale_factor,
+                          float(y) * scale_factor)
 
-    def line_to(self, x, y, draw_context, *args, **kwargs):
-        self._path.lineTo(float(x) * SCALE_FACTOR, float(y) * SCALE_FACTOR)
+    def line_to(self, x, y, scale_factor, *args, **kwargs):
+        self._path.lineTo(float(x) * scale_factor,
+                          float(y) * scale_factor)
 
     # Basic shapes
 
@@ -108,10 +108,10 @@ class Canvas(Widget):
     def fill(self, color, fill_rule, preserve, draw_context, *args, **kwargs):
         self.interface.factory.not_implemented('Canvas.fill()')
 
-    def stroke(self, color, line_width, line_dash, draw_context, *args, **kwargs):
+    def stroke(self, color, line_width, line_dash, draw_context, scale_factor, *args, **kwargs):
         self._draw_paint = Paint()
         self._draw_paint.setAntiAlias(True)
-        self._draw_paint.setStrokeWidth(float(line_width) * SCALE_FACTOR)
+        self._draw_paint.setStrokeWidth(float(line_width) * scale_factor)
         self._draw_paint.setStyle(Paint__Style.STROKE)
         if color is None:
             a, r, g, b = 255, 0, 0, 0

--- a/src/android/toga_android/widgets/canvas.py
+++ b/src/android/toga_android/widgets/canvas.py
@@ -52,12 +52,12 @@ class Canvas(Widget):
 
     def move_to(self, x, y, *args, **kwargs):
         self._path = Path()
-        self._path.moveTo(self.interface._impl.viewport.scale(x),
-                          self.interface._impl.viewport.scale(y))
+        self._path.moveTo(self.viewport.scale * x,
+                          self.viewport.scale * y)
 
     def line_to(self, x, y, *args, **kwargs):
-        self._path.lineTo(self.interface._impl.viewport.scale(x),
-                          self.interface._impl.viewport.scale(y))
+        self._path.lineTo(self.viewport.scale * x,
+                          self.viewport.scale * y)
 
     # Basic shapes
 
@@ -110,7 +110,7 @@ class Canvas(Widget):
     def stroke(self, color, line_width, line_dash, draw_context, *args, **kwargs):
         self._draw_paint = Paint()
         self._draw_paint.setAntiAlias(True)
-        self._draw_paint.setStrokeWidth(self.interface._impl.viewport.scale(line_width))
+        self._draw_paint.setStrokeWidth(self.viewport.scale * line_width)
         self._draw_paint.setStyle(Paint__Style.STROKE)
         if color is None:
             a, r, g, b = 255, 0, 0, 0

--- a/src/android/toga_android/widgets/canvas.py
+++ b/src/android/toga_android/widgets/canvas.py
@@ -1,5 +1,5 @@
 from ..libs import activity
-from ..libs.android.graphics import Paint, Paint__Style, Path
+from ..libs.android.graphics import DashPathEffect, Paint, Paint__Style, Path
 from .base import Widget
 
 
@@ -116,6 +116,9 @@ class Canvas(Widget):
             a, r, g, b = 255, 0, 0, 0
         else:
             a, r, g, b = round(color.a * 255), int(color.r), int(color.g), int(color.b)
+        if line_dash is not None:
+            self._draw_paint.setPathEffect(DashPathEffect(
+                [(self.viewport.scale * float(d)) for d in line_dash], 0.0))
         self._draw_paint.setARGB(a, r, g, b)
 
         draw_context.drawPath(self._path, self._draw_paint)

--- a/src/android/toga_android/widgets/canvas.py
+++ b/src/android/toga_android/widgets/canvas.py
@@ -9,8 +9,7 @@ class DrawHandler(activity.IDrawHandler):
         super().__init__()
 
     def handleDraw(self, canvas):
-        scale_factor = self.interface._impl.viewport.dpi / self.interface._impl.viewport.baseline_dpi
-        self.interface._draw(self.interface._impl, scale_factor=scale_factor, draw_context=canvas)
+        self.interface._draw(self.interface._impl, draw_context=canvas)
 
 
 class Canvas(Widget):
@@ -51,14 +50,14 @@ class Canvas(Widget):
     def closed_path(self, x, y, draw_context, *args, **kwargs):
         pass
 
-    def move_to(self, x, y, scale_factor, *args, **kwargs):
+    def move_to(self, x, y, *args, **kwargs):
         self._path = Path()
-        self._path.moveTo(float(x) * scale_factor,
-                          float(y) * scale_factor)
+        self._path.moveTo(self.interface._impl.viewport.scale(x),
+                          self.interface._impl.viewport.scale(y))
 
-    def line_to(self, x, y, scale_factor, *args, **kwargs):
-        self._path.lineTo(float(x) * scale_factor,
-                          float(y) * scale_factor)
+    def line_to(self, x, y, *args, **kwargs):
+        self._path.lineTo(self.interface._impl.viewport.scale(x),
+                          self.interface._impl.viewport.scale(y))
 
     # Basic shapes
 
@@ -108,10 +107,10 @@ class Canvas(Widget):
     def fill(self, color, fill_rule, preserve, draw_context, *args, **kwargs):
         self.interface.factory.not_implemented('Canvas.fill()')
 
-    def stroke(self, color, line_width, line_dash, draw_context, scale_factor, *args, **kwargs):
+    def stroke(self, color, line_width, line_dash, draw_context, *args, **kwargs):
         self._draw_paint = Paint()
         self._draw_paint.setAntiAlias(True)
-        self._draw_paint.setStrokeWidth(float(line_width) * scale_factor)
+        self._draw_paint.setStrokeWidth(self.interface._impl.viewport.scale(line_width))
         self._draw_paint.setStyle(Paint__Style.STROKE)
         if color is None:
             a, r, g, b = 255, 0, 0, 0

--- a/src/android/toga_android/window.py
+++ b/src/android/toga_android/window.py
@@ -10,10 +10,7 @@ class AndroidViewport:
         # Toga needs to know how the current DPI compares to the platform default,
         # which is 160: https://developer.android.com/training/multiscreen/screendensities
         self.baseline_dpi = 160
-        self._scale_factor = float(self.dpi / self.baseline_dpi)
-
-    def scale(self, x):
-        return self._scale_factor * x
+        self.scale = float(self.dpi / self.baseline_dpi)
 
     @property
     def width(self):

--- a/src/android/toga_android/window.py
+++ b/src/android/toga_android/window.py
@@ -10,7 +10,7 @@ class AndroidViewport:
         # Toga needs to know how the current DPI compares to the platform default,
         # which is 160: https://developer.android.com/training/multiscreen/screendensities
         self.baseline_dpi = 160
-        self.scale = float(self.dpi / self.baseline_dpi)
+        self.scale = float(self.dpi) / self.baseline_dpi
 
     @property
     def width(self):

--- a/src/android/toga_android/window.py
+++ b/src/android/toga_android/window.py
@@ -10,6 +10,10 @@ class AndroidViewport:
         # Toga needs to know how the current DPI compares to the platform default,
         # which is 160: https://developer.android.com/training/multiscreen/screendensities
         self.baseline_dpi = 160
+        self._scale_factor = float(self.dpi / self.baseline_dpi)
+
+    def scale(self, x):
+        return self._scale_factor * x
 
     @property
     def width(self):


### PR DESCRIPTION
Add dashed line support to Android Canvas

(depends on #1317 )

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct

## Comparison screenshots & questions

Android:

![image](https://user-images.githubusercontent.com/25457/128966813-65a60d92-3d47-4b05-bcff-b95f78a89a3e.png)


iOS:

![image](https://user-images.githubusercontent.com/25457/128966831-46b32abd-bc80-4466-97b0-9f67c9f9c32f.png)

I can't think of a way to make sense of `[4, 4]` resulting in what I see on iOS. Is the Toga iOS port buggy? Who's right? :D 