### PR TITLE
Correct conversion of min/max values on Winforms Numberinput.

### DIFF
--- a/src/winforms/toga_winforms/widgets/numberinput.py
+++ b/src/winforms/toga_winforms/widgets/numberinput.py
@@ -30,13 +30,13 @@ class NumberInput(Widget):
         if self.interface.min_value is None:
             self.native.Minimum = Convert.ToDecimal(-sys.maxsize - 1)
         else:
-            self.native.Minimum = Convert.ToDecimal(self.interface.min_value)
+            self.native.Minimum = Convert.ToDecimal(float(self.interface.min_value))
 
     def set_max_value(self, value):
         if self.interface.max_value is None:
             self.native.Maximum = Convert.ToDecimal(sys.maxsize)
         else:
-            self.native.Maximum = Convert.ToDecimal(self.interface.max_value)
+            self.native.Maximum = Convert.ToDecimal(float(self.interface.max_value))
 
     def set_value(self, value):
         if value is None or value == '':


### PR DESCRIPTION
Reported (indirectly) through freakboy3742/traveltips#9.

When a min/max value is defined on a NumberInput on Winforms, the min/max value wasn't able to be converted.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
