### PR TITLE
Fix canvas example on Windows

### DIFF
--- a/src/winforms/toga_winforms/widgets/canvas.py
+++ b/src/winforms/toga_winforms/widgets/canvas.py
@@ -290,7 +290,7 @@ class Canvas(Box):
             _, height = self.measure_text(line, font)
             origin = PointF(x, y + full_height - height)
             draw_context.current_path.AddString(
-                line, font_family, font_style, float(height), origin, StringFormat()
+                line, font_family, font_style.value__, float(height), origin, StringFormat()
             )
             full_height += height
 


### PR DESCRIPTION
Description
-------------
At the moment, the `Canvas` example is failing for *winforms*.
This PR fixes this problem

Why?
------
About two months ago we started using an alpha version of *Pythonnet 3.0*. This version now treats enums as objects instead of integers. the only way to get the integer value of the enum is using the `value__` attribute.

In the meanwhile, I opened an [issue](pythonnet/pythonnet#1585) for fixing this problem, and suggested adding the `__int__` method for getting `value__`. While *Pythonnet* did implement this ability in pythonnet/pythonnet#1661, it is not available in the alpha version.

In order for *Toga* to keep working until the next version of *Pythonnet* is released, I added this PR. once they publish their production version, I'll create a new PR and use the `__int__` method instead.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
