### PR TITLE
Use alpha version of pythonnet

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Minimum requirements
 
 * If you're on macOS, you need to be on 10.10 (Yosemite) or newer.
 
-* If you're on Linux, you need to have GTK+ 3.10 or later. This is the version
+* If you're on Linux, you need to have GTK+ 3.10 or newer. This is the version
   that ships starting with Ubuntu 14.04 and Fedora 20. You also need to install
   the Python 3 bindings and development files for GTK+.
 
@@ -57,9 +57,7 @@ Minimum requirements
 
   * **Arch / Manjaro** ``sudo pacman -Syu git pkgconf cairo python-cairo pango gobject-introspection gobject-introspection-runtime python-gobject webkit2gtk``
 
-* If you're on Windows, you'll need Windows 10. You'll also need the `.NET
-  6.0 SDK <https://dotnet.microsoft.com/download>`__ to develop Toga apps; users
-  do not need the SDK.
+* If you're on Windows, you'll need Windows 10 or newer.
 
 Quickstart
 ~~~~~~~~~~

--- a/src/winforms/setup.py
+++ b/src/winforms/setup.py
@@ -26,12 +26,10 @@ setup(
         # with Python 3.10. If we want to be able to support "current" Python,
         # we need to work off a source release until they formally release 3.0.
         #
-        # The 8d93c39d hash is, as best as I can work out, what was in the
-        # 3.0.0-preview2021-10-05 release published to nuget - but they didn't
-        # tag anything for that release. That release contained a bug
-        # (https://github.com/pythonnet/pythonnet/issues/1613) that didn't play well
-        # with pip 21.3, so we use 94b1a71c which was released about a month later.
-        'pythonnet @ git+https://github.com/pythonnet/pythonnet@94b1a71c#egg=pythonnet',
+        # The most recent version of pythonnet is the alpha version 3.0.0a1.
+        # At the moment we will use this version until an official release
+        # will be published.
+        'pythonnet==3.0.0a1',
         'toga-core==%s' % version,
     ],
     test_suite='tests',

--- a/src/winforms/setup.py
+++ b/src/winforms/setup.py
@@ -24,12 +24,11 @@ setup(
         # and their development effort seems to be focussed on the 3.X branch;
         # they've indicated they're not planning to make the 2.X branch compatible
         # with Python 3.10. If we want to be able to support "current" Python,
-        # we need to work off a source release until they formally release 3.0.
+        # we need to use the 3.0 branch.
         #
-        # The most recent version of pythonnet is the alpha version 3.0.0a1.
-        # At the moment we will use this version until an official release
-        # will be published.
-        'pythonnet==3.0.0a1',
+        # At time of writing, the most recent (and only) version of Python.net 3.0
+        # that has been released is the alpha version 3.0.0a1.
+        'pythonnet>=3.0.0a1',
         'toga-core==%s' % version,
     ],
     test_suite='tests',


### PR DESCRIPTION
Updated Pythonnet version to an [alpha version](https://pypi.org/project/pythonnet/3.0.0a1/)

Closes #1370 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
