### PR TITLE
Use new Rubicon APIs

### DIFF
--- a/src/android/setup.py
+++ b/src/android/setup.py
@@ -20,7 +20,7 @@ with open('toga_android/__init__.py', encoding='utf8') as version_file:
 setup(
     version=version,
     install_requires=[
-        'rubicon-java>=0.2.2',
+        'rubicon-java>=0.2.6',
         'toga-core==%s' % version,
     ],
     test_suite='tests',

--- a/src/android/toga_android/app.py
+++ b/src/android/toga_android/app.py
@@ -209,7 +209,7 @@ class App:
         :returns: A Dictionary containing "resultCode" (int) and "resultData" (Intent or None)
         :rtype: dict
         """
-        if intent.resolveActivity(self.native.getPackageManager()) is None:
+        if not intent.resolveActivity(self.native.getPackageManager()):
             raise RuntimeError('No appropriate Activity found to handle this intent.')
         self._listener.last_intent_requestcode += 1
         code = self._listener.last_intent_requestcode

--- a/src/android/toga_android/app.py
+++ b/src/android/toga_android/app.py
@@ -125,22 +125,23 @@ class TogaApp(IPythonApp):
             self.menuitem_mapping[itemid] = cmd  # store itemid for use in onOptionsItemSelected
 
         # create toolbar actions
-        for cmd in self._impl.interface.main_window.toolbar:
-            if cmd == toga.SECTION_BREAK or cmd == toga.GROUP_BREAK:
-                continue
-            itemid += 1
-            order = Menu.NONE if cmd.order is None else cmd.order
-            menuitem = menu.add(Menu.NONE, itemid, order, cmd.label)  # groupId, itemId, order, title
-            menuitem.setShowAsActionFlags(
-                MenuItem.SHOW_AS_ACTION_IF_ROOM)  # toolbar button / item in options menu on overflow
-            menuitem.setEnabled(cmd.enabled)
-            if cmd.icon:
-                icon = Drawable.createFromPath(str(cmd.icon._impl.path))
-                if icon:
-                    menuitem.setIcon(icon)
-                else:
-                    print('Could not create icon: ' + str(cmd.icon._impl.path))
-            self.menuitem_mapping[itemid] = cmd  # store itemid for use in onOptionsItemSelected
+        if self._impl.interface.main_window:
+            for cmd in self._impl.interface.main_window.toolbar:
+                if cmd == toga.SECTION_BREAK or cmd == toga.GROUP_BREAK:
+                    continue
+                itemid += 1
+                order = Menu.NONE if cmd.order is None else cmd.order
+                menuitem = menu.add(Menu.NONE, itemid, order, cmd.label)  # groupId, itemId, order, title
+                menuitem.setShowAsActionFlags(
+                    MenuItem.SHOW_AS_ACTION_IF_ROOM)  # toolbar button / item in options menu on overflow
+                menuitem.setEnabled(cmd.enabled)
+                if cmd.icon:
+                    icon = Drawable.createFromPath(str(cmd.icon._impl.path))
+                    if icon:
+                        menuitem.setIcon(icon)
+                    else:
+                        print('Could not create icon: ' + str(cmd.icon._impl.path))
+                self.menuitem_mapping[itemid] = cmd  # store itemid for use in onOptionsItemSelected
 
         return True
 

--- a/src/android/toga_android/widgets/base.py
+++ b/src/android/toga_android/widgets/base.py
@@ -1,4 +1,3 @@
-from rubicon.java.jni import java
 from toga.constants import CENTER, JUSTIFY, LEFT, RIGHT
 
 from ..libs.activity import MainActivity

--- a/src/android/toga_android/widgets/base.py
+++ b/src/android/toga_android/widgets/base.py
@@ -19,7 +19,7 @@ def _get_activity(_cache=[]):
     if not MainActivity.singletonThis:
         raise ValueError("Unable to find MainActivity.singletonThis from Python. This is typically set by "
                          "org.beeware.android.MainActivity.onCreate().")
-    _cache.append(MainActivity(__jni__=java.NewGlobalRef(MainActivity.singletonThis)))
+    _cache.append(MainActivity.singletonThis.__global__())
     return _cache[0]
 
 

--- a/src/android/toga_android/widgets/detailedlist.py
+++ b/src/android/toga_android/widgets/detailedlist.py
@@ -63,8 +63,7 @@ class DetailedList(Widget):
             self.native.removeAllViews()
 
         scroll_view = ScrollView(self._native_activity)
-        self._scroll_view = ScrollView(
-            __jni__=java.NewGlobalRef(scroll_view))
+        self._scroll_view = scroll_view.__global__()
         scroll_view_layout_params = LinearLayout__LayoutParams(
                 LinearLayout__LayoutParams.MATCH_PARENT,
                 LinearLayout__LayoutParams.MATCH_PARENT
@@ -72,14 +71,11 @@ class DetailedList(Widget):
         scroll_view_layout_params.gravity = Gravity.TOP
         swipe_refresh_wrapper = SwipeRefreshLayout(self._native_activity)
         swipe_refresh_wrapper.setOnRefreshListener(OnRefreshListener(self.interface))
-        self._swipe_refresh_layout = SwipeRefreshLayout(
-            __jni__=java.NewGlobalRef(swipe_refresh_wrapper))
+        self._swipe_refresh_layout = swipe_refresh_wrapper.__global__()
         swipe_refresh_wrapper.addView(scroll_view)
         self.native.addView(swipe_refresh_wrapper, scroll_view_layout_params)
         dismissable_container = LinearLayout(self._native_activity)
-        self._dismissable_container = LinearLayout(
-            __jni__=java.NewGlobalRef(dismissable_container)
-        )
+        self._dismissable_container = dismissable_container.__global__()
         dismissable_container.setOrientation(LinearLayout.VERTICAL)
         dismissable_container_params = LinearLayout__LayoutParams(
                 LinearLayout__LayoutParams.MATCH_PARENT,

--- a/src/android/toga_android/widgets/detailedlist.py
+++ b/src/android/toga_android/widgets/detailedlist.py
@@ -1,5 +1,4 @@
 from rubicon.java.android_events import Handler, PythonRunnable
-from rubicon.java.jni import java
 from travertino.size import at_least
 
 from ..libs.android import R__color

--- a/src/android/toga_android/widgets/scrollcontainer.py
+++ b/src/android/toga_android/widgets/scrollcontainer.py
@@ -65,7 +65,7 @@ class ScrollContainer(Widget):
             LinearLayout__LayoutParams.MATCH_PARENT
         )
         widget_parent = widget.native.getParent()
-        if widget_parent is not None:
+        if widget_parent:
             widget_parent.removeView(widget.native)
         self.hScrollView.addView(widget.native, content_view_params)
         for child in widget.interface.children:

--- a/src/android/toga_android/widgets/webview.py
+++ b/src/android/toga_android/widgets/webview.py
@@ -50,8 +50,10 @@ class WebView(Widget):
     def set_content(self, root_url, content):
         # Android WebView lacks an underlying set_content() primitive, so we navigate to
         # a data URL. This means we ignore the root_url parameter.
-        data_url = ("data:text/html; charset=utf-8; base64," +
-                    base64.b64encode(content.encode('utf-8')).decode('ascii'))
+        data_url = (
+            "data:text/html; charset=utf-8; base64," +
+            base64.b64encode(content.encode('utf-8')).decode('ascii')
+        )
         self.set_url(data_url)
 
     def set_user_agent(self, value):
@@ -64,7 +66,6 @@ class WebView(Widget):
         return await js_value
 
     def invoke_javascript(self, javascript):
-        print("omg trying to invoke " + repr(javascript))
         self.native.evaluateJavascript(str(javascript), ReceiveString())
 
     def set_alignment(self, value):


### PR DESCRIPTION
Updates Toga to use Rubicon 0.2.6, and the new APIs that come with that (in particular, `__global__()`; but also some other miscellaneous fixes that were required).

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
