### PR TITLE
Small changes to numberinput.py and textinput.py

### DIFF
--- a/src/core/toga/widgets/numberinput.py
+++ b/src/core/toga/widgets/numberinput.py
@@ -72,7 +72,7 @@ class NumberInput(Widget):
     @step.setter
     def step(self, step):
         try:
-            self._step = Decimal(step)
+            self._step = Decimal(str(step))
         except (ValueError, TypeError, InvalidOperation):
             raise ValueError("step must be an number")
         self._impl.set_step(self._step)
@@ -90,7 +90,7 @@ class NumberInput(Widget):
     @min_value.setter
     def min_value(self, value):
         try:
-            self._min_value = Decimal(value)
+            self._min_value = Decimal(str(value))
         except (ValueError, InvalidOperation):
             raise ValueError("min_value must be a number")
         except TypeError:
@@ -110,7 +110,7 @@ class NumberInput(Widget):
     @max_value.setter
     def max_value(self, value):
         try:
-            self._max_value = Decimal(value)
+            self._max_value = Decimal(str(value))
         except (ValueError, InvalidOperation):
             raise ValueError("max_value must be a number")
         except TypeError:
@@ -130,7 +130,7 @@ class NumberInput(Widget):
     @value.setter
     def value(self, value):
         try:
-            self._value = Decimal(value)
+            self._value = Decimal(str(value))
 
             if self.min_value is not None and self._value < self.min_value:
                 self._value = self.min_value

--- a/src/core/toga/widgets/textinput.py
+++ b/src/core/toga/widgets/textinput.py
@@ -173,7 +173,7 @@ class TextInput(Widget):
             if self.error_message is None:
                 self.error_message = validator(self.value)
 
-        if error_message is None:
+        if self.error_message is None:
             self._impl.clear_error()
             return True
         else:

--- a/src/core/toga/widgets/textinput.py
+++ b/src/core/toga/widgets/textinput.py
@@ -175,6 +175,7 @@ class TextInput(Widget):
 
         if error_message is None:
             self._impl.clear_error()
+            self.error_message = None
             return True
         else:
             self._impl.set_error(error_message)

--- a/src/core/toga/widgets/textinput.py
+++ b/src/core/toga/widgets/textinput.py
@@ -168,16 +168,14 @@ class TextInput(Widget):
         self._impl.set_on_lose_focus(self._on_lose_focus)
 
     def validate(self):
-        error_message = None
+        self.error_message = None
         for validator in self.validators:
-            if error_message is None:
-                error_message = validator(self.value)
+            if self.error_message is None:
+                self.error_message = validator(self.value)
 
         if error_message is None:
             self._impl.clear_error()
-            self.error_message = None
             return True
         else:
             self._impl.set_error(error_message)
-            self.error_message = error_message
             return False

--- a/src/core/toga/widgets/textinput.py
+++ b/src/core/toga/widgets/textinput.py
@@ -177,5 +177,5 @@ class TextInput(Widget):
             self._impl.clear_error()
             return True
         else:
-            self._impl.set_error(error_message)
+            self._impl.set_error(self.error_message)
             return False

--- a/src/core/toga/widgets/textinput.py
+++ b/src/core/toga/widgets/textinput.py
@@ -178,4 +178,5 @@ class TextInput(Widget):
             return True
         else:
             self._impl.set_error(error_message)
+            self.error_message = error_message
             return False


### PR DESCRIPTION
Describe your changes in detail:
1 - Convert numbers to string before applying the Decimal() function in the numberinput.py widget
2. - Make error_message variable as an instance variable (self..error_message) at the validate() method in the textinput.py widget.

What problem does this change solve?
1 - Avoid the weird bug generating irrational numbers when using steps between 0-1
2 - Makes the error_message from validate() method easily accessible to be used elsewhere in the app for platforms which _TextInput.set_error()_ are not implemented yet.

If this PR relates to an issue, include Refs:
1 - https://github.com/beeware/toga/issues/1455
2 - https://github.com/beeware/toga/discussions/1451#discussioncomment-2514801

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
*No new features
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
