### PR TITLE
Add check for NSAboutPanelOption symbols

### DIFF
--- a/src/cocoa/toga_cocoa/libs/appkit.py
+++ b/src/cocoa/toga_cocoa/libs/appkit.py
@@ -68,16 +68,13 @@ NSApplicationDidHideNotification = c_void_p.in_dll(appkit, 'NSApplicationDidHide
 NSApplicationDidUnhideNotification = c_void_p.in_dll(appkit, 'NSApplicationDidUnhideNotification')
 
 # NSAboutPanelOption* keys are available only 10.13+
-platform_version, _, _ = platform.mac_ver()
-platform_version = float('.'.join(platform_version.split('.')[:2]))
-
-if platform_version >= 10.13:
+try:
     NSAboutPanelOptionApplicationIcon = NSString(c_void_p.in_dll(appkit, "NSAboutPanelOptionApplicationIcon"))
     NSAboutPanelOptionApplicationName = NSString(c_void_p.in_dll(appkit, "NSAboutPanelOptionApplicationName"))
     NSAboutPanelOptionApplicationVersion = NSString(c_void_p.in_dll(appkit, "NSAboutPanelOptionApplicationVersion"))
     NSAboutPanelOptionCredits = NSString(c_void_p.in_dll(appkit, "NSAboutPanelOptionCredits"))
     NSAboutPanelOptionVersion = NSString(c_void_p.in_dll(appkit, "NSAboutPanelOptionVersion"))
-else:
+except AttributeError:
     NSAboutPanelOptionApplicationIcon = None
     NSAboutPanelOptionApplicationName = None
     NSAboutPanelOptionApplicationVersion = None

--- a/src/cocoa/toga_cocoa/libs/appkit.py
+++ b/src/cocoa/toga_cocoa/libs/appkit.py
@@ -74,7 +74,7 @@ try:
     NSAboutPanelOptionApplicationVersion = NSString(c_void_p.in_dll(appkit, "NSAboutPanelOptionApplicationVersion"))
     NSAboutPanelOptionCredits = NSString(c_void_p.in_dll(appkit, "NSAboutPanelOptionCredits"))
     NSAboutPanelOptionVersion = NSString(c_void_p.in_dll(appkit, "NSAboutPanelOptionVersion"))
-except AttributeError:
+except ValueError:
     NSAboutPanelOptionApplicationIcon = None
     NSAboutPanelOptionApplicationName = None
     NSAboutPanelOptionApplicationVersion = None

--- a/src/cocoa/toga_cocoa/libs/appkit.py
+++ b/src/cocoa/toga_cocoa/libs/appkit.py
@@ -67,11 +67,22 @@ NSEventTrackingRunLoopMode = c_void_p.in_dll(appkit, 'NSEventTrackingRunLoopMode
 NSApplicationDidHideNotification = c_void_p.in_dll(appkit, 'NSApplicationDidHideNotification')
 NSApplicationDidUnhideNotification = c_void_p.in_dll(appkit, 'NSApplicationDidUnhideNotification')
 
-NSAboutPanelOptionApplicationIcon = NSString(c_void_p.in_dll(appkit, "NSAboutPanelOptionApplicationIcon"))
-NSAboutPanelOptionApplicationName = NSString(c_void_p.in_dll(appkit, "NSAboutPanelOptionApplicationName"))
-NSAboutPanelOptionApplicationVersion = NSString(c_void_p.in_dll(appkit, "NSAboutPanelOptionApplicationVersion"))
-NSAboutPanelOptionCredits = NSString(c_void_p.in_dll(appkit, "NSAboutPanelOptionCredits"))
-NSAboutPanelOptionVersion = NSString(c_void_p.in_dll(appkit, "NSAboutPanelOptionVersion"))
+# NSAboutPanelOption* keys are available only 10.13+
+platform_version, _, _ = platform.mac_ver()
+platform_version = float('.'.join(platform_version.split('.')[:2]))
+
+if platform_version >= 10.13:
+    NSAboutPanelOptionApplicationIcon = NSString(c_void_p.in_dll(appkit, "NSAboutPanelOptionApplicationIcon"))
+    NSAboutPanelOptionApplicationName = NSString(c_void_p.in_dll(appkit, "NSAboutPanelOptionApplicationName"))
+    NSAboutPanelOptionApplicationVersion = NSString(c_void_p.in_dll(appkit, "NSAboutPanelOptionApplicationVersion"))
+    NSAboutPanelOptionCredits = NSString(c_void_p.in_dll(appkit, "NSAboutPanelOptionCredits"))
+    NSAboutPanelOptionVersion = NSString(c_void_p.in_dll(appkit, "NSAboutPanelOptionVersion"))
+else:
+    NSAboutPanelOptionApplicationIcon = None
+    NSAboutPanelOptionApplicationName = None
+    NSAboutPanelOptionApplicationVersion = None
+    NSAboutPanelOptionCredits = None
+    NSAboutPanelOptionVersion = None
 
 ######################################################################
 # NSAttributedString.h


### PR DESCRIPTION
<!--- Describe your changes in detail -->

Handle NSAboutPanelOption symbols for older version of macOS i.e., lower than 10.13

- Add check for platform version
- Set keys to None if version lower than minimum
supported version

<!--- What problem does this change solve? -->
Build the app for macOS versions lower than 10.13 due to unsupported symbols

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Fixes #1345 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
