### PR TITLE
Speed up creation of Cocoa TableViews

### DIFF
--- a/examples/table/table/app.py
+++ b/examples/table/table/app.py
@@ -67,14 +67,9 @@ class ExampleTableApp(toga.App):
         self.label_table2 = toga.Label('Try multiple row selection.', style=Pack(flex=1, padding_left=5))
         labelbox = toga.Box(children=[self.label_table1, self.label_table2], style=Pack(flex=0, padding_top=5))
 
-        # Data to populate the table.
-        data = []
-        for x in range(5):
-            data.append(tuple(str(x) for x in range(5)))
-
         self.table1 = toga.Table(
             headings=headings,
-            data=bee_movies[:4],
+            data=bee_movies*1000,
             style=Pack(flex=1, padding_right=5),
             multiple_select=False,
             on_select=self.on_select_handler1

--- a/src/cocoa/toga_cocoa/widgets/table.py
+++ b/src/cocoa/toga_cocoa/widgets/table.py
@@ -112,25 +112,29 @@ class TogaTable(NSTableView):
         if self.interface.on_select:
             self.interface.on_select(self.interface, row=selected)
 
-    @objc_method
-    def tableView_heightOfRow_(self, table, row: int) -> float:
-
-        default_row_height = self.rowHeight
-        margin = 2
-
-        # get all views in column
-        data_row = self.interface.data[row]
-
-        heights = [default_row_height]
-
-        for column in self.tableColumns:
-            col_identifier = str(column.identifier)
-            value = getattr(data_row, col_identifier, None)
-            if isinstance(value, toga.Widget):
-                # if the cell value is a widget, use its height
-                heights.append(value._impl.native.intrinsicContentSize().height + margin)
-
-        return max(heights)
+    # 2021-09-04: Commented out this method because it appears to be a
+    # source of significant slowdown when the table has a lot of data
+    # (10k rows). AFAICT, it's only needed if we want custom row heights
+    # for each row. Since we don't currently support custom row heights,
+    # we're paying the cost for no benefit.
+    # @objc_method
+    # def tableView_heightOfRow_(self, table, row: int) -> float:
+    #     default_row_height = self.rowHeight
+    #     margin = 2
+    #
+    #     # get all views in column
+    #     data_row = self.interface.data[row]
+    #
+    #     heights = [default_row_height]
+    #
+    #     for column in self.tableColumns:
+    #         col_identifier = str(column.identifier)
+    #         value = getattr(data_row, col_identifier, None)
+    #         if isinstance(value, toga.Widget):
+    #             # if the cell value is a widget, use its height
+    #             heights.append(value._impl.native.intrinsicContentSize().height + margin)
+    #
+    #     return max(heights)
 
     # target methods
     @objc_method


### PR DESCRIPTION
Significantly speeds up the instantiation time on Cocoa tables.

When the TableViewDelegate provides tableView:heightOfRow:, it is invoked for *every* row in the table. If you have a large table (50k rows), that takes a lot of time, even if you return a constant.

However, you only need to implement this method if the table rows have custom or different heights per-row. Since we don't currently support that feature, we're paying a cost for no benefit.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
