### PR TITLE
Wrap handler in interface layer for `add_background_task()`

### DIFF
--- a/src/android/toga_android/app.py
+++ b/src/android/toga_android/app.py
@@ -197,7 +197,7 @@ class App:
         pass
 
     def add_background_task(self, handler):
-        self.loop.call_soon(wrapped_handler(self, handler), self)
+        self.loop.call_soon(handler, self)
 
     async def intent_result(self, intent):
         """

--- a/src/android/toga_android/app.py
+++ b/src/android/toga_android/app.py
@@ -3,7 +3,6 @@ import toga
 
 from rubicon.java import android_events
 from toga.command import Group
-from toga.handlers import wrapped_handler
 
 from .libs.activity import IPythonApp, MainActivity
 from .libs.android.view import Menu, MenuItem

--- a/src/cocoa/toga_cocoa/app.py
+++ b/src/cocoa/toga_cocoa/app.py
@@ -410,7 +410,7 @@ class App:
         self._cursor_visible = False
 
     def add_background_task(self, handler):
-        self.loop.call_soon(wrapped_handler(self, handler), self)
+        self.loop.call_soon(handler, self)
 
     def open_document(self, fileURL):
         """No-op when the app is not a ``DocumentApp``."""

--- a/src/cocoa/toga_cocoa/app.py
+++ b/src/cocoa/toga_cocoa/app.py
@@ -7,7 +7,7 @@ from urllib.parse import unquote, urlparse
 from rubicon.objc.eventloop import CocoaLifecycle, EventLoopPolicy
 
 import toga
-from toga.handlers import wrapped_handler, NativeHandler
+from toga.handlers import NativeHandler
 
 from .keys import cocoa_key
 from .libs import (

--- a/src/core/tests/test_app.py
+++ b/src/core/tests/test_app.py
@@ -156,6 +156,14 @@ class AppTests(TestCase):
         for window in self.app.windows:
             self.assertIn(window, test_windows)
 
+    def test_add_background_task(self):
+
+        async def handler(sender):
+            pass
+
+        self.app.add_background_task(handler)
+        self.assertActionPerformed(self.app, 'add_background_task')
+
 
 class DocumentAppTests(TestCase):
     def setUp(self):

--- a/src/core/toga/app.py
+++ b/src/core/toga/app.py
@@ -554,7 +554,7 @@ class App:
         Args:
             handler (:obj:`callable`): Coroutine, generator or callable.
         """
-        self._impl.add_background_task(handler)
+        self._impl.add_background_task(wrapped_handler(self, handler))
 
 
 class DocumentApp(App):

--- a/src/gtk/toga_gtk/app.py
+++ b/src/gtk/toga_gtk/app.py
@@ -246,7 +246,7 @@ class App:
         self.interface.factory.not_implemented('App.hide_cursor()')
 
     def add_background_task(self, handler):
-        self.interface.factory.not_implemented('App.add_background_task()')
+        self.loop.call_soon(handler, self)
 
 
 class DocumentApp(App):

--- a/src/iOS/toga_iOS/app.py
+++ b/src/iOS/toga_iOS/app.py
@@ -3,7 +3,6 @@ import asyncio
 from rubicon.objc import SEL, objc_method
 from rubicon.objc.eventloop import EventLoopPolicy, iOSLifecycle
 
-from toga.handlers import wrapped_handler
 from toga_iOS.libs import (
     NSNotificationCenter,
     UIKeyboardFrameEndUserInfoKey,

--- a/src/iOS/toga_iOS/app.py
+++ b/src/iOS/toga_iOS/app.py
@@ -144,4 +144,4 @@ class App:
         pass
 
     def add_background_task(self, handler):
-        self.loop.call_soon(wrapped_handler(self, handler), self)
+        self.loop.call_soon(handler, self)

--- a/src/winforms/toga_winforms/app.py
+++ b/src/winforms/toga_winforms/app.py
@@ -268,7 +268,7 @@ class App:
         self.interface.factory.not_implemented('App.hide_cursor()')
 
     def add_background_task(self, handler):
-        self.loop.call_soon(wrapped_handler(self, handler), self)
+        self.loop.call_soon(handler, self)
 
 
 class DocumentApp(App):

--- a/src/winforms/toga_winforms/app.py
+++ b/src/winforms/toga_winforms/app.py
@@ -5,7 +5,6 @@ import traceback
 
 import toga
 from toga import Key
-from toga.handlers import wrapped_handler
 from .keys import toga_to_winforms_key
 
 from .libs import Threading, WinForms, shcore, user32, win_version


### PR DESCRIPTION
Currently, a handler passed to `toga.TogaApp.add_background_task()` is passed on as-is to the implementation layer and wrapped there. This has the consequence that the first argument passed to the handler is an instance of `toga_impl.App` instead of `toga.TogaApp`, therefore violating the contract that the first argument should be interface layer instance.

This PR fixes this by moving the `wrapped_handler(self, handler)` call to the interface layer.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
