### PR TITLE
[Gtk] fix replacing a window content by another one

### DIFF
--- a/src/gtk/toga_gtk/window.py
+++ b/src/gtk/toga_gtk/window.py
@@ -37,6 +37,8 @@ class Window:
         self.create()
 
     def create(self):
+        self.layout = None
+
         self.native = self._IMPL_CLASS()
         self.native._impl = self
 
@@ -87,6 +89,9 @@ class Window:
         # Construct the top-level layout, and set the window's view to
         # the be the widget's native object.
         # Alaway avoid using deprecated widgets and methods.
+        if self.layout:
+            self.native.remove(self.layout)
+
         self.layout = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
 
         if self.toolbar_native:


### PR DESCRIPTION
Currently, it doesn't work to set a content on a window if there is
already one, Gtk displays this error:

> Attempting to add a widget with type GtkBox to a GtkApplicationWindow,
but as a GtkBin subclass a GtkApplicationWindow can only contain one
widget at a time; it already contains a widget of type GtkBox

This is because there is an existing Box layout inside the window.

To fix it, we remove the existing layout if it already exists.

Note that to work, it is required to call again 'window.show()' after
replacing the content.

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
