### PR TITLE
Android switch content

### DIFF
--- a/src/android/toga_android/widgets/base.py
+++ b/src/android/toga_android/widgets/base.py
@@ -57,7 +57,6 @@ class Widget:
                 self._container = None
         elif container:
             self._container = container
-            # self.viewport = container.viewport
             if self.native:
                 # When initially setting the container and adding widgets to the container,
                 # we provide no `LayoutParams`. Those are promptly added when Toga

--- a/src/android/toga_android/widgets/base.py
+++ b/src/android/toga_android/widgets/base.py
@@ -27,6 +27,7 @@ class Widget:
         self.interface = interface
         self.interface._impl = self
         self._container = None
+        self.viewport = None
         self.native = None
         self._native_activity = _get_activity()
         self.create()
@@ -56,7 +57,7 @@ class Widget:
                 self._container = None
         elif container:
             self._container = container
-            self.viewport = container.viewport
+            # self.viewport = container.viewport
             if self.native:
                 # When initially setting the container and adding widgets to the container,
                 # we provide no `LayoutParams`. Those are promptly added when Toga
@@ -109,7 +110,10 @@ class Widget:
     # INTERFACE
 
     def add_child(self, child):
-        if self.container:
+        if self.viewport:
+            # we are the top level widget
+            child.container = self
+        else:
             child.container = self.container
 
     def insert_child(self, index, child):

--- a/src/android/toga_android/widgets/canvas.py
+++ b/src/android/toga_android/widgets/canvas.py
@@ -52,10 +52,10 @@ class Canvas(Widget):
         path.close()
 
     def move_to(self, x, y, path, *args, **kwargs):
-        path.moveTo(self.viewport.scale * x, self.viewport.scale * y)
+        path.moveTo(self.container.viewport.scale * x, self.container.viewport.scale * y)
 
     def line_to(self, x, y, path, *args, **kwargs):
-        path.lineTo(self.viewport.scale * x, self.viewport.scale * y)
+        path.lineTo(self.container.viewport.scale * x, self.container.viewport.scale * y)
 
     # Basic shapes
 
@@ -63,20 +63,20 @@ class Canvas(Widget):
             self, cp1x, cp1y, cp2x, cp2y, x, y, path, *args, **kwargs
     ):
         path.cubicTo(
-            cp1x * self.viewport.scale,
-            cp1y * self.viewport.scale,
-            cp2x * self.viewport.scale,
-            cp2y * self.viewport.scale,
-            x * self.viewport.scale,
-            y * self.viewport.scale,
+            cp1x * self.container.viewport.scale,
+            cp1y * self.container.viewport.scale,
+            cp2x * self.container.viewport.scale,
+            cp2y * self.container.viewport.scale,
+            x * self.container.viewport.scale,
+            y * self.container.viewport.scale,
         )
 
     def quadratic_curve_to(self, cpx, cpy, x, y, path, *args, **kwargs):
         path.quadTo(
-            cpx * self.viewport.scale,
-            cpy * self.viewport.scale,
-            x * self.viewport.scale,
-            y * self.viewport.scale,
+            cpx * self.container.viewport.scale,
+            cpy * self.container.viewport.scale,
+            x * self.container.viewport.scale,
+            y * self.container.viewport.scale,
         )
 
     def arc(
@@ -95,10 +95,10 @@ class Canvas(Widget):
         if anticlockwise:
             sweep_angle -= math.radians(360)
         path.arcTo(
-            self.viewport.scale * (x - radius),
-            self.viewport.scale * (y - radius),
-            self.viewport.scale * (x + radius),
-            self.viewport.scale * (y + radius),
+            self.container.viewport.scale * (x - radius),
+            self.container.viewport.scale * (y - radius),
+            self.container.viewport.scale * (x + radius),
+            self.container.viewport.scale * (y + radius),
             math.degrees(startangle),
             math.degrees(sweep_angle),
             False,
@@ -123,24 +123,28 @@ class Canvas(Widget):
             sweep_angle -= math.radians(360)
         ellipse_path = Path()
         ellipse_path.addArc(
-            self.viewport.scale * (x - radiusx),
-            self.viewport.scale * (y - radiusy),
-            self.viewport.scale * (x + radiusx),
-            self.viewport.scale * (y + radiusy),
+            self.container.viewport.scale * (x - radiusx),
+            self.container.viewport.scale * (y - radiusy),
+            self.container.viewport.scale * (x + radiusx),
+            self.container.viewport.scale * (y + radiusy),
             math.degrees(startangle),
             math.degrees(sweep_angle),
         )
         rotation_matrix = Matrix()
-        rotation_matrix.postRotate(math.degrees(rotation), self.viewport.scale * x, self.viewport.scale * y)
+        rotation_matrix.postRotate(
+            math.degrees(rotation),
+            self.container.viewport.scale * x,
+            self.container.viewport.scale * y
+        )
         ellipse_path.transform(rotation_matrix)
         path.addPath(ellipse_path)
 
     def rect(self, x, y, width, height, path, *args, **kwargs):
         path.addRect(
-            self.viewport.scale * x,
-            self.viewport.scale * y,
-            self.viewport.scale * (x + width),
-            self.viewport.scale * (y + height),
+            self.container.viewport.scale * x,
+            self.container.viewport.scale * y,
+            self.container.viewport.scale * (x + width),
+            self.container.viewport.scale * (y + height),
             Path__Direction.CW,
         )
 
@@ -162,7 +166,7 @@ class Canvas(Widget):
     def stroke(self, color, line_width, line_dash, path, canvas, *args, **kwargs):
         draw_paint = Paint()
         draw_paint.setAntiAlias(True)
-        draw_paint.setStrokeWidth(self.viewport.scale * line_width)
+        draw_paint.setStrokeWidth(self.container.viewport.scale * line_width)
         draw_paint.setStyle(Paint__Style.STROKE)
         if color is None:
             a, r, g, b = 255, 0, 0, 0
@@ -170,7 +174,7 @@ class Canvas(Widget):
             a, r, g, b = round(color.a * 255), int(color.r), int(color.g), int(color.b)
         if line_dash is not None:
             draw_paint.setPathEffect(DashPathEffect(
-                [(self.viewport.scale * float(d)) for d in line_dash], 0.0))
+                [(self.container.viewport.scale * float(d)) for d in line_dash], 0.0))
         draw_paint.setARGB(a, r, g, b)
 
         canvas.drawPath(path, draw_paint)
@@ -185,7 +189,7 @@ class Canvas(Widget):
         canvas.scale(float(sx), float(sy))
 
     def translate(self, tx, ty, canvas, *args, **kwargs):
-        canvas.translate(self.viewport.scale * tx, self.viewport.scale * ty)
+        canvas.translate(self.container.viewport.scale * tx, self.container.viewport.scale * ty)
 
     def reset_transform(self, canvas, *args, **kwargs):
         canvas.restore()

--- a/src/android/toga_android/widgets/scrollcontainer.py
+++ b/src/android/toga_android/widgets/scrollcontainer.py
@@ -64,11 +64,14 @@ class ScrollContainer(Widget):
             LinearLayout__LayoutParams.MATCH_PARENT,
             LinearLayout__LayoutParams.MATCH_PARENT
         )
-        widget_parent = widget.native.getParent()
-        if widget_parent:
-            widget_parent.removeView(widget.native)
+        if widget.container:
+            widget.container = None
+        if self.interface.content:
+            self.hScrollView.removeAllViews()
         self.hScrollView.addView(widget.native, content_view_params)
         for child in widget.interface.children:
+            if child._impl.container:
+                child._impl.container = None
             child._impl.container = widget
 
     def set_vertical(self, value):

--- a/src/android/toga_android/window.py
+++ b/src/android/toga_android/window.py
@@ -68,7 +68,7 @@ class Window:
         # Attach child widgets to widget as their container.
         for child in widget.interface.children:
             child._impl.container = widget
-            child._impl.viewport = widget.viewport
+            # child._impl.viewport = widget.viewport
 
     def set_title(self, title):
         pass

--- a/src/android/toga_android/window.py
+++ b/src/android/toga_android/window.py
@@ -68,7 +68,6 @@ class Window:
         # Attach child widgets to widget as their container.
         for child in widget.interface.children:
             child._impl.container = widget
-            # child._impl.viewport = widget.viewport
 
     def set_title(self, title):
         pass


### PR DESCRIPTION
This PR fixes several UI problems on Android:
1. adding Widgets to a Box after startup has no effect
2. adding Widgets to the ScrollContainer's content box did not update the ScrollContainer
3. setting a new content on the ScrollContainer when there already was a content caused an app crash

The PR has been tested with following demo apps:
https://bitbucket.org/TomArn/demoapp.git      branch: switch_content
https://github.com/paulproteus/toganvas.git   commit [854b6ad]

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
