### PR TITLE
Support closing a path in Android

### DIFF
--- a/src/android/toga_android/widgets/canvas.py
+++ b/src/android/toga_android/widgets/canvas.py
@@ -48,7 +48,7 @@ class Canvas(Widget):
         self.interface.factory.not_implemented('Canvas.new_path()')
 
     def closed_path(self, x, y, draw_context, *args, **kwargs):
-        pass
+        self._path.close()
 
     def move_to(self, x, y, *args, **kwargs):
         self._path = Path()


### PR DESCRIPTION
Implement support for `.closed_path` at the Android impl layer.

This allows one to draw e.g. two line segments, then by "closing" the path, let the platform connect the dots to make sure you have built a 2D shape that would "hold water" if you poured water into it. I'm not sure I know a better way to describe it.

## How I tested

Mac app:

![image](https://user-images.githubusercontent.com/25457/137052613-9220f4e5-6e8e-4278-b90f-07b71fe5a442.png)

Android app:

![image](https://user-images.githubusercontent.com/25457/137052626-2598d24f-dcc5-4bb9-a705-62f3248f7fdd.png)

Android app _before this change_:

![image](https://user-images.githubusercontent.com/25457/137052710-38fd5065-848a-4e36-a336-2dea3494d65f.png)

Tested with this code: 

https://github.com/paulproteus/toganvas/blob/6b52d1c4481294114cc217f71f8c740275cb4a7b/toganvas/src/toganvas/app.py#L63-L87

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [ ] I have read the **CONTRIBUTING.md** file
- [ ] I will abide by the code of conduct
