### PR TITLE
Add protection against empty URLs on winforms.

### DIFF
--- a/src/winforms/toga_winforms/widgets/webview.py
+++ b/src/winforms/toga_winforms/widgets/webview.py
@@ -110,10 +110,11 @@ class WebView(Widget):
         pass
 
     def set_url(self, value):
-        self.native.Source = Uri(self.interface.url)
+        if value:
+            self.native.Source = Uri(self.interface.url)
 
     def set_content(self, root_url, content):
-        if self.native.CoreWebView2:
+        if content and self.native.CoreWebView2:
             self.native.CoreWebView2.NavigateToString(content)
 
     def get_dom(self):


### PR DESCRIPTION
If no URL is set on a webview, don't try to set the webview's URL.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
