### PR TITLE
Add no-op implementation of `open_document` on Cocoa `App`

### DIFF
--- a/src/cocoa/toga_cocoa/app.py
+++ b/src/cocoa/toga_cocoa/app.py
@@ -411,6 +411,9 @@ class App:
     def add_background_task(self, handler):
         self.loop.call_soon(wrapped_handler(self, handler), self)
 
+    def open_document(self, fileURL):
+        """No-op when the app is not a ``DocumentApp``."""
+
 
 class DocumentApp(App):
     def _create_app_commands(self):


### PR DESCRIPTION
When the base `App` is launched with arguments, `application_openFiles_`
on the delegate will attempt to call `open_document` resulting in
an attribute error.

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
