### PR TITLE
Fix closing window without the close button

### DIFF
--- a/src/cocoa/toga_cocoa/window.py
+++ b/src/cocoa/toga_cocoa/window.py
@@ -266,9 +266,10 @@ class Window:
         return should_close
 
     def close(self):
-        # Calling performClose instead of close ensures that the on_close
-        # handlers in the delegates will be called
-        self.native.performClose(self.native)
+        # Close window directly here, don't use `NSWindow.performClose()`
+        # because it won't work if the window does not have a close button.
+        if self.cocoa_windowShouldClose():
+            self.native.close()
 
     def info_dialog(self, title, message):
         return dialogs.info(self.interface, title, message)

--- a/src/core/toga/window.py
+++ b/src/core/toga/window.py
@@ -186,19 +186,21 @@ class Window:
 
     @property
     def on_close(self):
-        """The handler to invoke when the window is closed.
+        """The handler to invoke before the window is closed.
 
         Returns:
-            The function ``callable`` that is called on window closing event.
+            The function ``callable`` that is called before the window is closed.
         """
         return self._on_close
 
     @on_close.setter
     def on_close(self, handler):
-        """Set the handler to invoke when the window is closed.
+        """Set the handler to invoke when before window is closed. If the handler
+        returns ``False``, the window will not be closed. This can be used for example
+        for confirmation dialogs.
 
         Args:
-            handler (:obj:`callable`): The handler to invoke when the window is closing.
+            handler (:obj:`callable`): The handler to invoke before the window is closed.
         """
         self._on_close = wrapped_handler(self, handler)
         self._impl.set_on_close(self._on_close)


### PR DESCRIPTION
This PR fixes #1329 which prevents windows with a disabled a close button on macOS from being closed programatically.

It also updates the doc string for `toga.Window.on_close`.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
