### PR TITLE
Implement scale on Android canvas

### DIFF
--- a/src/android/toga_android/widgets/canvas.py
+++ b/src/android/toga_android/widgets/canvas.py
@@ -149,7 +149,7 @@ class Canvas(Widget):
         self.interface.factory.not_implemented('Canvas.rotate')
 
     def scale(self, sx, sy, draw_context, *args, **kwargs):
-        self.interface.factory.not_implemented('Canvas.scale')
+        draw_context.scale(float(sx), float(sy))
 
     def translate(self, tx, ty, draw_context, *args, **kwargs):
         self.interface.factory.not_implemented('Canvas.translate')


### PR DESCRIPTION
## Testing done

The Android output is slightly smaller than the macOS one -- I _think_ this is just the status quo with my emulator. I'm focusing on the aspect ratio here, which does seem correctly scaled.

With this code: https://github.com/paulproteus/toganvas/blob/ff09b3cbe61143ba223c391af5fed069addd21c0/toganvas/src/toganvas/app.py#L156

macOS:

![image](https://user-images.githubusercontent.com/25457/139181034-3fa060f1-bfea-439f-9d2c-019715c4dbea.png)


Android:

![image](https://user-images.githubusercontent.com/25457/139180977-18466611-8502-4d99-b138-62e31a40b87f.png)



## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
