### PR TITLE
More `send_super` fixes

### DIFF
--- a/src/cocoa/toga_cocoa/widgets/tree.py
+++ b/src/cocoa/toga_cocoa/widgets/tree.py
@@ -1,3 +1,4 @@
+from ctypes import c_void_p
 from travertino.size import at_least
 
 import toga
@@ -168,7 +169,7 @@ class TogaTree(NSOutlineView):
                 self.selectAll(self)
         else:
             # forward call to super
-            send_super(__class__, self, 'keyDown:', event)
+            send_super(__class__, self, 'keyDown:', event, argtypes=[c_void_p])
 
     # OutlineViewDelegate methods
     @objc_method

--- a/src/cocoa/toga_cocoa/widgets/webview.py
+++ b/src/cocoa/toga_cocoa/widgets/webview.py
@@ -1,4 +1,5 @@
 from asyncio import get_event_loop
+from ctypes import c_void_p
 
 from travertino.size import at_least
 
@@ -24,7 +25,7 @@ class TogaWebView(WKWebView):
     def keyDown_(self, event) -> None:
         if self.interface.on_key_down:
             self.interface.on_key_down(self.interface, **toga_key(event))
-        send_super(__class__, self, 'keyDown:', event)
+        send_super(__class__, self, 'keyDown:', event, argtypes=[c_void_p])
 
     @objc_method
     def touchBar(self):


### PR DESCRIPTION
This PR fixes remaining usages of `send_super` in toga-cocoa. See https://github.com/beeware/rubicon-objc/issues/219 for the rationale.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
