### PR TITLE
Ensure data objects used by DetailedList are correctly retained

### DIFF
--- a/src/cocoa/toga_cocoa/widgets/detailedlist.py
+++ b/src/cocoa/toga_cocoa/widgets/detailedlist.py
@@ -57,6 +57,7 @@ class TogaList(NSTableView):
             data = value._impl
         except AttributeError:
             data = TogaData.alloc().init()
+            data.retain()
             value._impl = data
 
         data.attrs = {

--- a/src/cocoa/toga_cocoa/widgets/internal/data.py
+++ b/src/cocoa/toga_cocoa/widgets/internal/data.py
@@ -4,6 +4,7 @@ from toga_cocoa.libs import NSObject, objc_method
 class TogaData(NSObject):
     @objc_method
     def copyWithZone_(self):
-        copy = TogaData.alloc().init()
-        copy.attrs = self.attrs
-        return copy
+        # TogaData is used as an immutable reference to a row
+        # so the same object can be returned as a copy.
+        self.retain()
+        return self


### PR DESCRIPTION
DetailedList examples (beeliza, detailedlist) were both crashing as of dc565f9c5d. I couldn't narrow down a specific change where this problem was introduced; it appears that it may have *always* been there, but something subtle in a recent macOS change has surfaced the problem. 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
