### PR TITLE
Remove explicit comparisons with None.

### DIFF
--- a/src/android/toga_android/widgets/base.py
+++ b/src/android/toga_android/widgets/base.py
@@ -16,7 +16,7 @@ def _get_activity(_cache=[]):
         return _cache[0]
     # See MainActivity.onCreate() for initialization of .singletonThis:
     # https://github.com/beeware/briefcase-android-gradle-template/blob/3.7/%7B%7B%20cookiecutter.formal_name%20%7D%7D/app/src/main/java/org/beeware/android/MainActivity.java
-    if MainActivity.singletonThis is None:
+    if not MainActivity.singletonThis:
         raise ValueError("Unable to find MainActivity.singletonThis from Python. This is typically set by "
                          "org.beeware.android.MainActivity.onCreate().")
     _cache.append(MainActivity(__jni__=java.NewGlobalRef(MainActivity.singletonThis)))

--- a/src/android/toga_android/widgets/button.py
+++ b/src/android/toga_android/widgets/button.py
@@ -52,7 +52,7 @@ class Button(Widget):
     def rehint(self):
         # Like other text-viewing widgets, Android crashes when rendering
         # `Button` unless it has its layout params set. Guard for that case.
-        if self.native.getLayoutParams() is None:
+        if not self.native.getLayoutParams():
             return
         self.native.measure(
             View__MeasureSpec.UNSPECIFIED,

--- a/src/android/toga_android/widgets/detailedlist.py
+++ b/src/android/toga_android/widgets/detailedlist.py
@@ -202,7 +202,7 @@ class DetailedList(Widget):
 
     def rehint(self):
         # Android can crash when rendering some widgets until they have their layout params set. Guard for that case.
-        if self.native.getLayoutParams() is None:
+        if not self.native.getLayoutParams():
             return
         self.native.measure(
             View__MeasureSpec.UNSPECIFIED,

--- a/src/android/toga_android/widgets/label.py
+++ b/src/android/toga_android/widgets/label.py
@@ -23,7 +23,7 @@ class Label(Widget):
     def rehint(self):
         # Refuse to rehint an Android TextView if it has no LayoutParams yet.
         # Calling measure() on an Android TextView w/o LayoutParams raises NullPointerException.
-        if self.native.getLayoutParams() is None:
+        if not self.native.getLayoutParams():
             return
         # Ask the Android TextView first for the height it would use in its
         # wildest dreams. This is the height of one line of text.
@@ -48,6 +48,6 @@ class Label(Widget):
         # Refuse to set alignment if widget has no container.
         # On Android, calling setGravity() when the widget has no LayoutParams
         # results in a NullPointerException.
-        if self.native.getLayoutParams() is None:
+        if not self.native.getLayoutParams():
             return
         self.native.setGravity(Gravity.CENTER_VERTICAL | align(value))

--- a/src/android/toga_android/widgets/scrollcontainer.py
+++ b/src/android/toga_android/widgets/scrollcontainer.py
@@ -104,7 +104,7 @@ class ScrollContainer(Widget):
 
     def rehint(self):
         # Android can crash when rendering some widgets until they have their layout params set. Guard for that case.
-        if self.native.getLayoutParams() is None:
+        if not self.native.getLayoutParams():
             return
         self.native.measure(
             View__MeasureSpec.UNSPECIFIED,

--- a/src/android/toga_android/widgets/switch.py
+++ b/src/android/toga_android/widgets/switch.py
@@ -51,7 +51,7 @@ class Switch(Widget):
         pass
 
     def rehint(self):
-        if self.native.getLayoutParams() is None:
+        if not self.native.getLayoutParams():
             return
         self.native.measure(
             View__MeasureSpec.UNSPECIFIED, View__MeasureSpec.UNSPECIFIED

--- a/src/android/toga_android/widgets/table.py
+++ b/src/android/toga_android/widgets/table.py
@@ -212,7 +212,7 @@ class Table(Widget):
     def rehint(self):
         # Android can crash when rendering some widgets until
         # they have their layout params set. Guard for that case.
-        if self.native.getLayoutParams() is None:
+        if not self.native.getLayoutParams():
             return
 
         self.native.measure(

--- a/src/android/toga_android/widgets/textinput.py
+++ b/src/android/toga_android/widgets/textinput.py
@@ -43,7 +43,7 @@ class TextInput(Widget):
         # Refuse to set alignment unless widget has been added to a container.
         # This is because Android EditText requires LayoutParams before
         # setGravity() can be called.
-        if self.native.getLayoutParams() is None:
+        if not self.native.getLayoutParams():
             return
         self.native.setGravity(Gravity.CENTER_VERTICAL | align(value))
 
@@ -71,7 +71,7 @@ class TextInput(Widget):
         # Refuse to call measure() if widget has no container, i.e., has no LayoutParams.
         # On Android, EditText's measure() throws NullPointerException if the widget has no
         # LayoutParams.
-        if self.native.getLayoutParams() is None:
+        if not self.native.getLayoutParams():
             return
         self.native.measure(
             View__MeasureSpec.UNSPECIFIED, View__MeasureSpec.UNSPECIFIED

--- a/src/android/toga_android/widgets/webview.py
+++ b/src/android/toga_android/widgets/webview.py
@@ -70,7 +70,7 @@ class WebView(Widget):
     def set_alignment(self, value):
         # Refuse to set alignment unless widget has been added to a container.
         # This is because this widget's setGravity() requires LayoutParams before it can be called.
-        if self.native.getLayoutParams() is None:
+        if not self.native.getLayoutParams():
             return
         self.native.setGravity(Gravity.CENTER_VERTICAL | align(value))
 
@@ -78,7 +78,7 @@ class WebView(Widget):
         self.interface.intrinsic.width = at_least(self.interface.MIN_WIDTH)
         # Refuse to call measure() if widget has no container, i.e., has no LayoutParams.
         # Android's measure() throws NullPointerException if the widget has no LayoutParams.
-        if self.native.getLayoutParams() is None:
+        if not self.native.getLayoutParams():
             return
         self.native.measure(
             View__MeasureSpec.UNSPECIFIED,


### PR DESCRIPTION
beeware/rubicon-java#67 modified the handling of NULL return values, returning a typed `JavaNull` rather than a Python `None`.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
