### PR TITLE
Fix for following creation error on Android: 'TextInput' object has no attribute _on_change

### DIFF
--- a/src/android/toga_android/widgets/textinput.py
+++ b/src/android/toga_android/widgets/textinput.py
@@ -27,8 +27,8 @@ class TogaTextWatcher(TextWatcher):
 class TextInput(Widget):
     def create(self):
         self.native = EditText(self._native_activity)
-        self.native.addTextChangedListener(TogaTextWatcher(self))
         self.native.setInputType(InputType.TYPE_CLASS_TEXT)
+        self.native.addTextChangedListener(TogaTextWatcher(self))
 
     def get_value(self):
         return self.native.getText().toString()

--- a/src/android/toga_android/widgets/textinput.py
+++ b/src/android/toga_android/widgets/textinput.py
@@ -28,6 +28,10 @@ class TextInput(Widget):
     def create(self):
         self.native = EditText(self._native_activity)
         self.native.setInputType(InputType.TYPE_CLASS_TEXT)
+
+        # Add the listener last; some actions (such as setting the input type)
+        # emit a change message, and we don't want to pass those on until
+        # the widget is fully configured.
         self.native.addTextChangedListener(TogaTextWatcher(self))
 
     def get_value(self):


### PR DESCRIPTION
This PR fixes the problem on Android that there is following error message when creating a TextInput:
'TextInput' object has no attribute _on_change

It seems that the lately added setInputType triggers a change event, but at this time, the on_change handler is not yet in place.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
