### PR TITLE
[Android] make TextInput single-line

### DIFF
--- a/src/android/toga_android/widgets/textinput.py
+++ b/src/android/toga_android/widgets/textinput.py
@@ -1,6 +1,6 @@
 from travertino.size import at_least
 
-from ..libs.android.text import TextWatcher
+from ..libs.android.text import InputType, TextWatcher
 from ..libs.android.util import TypedValue
 from ..libs.android.view import Gravity, View__MeasureSpec
 from ..libs.android.widget import EditText
@@ -28,6 +28,7 @@ class TextInput(Widget):
     def create(self):
         self.native = EditText(self._native_activity)
         self.native.addTextChangedListener(TogaTextWatcher(self))
+        self.native.setInputType(InputType.TYPE_CLASS_TEXT)
 
     def get_value(self):
         return self.native.getText().toString()


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Without input type set, the textinput will be a multi-line text input widget in my test.
This patch set the input type and then the text input becomes single-line.
The above code is used in text, in which height was set to a large value so that multiple lines can be seen in a screenshot picture:
```python
import toga
from toga.style import Pack
from toga.style.pack import COLUMN, ROW


class HelloWorld(toga.App):

    def startup(self):
        main_box = toga.Box()
        main_box.add(toga.TextInput(style=Pack(flex=1, height=512)))
        self.main_window = toga.MainWindow(title=self.formal_name)
        self.main_window.content = main_box
        self.main_window.show()


def main():
    return HelloWorld()
```
Before setting the input type:
![before](https://user-images.githubusercontent.com/10961094/146947036-4bd3e5af-3e42-4a9c-a123-f01963fd57ec.png)

After setting the input type:

![after](https://user-images.githubusercontent.com/10961094/146947388-d38cc64f-50a1-45df-b365-c5cbd0c6eb66.png)


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
