### PR TITLE
Add support for foreground colors in TextInput

### DIFF
--- a/src/cocoa/toga_cocoa/widgets/textinput.py
+++ b/src/cocoa/toga_cocoa/widgets/textinput.py
@@ -1,6 +1,8 @@
 from travertino.size import at_least
 
+from toga_cocoa.colors import native_color
 from toga_cocoa.libs import (
+    NSColor,
     NSTextAlignment,
     NSTextField,
     NSTextFieldSquareBezel,
@@ -70,6 +72,12 @@ class TextInput(Widget):
     def set_font(self, font):
         if font:
             self.native.font = font.bind(self.interface.factory).native
+
+    def set_color(self, color):
+        if color:
+            self.native.textColor = native_color(color)
+        else:
+            self.native.textColor = NSColor.labelColor
 
     def get_value(self):
         return str(self.native.stringValue)

--- a/src/winforms/toga_winforms/widgets/textinput.py
+++ b/src/winforms/toga_winforms/widgets/textinput.py
@@ -2,7 +2,9 @@ from ctypes import c_uint
 from ctypes.wintypes import HWND, WPARAM
 
 from travertino.size import at_least
+from travertino.constants import TRANSPARENT
 
+from toga_winforms.colors import native_color
 from toga_winforms.libs import HorizontalTextAlignment, WinForms, user32
 
 from .base import Widget
@@ -51,6 +53,18 @@ class TextInput(Widget):
     def set_font(self, font):
         if font:
             self.native.Font = font.bind(self.interface.factory).native
+
+    def set_color(self, color):
+        if color:
+            self.native.ForeColor = native_color(color)
+        else:
+            self.native.ForeColor = self.native.DefaultForeColor
+
+    def set_background_color(self, value):
+        if value:
+            self.native.BackColor = native_color(value)
+        else:
+            self.native.BackColor = native_color(TRANSPARENT)
 
     def rehint(self):
         # Height of a text input is known and fixed.


### PR DESCRIPTION
Adds support for `color` style directives on TextInput widgets

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
