### PR TITLE
Correct weight handling for Cocoa split containers.

### DIFF
--- a/src/cocoa/toga_cocoa/widgets/splitcontainer.py
+++ b/src/cocoa/toga_cocoa/widgets/splitcontainer.py
@@ -18,12 +18,15 @@ class TogaSplitViewDelegate(NSObject):
         view.adjustSubviews()
 
         # Set the splitter positions based on the new weight fractions.
+        cumulative = 0.0
         if self.interface.direction == self.interface.VERTICAL:
             for i, weight in enumerate(self.interface._weight[:-1]):
-                view.setPosition(view.frame.size.width * weight, ofDividerAtIndex=i)
+                cumulative += weight
+                view.setPosition(view.frame.size.width * cumulative, ofDividerAtIndex=i)
         else:
             for i, weight in enumerate(self.interface._weight[:-1]):
-                view.setPosition(view.frame.size.height * weight, ofDividerAtIndex=i)
+                cumulative += weight
+                view.setPosition(view.frame.size.height * cumulative, ofDividerAtIndex=i)
 
     @objc_method
     def splitViewDidResizeSubviews_(self, notification) -> None:


### PR DESCRIPTION
Split containers with more than 2 panels didn't apply the position correctly.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
