### PR TITLE
Fix for "access denied" error when using WebView2 on Windows 11

### DIFF
--- a/src/winforms/toga_winforms/widgets/webview.py
+++ b/src/winforms/toga_winforms/widgets/webview.py
@@ -36,7 +36,7 @@ class WebView(Widget):
         self.native.KeyDown += self.winforms_key_down
 
         props = CoreWebView2CreationProperties()
-        props.UserDataFolder = str(toga.App.app.paths.cache/ "WebView2")
+        props.UserDataFolder = str(toga.App.app.paths.cache / "WebView2")
         self.native.CreationProperties = props
 
         # Trigger the configuration of the webview

--- a/src/winforms/toga_winforms/widgets/webview.py
+++ b/src/winforms/toga_winforms/widgets/webview.py
@@ -1,4 +1,5 @@
 from asyncio import get_event_loop
+import toga
 import traceback
 import webbrowser
 
@@ -35,7 +36,7 @@ class WebView(Widget):
         self.native.KeyDown += self.winforms_key_down
 
         props = CoreWebView2CreationProperties()
-        props.UserDataFolder = None
+        props.UserDataFolder = str(toga.App.app.paths.cache/ "WebView2")
         self.native.CreationProperties = props
 
         # Trigger the configuration of the webview


### PR DESCRIPTION
This PR fixes the problem that on Windows 11, you get an "Access Denied" error when using WebView2 with 'briefcase dev' because Python tries to create the WebView2 user data dir in a subdirectory of the python.exe
With 'briefcase dev', this is a subdirectory of C:\Program Files\PythonXX\ where a normal user does not have write access.

![webview-problem](https://user-images.githubusercontent.com/8982757/162391768-873abd04-e333-4f9e-b386-c033307feb69.png)

With 'briefcase run', you do not get the error because the user has write access to the folder where the (embedded) python.exe is located.

The PR now sets the WebView2 user data dir to toga.App.app.paths.cache / "WebView2"

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
