### PR TITLE
Implement arc on Android Canvas

### DIFF
--- a/src/android/toga_android/widgets/canvas.py
+++ b/src/android/toga_android/widgets/canvas.py
@@ -1,3 +1,5 @@
+import math
+
 from ..libs import activity
 from ..libs.android.graphics import DashPathEffect, Paint, Paint__Style, Path
 from .base import Widget
@@ -81,7 +83,18 @@ class Canvas(Widget):
             *args,
             **kwargs
     ):
-        self.interface.factory.not_implemented('Canvas.arc()')
+        self.move_to(x, y)
+        sweep_angle = endangle - startangle
+        if anticlockwise:
+            sweep_angle -= 2 * math.pi
+        self._path.addArc(
+            self.viewport.scale * (x - radius),
+            self.viewport.scale * (y - radius),
+            self.viewport.scale * (x + radius),
+            self.viewport.scale * (y + radius),
+            startangle * (180 / math.pi),
+            sweep_angle * (180 / math.pi),
+        )
 
     def ellipse(
         self,


### PR DESCRIPTION
Allow drawing circles, semicircles, etc. in Android Canvas

## Testing

I used this sample code: https://github.com/paulproteus/toganvas/blob/0dcc2554f0fa7a2a68c78f4361187149b69b26d6/toganvas/src/toganvas/app.py#L89

macOS:

![image](https://user-images.githubusercontent.com/25457/137824386-521d1be4-7a6f-4515-99ea-5f9c5b34946e.png)

Android:

![image](https://user-images.githubusercontent.com/25457/137824394-35174325-e825-4354-a35e-806f206c4f8e.png)

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
