### PR TITLE
Add std-nslog shim to example projects.

### DIFF
--- a/examples/.template/{{ cookiecutter.name }}/pyproject.toml
+++ b/examples/.template/{{ cookiecutter.name }}/pyproject.toml
@@ -22,6 +22,7 @@ requires = [
 [tool.briefcase.app.{{ cookiecutter.name }}.macOS]
 requires = [
     '../../src/cocoa',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.{{ cookiecutter.name }}.linux]
@@ -38,6 +39,7 @@ requires = [
 [tool.briefcase.app.{{ cookiecutter.name }}.iOS]
 requires = [
     '../../src/iOS',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.{{ cookiecutter.name }}.android]

--- a/examples/activityindicator/pyproject.toml
+++ b/examples/activityindicator/pyproject.toml
@@ -22,6 +22,7 @@ requires = [
 [tool.briefcase.app.activityindicator.macOS]
 requires = [
     '../../src/cocoa',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.activityindicator.linux]
@@ -38,6 +39,7 @@ requires = [
 [tool.briefcase.app.activityindicator.iOS]
 requires = [
     '../../src/iOS',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.activityindicator.android]

--- a/examples/beeliza/pyproject.toml
+++ b/examples/beeliza/pyproject.toml
@@ -22,6 +22,7 @@ requires = [
 [tool.briefcase.app.beeliza.macOS]
 requires = [
     '../../src/cocoa',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.beeliza.linux]
@@ -38,6 +39,7 @@ requires = [
 [tool.briefcase.app.beeliza.iOS]
 requires = [
     '../../src/iOS',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.beeliza.android]

--- a/examples/box/pyproject.toml
+++ b/examples/box/pyproject.toml
@@ -22,6 +22,7 @@ requires = [
 [tool.briefcase.app.box.macOS]
 requires = [
     '../../src/cocoa',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.box.linux]
@@ -38,6 +39,7 @@ requires = [
 [tool.briefcase.app.box.iOS]
 requires = [
     '../../src/iOS',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.box.android]

--- a/examples/button/pyproject.toml
+++ b/examples/button/pyproject.toml
@@ -22,6 +22,7 @@ requires = [
 [tool.briefcase.app.button.macOS]
 requires = [
     '../../src/cocoa',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.button.linux]
@@ -38,6 +39,7 @@ requires = [
 [tool.briefcase.app.button.iOS]
 requires = [
     '../../src/iOS',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.button.android]

--- a/examples/canvas/pyproject.toml
+++ b/examples/canvas/pyproject.toml
@@ -22,6 +22,7 @@ requires = [
 [tool.briefcase.app.canvas.macOS]
 requires = [
     '../../src/cocoa',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.canvas.linux]
@@ -38,6 +39,7 @@ requires = [
 [tool.briefcase.app.canvas.iOS]
 requires = [
     '../../src/iOS',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.canvas.android]

--- a/examples/command/pyproject.toml
+++ b/examples/command/pyproject.toml
@@ -22,6 +22,7 @@ requires = [
 [tool.briefcase.app.command.macOS]
 requires = [
     '../../src/cocoa',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.command.linux]
@@ -38,6 +39,7 @@ requires = [
 [tool.briefcase.app.command.iOS]
 requires = [
     '../../src/iOS',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.command.android]

--- a/examples/date_and_time/pyproject.toml
+++ b/examples/date_and_time/pyproject.toml
@@ -22,6 +22,7 @@ requires = [
 [tool.briefcase.app.date_and_time.macOS]
 requires = [
     '../../src/cocoa',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.date_and_time.linux]
@@ -38,6 +39,7 @@ requires = [
 [tool.briefcase.app.date_and_time.iOS]
 requires = [
     '../../src/iOS',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.date_and_time.android]

--- a/examples/detailedlist/pyproject.toml
+++ b/examples/detailedlist/pyproject.toml
@@ -22,6 +22,7 @@ requires = [
 [tool.briefcase.app.detailedlist.macOS]
 requires = [
     '../../src/cocoa',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.detailedlist.linux]
@@ -38,6 +39,7 @@ requires = [
 [tool.briefcase.app.detailedlist.iOS]
 requires = [
     '../../src/iOS',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.detailedlist.android]

--- a/examples/dialogs/pyproject.toml
+++ b/examples/dialogs/pyproject.toml
@@ -22,6 +22,7 @@ requires = [
 [tool.briefcase.app.dialogs.macOS]
 requires = [
     '../../src/cocoa',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.dialogs.linux]
@@ -38,6 +39,7 @@ requires = [
 [tool.briefcase.app.dialogs.iOS]
 requires = [
     '../../src/iOS',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.dialogs.android]

--- a/examples/divider/pyproject.toml
+++ b/examples/divider/pyproject.toml
@@ -22,6 +22,7 @@ requires = [
 [tool.briefcase.app.divider.macOS]
 requires = [
     '../../src/cocoa',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.divider.linux]
@@ -38,6 +39,7 @@ requires = [
 [tool.briefcase.app.divider.iOS]
 requires = [
     '../../src/iOS',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.divider.android]

--- a/examples/examples_overview/pyproject.toml
+++ b/examples/examples_overview/pyproject.toml
@@ -22,6 +22,7 @@ requires = [
 [tool.briefcase.app.examples_overview.macOS]
 requires = [
     '../../src/cocoa',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.examples_overview.linux]
@@ -38,6 +39,7 @@ requires = [
 [tool.briefcase.app.examples_overview.iOS]
 requires = [
     '../../src/iOS',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.examples_overview.android]

--- a/examples/focus/pyproject.toml
+++ b/examples/focus/pyproject.toml
@@ -22,6 +22,7 @@ requires = [
 [tool.briefcase.app.focus.macOS]
 requires = [
     '../../src/cocoa',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.focus.linux]
@@ -38,6 +39,7 @@ requires = [
 [tool.briefcase.app.focus.iOS]
 requires = [
     '../../src/iOS',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.focus.android]

--- a/examples/font/pyproject.toml
+++ b/examples/font/pyproject.toml
@@ -22,6 +22,7 @@ requires = [
 [tool.briefcase.app.font.macOS]
 requires = [
     '../../src/cocoa',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.font.linux]
@@ -38,6 +39,7 @@ requires = [
 [tool.briefcase.app.font.iOS]
 requires = [
     '../../src/iOS',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.font.android]

--- a/examples/handlers/pyproject.toml
+++ b/examples/handlers/pyproject.toml
@@ -22,6 +22,7 @@ requires = [
 [tool.briefcase.app.handlers.macOS]
 requires = [
     '../../src/cocoa',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.handlers.linux]
@@ -38,6 +39,7 @@ requires = [
 [tool.briefcase.app.handlers.iOS]
 requires = [
     '../../src/iOS',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.handlers.android]

--- a/examples/imageview/pyproject.toml
+++ b/examples/imageview/pyproject.toml
@@ -22,6 +22,7 @@ requires = [
 [tool.briefcase.app.imageview.macOS]
 requires = [
     '../../src/cocoa',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.imageview.linux]
@@ -38,6 +39,7 @@ requires = [
 [tool.briefcase.app.imageview.iOS]
 requires = [
     '../../src/iOS',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.imageview.android]

--- a/examples/layout/pyproject.toml
+++ b/examples/layout/pyproject.toml
@@ -22,6 +22,7 @@ requires = [
 [tool.briefcase.app.layout.macOS]
 requires = [
     '../../src/cocoa',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.layout.linux]
@@ -38,6 +39,7 @@ requires = [
 [tool.briefcase.app.layout.iOS]
 requires = [
     '../../src/iOS',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.layout.android]

--- a/examples/multilinetextinput/pyproject.toml
+++ b/examples/multilinetextinput/pyproject.toml
@@ -22,6 +22,7 @@ requires = [
 [tool.briefcase.app.multilinetextinput.macOS]
 requires = [
     '../../src/cocoa',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.multilinetextinput.linux]
@@ -38,6 +39,7 @@ requires = [
 [tool.briefcase.app.multilinetextinput.iOS]
 requires = [
     '../../src/iOS',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.multilinetextinput.android]

--- a/examples/numberinput/pyproject.toml
+++ b/examples/numberinput/pyproject.toml
@@ -22,6 +22,7 @@ requires = [
 [tool.briefcase.app.numberinput.macOS]
 requires = [
     '../../src/cocoa',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.numberinput.linux]
@@ -38,6 +39,7 @@ requires = [
 [tool.briefcase.app.numberinput.iOS]
 requires = [
     '../../src/iOS',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.numberinput.android]

--- a/examples/optioncontainer/pyproject.toml
+++ b/examples/optioncontainer/pyproject.toml
@@ -22,6 +22,7 @@ requires = [
 [tool.briefcase.app.optioncontainer.macOS]
 requires = [
     '../../src/cocoa',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.optioncontainer.linux]
@@ -38,6 +39,7 @@ requires = [
 [tool.briefcase.app.optioncontainer.iOS]
 requires = [
     '../../src/iOS',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.optioncontainer.android]

--- a/examples/progressbar/pyproject.toml
+++ b/examples/progressbar/pyproject.toml
@@ -22,6 +22,7 @@ requires = [
 [tool.briefcase.app.progressbar.macOS]
 requires = [
     '../../src/cocoa',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.progressbar.linux]
@@ -38,6 +39,7 @@ requires = [
 [tool.briefcase.app.progressbar.iOS]
 requires = [
     '../../src/iOS',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.progressbar.android]

--- a/examples/scrollcontainer/pyproject.toml
+++ b/examples/scrollcontainer/pyproject.toml
@@ -22,6 +22,7 @@ requires = [
 [tool.briefcase.app.scrollcontainer.macOS]
 requires = [
     '../../src/cocoa',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.scrollcontainer.linux]
@@ -38,6 +39,7 @@ requires = [
 [tool.briefcase.app.scrollcontainer.iOS]
 requires = [
     '../../src/iOS',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.scrollcontainer.android]

--- a/examples/selection/pyproject.toml
+++ b/examples/selection/pyproject.toml
@@ -22,6 +22,7 @@ requires = [
 [tool.briefcase.app.selection.macOS]
 requires = [
     '../../src/cocoa',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.selection.linux]
@@ -38,6 +39,7 @@ requires = [
 [tool.briefcase.app.selection.iOS]
 requires = [
     '../../src/iOS',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.selection.android]

--- a/examples/slider/pyproject.toml
+++ b/examples/slider/pyproject.toml
@@ -22,6 +22,7 @@ requires = [
 [tool.briefcase.app.slider.macOS]
 requires = [
     '../../src/cocoa',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.slider.linux]
@@ -38,6 +39,7 @@ requires = [
 [tool.briefcase.app.slider.iOS]
 requires = [
     '../../src/iOS',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.slider.android]

--- a/examples/switch_demo/pyproject.toml
+++ b/examples/switch_demo/pyproject.toml
@@ -22,6 +22,7 @@ requires = [
 [tool.briefcase.app.switch_demo.macOS]
 requires = [
     '../../src/cocoa',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.switch_demo.linux]
@@ -38,6 +39,7 @@ requires = [
 [tool.briefcase.app.switch_demo.iOS]
 requires = [
     '../../src/iOS',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.switch_demo.android]

--- a/examples/table/pyproject.toml
+++ b/examples/table/pyproject.toml
@@ -21,6 +21,7 @@ requires = [
 [tool.briefcase.app.table.macOS]
 requires = [
     '../../src/cocoa',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.table.linux]
@@ -37,6 +38,7 @@ requires = [
 [tool.briefcase.app.table.iOS]
 requires = [
     '../../src/iOS',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.table.android]

--- a/examples/table_source/pyproject.toml
+++ b/examples/table_source/pyproject.toml
@@ -22,6 +22,7 @@ requires = [
 [tool.briefcase.app.table_source.macOS]
 requires = [
     '../../src/cocoa',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.table_source.linux]
@@ -38,6 +39,7 @@ requires = [
 [tool.briefcase.app.table_source.iOS]
 requires = [
     '../../src/iOS',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.table_source.android]

--- a/examples/textinput/pyproject.toml
+++ b/examples/textinput/pyproject.toml
@@ -22,6 +22,7 @@ requires = [
 [tool.briefcase.app.textinput.macOS]
 requires = [
     '../../src/cocoa',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.textinput.linux]
@@ -38,6 +39,7 @@ requires = [
 [tool.briefcase.app.textinput.iOS]
 requires = [
     '../../src/iOS',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.textinput.android]

--- a/examples/tree/pyproject.toml
+++ b/examples/tree/pyproject.toml
@@ -22,6 +22,7 @@ requires = [
 [tool.briefcase.app.tree.macOS]
 requires = [
     '../../src/cocoa',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.tree.linux]
@@ -38,6 +39,7 @@ requires = [
 [tool.briefcase.app.tree.iOS]
 requires = [
     '../../src/iOS',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.tree.android]

--- a/examples/tree_source/pyproject.toml
+++ b/examples/tree_source/pyproject.toml
@@ -22,6 +22,7 @@ requires = [
 [tool.briefcase.app.tree_source.macOS]
 requires = [
     '../../src/cocoa',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.tree_source.linux]
@@ -38,6 +39,7 @@ requires = [
 [tool.briefcase.app.tree_source.iOS]
 requires = [
     '../../src/iOS',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.tree_source.android]

--- a/examples/tutorial0/pyproject.toml
+++ b/examples/tutorial0/pyproject.toml
@@ -22,6 +22,7 @@ requires = [
 [tool.briefcase.app.tutorial.macOS]
 requires = [
     '../../src/cocoa',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.tutorial.linux]
@@ -38,6 +39,7 @@ requires = [
 [tool.briefcase.app.tutorial.iOS]
 requires = [
     '../../src/iOS',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.tutorial.android]

--- a/examples/tutorial1/pyproject.toml
+++ b/examples/tutorial1/pyproject.toml
@@ -22,6 +22,7 @@ requires = [
 [tool.briefcase.app.tutorial.macOS]
 requires = [
     '../../src/cocoa',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.tutorial.linux]
@@ -38,6 +39,7 @@ requires = [
 [tool.briefcase.app.tutorial.iOS]
 requires = [
     '../../src/iOS',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.tutorial.android]

--- a/examples/tutorial2/pyproject.toml
+++ b/examples/tutorial2/pyproject.toml
@@ -22,6 +22,7 @@ requires = [
 [tool.briefcase.app.tutorial.macOS]
 requires = [
     '../../src/cocoa',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.tutorial.linux]
@@ -38,6 +39,7 @@ requires = [
 [tool.briefcase.app.tutorial.iOS]
 requires = [
     '../../src/iOS',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.tutorial.android]

--- a/examples/tutorial3/pyproject.toml
+++ b/examples/tutorial3/pyproject.toml
@@ -22,6 +22,7 @@ requires = [
 [tool.briefcase.app.tutorial.macOS]
 requires = [
     '../../src/cocoa',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.tutorial.linux]
@@ -38,6 +39,7 @@ requires = [
 [tool.briefcase.app.tutorial.iOS]
 requires = [
     '../../src/iOS',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.tutorial.android]

--- a/examples/tutorial4/pyproject.toml
+++ b/examples/tutorial4/pyproject.toml
@@ -22,6 +22,7 @@ requires = [
 [tool.briefcase.app.tutorial.macOS]
 requires = [
     '../../src/cocoa',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.tutorial.linux]
@@ -38,6 +39,7 @@ requires = [
 [tool.briefcase.app.tutorial.iOS]
 requires = [
     '../../src/iOS',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.tutorial.android]

--- a/examples/webview/pyproject.toml
+++ b/examples/webview/pyproject.toml
@@ -21,6 +21,7 @@ requires = [
 [tool.briefcase.app.webview.macOS]
 requires = [
     '../../src/cocoa',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.webview.linux]
@@ -36,7 +37,8 @@ requires = [
 # Mobile deployments
 [tool.briefcase.app.webview.iOS]
 requires = [
-    '../../src/ios',
+    '../../src/iOS',
+    'std-nslog>=1.0.0',
 ]
 
 [tool.briefcase.app.webview.android]


### PR DESCRIPTION
Briefcase 0.3.6 added the need for a shim to capture stdout/stderr. Without this shim, apps fail with ImportError on `nslog`.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
