### PR TITLE
Move to a pre-release version of Python.net.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
         python-version: "3.9"
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade "pip<21.3"
         python -m pip install --upgrade setuptools
         python -m pip install pytest-tldr
         python -m pip install -e src/core

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,16 +94,21 @@ jobs:
     - name: Set up Python 3.9
       uses: actions/setup-python@v1
       with:
+        # Py3.9 is the first Python version for which
+        # a wheel of pythonnet isn't available on PyPI.
         python-version: "3.9"
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade "pip<21.3"
+        python -m pip install --upgrade pip
         python -m pip install --upgrade setuptools
         python -m pip install pytest-tldr
         python -m pip install -e src/core
         python -m pip install -e src/dummy
         python -m pip install -e src/winforms
     - name: Test
+      env:
+          # See pythonnet/pythonnet#1613 - .NET does something odd that clashes with pip 21.3
+          EnableSourceControlManagerQueries: False
       run: |
         cd src/winforms
         python setup.py test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Python 3.6
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: "3.6"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -42,7 +42,7 @@ jobs:
     - name: Set up Python 3.6
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: "3.6"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -91,10 +91,10 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.6
+    - name: Set up Python 3.9
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: "3.9"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -117,7 +117,7 @@ jobs:
     - name: Set up Python 3.6
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: "3.6"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -140,7 +140,7 @@ jobs:
     - name: Set up Python 3.6
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: "3.6"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -163,7 +163,7 @@ jobs:
     - name: Set up Python 3.6
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: "3.6"
     - name: Install dependencies
       run: |
         sudo apt-get install -y python3-gi python3-gi-cairo gir1.2-gtk-3.0 python3-dev libgirepository1.0-dev libcairo2-dev pkg-config
@@ -187,7 +187,7 @@ jobs:
     - name: Set up Python 3.6
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: "3.6"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -210,7 +210,7 @@ jobs:
     - name: Set up Python 3.6
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: "3.6"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,9 @@ jobs:
         # a wheel of pythonnet isn't available on PyPI.
         python-version: "3.9"
     - name: Install dependencies
+      env:
+          # See pythonnet/pythonnet#1613 - .NET does something odd that clashes with pip 21.3
+          EnableSourceControlManagerQueries: false
       run: |
         python -m pip install --upgrade pip
         python -m pip install --upgrade setuptools
@@ -106,9 +109,6 @@ jobs:
         python -m pip install -e src/dummy
         python -m pip install -e src/winforms
     - name: Test
-      env:
-          # See pythonnet/pythonnet#1613 - .NET does something odd that clashes with pip 21.3
-          EnableSourceControlManagerQueries: False
       run: |
         cd src/winforms
         python setup.py test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,9 +98,6 @@ jobs:
         # a wheel of pythonnet isn't available on PyPI.
         python-version: "3.9"
     - name: Install dependencies
-      env:
-          # See pythonnet/pythonnet#1613 - .NET does something odd that clashes with pip 21.3
-          EnableSourceControlManagerQueries: false
       run: |
         python -m pip install --upgrade pip
         python -m pip install --upgrade setuptools

--- a/README.rst
+++ b/README.rst
@@ -57,8 +57,9 @@ Minimum requirements
 
   * **Arch / Manjaro** ``sudo pacman -Syu git pkgconf cairo python-cairo pango gobject-introspection gobject-introspection-runtime python-gobject webkit2gtk``
 
-* If you're on Windows, you'll need Windows 10, and the `.NET 6.0 SDK
-  <https://dotnet.microsoft.com/download>`__.
+* If you're on Windows, you'll need Windows 10. You'll also need the `.NET
+  6.0 SDK <https://dotnet.microsoft.com/download>`__ to develop Toga apps; users
+  do not need the SDK.
 
 Quickstart
 ~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -57,10 +57,8 @@ Minimum requirements
 
   * **Arch / Manjaro** ``sudo pacman -Syu git pkgconf cairo python-cairo pango gobject-introspection gobject-introspection-runtime python-gobject webkit2gtk``
 
-* If you're on Windows, you'll need Windows 10, and .NET Framework 4. You'll
-  also need to use Python 3.8 or lower; unfortunately, we're dependent on a
-  library (`Python.net <https://github.com/pythonnet/pythonnet/>`__) that
-  hasn't been published for Python 3.9 or higher.
+* If you're on Windows, you'll need Windows 10, and the `.NET 6.0 SDK
+  <https://dotnet.microsoft.com/download>`__.
 
 Quickstart
 ~~~~~~~~~~

--- a/docs/reference/api/widgets/webview.rst
+++ b/docs/reference/api/widgets/webview.rst
@@ -30,6 +30,22 @@ Usage
 
     web = toga.WebView(url='https://google.com')
 
+Debugging
+---------
+
+If you need to debug the HTML, JavaScript or CSS content of a view, you may want
+to use the "inspect element" feature of the WebView. This is not be turned on by
+default on some platforms. To enable WebView debugging:
+
+* macOS
+
+    Run the following at the terminal::
+
+        $ defaults write com.example.appname WebKitDeveloperExtras -bool true
+
+    substituting `com.example.appname` with the bundle ID for your app.
+
+
 Reference
 ---------
 

--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -89,6 +89,11 @@ Next, install Toga into your virtual environment:
 
   .. group-tab:: Windows
 
+    Before you install Toga, you'll need to install the `.NET 6.0 SDK
+    <https://dotnet.microsoft.com/download>`__. Once you've installed
+    that SDK, open a new terminal, re-activate your virtual environment,
+    and run:
+
     .. code-block:: doscon
 
       (venv) C:\...>pip install --pre toga

--- a/src/winforms/setup.py
+++ b/src/winforms/setup.py
@@ -20,7 +20,16 @@ with open('toga_winforms/__init__.py', encoding='utf8') as version_file:
 setup(
     version=version,
     install_requires=[
-        'pythonnet',
+        # The Python.net team hasn't published 2.X wheels for Python 3.9 or 3.10,
+        # and their development effort seems to be focussed on the 3.X branch;
+        # they've indicated they're not planning to make the 2.X branch compatible
+        # with Python 3.10. If we want to be able to support "current" Python,
+        # we need to work off a source release until they formally release 3.0.
+        #
+        # # The 8d93c39d hash is, as best as I can work out, what was in the
+        # 3.0.0-preview2021-10-05 release published to nuget - but they didn't
+        # tag anything for that release.
+        'git+https://github.com/pythonnet/pythonnet@8d93c39d#egg=pythonnet',
         'toga-core==%s' % version,
     ],
     test_suite='tests',

--- a/src/winforms/setup.py
+++ b/src/winforms/setup.py
@@ -26,10 +26,12 @@ setup(
         # with Python 3.10. If we want to be able to support "current" Python,
         # we need to work off a source release until they formally release 3.0.
         #
-        # # The 8d93c39d hash is, as best as I can work out, what was in the
+        # The 8d93c39d hash is, as best as I can work out, what was in the
         # 3.0.0-preview2021-10-05 release published to nuget - but they didn't
-        # tag anything for that release.
-        'pythonnet @ git+https://github.com/pythonnet/pythonnet@8d93c39d#egg=pythonnet',
+        # tag anything for that release. That release contained a bug
+        # (https://github.com/pythonnet/pythonnet/issues/1613) that didn't play well
+        # with pip 21.3, so we use 94b1a71c which was released about a month later.
+        'pythonnet @ git+https://github.com/pythonnet/pythonnet@94b1a71c#egg=pythonnet',
         'toga-core==%s' % version,
     ],
     test_suite='tests',

--- a/src/winforms/setup.py
+++ b/src/winforms/setup.py
@@ -29,7 +29,7 @@ setup(
         # # The 8d93c39d hash is, as best as I can work out, what was in the
         # 3.0.0-preview2021-10-05 release published to nuget - but they didn't
         # tag anything for that release.
-        'git+https://github.com/pythonnet/pythonnet@8d93c39d#egg=pythonnet',
+        'pythonnet @ git+https://github.com/pythonnet/pythonnet@8d93c39d#egg=pythonnet',
         'toga-core==%s' % version,
     ],
     test_suite='tests',


### PR DESCRIPTION
The Python.net team hasn't published 2.X wheels for Python 3.9 or 3.10, and their development effort seems to be focussed on the 3.X branch. They've indicated they're not planning to make the 2.X branch compatible with Python 3.10. 

The vast majority of first-time users are coming to Toga with Python 3.10 or 3.9. If we want to be able to support these users, we need to work off a source release until Python.net formally releases 3.0.

The 8d93c39d hash is, as best as I can work out, what was in the 3.0.0-preview2021-10-05 release published to nuget - but they didn't tag anything for that release, so we have to guess based on commit dates.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
