### PR TITLE
Fixing error using this example on_select handler definition

### DIFF
--- a/src/core/toga/widgets/detailedlist.py
+++ b/src/core/toga/widgets/detailedlist.py
@@ -23,8 +23,8 @@ class DetailedList(Widget):
 
     Examples:
         >>> import toga
-        >>> def selection_handler(widget, selection):
-        >>>     print('Row {} of widget {} was selected.'.format(selection, widget))
+        >>> def selection_handler(widget, row):
+        >>>     print('Row {} of widget {} was selected.'.format(row, widget))
         >>>
         >>> dlist = toga.DetailedList(
         ...     data=[


### PR DESCRIPTION
I'm getting error `got an unexpected keyword argument 'row'` when trying to create `on_select` handler for `DetailedList` using provided example from documentation (I'm on MacOS)

This commit changes `Examples:` section of `DetailedList` class documentation to use the proper argument name


Currently documentation for DetailsList contains example, which raises exception

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
