### PR TITLE
toga_cocoa: Implement the Window set_position method.

### DIFF
--- a/examples/button/button/app.py
+++ b/examples/button/button/app.py
@@ -40,19 +40,23 @@ class ExampleButtonApp(toga.App):
         # Button with label and style option
         button3 = toga.Button('Bigger', style=Pack(width=200))
 
-        # Button with label and callback function called
-        button4a = toga.Button('Make window larger', on_press=self.callbackLarger)
-        button4b = toga.Button('Make window smaller', on_press=self.callbackSmaller)
-
-        # Box class
-        # Container of components
-        #   Add components for the first row of the outer box
         inner_box1 = toga.Box(
             style=style_inner_box,
             children=[
                 button1,
                 self.button2,
                 button3,
+            ]
+        )
+
+        # Button with label and callback function called
+        button4a = toga.Button('Make window larger', on_press=self.callbackLarger)
+        button4b = toga.Button('Make window smaller', on_press=self.callbackSmaller)
+
+        # Add components for the second row of the outer box
+        inner_box2 = toga.Box(
+            style=style_inner_box,
+            children=[
                 button4a,
                 button4b,
             ]
@@ -62,29 +66,45 @@ class ExampleButtonApp(toga.App):
         button5 = toga.Button('Far from home', style=Pack(padding=50, color=BLUE))
 
         # Button with label and RGB color
-        button6 = toga.Button('RGB : Fashion', style=Pack(background_color=RED))
+        button6 = toga.Button('RGB : Fashion', style=Pack(padding=10, background_color=RED))
 
         # Button with label and string color
-        button7 = toga.Button('String : Fashion', style=Pack(background_color=BLUE))
+        button7 = toga.Button('String : Fashion', style=Pack(padding=10, background_color=BLUE))
 
         # Button with label and string color
-        button8 = toga.Button('Big Font', style=Pack(font_family='serif', font_size=20, font_weight='bold'))
+        button8 = toga.Button('Big Font', style=Pack(padding=5, font_family='serif', font_size=20, font_weight='bold'))
 
-        # Add components for the second row of the outer box
-        inner_box2 = toga.Box(
+        # Add components for the third row of the outer box
+        inner_box3 = toga.Box(
             style=style_inner_box,
             children=[
                 button5,
                 button6,
                 button7,
-                button8
+                button8,
             ]
         )
 
-        #  Create the outer box with 2 rows
+        # Buttons to change window position
+        button9 = toga.Button('Not quite the origin', style=Pack(padding=5), on_press=self.seek_origin)
+        button10 = toga.Button('To the left screen', style=Pack(padding=5), on_press=self.seek_left_screen)
+        button11 = toga.Button('To the right screen', style=Pack(padding=5), on_press=self.seek_right_screen)
+
+        # Add components for the fourth row of the outer box
+        inner_box4 = toga.Box(
+            style=style_inner_box,
+            children=[
+                button9,
+                button10,
+                button11,
+            ]
+        )
+
+
+        #  Create the outer box with 4 rows
         outer_box = toga.Box(
             style=Pack(direction=COLUMN, height=10),
-            children=[inner_box1, inner_box2]
+            children=[inner_box1, inner_box2, inner_box3, inner_box4]
         )
 
         # Add the content on the main window
@@ -116,6 +136,22 @@ class ExampleButtonApp(toga.App):
         # Some action when you hit the button
         #   In this case the window size will change
         self.main_window.size = (200, 200)
+
+    def seek_origin(self, button):
+        # Move the window to the somewhere near the top-left of the main screen
+        self.main_window.position = (100, 200)
+
+    def seek_right_screen(self, button):
+        # Move the window off the right hand side of the main screen.
+        # If the user has multiple monitors with a screen to the right
+        # of the main screen, the window should appear there.
+        self.main_window.position = (2000, 400)
+
+    def seek_left_screen(self, button):
+        # Move the window off the left hand side of the main screen.
+        # If the user has multiple monitors with a screen to the left
+        # of the main screen, the window should appear there.
+        self.main_window.position = (-1000, 300)
 
 
 def main():

--- a/examples/button/button/app.py
+++ b/examples/button/button/app.py
@@ -100,7 +100,6 @@ class ExampleButtonApp(toga.App):
             ]
         )
 
-
         #  Create the outer box with 4 rows
         outer_box = toga.Box(
             style=Pack(direction=COLUMN, height=10),
@@ -139,7 +138,7 @@ class ExampleButtonApp(toga.App):
 
     def seek_origin(self, button):
         # Move the window to the somewhere near the top-left of the main screen
-        self.main_window.position = (100, 200)
+        self.main_window.position = (100, 30)
 
     def seek_right_screen(self, button):
         # Move the window off the right hand side of the main screen.

--- a/examples/button/button/app.py
+++ b/examples/button/button/app.py
@@ -89,6 +89,8 @@ class ExampleButtonApp(toga.App):
         button9 = toga.Button('Not quite the origin', style=Pack(padding=5), on_press=self.seek_origin)
         button10 = toga.Button('To the left screen', style=Pack(padding=5), on_press=self.seek_left_screen)
         button11 = toga.Button('To the right screen', style=Pack(padding=5), on_press=self.seek_right_screen)
+        button12 = toga.Button('Bump left', style=Pack(padding=5), on_press=self.bump_left)
+        button13 = toga.Button('Bump right', style=Pack(padding=5), on_press=self.bump_right)
 
         # Add components for the fourth row of the outer box
         inner_box4 = toga.Box(
@@ -97,6 +99,8 @@ class ExampleButtonApp(toga.App):
                 button9,
                 button10,
                 button11,
+                button12,
+                button13,
             ]
         )
 
@@ -151,6 +155,16 @@ class ExampleButtonApp(toga.App):
         # If the user has multiple monitors with a screen to the left
         # of the main screen, the window should appear there.
         self.main_window.position = (-1000, 300)
+
+    def bump_left(self, button):
+        # Move the window to the left a bit.
+        x, y = self.main_window.position
+        self.main_window.position = (x - 50, y)
+
+    def bump_right(self, button):
+        # Move the window to the right a bit.
+        x, y = self.main_window.position
+        self.main_window.position = (x + 50, y)
 
 
 def main():

--- a/src/cocoa/toga_cocoa/libs/__init__.py
+++ b/src/cocoa/toga_cocoa/libs/__init__.py
@@ -24,3 +24,20 @@ from .core_graphics import *  # noqa: F401, F403
 from .core_text import *  # noqa: F401, F403
 from .foundation import *  # noqa: F401, F403
 from .webkit import *  # noqa: F401, F403
+
+
+def NSPoint__repr__(self):
+    return '<NSPoint x={} y={}>'.format(self.x, self.y)
+
+
+def NSRect__repr__(self):
+    return '<NSRect origin={} size={}>'.format(self.origin, self.size)
+
+
+def NSSize__repr__(self):
+    return '<NSSize width={} height={}>'.format(self.width, self.height)
+
+
+NSPoint.__repr__ = NSPoint__repr__
+NSRect.__repr__ = NSRect__repr__
+NSSize.__repr__ = NSSize__repr__

--- a/src/cocoa/toga_cocoa/window.py
+++ b/src/cocoa/toga_cocoa/window.py
@@ -237,12 +237,9 @@ class Window:
     def set_position(self, position):
         x, y = position
         # The "principal" screen has index 0 and origin (0, 0).
-        screen = NSScreen.screens[0]
-
-        # If the window isn't visible, it won't be on a screen;
-        # don't try to set the position.
-        if screen is None:
+        if len(NSScreen.screens) == 0:
             return
+        screen = NSScreen.screens[0]
 
         frame = screen.frame
 

--- a/src/cocoa/toga_cocoa/window.py
+++ b/src/cocoa/toga_cocoa/window.py
@@ -235,7 +235,9 @@ class Window:
 
         # From the top left corner of the screen to the top left corner
         # of the window.
-        self.native.setFrameTopLeftPoint(NSPoint(x, frame.size.height - y))
+        x = frame.origin.x + x
+        y = frame.origin.y + frame.size.height - y
+        self.native.setFrameTopLeftPoint(NSPoint(x, y))
 
     def set_size(self, size):
         frame = self.native.frame

--- a/src/cocoa/toga_cocoa/window.py
+++ b/src/cocoa/toga_cocoa/window.py
@@ -222,6 +222,18 @@ class Window:
     def set_title(self, title):
         self.native.title = title
 
+    def update_position(self):
+        screen = self.native.screen
+        window = self.native
+        if screen is not None:
+            y = screen.frame.size.height - (
+                window.frame.origin.y + window.frame.size.height
+            )
+            self.interface._position = (
+                screen.frame.origin.x + window.frame.origin.x,
+                screen.frame.origin.y + y
+            )
+
     def set_position(self, position):
         x, y = position
         # The "principal" screen has index 0 and origin (0, 0).
@@ -241,20 +253,13 @@ class Window:
         self.native.setFrameTopLeftPoint(NSPoint(x, y))
 
         # Update the actual position.
-        screen = self.native.screen
-        window = self.native
-        y = screen.frame.size.height - (
-            window.frame.origin.y + window.frame.size.height
-        )
-        self.interface._position = (
-            screen.frame.origin.x + window.frame.origin.x,
-            screen.frame.origin.y + y
-        )
+        self.update_position()
 
     def set_size(self, size):
         frame = self.native.frame
         frame.size = NSSize(self.interface._size[0], self.interface._size[1])
         self.native.setFrame(frame, display=True, animate=True)
+        self.update_position()
 
     def set_app(self, app):
         pass

--- a/src/cocoa/toga_cocoa/window.py
+++ b/src/cocoa/toga_cocoa/window.py
@@ -14,6 +14,7 @@ from toga_cocoa.libs import (
     NSMiniaturizableWindowMask,
     NSMutableArray,
     NSObject,
+    NSPoint,
     NSResizableWindowMask,
     NSScreen,
     NSSize,
@@ -222,7 +223,18 @@ class Window:
         self.native.title = title
 
     def set_position(self, position):
-        pass
+
+        x, y = position
+        screen = self.native.screen
+        frame = screen.frame
+
+        # From the bottom left corner of the screen to the bottom left corner
+        # of the window.
+        # self.native.setFrameOrigin(NSPoint(x, y))
+
+        # From the top left corner of the screen to the top left corner
+        # of the window.
+        self.native.setFrameTopLeftPoint(NSPoint(x, frame.size.height - y))
 
     def set_size(self, size):
         frame = self.native.frame

--- a/src/cocoa/toga_cocoa/window.py
+++ b/src/cocoa/toga_cocoa/window.py
@@ -222,17 +222,22 @@ class Window:
     def set_title(self, title):
         self.native.title = title
 
-    def update_position(self):
-        screen = self.native.screen
-        window = self.native
-        if screen is not None:
+    def get_position(self):
+        try:
+            screen = self.native.screen
+            window = self.native
             y = screen.frame.size.height - (
                 window.frame.origin.y + window.frame.size.height
             )
-            self.interface._position = (
+            return (
                 screen.frame.origin.x + window.frame.origin.x,
                 screen.frame.origin.y + y
             )
+        except AttributeError:
+            return self.interface._position
+
+    def update_position(self):
+        self.interface._position = self.get_position()
 
     def set_position(self, position):
         x, y = position

--- a/src/cocoa/toga_cocoa/window.py
+++ b/src/cocoa/toga_cocoa/window.py
@@ -255,6 +255,12 @@ class Window:
         # Update the actual position.
         self.update_position()
 
+        # If we ended up off screen, or not where requested,
+        # fall back to the "main" screen.
+        if screen is None or not self.interface._position == position:
+            frame = NSScreen.mainScreen.frame
+            self.set_position((frame.origin.x + 100, frame.origin.y + 100))
+
     def set_size(self, size):
         frame = self.native.frame
         frame.size = NSSize(self.interface._size[0], self.interface._size[1])

--- a/src/cocoa/toga_cocoa/window.py
+++ b/src/cocoa/toga_cocoa/window.py
@@ -142,7 +142,7 @@ class Window:
     def create(self):
         # OSX origin is bottom left of screen, and the screen might be
         # offset relative to other screens. Adjust for this.
-        screen = NSScreen.mainScreen.visibleFrame
+        screen = NSScreen.screens[0].visibleFrame
         position = NSMakeRect(
             screen.origin.x + self.interface.position[0],
             screen.size.height + screen.origin.y - self.interface.position[1] - self.interface._size[1],
@@ -224,7 +224,8 @@ class Window:
 
     def set_position(self, position):
         x, y = position
-        screen = self.native.screen
+        # The "principal" screen has index 0 and origin (0, 0).
+        screen = NSScreen.screens[0]
 
         # If the window isn't visible, it won't be on a screen;
         # don't try to set the position.

--- a/src/cocoa/toga_cocoa/window.py
+++ b/src/cocoa/toga_cocoa/window.py
@@ -236,7 +236,7 @@ class Window:
         except AttributeError:
             return self.interface._position
 
-    def update_position(self):
+    def __update_position(self):
         self.interface._position = self.get_position()
 
     def set_position(self, position):
@@ -255,7 +255,7 @@ class Window:
         self.native.setFrameTopLeftPoint(NSPoint(x, y))
 
         # Update the actual position.
-        self.update_position()
+        self.__update_position()
 
         # If we ended up off screen, or not where requested,
         # fall back to the "main" screen.
@@ -267,7 +267,7 @@ class Window:
         frame = self.native.frame
         frame.size = NSSize(self.interface._size[0], self.interface._size[1])
         self.native.setFrame(frame, display=True, animate=True)
-        self.update_position()
+        self.__update_position()
 
     def set_app(self, app):
         pass

--- a/src/cocoa/toga_cocoa/window.py
+++ b/src/cocoa/toga_cocoa/window.py
@@ -240,6 +240,17 @@ class Window:
         y = frame.origin.y + frame.size.height - y
         self.native.setFrameTopLeftPoint(NSPoint(x, y))
 
+        # Update the actual position.
+        screen = self.native.screen
+        window = self.native
+        y = screen.frame.size.height - (
+            window.frame.origin.y + window.frame.size.height
+        )
+        self.interface._position = (
+            screen.frame.origin.x + window.frame.origin.x,
+            screen.frame.origin.y + y
+        )
+
     def set_size(self, size):
         frame = self.native.frame
         frame.size = NSSize(self.interface._size[0], self.interface._size[1])

--- a/src/cocoa/toga_cocoa/window.py
+++ b/src/cocoa/toga_cocoa/window.py
@@ -226,6 +226,8 @@ class Window:
 
         x, y = position
         screen = self.native.screen
+        if screen is None:
+            return
         frame = screen.frame
 
         # From the bottom left corner of the screen to the bottom left corner

--- a/src/cocoa/toga_cocoa/window.py
+++ b/src/cocoa/toga_cocoa/window.py
@@ -223,16 +223,15 @@ class Window:
         self.native.title = title
 
     def set_position(self, position):
-
         x, y = position
         screen = self.native.screen
+
+        # If the window isn't visible, it won't be on a screen;
+        # don't try to set the position.
         if screen is None:
             return
-        frame = screen.frame
 
-        # From the bottom left corner of the screen to the bottom left corner
-        # of the window.
-        # self.native.setFrameOrigin(NSPoint(x, y))
+        frame = screen.frame
 
         # From the top left corner of the screen to the top left corner
         # of the window.

--- a/src/cocoa/toga_cocoa/window.py
+++ b/src/cocoa/toga_cocoa/window.py
@@ -257,12 +257,6 @@ class Window:
         # Update the actual position.
         self.__update_position()
 
-        # If we ended up off screen, or not where requested,
-        # fall back to the "main" screen.
-        if screen is None or not self.interface._position == position:
-            frame = NSScreen.mainScreen.frame
-            self.set_position((frame.origin.x + 100, frame.origin.y + 100))
-
     def set_size(self, size):
         frame = self.native.frame
         frame.size = NSSize(self.interface._size[0], self.interface._size[1])

--- a/src/core/tests/test_window.py
+++ b/src/core/tests/test_window.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 import toga
 import toga_dummy
 from toga.command import CommandSet
+from toga.platform import current_platform
 from toga_dummy.utils import TestCase
 
 
@@ -57,6 +58,18 @@ class TestWindow(TestCase):
         with patch.object(self.window, '_impl'):
             self.window.position = new_position
             self.window._impl.set_position.assert_called_once_with(new_position)
+
+        # The Window.set_position method is only implemented in toga_cocoa
+        # at the moment.
+        if current_platform in ['darwin']:
+            window = toga.Window()
+            window.app = self.app
+            window.content = toga.Box()
+            window.show()
+            x, y = window.position
+            x, y = (x + 100, y + 100)
+            window.position = (x, y)
+            self.assertEqual((x, y), window.position)
 
     def test_full_screen_set(self):
         self.assertFalse(self.window.full_screen)

--- a/src/core/toga/window.py
+++ b/src/core/toga/window.py
@@ -162,6 +162,8 @@ class Window:
         Returns:
             A ``tuple`` of (``int``, ``int``) int the from (x, y).
         """
+        if hasattr(self._impl, 'get_position'):
+            return self._impl.get_position()
         return self._position
 
     @position.setter


### PR DESCRIPTION
The coordinate system on Cocoa has its origin at the bottom left corner of the screen, and the [setFrameOrigin](https://developer.apple.com/documentation/appkit/nswindow/1419690-setframeorigin?language=objc) method of NSWindow sets the position of the bottom-left corner of the window.

To be consistent with the other backends (position is from the top left corner of the screen to the top left corner of the window), I use [setFrameTopLeftPoint](https://developer.apple.com/documentation/appkit/nswindow/1419658-setframetopleftpoint?language=objc) and flip the y coordinate.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
