### PR TITLE
[Android] fix paths to use right ones

### DIFF
--- a/src/android/toga_android/paths.py
+++ b/src/android/toga_android/paths.py
@@ -15,15 +15,15 @@ class Paths:
 
     @property
     def data(self):
-        return Path.home() / 'Library' / 'Application Support' / App.app.app_id
+        return Path(App.app._impl.native.getApplicationContext().getFilesDir().getPath())
 
     @property
     def cache(self):
-        return Path.home() / 'Library' / 'Caches' / App.app.app_id
+        return Path(App.app._impl.native.getApplicationContext().getCacheDir().getPath())
 
     @property
     def logs(self):
-        return Path.home() / 'Library' / 'Logs' / App.app.app_id
+        return Path(App.app._impl.native.getApplicationContext().getCacheDir().getPath()) / 'log'
 
     @property
     def toga(self):


### PR DESCRIPTION
This file was a copy/paste from the iOS one, so it didn't make sense.

Now use `getApplicationContext().getFilesDir()` for data directory, and
`getApplicationContext().getCacheDir()` for cache and logs directories.

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
