### PR TITLE
Fix TextInput crash on Apple M1. Add noop select_file to cocoa.app.App to prevent an exception being raised

### DIFF
--- a/src/cocoa/toga_cocoa/app.py
+++ b/src/cocoa/toga_cocoa/app.py
@@ -415,6 +415,9 @@ class App:
     def open_document(self, fileURL):
         """No-op when the app is not a ``DocumentApp``."""
 
+    def select_file(self, **kwargs):
+        """No-op when the app is not a ``DocumentApp``."""
+
 
 class DocumentApp(App):
     def _create_app_commands(self):

--- a/src/cocoa/toga_cocoa/widgets/textinput.py
+++ b/src/cocoa/toga_cocoa/widgets/textinput.py
@@ -6,6 +6,7 @@ from toga_cocoa.libs import (
     NSTextAlignment,
     NSTextField,
     NSTextFieldSquareBezel,
+    c_void_p,
     objc_method,
     send_super,
 )
@@ -44,7 +45,7 @@ class TogaTextField(NSTextField):
         else:
             self._configured = True
 
-        send_super(__class__, self, 'textDidEndEditing:', textObject)
+        send_super(__class__, self, 'textDidEndEditing:', textObject, argtypes=[c_void_p])
 
 
 class TextInput(Widget):


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Added `argtypes=[c_void_p]` to the `send_super` call in `TogaTextField.textDidEndEditing_()`
This adds a noop mehtod for the `select_file` callback in toga_cocoa.app.App

<!--- What problem does this change solve? -->
TextInput crashes on Apple M1 silicon when losing focus
This exception is raised when creating a Toga app on macOS

```
Exception ignored on calling ctypes callback function: <rubicon.objc.api.objc_method object at 0x10796f7f0>
Traceback (most recent call last):
  File "/Users/fuzz/dev/dev-venv/lib/python3.10/site-packages/rubicon/objc/api.py", line 275, in __call__
    result = self.py_method(py_self, *args)
  File "/Users/fuzz/dev/dev-venv/lib/python3.10/site-packages/toga_cocoa/app.py", line 56, in applicationOpenUntitledFile_
    self.impl.select_file()
AttributeError: 'App' object has no attribute 'select_file'
```

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ X] All new features have been tested
- [X ] All new features have been documented
- [ X] I have read the **CONTRIBUTING.md** file
- [ X] I will abide by the code of conduct
