### PR TITLE
Fix handling of font traits on Cocoa.

### DIFF
--- a/src/cocoa/toga_cocoa/fonts.py
+++ b/src/cocoa/toga_cocoa/fonts.py
@@ -2,11 +2,13 @@ from toga.fonts import (
     BOLD,
     CURSIVE,
     FANTASY,
+    ITALIC,
     MESSAGE,
     MONOSPACE,
     NORMAL,
     SANS_SERIF,
     SERIF,
+    SMALL_CAPS,
     SYSTEM,
     SYSTEM_DEFAULT_FONT_SIZE
 )
@@ -14,6 +16,8 @@ from toga_cocoa.libs import (
     NSAttributedString,
     NSFont,
     NSFontAttributeName,
+    NSFontManager,
+    NSFontMask,
     NSMutableDictionary
 )
 
@@ -53,12 +57,33 @@ class Font:
                 else:
                     family = self.interface.family
 
+                font = NSFont.fontWithName(family, size=self.interface.size)
+
+                if font is None:
+                    print(
+                        "Unable to load font: {}pt {}".format(
+                            self.interface.size, family
+                        )
+                    )
+
+                # Convert the base font definition into a font with all the desired traits.
+                attributes_mask = 0
+                if self.interface.weight == BOLD:
+                    attributes_mask |= NSFontMask.Bold.value
+
+                if self.interface.style == ITALIC:
+                    attributes_mask |= NSFontMask.Italic.value
+                elif self.interface.style == SMALL_CAPS:
+                    attributes_mask |= NSFontMask.SmallCaps.value
+
+                if attributes_mask:
+                    font = NSFontManager.sharedFontManager.convertFont(font, toHaveTrait=attributes_mask)
+
                 full_name = '{family}{weight}{style}'.format(
                     family=family,
                     weight=(' ' + self.interface.weight.title()) if self.interface.weight is not NORMAL else '',
                     style=(' ' + self.interface.style.title()) if self.interface.style is not NORMAL else '',
                 )
-                font = NSFont.fontWithName(full_name, size=self.interface.size)
 
                 if font is None:
                     print(

--- a/src/cocoa/toga_cocoa/libs/appkit.py
+++ b/src/cocoa/toga_cocoa/libs/appkit.py
@@ -332,6 +332,23 @@ class NSEventType(IntEnum):
 ######################################################################
 # NSFont.h
 NSFont = ObjCClass('NSFont')
+NSFontManager = ObjCClass('NSFontManager')
+
+
+class NSFontMask(Enum):
+    Italic = 0x01
+    Bold = 0x02
+    Unbold = 0x04
+    NonStandardCharacterSet = 0x08
+    Narrow = 0x10
+    Expanded = 0x20
+    Condensed = 0x40
+    SmallCaps = 0x80
+    Poster = 0x100
+    Compressed = 0x200
+    FixedPitch = 0x400
+    Unitalic = 0x01000000
+
 
 ######################################################################
 # NSGraphics.h


### PR DESCRIPTION
The Cocoa implementation of font traits (bold, italic, etc) wasn't correct; it assumed a consistent naming scheme in font names, which didn't exist.

This changes font loading to use the sharedFontManager to convert the base font into a font with the requested traits.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
