### PR TITLE
Fixed NULL pointer exception in Android ScrollContainer

### DIFF
--- a/src/android/toga_android/widgets/scrollcontainer.py
+++ b/src/android/toga_android/widgets/scrollcontainer.py
@@ -55,7 +55,7 @@ class ScrollContainer(Widget):
         self.hScrollListener.is_scrolling_enabled = self.interface.horizontal
         self.hScrollView.setOnTouchListener(self.hScrollListener)
         vScrollView.addView(self.hScrollView, hScrollView_layout_params)
-        if self.interface.content is not None:
+        if self.interface.content:
             self.set_content(self.interface.content)
 
     def set_content(self, widget):
@@ -65,7 +65,7 @@ class ScrollContainer(Widget):
             LinearLayout__LayoutParams.MATCH_PARENT
         )
         widget_parent = widget.native.getParent()
-        if widget_parent is not None:
+        if widget_parent:
             widget_parent.removeView(widget.native)
         self.hScrollView.addView(widget.native, content_view_params)
         for child in widget.interface.children:


### PR DESCRIPTION
This PR fixes a NULL pointer exception in Android ScrollContainer.
The problem stems from the introduction of JavaNull in rubicon-java 0.2.6

This fix can be tested with the ScrollContainer example.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
