### PR TITLE
Correct reference to impl in macOS canvas

### DIFF
--- a/src/cocoa/toga_cocoa/widgets/canvas.py
+++ b/src/cocoa/toga_cocoa/widgets/canvas.py
@@ -36,7 +36,7 @@ class TogaCanvas(NSView):
         # Save the "clean" state of the graphics context.
         core_graphics.CGContextSaveGState(context)
         if self.interface.redraw:
-            self.interface._draw(self._impl, draw_context=context)
+            self.interface._draw(self.impl, draw_context=context)
 
     @objc_method
     def isFlipped(self) -> bool:


### PR DESCRIPTION
The recent change to weak properties broke one of the references to the implementation layer on macOS canvas.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
