### PR TITLE
Canvas resize

### DIFF
--- a/src/cocoa/toga_cocoa/widgets/canvas.py
+++ b/src/cocoa/toga_cocoa/widgets/canvas.py
@@ -42,11 +42,6 @@ class TogaCanvas(NSView):
         return True
 
     @objc_method
-    def frameChanged_(self, notification) -> None:
-        if self.interface.on_resize:
-            self.interface.on_resize(self.interface)
-
-    @objc_method
     def mouseDown_(self, event) -> None:
         """Invoke the on_press handler if configured."""
         if self.interface.on_press:
@@ -95,18 +90,16 @@ class Canvas(Widget):
         self.native.interface = self.interface
         self.native._impl = self
 
-        NSNotificationCenter.defaultCenter.addObserver(
-            self.native,
-            selector=SEL("frameChanged:"),
-            name=NSViewFrameDidChangeNotification,
-            object=self.native
-        )
-
         # Add the layout constraints
         self.add_constraints()
 
     def redraw(self):
         self.native.needsDisplay = True
+
+    def set_bounds(self, x, y, width, height):
+        super().set_bounds(x, y, width, height)
+        if self.interface.on_resize:
+            self.interface.on_resize(self.interface)
 
     # Basic paths
 

--- a/src/cocoa/toga_cocoa/widgets/canvas.py
+++ b/src/cocoa/toga_cocoa/widgets/canvas.py
@@ -1,7 +1,6 @@
 from toga.widgets.canvas import FillRule
 from toga_cocoa.colors import native_color
 from toga_cocoa.libs import (
-    SEL,
     CGFloat,
     CGPathDrawingMode,
     CGRectMake,
@@ -10,13 +9,11 @@ from toga_cocoa.libs import (
     NSForegroundColorAttributeName,
     NSGraphicsContext,
     NSMutableDictionary,
-    NSNotificationCenter,
     NSPoint,
     NSRect,
     NSStrokeColorAttributeName,
     NSStrokeWidthAttributeName,
     NSView,
-    NSViewFrameDidChangeNotification,
     core_graphics,
     kCGPathEOFill,
     kCGPathFill,
@@ -98,7 +95,7 @@ class Canvas(Widget):
 
     def set_bounds(self, x, y, width, height):
         super().set_bounds(x, y, width, height)
-        if self.interface.on_resize:
+        if self.interface.window and self.interface.on_resize:
             self.interface.on_resize(self.interface)
 
     # Basic paths


### PR DESCRIPTION
Via a report from @wesley5040 about toga-chart.

If a Canvas is a top level widget, the initial `on_resize` call it made would report a size of (0,0). This is because resize was handled as a widget-level change, and when the widget is at the top level, it is managed using an autoresize mask, which means it gets `frameChanged:` events *before* the layout algorithm is invoked.

Changing on_resize event handling to be triggered by the application of results from the layout algorithm means the Toga event can provide the final layout size.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
