### PR TITLE
Force a refresh when the tab changes.

### DIFF
--- a/src/cocoa/toga_cocoa/widgets/optioncontainer.py
+++ b/src/cocoa/toga_cocoa/widgets/optioncontainer.py
@@ -7,6 +7,13 @@ from .base import Widget
 class TogaTabViewDelegate(NSObject):
     @objc_method
     def tabView_didSelectTabViewItem_(self, view, item) -> None:
+        # If the widget is part of a visible layout, and a resize event has
+        # occurred while the tab wasn't visible, the layout of *this* tab won't
+        # reflect the new availalble size. Refresh the layout.
+        if self.interface.window:
+            self.interface.refresh()
+
+        # Trigger any selection handler
         if self.interface.on_select:
             index = view.indexOfTabViewItem(view.selectedTabViewItem)
             self.interface.on_select(


### PR DESCRIPTION
On Cocoa, if an OptionContainer is part of a layout, and the window is resized, the layout of non-visible content won't reflect the new overall window size. So - when a tab is selected, force a refresh of the content layout.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
