### PR TITLE
Modify examples to use "local source" installs of toga

### DIFF
--- a/examples/.template/{{ cookiecutter.name }}/pyproject.toml
+++ b/examples/.template/{{ cookiecutter.name }}/pyproject.toml
@@ -14,31 +14,33 @@ author_email = "tiberius@beeware.org"
 formal_name = "{{ cookiecutter.formal_name }}"
 description = "A testing app"
 sources = ['{{ cookiecutter.name }}']
-requires = []
+requires = [
+    '../../src/core',
+]
 
 
 [tool.briefcase.app.{{ cookiecutter.name }}.macOS]
 requires = [
-    'toga-cocoa',
+    '../../src/cocoa',
 ]
 
 [tool.briefcase.app.{{ cookiecutter.name }}.linux]
 requires = [
-    'toga-gtk',
+    '../../src/gtk',
 ]
 
 [tool.briefcase.app.{{ cookiecutter.name }}.windows]
 requires = [
-    'toga-winforms',
+    '../../src/winforms',
 ]
 
 # Mobile deployments
 [tool.briefcase.app.{{ cookiecutter.name }}.iOS]
 requires = [
-    'toga-iOS',
+    '../../src/iOS',
 ]
 
 [tool.briefcase.app.{{ cookiecutter.name }}.android]
 requires = [
-    'toga-android',
+    '../../src/android',
 ]

--- a/examples/activityindicator/pyproject.toml
+++ b/examples/activityindicator/pyproject.toml
@@ -14,31 +14,33 @@ author_email = "tiberius@beeware.org"
 formal_name = "Activity Indicator"
 description = "A testing app"
 sources = ['activityindicator']
-requires = []
+requires = [
+    '../../src/core',
+]
 
 
 [tool.briefcase.app.activityindicator.macOS]
 requires = [
-    'toga-cocoa',
+    '../../src/cocoa',
 ]
 
 [tool.briefcase.app.activityindicator.linux]
 requires = [
-    'toga-gtk',
+    '../../src/gtk',
 ]
 
 [tool.briefcase.app.activityindicator.windows]
 requires = [
-    'toga-winforms',
+    '../../src/winforms',
 ]
 
 # Mobile deployments
 [tool.briefcase.app.activityindicator.iOS]
 requires = [
-    'toga-iOS',
+    '../../src/iOS',
 ]
 
 [tool.briefcase.app.activityindicator.android]
 requires = [
-    'toga-android',
+    '../../src/android',
 ]

--- a/examples/beeliza/pyproject.toml
+++ b/examples/beeliza/pyproject.toml
@@ -14,31 +14,33 @@ author_email = "tiberius@beeware.org"
 formal_name = "Beeliza"
 description = "A testing app"
 sources = ['beeliza']
-requires = []
+requires = [
+    '../../src/core',
+]
 
 
 [tool.briefcase.app.beeliza.macOS]
 requires = [
-    'toga-cocoa',
+    '../../src/cocoa',
 ]
 
 [tool.briefcase.app.beeliza.linux]
 requires = [
-    'toga-gtk',
+    '../../src/gtk',
 ]
 
 [tool.briefcase.app.beeliza.windows]
 requires = [
-    'toga-winforms',
+    '../../src/winforms',
 ]
 
 # Mobile deployments
 [tool.briefcase.app.beeliza.iOS]
 requires = [
-    'toga-iOS',
+    '../../src/iOS',
 ]
 
 [tool.briefcase.app.beeliza.android]
 requires = [
-    'toga-android',
+    '../../src/android',
 ]

--- a/examples/box/box/app.py
+++ b/examples/box/box/app.py
@@ -96,3 +96,8 @@ def main():
     #   App name and namespace
     app = ExampleBoxApp("Box", "org.beeware.widgets.boxes")
     return app
+
+
+if __name__ == '__main__':
+    app = main()
+    app.main_loop()

--- a/examples/box/pyproject.toml
+++ b/examples/box/pyproject.toml
@@ -14,31 +14,33 @@ author_email = "tiberius@beeware.org"
 formal_name = "Box Demo"
 description = "A testing app"
 sources = ['box']
-requires = []
+requires = [
+    '../../src/core',
+]
 
 
 [tool.briefcase.app.box.macOS]
 requires = [
-    'toga-cocoa',
+    '../../src/cocoa',
 ]
 
 [tool.briefcase.app.box.linux]
 requires = [
-    'toga-gtk',
+    '../../src/gtk',
 ]
 
 [tool.briefcase.app.box.windows]
 requires = [
-    'toga-winforms',
+    '../../src/winforms',
 ]
 
 # Mobile deployments
 [tool.briefcase.app.box.iOS]
 requires = [
-    'toga-iOS',
+    '../../src/iOS',
 ]
 
 [tool.briefcase.app.box.android]
 requires = [
-    'toga-android',
+    '../../src/android',
 ]

--- a/examples/button/button/app.py
+++ b/examples/button/button/app.py
@@ -123,3 +123,8 @@ def main():
     #   App name and namespace
     app = ExampleButtonApp('Button', 'org.beeware.widgets.buttons')
     return app
+
+
+if __name__ == '__main__':
+    app = main()
+    app.main_loop()

--- a/examples/button/pyproject.toml
+++ b/examples/button/pyproject.toml
@@ -14,31 +14,33 @@ author_email = "tiberius@beeware.org"
 formal_name = "Button Demo"
 description = "A testing app"
 sources = ['button']
-requires = []
+requires = [
+    '../../src/core',
+]
 
 
 [tool.briefcase.app.button.macOS]
 requires = [
-    'toga-cocoa',
+    '../../src/cocoa',
 ]
 
 [tool.briefcase.app.button.linux]
 requires = [
-    'toga-gtk',
+    '../../src/gtk',
 ]
 
 [tool.briefcase.app.button.windows]
 requires = [
-    'toga-winforms',
+    '../../src/winforms',
 ]
 
 # Mobile deployments
 [tool.briefcase.app.button.iOS]
 requires = [
-    'toga-iOS',
+    '../../src/iOS',
 ]
 
 [tool.briefcase.app.button.android]
 requires = [
-    'toga-android',
+    '../../src/android',
 ]

--- a/examples/canvas/pyproject.toml
+++ b/examples/canvas/pyproject.toml
@@ -14,31 +14,33 @@ author_email = "tiberius@beeware.org"
 formal_name = "Canvas Demo"
 description = "A testing app"
 sources = ['canvas']
-requires = []
+requires = [
+    '../../src/core',
+]
 
 
 [tool.briefcase.app.canvas.macOS]
 requires = [
-    'toga-cocoa',
+    '../../src/cocoa',
 ]
 
 [tool.briefcase.app.canvas.linux]
 requires = [
-    'toga-gtk',
+    '../../src/gtk',
 ]
 
 [tool.briefcase.app.canvas.windows]
 requires = [
-    'toga-winforms',
+    '../../src/winforms',
 ]
 
 # Mobile deployments
 [tool.briefcase.app.canvas.iOS]
 requires = [
-    'toga-iOS',
+    '../../src/iOS',
 ]
 
 [tool.briefcase.app.canvas.android]
 requires = [
-    'toga-android',
+    '../../src/android',
 ]

--- a/examples/command/pyproject.toml
+++ b/examples/command/pyproject.toml
@@ -15,18 +15,18 @@ formal_name = "Command Example"
 description = "A testing app"
 sources = ['command']
 requires = [
-    'toga-core'
+    '../../src/core',
 ]
 
 
 [tool.briefcase.app.command.macOS]
 requires = [
-    'toga-cocoa',
+    '../../src/cocoa',
 ]
 
 [tool.briefcase.app.command.linux]
 requires = [
-    'toga-gtk',
+    '../../src/gtk',
 ]
 
 [tool.briefcase.app.command.windows]
@@ -37,10 +37,10 @@ requires = [
 # Mobile deployments
 [tool.briefcase.app.command.iOS]
 requires = [
-    'toga-iOS',
+    '../../src/iOS',
 ]
 
 [tool.briefcase.app.command.android]
 requires = [
-    'toga-android',
+    '../../src/android',
 ]

--- a/examples/detailedlist/pyproject.toml
+++ b/examples/detailedlist/pyproject.toml
@@ -14,31 +14,33 @@ author_email = "tiberius@beeware.org"
 formal_name = "DetailedList Demo"
 description = "A testing app"
 sources = ['detailedlist']
-requires = []
+requires = [
+    '../../src/core',
+]
 
 
 [tool.briefcase.app.detailedlist.macOS]
 requires = [
-    'toga-cocoa',
+    '../../src/cocoa',
 ]
 
 [tool.briefcase.app.detailedlist.linux]
 requires = [
-    'toga-gtk',
+    '../../src/gtk',
 ]
 
 [tool.briefcase.app.detailedlist.windows]
 requires = [
-    'toga-winforms',
+    '../../src/winforms',
 ]
 
 # Mobile deployments
 [tool.briefcase.app.detailedlist.iOS]
 requires = [
-    'toga-iOS',
+    '../../src/iOS',
 ]
 
 [tool.briefcase.app.detailedlist.android]
 requires = [
-    'toga-android',
+    '../../src/android',
 ]

--- a/examples/dialogs/pyproject.toml
+++ b/examples/dialogs/pyproject.toml
@@ -14,31 +14,33 @@ author_email = "tiberius@beeware.org"
 formal_name = "Dialog Demo"
 description = "A testing app"
 sources = ['dialogs']
-requires = []
+requires = [
+    '../../src/core',
+]
 
 
 [tool.briefcase.app.dialogs.macOS]
 requires = [
-    'toga-cocoa',
+    '../../src/cocoa',
 ]
 
 [tool.briefcase.app.dialogs.linux]
 requires = [
-    'toga-gtk',
+    '../../src/gtk',
 ]
 
 [tool.briefcase.app.dialogs.windows]
 requires = [
-    'toga-winforms',
+    '../../src/winforms',
 ]
 
 # Mobile deployments
 [tool.briefcase.app.dialogs.iOS]
 requires = [
-    'toga-iOS',
+    '../../src/iOS',
 ]
 
 [tool.briefcase.app.dialogs.android]
 requires = [
-    'toga-android',
+    '../../src/android',
 ]

--- a/examples/divider/divider/app.py
+++ b/examples/divider/divider/app.py
@@ -42,3 +42,8 @@ def main():
     #   App name and namespace
     app = DividerApp('Dividers', 'org.beeware.helloworld')
     return app
+
+
+if __name__ == '__main__':
+    app = main()
+    app.main_loop()

--- a/examples/divider/pyproject.toml
+++ b/examples/divider/pyproject.toml
@@ -14,31 +14,33 @@ author_email = "tiberius@beeware.org"
 formal_name = "Divider Demo"
 description = "A testing app"
 sources = ['divider']
-requires = []
+requires = [
+    '../../src/core',
+]
 
 
 [tool.briefcase.app.divider.macOS]
 requires = [
-    'toga-cocoa',
+    '../../src/cocoa',
 ]
 
 [tool.briefcase.app.divider.linux]
 requires = [
-    'toga-gtk',
+    '../../src/gtk',
 ]
 
 [tool.briefcase.app.divider.windows]
 requires = [
-    'toga-winforms',
+    '../../src/winforms',
 ]
 
 # Mobile deployments
 [tool.briefcase.app.divider.iOS]
 requires = [
-    'toga-iOS',
+    '../../src/iOS',
 ]
 
 [tool.briefcase.app.divider.android]
 requires = [
-    'toga-android',
+    '../../src/android',
 ]

--- a/examples/examples_overview/pyproject.toml
+++ b/examples/examples_overview/pyproject.toml
@@ -14,31 +14,33 @@ author_email = "tiberius@beeware.org"
 formal_name = "Examples Overview"
 description = "A testing app"
 sources = ['examples_overview']
-requires = []
+requires = [
+    '../../src/core',
+]
 
 
 [tool.briefcase.app.examples_overview.macOS]
 requires = [
-    'toga-cocoa',
+    '../../src/cocoa',
 ]
 
 [tool.briefcase.app.examples_overview.linux]
 requires = [
-    'toga-gtk',
+    '../../src/gtk',
 ]
 
 [tool.briefcase.app.examples_overview.windows]
 requires = [
-    'toga-winforms',
+    '../../src/winforms',
 ]
 
 # Mobile deployments
 [tool.briefcase.app.examples_overview.iOS]
 requires = [
-    'toga-iOS',
+    '../../src/iOS',
 ]
 
 [tool.briefcase.app.examples_overview.android]
 requires = [
-    'toga-android',
+    '../../src/android',
 ]

--- a/examples/focus/focus/app.py
+++ b/examples/focus/focus/app.py
@@ -112,3 +112,8 @@ def main():
     #   App name and namespace
     app = ExampleFocusApp('Focus', 'org.beeware.widgets.focus')
     return app
+
+
+if __name__ == '__main__':
+    app = main()
+    app.main_loop()

--- a/examples/focus/pyproject.toml
+++ b/examples/focus/pyproject.toml
@@ -14,31 +14,33 @@ author_email = "tiberius@beeware.org"
 formal_name = "Focus Demo"
 description = "A testing app"
 sources = ['focus']
-requires = []
+requires = [
+    '../../src/core',
+]
 
 
 [tool.briefcase.app.focus.macOS]
 requires = [
-    'toga-cocoa',
+    '../../src/cocoa',
 ]
 
 [tool.briefcase.app.focus.linux]
 requires = [
-    'toga-gtk',
+    '../../src/gtk',
 ]
 
 [tool.briefcase.app.focus.windows]
 requires = [
-    'toga-winforms',
+    '../../src/winforms',
 ]
 
 # Mobile deployments
 [tool.briefcase.app.focus.iOS]
 requires = [
-    'toga-iOS',
+    '../../src/iOS',
 ]
 
 [tool.briefcase.app.focus.android]
 requires = [
-    'toga-android',
+    '../../src/android',
 ]

--- a/examples/handlers/pyproject.toml
+++ b/examples/handlers/pyproject.toml
@@ -14,31 +14,33 @@ author_email = "tiberius@beeware.org"
 formal_name = "Handler Demo"
 description = "A testing app"
 sources = ['handlers']
-requires = []
+requires = [
+    '../../src/core',
+]
 
 
 [tool.briefcase.app.handlers.macOS]
 requires = [
-    'toga-cocoa',
+    '../../src/cocoa',
 ]
 
 [tool.briefcase.app.handlers.linux]
 requires = [
-    'toga-gtk',
+    '../../src/gtk',
 ]
 
 [tool.briefcase.app.handlers.windows]
 requires = [
-    'toga-winforms',
+    '../../src/winforms',
 ]
 
 # Mobile deployments
 [tool.briefcase.app.handlers.iOS]
 requires = [
-    'toga-iOS',
+    '../../src/iOS',
 ]
 
 [tool.briefcase.app.handlers.android]
 requires = [
-    'toga-android',
+    '../../src/android',
 ]

--- a/examples/imageview/pyproject.toml
+++ b/examples/imageview/pyproject.toml
@@ -14,31 +14,33 @@ author_email = "tiberius@beeware.org"
 formal_name = "ImageView Demo"
 description = "A testing app"
 sources = ['imageview']
-requires = []
+requires = [
+    '../../src/core',
+]
 
 
 [tool.briefcase.app.imageview.macOS]
 requires = [
-    'toga-cocoa',
+    '../../src/cocoa',
 ]
 
 [tool.briefcase.app.imageview.linux]
 requires = [
-    'toga-gtk',
+    '../../src/gtk',
 ]
 
 [tool.briefcase.app.imageview.windows]
 requires = [
-    'toga-winforms',
+    '../../src/winforms',
 ]
 
 # Mobile deployments
 [tool.briefcase.app.imageview.iOS]
 requires = [
-    'toga-iOS',
+    '../../src/iOS',
 ]
 
 [tool.briefcase.app.imageview.android]
 requires = [
-    'toga-android',
+    '../../src/android',
 ]

--- a/examples/layout/pyproject.toml
+++ b/examples/layout/pyproject.toml
@@ -14,31 +14,33 @@ author_email = "tiberius@beeware.org"
 formal_name = "Layout Test"
 description = "A testing app"
 sources = ['layout']
-requires = []
+requires = [
+    '../../src/core',
+]
 
 
 [tool.briefcase.app.layout.macOS]
 requires = [
-    'toga-cocoa',
+    '../../src/cocoa',
 ]
 
 [tool.briefcase.app.layout.linux]
 requires = [
-    'toga-gtk',
+    '../../src/gtk',
 ]
 
 [tool.briefcase.app.layout.windows]
 requires = [
-    'toga-winforms',
+    '../../src/winforms',
 ]
 
 # Mobile deployments
 [tool.briefcase.app.layout.iOS]
 requires = [
-    'toga-iOS',
+    '../../src/iOS',
 ]
 
 [tool.briefcase.app.layout.android]
 requires = [
-    'toga-android',
+    '../../src/android',
 ]

--- a/examples/multilinetextinput/pyproject.toml
+++ b/examples/multilinetextinput/pyproject.toml
@@ -14,31 +14,33 @@ author_email = "tiberius@beeware.org"
 formal_name = "MultilineTextInput Demo"
 description = "A testing app"
 sources = ['multilinetextinput']
-requires = []
+requires = [
+    '../../src/core',
+]
 
 
 [tool.briefcase.app.multilinetextinput.macOS]
 requires = [
-    'toga-cocoa',
+    '../../src/cocoa',
 ]
 
 [tool.briefcase.app.multilinetextinput.linux]
 requires = [
-    'toga-gtk',
+    '../../src/gtk',
 ]
 
 [tool.briefcase.app.multilinetextinput.windows]
 requires = [
-    'toga-winforms',
+    '../../src/winforms',
 ]
 
 # Mobile deployments
 [tool.briefcase.app.multilinetextinput.iOS]
 requires = [
-    'toga-iOS',
+    '../../src/iOS',
 ]
 
 [tool.briefcase.app.multilinetextinput.android]
 requires = [
-    'toga-android',
+    '../../src/android',
 ]

--- a/examples/optioncontainer/pyproject.toml
+++ b/examples/optioncontainer/pyproject.toml
@@ -14,31 +14,33 @@ author_email = "tiberius@beeware.org"
 formal_name = "Option Container Example"
 description = "A testing app"
 sources = ['optioncontainer']
-requires = []
+requires = [
+    '../../src/core',
+]
 
 
 [tool.briefcase.app.optioncontainer.macOS]
 requires = [
-    'toga-cocoa',
+    '../../src/cocoa',
 ]
 
 [tool.briefcase.app.optioncontainer.linux]
 requires = [
-    'toga-gtk',
+    '../../src/gtk',
 ]
 
 [tool.briefcase.app.optioncontainer.windows]
 requires = [
-    'toga-winforms',
+    '../../src/winforms',
 ]
 
 # Mobile deployments
 [tool.briefcase.app.optioncontainer.iOS]
 requires = [
-    'toga-iOS',
+    '../../src/iOS',
 ]
 
 [tool.briefcase.app.optioncontainer.android]
 requires = [
-    'toga-android',
+    '../../src/android',
 ]

--- a/examples/progressbar/progressbar/app.py
+++ b/examples/progressbar/progressbar/app.py
@@ -91,3 +91,8 @@ class ProgressBarApp(toga.App):
 def main():
     # App name and namespace
     return ProgressBarApp('ProgressBar', 'org.beeware.examples.progressbar')
+
+
+if __name__ == '__main__':
+    app = main()
+    app.main_loop()

--- a/examples/progressbar/pyproject.toml
+++ b/examples/progressbar/pyproject.toml
@@ -14,31 +14,33 @@ author_email = "tiberius@beeware.org"
 formal_name = "ProgressBar demo"
 description = "A testing app"
 sources = ['progressbar']
-requires = []
+requires = [
+    '../../src/core',
+]
 
 
 [tool.briefcase.app.progressbar.macOS]
 requires = [
-    'toga-cocoa',
+    '../../src/cocoa',
 ]
 
 [tool.briefcase.app.progressbar.linux]
 requires = [
-    'toga-gtk',
+    '../../src/gtk',
 ]
 
 [tool.briefcase.app.progressbar.windows]
 requires = [
-    'toga-winforms',
+    '../../src/winforms',
 ]
 
 # Mobile deployments
 [tool.briefcase.app.progressbar.iOS]
 requires = [
-    'toga-iOS',
+    '../../src/iOS',
 ]
 
 [tool.briefcase.app.progressbar.android]
 requires = [
-    'toga-android',
+    '../../src/android',
 ]

--- a/examples/scrollcontainer/pyproject.toml
+++ b/examples/scrollcontainer/pyproject.toml
@@ -14,31 +14,33 @@ author_email = "tiberius@beeware.org"
 formal_name = "ScrollContainer Demo"
 description = "A testing app"
 sources = ['scrollcontainer']
-requires = []
+requires = [
+    '../../src/core',
+]
 
 
 [tool.briefcase.app.scrollcontainer.macOS]
 requires = [
-    'toga-cocoa',
+    '../../src/cocoa',
 ]
 
 [tool.briefcase.app.scrollcontainer.linux]
 requires = [
-    'toga-gtk',
+    '../../src/gtk',
 ]
 
 [tool.briefcase.app.scrollcontainer.windows]
 requires = [
-    'toga-winforms',
+    '../../src/winforms',
 ]
 
 # Mobile deployments
 [tool.briefcase.app.scrollcontainer.iOS]
 requires = [
-    'toga-iOS',
+    '../../src/iOS',
 ]
 
 [tool.briefcase.app.scrollcontainer.android]
 requires = [
-    'toga-android',
+    '../../src/android',
 ]

--- a/examples/selection/pyproject.toml
+++ b/examples/selection/pyproject.toml
@@ -14,31 +14,33 @@ author_email = "tiberius@beeware.org"
 formal_name = "Selection Demo"
 description = "A testing app"
 sources = ['selection']
-requires = []
+requires = [
+    '../../src/core',
+]
 
 
 [tool.briefcase.app.selection.macOS]
 requires = [
-    'toga-cocoa',
+    '../../src/cocoa',
 ]
 
 [tool.briefcase.app.selection.linux]
 requires = [
-    'toga-gtk',
+    '../../src/gtk',
 ]
 
 [tool.briefcase.app.selection.windows]
 requires = [
-    'toga-winforms',
+    '../../src/winforms',
 ]
 
 # Mobile deployments
 [tool.briefcase.app.selection.iOS]
 requires = [
-    'toga-iOS',
+    '../../src/iOS',
 ]
 
 [tool.briefcase.app.selection.android]
 requires = [
-    'toga-android',
+    '../../src/android',
 ]

--- a/examples/selection/selection/app.py
+++ b/examples/selection/selection/app.py
@@ -118,3 +118,8 @@ class SelectionApp(toga.App):
 def main():
     # App name and namespace
     return SelectionApp("Selection", "org.beeware.selection")
+
+
+if __name__ == '__main__':
+    app = main()
+    app.main_loop()

--- a/examples/slider/pyproject.toml
+++ b/examples/slider/pyproject.toml
@@ -14,31 +14,33 @@ author_email = "tiberius@beeware.org"
 formal_name = "Slider Demo"
 description = "A testing app"
 sources = ['slider']
-requires = []
+requires = [
+    '../../src/core',
+]
 
 
 [tool.briefcase.app.slider.macOS]
 requires = [
-    'toga-cocoa',
+    '../../src/cocoa',
 ]
 
 [tool.briefcase.app.slider.linux]
 requires = [
-    'toga-gtk',
+    '../../src/gtk',
 ]
 
 [tool.briefcase.app.slider.windows]
 requires = [
-    'toga-winforms',
+    '../../src/winforms',
 ]
 
 # Mobile deployments
 [tool.briefcase.app.slider.iOS]
 requires = [
-    'toga-iOS',
+    '../../src/iOS',
 ]
 
 [tool.briefcase.app.slider.android]
 requires = [
-    'toga-android',
+    '../../src/android',
 ]

--- a/examples/switch_demo/pyproject.toml
+++ b/examples/switch_demo/pyproject.toml
@@ -14,31 +14,33 @@ author_email = "tiberius@beeware.org"
 formal_name = "Switch Demo"
 description = "A testing app"
 sources = ['switch_demo']
-requires = []
+requires = [
+    '../../src/core',
+]
 
 
 [tool.briefcase.app.switch_demo.macOS]
 requires = [
-    'toga-cocoa',
+    '../../src/cocoa',
 ]
 
 [tool.briefcase.app.switch_demo.linux]
 requires = [
-    'toga-gtk',
+    '../../src/gtk',
 ]
 
 [tool.briefcase.app.switch_demo.windows]
 requires = [
-    'toga-winforms',
+    '../../src/winforms',
 ]
 
 # Mobile deployments
 [tool.briefcase.app.switch_demo.iOS]
 requires = [
-    'toga-iOS',
+    '../../src/iOS',
 ]
 
 [tool.briefcase.app.switch_demo.android]
 requires = [
-    'toga-android',
+    '../../src/android',
 ]

--- a/examples/switch_demo/switch_demo/app.py
+++ b/examples/switch_demo/switch_demo/app.py
@@ -43,3 +43,8 @@ def main():
     #   App name and namespace
     app = SwitchApp('Switches', 'org.beeware.helloworld')
     return app
+
+
+if __name__ == '__main__':
+    app = main()
+    app.main_loop()

--- a/examples/table/pyproject.toml
+++ b/examples/table/pyproject.toml
@@ -14,30 +14,32 @@ author_email = "tiberius@beeware.org"
 formal_name = "Table Demo"
 description = "A testing app"
 sources = ['table']
-requires = []
+requires = [
+    '../../src/core',
+]
 
 [tool.briefcase.app.table.macOS]
 requires = [
-    'toga-cocoa',
+    '../../src/cocoa',
 ]
 
 [tool.briefcase.app.table.linux]
 requires = [
-    'toga-gtk',
+    '../../src/gtk',
 ]
 
 [tool.briefcase.app.table.windows]
 requires = [
-    'toga-winforms',
+    '../../src/winforms',
 ]
 
 # Mobile deployments
 [tool.briefcase.app.table.iOS]
 requires = [
-    'toga-iOS',
+    '../../src/iOS',
 ]
 
 [tool.briefcase.app.table.android]
 requires = [
-    'toga-android',
+    '../../src/android',
 ]

--- a/examples/table_source/pyproject.toml
+++ b/examples/table_source/pyproject.toml
@@ -14,31 +14,33 @@ author_email = "tiberius@beeware.org"
 formal_name = "TableSource Demo"
 description = "A testing app"
 sources = ['table_source']
-requires = []
+requires = [
+    '../../src/core',
+]
 
 
 [tool.briefcase.app.table_source.macOS]
 requires = [
-    'toga-cocoa',
+    '../../src/cocoa',
 ]
 
 [tool.briefcase.app.table_source.linux]
 requires = [
-    'toga-gtk',
+    '../../src/gtk',
 ]
 
 [tool.briefcase.app.table_source.windows]
 requires = [
-    'toga-winforms',
+    '../../src/winforms',
 ]
 
 # Mobile deployments
 [tool.briefcase.app.table_source.iOS]
 requires = [
-    'toga-iOS',
+    '../../src/iOS',
 ]
 
 [tool.briefcase.app.table_source.android]
 requires = [
-    'toga-android',
+    '../../src/android',
 ]

--- a/examples/textinput/pyproject.toml
+++ b/examples/textinput/pyproject.toml
@@ -14,31 +14,33 @@ author_email = "tiberius@beeware.org"
 formal_name = "Text Input Demo"
 description = "A testing app"
 sources = ['textinput']
-requires = []
+requires = [
+    '../../src/core',
+]
 
 
 [tool.briefcase.app.textinput.macOS]
 requires = [
-    'toga-cocoa',
+    '../../src/cocoa',
 ]
 
 [tool.briefcase.app.textinput.linux]
 requires = [
-    'toga-gtk',
+    '../../src/gtk',
 ]
 
 [tool.briefcase.app.textinput.windows]
 requires = [
-    'toga-winforms',
+    '../../src/winforms',
 ]
 
 # Mobile deployments
 [tool.briefcase.app.textinput.iOS]
 requires = [
-    'toga-iOS',
+    '../../src/iOS',
 ]
 
 [tool.briefcase.app.textinput.android]
 requires = [
-    'toga-android',
+    '../../src/android',
 ]

--- a/examples/tree/pyproject.toml
+++ b/examples/tree/pyproject.toml
@@ -14,31 +14,33 @@ author_email = "tiberius@beeware.org"
 formal_name = "Tree Demo"
 description = "A testing app"
 sources = ['tree']
-requires = []
+requires = [
+    '../../src/core',
+]
 
 
 [tool.briefcase.app.tree.macOS]
 requires = [
-    'toga-cocoa',
+    '../../src/cocoa',
 ]
 
 [tool.briefcase.app.tree.linux]
 requires = [
-    'toga-gtk',
+    '../../src/gtk',
 ]
 
 [tool.briefcase.app.tree.windows]
 requires = [
-    'toga-winforms',
+    '../../src/winforms',
 ]
 
 # Mobile deployments
 [tool.briefcase.app.tree.iOS]
 requires = [
-    'toga-iOS',
+    '../../src/iOS',
 ]
 
 [tool.briefcase.app.tree.android]
 requires = [
-    'toga-android',
+    '../../src/android',
 ]

--- a/examples/tree_source/pyproject.toml
+++ b/examples/tree_source/pyproject.toml
@@ -14,31 +14,33 @@ author_email = "tiberius@beeware.org"
 formal_name = "TreeSource Demo"
 description = "A testing app"
 sources = ['tree_source']
-requires = []
+requires = [
+    '../../src/core',
+]
 
 
 [tool.briefcase.app.tree_source.macOS]
 requires = [
-    'toga-cocoa',
+    '../../src/cocoa',
 ]
 
 [tool.briefcase.app.tree_source.linux]
 requires = [
-    'toga-gtk',
+    '../../src/gtk',
 ]
 
 [tool.briefcase.app.tree_source.windows]
 requires = [
-    'toga-winforms',
+    '../../src/winforms',
 ]
 
 # Mobile deployments
 [tool.briefcase.app.tree_source.iOS]
 requires = [
-    'toga-iOS',
+    '../../src/iOS',
 ]
 
 [tool.briefcase.app.tree_source.android]
 requires = [
-    'toga-android',
+    '../../src/android',
 ]

--- a/examples/tutorial0/pyproject.toml
+++ b/examples/tutorial0/pyproject.toml
@@ -14,31 +14,33 @@ author_email = "tiberius@beeware.org"
 formal_name = "Tutorial 0"
 description = "A testing app"
 sources = ['tutorial']
-requires = []
+requires = [
+    '../../src/core',
+]
 
 
 [tool.briefcase.app.tutorial.macOS]
 requires = [
-    'toga-cocoa',
+    '../../src/cocoa',
 ]
 
 [tool.briefcase.app.tutorial.linux]
 requires = [
-    'toga-gtk',
+    '../../src/gtk',
 ]
 
 [tool.briefcase.app.tutorial.windows]
 requires = [
-    'toga-winforms',
+    '../../src/winforms',
 ]
 
 # Mobile deployments
 [tool.briefcase.app.tutorial.iOS]
 requires = [
-    'toga-iOS',
+    '../../src/iOS',
 ]
 
 [tool.briefcase.app.tutorial.android]
 requires = [
-    'toga-android',
+    '../../src/android',
 ]

--- a/examples/tutorial1/pyproject.toml
+++ b/examples/tutorial1/pyproject.toml
@@ -14,31 +14,33 @@ author_email = "tiberius@beeware.org"
 formal_name = "Tutorial 1"
 description = "A testing app"
 sources = ['tutorial']
-requires = []
+requires = [
+    '../../src/core',
+]
 
 
 [tool.briefcase.app.tutorial.macOS]
 requires = [
-    'toga-cocoa',
+    '../../src/cocoa',
 ]
 
 [tool.briefcase.app.tutorial.linux]
 requires = [
-    'toga-gtk',
+    '../../src/gtk',
 ]
 
 [tool.briefcase.app.tutorial.windows]
 requires = [
-    'toga-winforms',
+    '../../src/winforms',
 ]
 
 # Mobile deployments
 [tool.briefcase.app.tutorial.iOS]
 requires = [
-    'toga-iOS',
+    '../../src/iOS',
 ]
 
 [tool.briefcase.app.tutorial.android]
 requires = [
-    'toga-android',
+    '../../src/android',
 ]

--- a/examples/tutorial2/pyproject.toml
+++ b/examples/tutorial2/pyproject.toml
@@ -14,31 +14,33 @@ author_email = "tiberius@beeware.org"
 formal_name = "Tutorial 2"
 description = "A testing app"
 sources = ['tutorial']
-requires = []
+requires = [
+    '../../src/core',
+]
 
 
 [tool.briefcase.app.tutorial.macOS]
 requires = [
-    'toga-cocoa',
+    '../../src/cocoa',
 ]
 
 [tool.briefcase.app.tutorial.linux]
 requires = [
-    'toga-gtk',
+    '../../src/gtk',
 ]
 
 [tool.briefcase.app.tutorial.windows]
 requires = [
-    'toga-winforms',
+    '../../src/winforms',
 ]
 
 # Mobile deployments
 [tool.briefcase.app.tutorial.iOS]
 requires = [
-    'toga-iOS',
+    '../../src/iOS',
 ]
 
 [tool.briefcase.app.tutorial.android]
 requires = [
-    'toga-android',
+    '../../src/android',
 ]

--- a/examples/tutorial3/pyproject.toml
+++ b/examples/tutorial3/pyproject.toml
@@ -14,31 +14,33 @@ author_email = "tiberius@beeware.org"
 formal_name = "Tutorial 3"
 description = "A testing app"
 sources = ['tutorial']
-requires = []
+requires = [
+    '../../src/core',
+]
 
 
 [tool.briefcase.app.tutorial.macOS]
 requires = [
-    'toga-cocoa',
+    '../../src/cocoa',
 ]
 
 [tool.briefcase.app.tutorial.linux]
 requires = [
-    'toga-gtk',
+    '../../src/gtk',
 ]
 
 [tool.briefcase.app.tutorial.windows]
 requires = [
-    'toga-winforms',
+    '../../src/winforms',
 ]
 
 # Mobile deployments
 [tool.briefcase.app.tutorial.iOS]
 requires = [
-    'toga-iOS',
+    '../../src/iOS',
 ]
 
 [tool.briefcase.app.tutorial.android]
 requires = [
-    'toga-android',
+    '../../src/android',
 ]

--- a/examples/tutorial4/pyproject.toml
+++ b/examples/tutorial4/pyproject.toml
@@ -14,31 +14,33 @@ author_email = "tiberius@beeware.org"
 formal_name = "Tutorial 4"
 description = "A testing app"
 sources = ['tutorial']
-requires = []
+requires = [
+    '../../src/core',
+]
 
 
 [tool.briefcase.app.tutorial.macOS]
 requires = [
-    'toga-cocoa',
+    '../../src/cocoa',
 ]
 
 [tool.briefcase.app.tutorial.linux]
 requires = [
-    'toga-gtk',
+    '../../src/gtk',
 ]
 
 [tool.briefcase.app.tutorial.windows]
 requires = [
-    'toga-winforms',
+    '../../src/winforms',
 ]
 
 # Mobile deployments
 [tool.briefcase.app.tutorial.iOS]
 requires = [
-    'toga-iOS',
+    '../../src/iOS',
 ]
 
 [tool.briefcase.app.tutorial.android]
 requires = [
-    'toga-android',
+    '../../src/android',
 ]

--- a/examples/webview/pyproject.toml
+++ b/examples/webview/pyproject.toml
@@ -14,30 +14,32 @@ author_email = "tiberius@beeware.org"
 formal_name = "WebView Demo"
 description = "A demo app using all WebView features"
 sources = ['webview']
-requires = []
+requires = [
+    '../../src/core',
+]
 
 [tool.briefcase.app.webview.macOS]
 requires = [
-    'toga-cocoa',
+    '../../src/cocoa',
 ]
 
 [tool.briefcase.app.webview.linux]
 requires = [
-    'toga-gtk',
+    '../../src/gtk',
 ]
 
 [tool.briefcase.app.webview.windows]
 requires = [
-    'toga-winforms',
+    '../../src/winforms',
 ]
 
 # Mobile deployments
 [tool.briefcase.app.webview.iOS]
 requires = [
-    'toga-ios',
+    '../../src/ios',
 ]
 
 [tool.briefcase.app.webview.android]
 requires = [
-    'toga-android',
+    '../../src/android',
 ]


### PR DESCRIPTION
The examples can't be run unless you clone the repository; and if you're cloning the repository, you almost certainly want to use the checked-out version of Toga, rather than the PyPI released versions. 

Therefore, it makes sense for the examples to reference the cloned code, rather than PyPI versions. This also makes testing easier, as there's no need to modify the examples in order to run a test of Toga changes.

Also fixes #1369, since it was easy to audit the examples as I went.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
