### PR TITLE
[Gtk] replace app.name to app.app_name in paths

### DIFF
--- a/src/gtk/toga_gtk/paths.py
+++ b/src/gtk/toga_gtk/paths.py
@@ -15,15 +15,15 @@ class Paths:
 
     @property
     def data(self):
-        return Path.home() / '.local' / 'share' / App.app.name
+        return Path.home() / '.local' / 'share' / App.app.app_name
 
     @property
     def cache(self):
-        return Path.home() / '.cache' / App.app.name
+        return Path.home() / '.cache' / App.app.app_name
 
     @property
     def logs(self):
-        return Path.home() / '.cache' / App.app.name / 'log'
+        return Path.home() / '.cache' / App.app.app_name / 'log'
 
     @property
     def toga(self):


### PR DESCRIPTION
The app.name is a displayable name, it is preferable to use the app_name
which is a technical name (the python module name).

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
