### PR TITLE
Cocoa button size

### DIFF
--- a/src/cocoa/toga_cocoa/fonts.py
+++ b/src/cocoa/toga_cocoa/fonts.py
@@ -99,7 +99,7 @@ class Font:
     def measure(self, text, tight=False):
         textAttributes = NSMutableDictionary.alloc().init()
         textAttributes[NSFontAttributeName] = self.native
-        text_string = NSAttributedString.alloc().initWithString_attributes_(text, textAttributes)
+        text_string = NSAttributedString.alloc().initWithString(text, attributes=textAttributes)
         size = text_string.size()
 
         # TODO: This is a magic fudge factor...

--- a/src/cocoa/toga_cocoa/libs/appkit.py
+++ b/src/cocoa/toga_cocoa/libs/appkit.py
@@ -162,20 +162,24 @@ NSRadioButton = 4
 NSMomentaryChangeButton = 5
 NSOnOffButton = 6
 NSMomentaryPushInButton = 7
-NSRoundedBezelStyle = 1
-NSRegularSquareBezelStyle = 2
-NSThickSquareBezelStyle = 3
-NSThickerSquareBezelStyle = 4
-NSDisclosureBezelStyle = 5
-NSShadowlessSquareBezelStyle = 6
-NSCircularBezelStyle = 7
-NSTexturedSquareBezelStyle = 8
-NSHelpButtonBezelStyle = 9
-NSSmallSquareBezelStyle = 10
-NSTexturedRoundedBezelStyle = 11
-NSRoundRectBezelStyle = 12
-NSRecessedBezelStyle = 13
-NSRoundedDisclosureBezelStyle = 14
+
+
+class NSBezelStyle(IntEnum):
+    Rounded = 1
+    RegularSquare = 2
+    ThickSquare = 3
+    ThickerSquare = 4
+    Disclosure = 5
+    ShadowlessSquare = 6
+    Circular = 7
+    TexturedSquare = 8
+    HelpButton = 9
+    SmallSquare = 10
+    TexturedRounded = 11
+    RoundRect = 12
+    Recessed = 13
+    RoundedDisclosure = 14
+
 
 ######################################################################
 # NSCell.h

--- a/src/cocoa/toga_cocoa/widgets/button.py
+++ b/src/cocoa/toga_cocoa/widgets/button.py
@@ -45,6 +45,18 @@ class Button(Widget):
         pass
 
     def rehint(self):
+        # Normal Cocoa "rounded" buttons have a fixed height by definition.
+        # If the user specifies any font size other than the default,
+        # or specifies an explicit height for layout, switch to using a
+        # RegularSquare button.
+        if (
+            self.interface.style.font_size != SYSTEM_DEFAULT_FONT_SIZE
+            or self.interface.style.height
+        ):
+            self.native.bezelStyle = NSBezelStyle.RegularSquare
+        else:
+            self.native.bezelStyle = NSBezelStyle.Rounded
+
         content_size = self.native.intrinsicContentSize()
         self.interface.intrinsic.width = at_least(content_size.width)
         self.interface.intrinsic.height = content_size.height

--- a/src/cocoa/toga_cocoa/widgets/button.py
+++ b/src/cocoa/toga_cocoa/widgets/button.py
@@ -1,10 +1,12 @@
 from travertino.size import at_least
 
+from toga.fonts import SYSTEM_DEFAULT_FONT_SIZE
+
 from toga_cocoa.libs import (
     SEL,
+    NSBezelStyle,
     NSButton,
     NSMomentaryPushInButton,
-    NSRoundedBezelStyle,
     objc_method
 )
 
@@ -23,7 +25,7 @@ class Button(Widget):
         self.native = TogaButton.alloc().init()
         self.native.interface = self.interface
 
-        self.native.bezelStyle = NSRoundedBezelStyle
+        self.native.bezelStyle = NSBezelStyle.Rounded
         self.native.buttonType = NSMomentaryPushInButton
         self.native.target = self.native
         self.native.action = SEL('onPress:')

--- a/src/cocoa/toga_cocoa/widgets/canvas.py
+++ b/src/cocoa/toga_cocoa/widgets/canvas.py
@@ -258,9 +258,7 @@ class Canvas(Widget):
         else:
             raise ValueError("No stroke or fill of write text")
 
-        text_string = NSAttributedString.alloc().initWithString_attributes_(
-            text, textAttributes
-        )
+        text_string = NSAttributedString.alloc().initWithString(text, attributes=textAttributes)
         text_string.drawAtPoint(NSPoint(x, y - height))
 
     # Rehint

--- a/src/cocoa/toga_cocoa/widgets/switch.py
+++ b/src/cocoa/toga_cocoa/widgets/switch.py
@@ -2,10 +2,10 @@ from travertino.size import at_least
 
 from toga_cocoa.libs import (
     SEL,
+    NSBezelStyle,
     NSButton,
     NSOffState,
     NSOnState,
-    NSRoundedBezelStyle,
     NSSwitchButton,
     objc_method
 )
@@ -25,7 +25,7 @@ class Switch(Widget):
         self.native = TogaSwitch.alloc().init()
         self.native.interface = self.interface
 
-        self.native.bezelStyle = NSRoundedBezelStyle
+        self.native.bezelStyle = NSBezelStyle.Rounded
         self.native.setButtonType(NSSwitchButton)
         self.native.target = self.native
         self.native.action = SEL('onPress:')


### PR DESCRIPTION
The default Cocoa button has, by definition, a fixed height. This is because the macOS HIG doesn't recommend changing the font size on text buttons, and doesn't recommend having buttons of arbitrary size.

There is occasionally a need to violate this; and requests for setting the height of a button are common, so we might as well support the request.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
