### PR TITLE
Replaces deprecated usage of `asyncio.get_event_loop()`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3 :: Only
     Topic :: Software Development
     Topic :: Software Development :: User Interfaces

--- a/src/cocoa/toga_cocoa/app.py
+++ b/src/cocoa/toga_cocoa/app.py
@@ -111,8 +111,9 @@ class App:
 
         self._cursor_visible = True
 
-        asyncio.set_event_loop_policy(EventLoopPolicy())
-        self.loop = asyncio.get_event_loop()
+        policy = EventLoopPolicy()
+        asyncio.set_event_loop_policy(policy)
+        self.loop = policy.get_event_loop()
 
     def create(self):
         self.native = NSApplication.sharedApplication

--- a/src/gtk/toga_gtk/app.py
+++ b/src/gtk/toga_gtk/app.py
@@ -62,7 +62,7 @@ class App:
         self.interface._impl = self
 
         gbulb.install(gtk=True)
-        self.loop = asyncio.get_event_loop()
+        self.loop = asyncio.get_event_loop_policy().get_event_loop()
 
         self.create()
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = flake8,towncrier-check,docs,package,py{36,37,38,39}
+envlist = flake8,towncrier-check,docs,package,py{36,37,38,39,310}
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
This PR replaces the usage of `asyncio.get_event_loop()` in toga-cocoa and toga-gtk where it was used to retrieve the default but not running event loop. From the Python docs [here](https://docs.python.org/3.10/library/asyncio-eventloop.html#asyncio.get_event_loop):

> Deprecated since version 3.10: Deprecation warning is emitted if there is no running event loop. In future Python releases, this function will be an alias of get_running_loop().

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
