### PR TITLE
Add docstring to `App.add_background_task()`

### DIFF
--- a/src/core/toga/app.py
+++ b/src/core/toga/app.py
@@ -543,6 +543,17 @@ class App:
         self._impl.set_on_exit(self._on_exit)
 
     def add_background_task(self, handler):
+        """Schedule a task to run in the background.
+
+        Schedules a coroutine or a generator to run in the background. Control will be
+        returned to the event loop during await or yield statements, respectively. Use
+        this to run background tasks without blocking the GUI. If a regular callable is
+        passed, it will be called as is and will still block the GUI until the call
+        returns.
+
+        Args:
+            handler (:obj:`callable`): Coroutine, generator or callable.
+        """
         self._impl.add_background_task(handler)
 
 


### PR DESCRIPTION
This PR adds a doc string to `toga.App.add_background_task()`. Questions regarding its the usage or requests for functionality which is provided by `add_background_task()` have come up sufficiently often on Discord or GH Issues that this API should be documented.

This is a first step to address #1371.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
