### PR TITLE
Mark currentRunLoop as a property.

### DIFF
--- a/src/iOS/toga_iOS/dialogs.py
+++ b/src/iOS/toga_iOS/dialogs.py
@@ -112,7 +112,7 @@ class TogaModalDialog:
         )
 
         while self.response is None:
-            NSRunLoop.currentRunLoop().runUntilDate(NSDate.alloc().init())
+            NSRunLoop.currentRunLoop.runUntilDate(NSDate.alloc().init())
 
         return self.response
 

--- a/src/iOS/toga_iOS/libs/foundation.py
+++ b/src/iOS/toga_iOS/libs/foundation.py
@@ -47,6 +47,8 @@ NSNotificationCenter = ObjCClass('NSNotificationCenter')
 # NSRunLoop.h
 NSRunLoop = ObjCClass('NSRunLoop')
 
+NSRunLoop.declare_class_property('currentRunLoop')
+
 
 ######################################################################
 # NSURL.h


### PR DESCRIPTION
iOS 15 explicitly makes `NSRunLoop.currentRunLoop` a property, which breaks the usage accessing the property as a function. Explicitly declaring as a property allows both old and new iOS versions to use property-based access.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
