### PR TITLE
Move to a "source of truth" model for window title, size and position

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ _build
 distribute-*
 docs/env
 local
-venv
+*venv*
 .idea
 Pipfile*
 .tox

--- a/examples/window/README.rst
+++ b/examples/window/README.rst
@@ -1,0 +1,12 @@
+Window Demo
+===========
+
+Test app for the Window Demo widget.
+
+Quickstart
+~~~~~~~~~~
+
+To run this example:
+
+    $ pip install toga
+    $ python -m window

--- a/examples/window/pyproject.toml
+++ b/examples/window/pyproject.toml
@@ -1,0 +1,48 @@
+[build-system]
+requires = ["briefcase"]
+
+[tool.briefcase]
+project_name = "Window Demo"
+bundle = "org.beeware"
+version = "0.3.0.dev33"
+url = "https://beeware.org"
+license = "BSD license"
+author = 'Tiberius Yak'
+author_email = "tiberius@beeware.org"
+
+[tool.briefcase.app.window]
+formal_name = "Window Demo"
+description = "A testing app"
+sources = ['window']
+requires = [
+    '../../src/core',
+]
+
+
+[tool.briefcase.app.window.macOS]
+requires = [
+    '../../src/cocoa',
+    'std-nslog>=1.0.0',
+]
+
+[tool.briefcase.app.window.linux]
+requires = [
+    '../../src/gtk',
+]
+
+[tool.briefcase.app.window.windows]
+requires = [
+    '../../src/winforms',
+]
+
+# Mobile deployments
+[tool.briefcase.app.window.iOS]
+requires = [
+    '../../src/iOS',
+    'std-nslog>=1.0.0',
+]
+
+[tool.briefcase.app.window.android]
+requires = [
+    '../../src/android',
+]

--- a/examples/window/window/__init__.py
+++ b/examples/window/window/__init__.py
@@ -1,0 +1,9 @@
+# Examples of valid version strings
+# __version__ = '1.2.3.dev1'  # Development release 1
+# __version__ = '1.2.3a1'     # Alpha Release 1
+# __version__ = '1.2.3b1'     # Beta Release 1
+# __version__ = '1.2.3rc1'    # RC Release 1
+# __version__ = '1.2.3'       # Final Release
+# __version__ = '1.2.3.post1' # Post Release 1
+
+__version__ = '0.0.1'

--- a/examples/window/window/__main__.py
+++ b/examples/window/window/__main__.py
@@ -1,0 +1,4 @@
+from window.app import main
+
+if __name__ == '__main__':
+    main().main_loop()

--- a/examples/window/window/app.py
+++ b/examples/window/window/app.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 import toga
 from toga.style import Pack
-from toga.constants import COLUMN, ROW
+from toga.constants import COLUMN
 
 
 class WindowDemoApp(toga.App):
@@ -26,13 +26,27 @@ class WindowDemoApp(toga.App):
         self.main_window.title = f"Time is {datetime.now()}"
 
     def do_new_windows(self, widget, **kwargs):
-        non_resize_window = toga.Window("Non-resizable Window", position=(200,200), size=(300,300), resizeable=False)
-        non_resize_window.content = toga.Box(children=[toga.Label("This window is not resizable")])
+        non_resize_window = toga.Window(
+            "Non-resizable Window",
+            position=(200, 200),
+            size=(300, 300),
+            resizeable=False,
+        )
+        non_resize_window.content = toga.Box(
+            children=[toga.Label("This window is not resizable")]
+        )
         self.app.windows += non_resize_window
         non_resize_window.show()
 
-        non_close_window = toga.Window("Non-closeable Window", position=(300,300), size=(300,300), closeable=False)
-        non_close_window.content = toga.Box(children=[toga.Label("This window is not closeable")])
+        non_close_window = toga.Window(
+            "Non-closeable Window",
+            position=(300, 300),
+            size=(300, 300),
+            closeable=False,
+        )
+        non_close_window.content = toga.Box(
+            children=[toga.Label("This window is not closeable")]
+        )
         self.app.windows += non_close_window
         non_close_window.show()
 

--- a/examples/window/window/app.py
+++ b/examples/window/window/app.py
@@ -1,0 +1,91 @@
+from datetime import datetime
+
+import toga
+from toga.style import Pack
+from toga.constants import COLUMN, ROW
+
+
+class WindowDemoApp(toga.App):
+    # Button callback functions
+    def do_origin(self, widget, **kwargs):
+        self.main_window.position = (0, 0)
+
+    def do_left(self, widget, **kwargs):
+        self.main_window.position = (-1000, 500)
+
+    def do_right(self, widget, **kwargs):
+        self.main_window.position = (2000, 500)
+
+    def do_small(self, widget, **kwargs):
+        self.main_window.size = (400, 300)
+
+    def do_large(self, widget, **kwargs):
+        self.main_window.size = (1500, 1000)
+
+    def do_title(self, widget, **kwargs):
+        self.main_window.title = f"Time is {datetime.now()}"
+
+    def do_new_windows(self, widget, **kwargs):
+        non_resize_window = toga.Window("Non-resizable Window", position=(200,200), size=(300,300), resizeable=False)
+        non_resize_window.content = toga.Box(children=[toga.Label("This window is not resizable")])
+        self.app.windows += non_resize_window
+        non_resize_window.show()
+
+        non_close_window = toga.Window("Non-closeable Window", position=(300,300), size=(300,300), closeable=False)
+        non_close_window.content = toga.Box(children=[toga.Label("This window is not closeable")])
+        self.app.windows += non_close_window
+        non_close_window.show()
+
+    def do_report(self, widget, **kwargs):
+        self.label.text = (
+            f"Window {self.main_window.title!r} "
+            f"has size {self.main_window.size!r} "
+            f"at {self.main_window.position!r}"
+        )
+
+    def startup(self):
+        # Set up main window
+        self.main_window = toga.MainWindow(title=self.name)
+
+        # Label to show responses.
+        self.label = toga.Label('Ready.')
+
+        # Buttons
+        btn_style = Pack(flex=1, padding=5)
+        btn_do_origin = toga.Button('Go to origin', on_press=self.do_origin, style=btn_style)
+        btn_do_left = toga.Button('Go left', on_press=self.do_left, style=btn_style)
+        btn_do_right = toga.Button('Go right', on_press=self.do_right, style=btn_style)
+        btn_do_small = toga.Button('Become small', on_press=self.do_small, style=btn_style)
+        btn_do_large = toga.Button('Become large', on_press=self.do_large, style=btn_style)
+        btn_do_title = toga.Button('Change title', on_press=self.do_title, style=btn_style)
+        btn_do_new_windows = toga.Button('Create Window', on_press=self.do_new_windows, style=btn_style)
+        btn_do_report = toga.Button('Report', on_press=self.do_report, style=btn_style)
+        btn_box = toga.Box(
+            children=[
+                self.label,
+                btn_do_origin,
+                btn_do_left,
+                btn_do_right,
+                btn_do_small,
+                btn_do_large,
+                btn_do_title,
+                btn_do_new_windows,
+                btn_do_report,
+            ],
+            style=Pack(direction=COLUMN)
+        )
+
+        # Add the content on the main window
+        self.main_window.content = btn_box
+
+        # Show the main window
+        self.main_window.show()
+
+
+def main():
+    return WindowDemoApp('Window Demo', 'org.beeware.widgets.window')
+
+
+if __name__ == '__main__':
+    app = main()
+    app.main_loop()

--- a/examples/window/window/resources/README
+++ b/examples/window/window/resources/README
@@ -1,0 +1,1 @@
+Put any icons or images in this directory.

--- a/src/android/toga_android/window.py
+++ b/src/android/toga_android/window.py
@@ -68,6 +68,7 @@ class Window:
             child._impl.container = widget
 
     def get_title(self):
+        self.interface.factory.not_implemented("Window.get_title()")
         return "?"
 
     def set_title(self, title):
@@ -82,7 +83,7 @@ class Window:
         pass
 
     def get_size(self):
-        display_metrics = self.app.contentView.getContext().getResources().getDisplayMetrics()
+        display_metrics = self.interface.content._impl.native.getContext().getResources().getDisplayMetrics()
         return (display_metrics.widthPixels, display_metrics.heightPixels)
 
     def set_size(self, size):

--- a/src/android/toga_android/window.py
+++ b/src/android/toga_android/window.py
@@ -75,14 +75,15 @@ class Window:
         pass
 
     def get_position(self):
-        return (0,0)
+        return (0, 0)
 
     def set_position(self, position):
         # Does nothing on mobile
         pass
 
     def get_size(self):
-        return (self.viewport.width, self.viewport.height)
+        display_metrics = self.app.contentView.getContext().getResources().getDisplayMetrics()
+        return (display_metrics.widthPixels, display_metrics.heightPixels)
 
     def set_size(self, size):
         # Does nothing on mobile

--- a/src/android/toga_android/window.py
+++ b/src/android/toga_android/window.py
@@ -46,13 +46,11 @@ class AndroidViewport:
 
 
 class Window:
-    def __init__(self, interface):
+    def __init__(self, interface, title, position, size):
         self.interface = interface
         self.interface._impl = self
-        self.create()
 
-    def create(self):
-        pass
+        # self.set_title(title)
 
     def set_app(self, app):
         self.app = app
@@ -69,13 +67,25 @@ class Window:
         for child in widget.interface.children:
             child._impl.container = widget
 
+    def get_title(self):
+        return "?"
+
     def set_title(self, title):
+        self.interface.factory.not_implemented("Window.set_title()")
         pass
+
+    def get_position(self):
+        return (0,0)
 
     def set_position(self, position):
+        # Does nothing on mobile
         pass
 
+    def get_size(self):
+        return (self.viewport.width, self.viewport.height)
+
     def set_size(self, size):
+        # Does nothing on mobile
         pass
 
     def create_toolbar(self):

--- a/src/core/tests/test_window.py
+++ b/src/core/tests/test_window.py
@@ -39,6 +39,15 @@ class TestWindow(TestCase):
         self.assertValueGet(self.window, 'title')
         self.assertEqual(title, 'New title')
 
+        # Set a default window title
+        self.window.title = None
+        self.assertValueSet(self.window, 'title', "Toga")
+
+        # New window title can be retrieved
+        title = self.window.title
+        self.assertValueGet(self.window, 'title')
+        self.assertEqual(title, 'Toga')
+
     def test_toolbar(self):
         toolbar = self.window.toolbar
         self.assertIsInstance(toolbar, CommandSet)
@@ -100,6 +109,18 @@ class TestWindow(TestCase):
                 self.window.on_close('widget', a=1),
                 "called <class 'toga.window.Window'> with {'a': 1}"
             )
+
+    def test_on_close_at_create(self):
+        def callback(window, **extra):
+            return 'called {} with {}'.format(type(window), extra)
+
+        window = toga.Window(factory=toga_dummy.factory, on_close=callback)
+
+        self.assertEqual(window.on_close._raw, callback)
+        self.assertEqual(
+            window.on_close('widget', a=1),
+            "called <class 'toga.window.Window'> with {'a': 1}"
+        )
 
     def test_close(self):
         with patch.object(self.window, "_impl"):

--- a/src/core/tests/test_window.py
+++ b/src/core/tests/test_window.py
@@ -25,38 +25,58 @@ class TestWindow(TestCase):
             self.window.app = new_app
 
     def test_window_title(self):
+        # Assert default value
         title = self.window.title
         self.assertEqual(title, 'Toga')
+        self.assertValueGet(self.window, 'title')
+
+        # Set a new window title
+        self.window.title = "New title"
+        self.assertValueSet(self.window, 'title', "New title")
+
+        # New window title can be retrieved
+        title = self.window.title
+        self.assertValueGet(self.window, 'title')
+        self.assertEqual(title, 'New title')
 
     def test_toolbar(self):
         toolbar = self.window.toolbar
         self.assertIsInstance(toolbar, CommandSet)
 
-    def test_size_getter_and_setter(self):
+    def test_size(self):
         # Add some content
         mock_content = MagicMock(toga.Box(factory=toga_dummy.factory))
         self.window.content = mock_content
 
         # Confirm defaults
-        self.assertEqual((640, 480), self.window.size)
+        self.assertEqual(self.window.size, (640, 480))
+        self.assertValueGet(self.window, 'size')
 
-        # Test setter
-        new_size = (1200, 40)
+        # A new size can be assigned
         mock_content.reset_mock()
-        with patch.object(self.window, '_impl'):
-            self.window.size = new_size
-            self.window._impl.set_size.assert_called_once_with(new_size)
-            self.window.content.refresh.assert_called_once_with()
+        new_size = (1200, 40)
+        self.window.size = new_size
+        self.assertValueSet(self.window, 'size', new_size)
 
-    def test_position_getter_and_setter(self):
+        # Side effect of setting window size is a refresh on window content
+        self.window.content.refresh.assert_called_once_with()
+
+        # New size can be retrieved
+        self.assertEqual(self.window.size, new_size)
+        self.assertValueGet(self.window, 'size')
+
+    def test_position(self):
         # Confirm defaults
-        self.assertEqual((100, 100), self.window.position)
+        self.assertEqual(self.window.position, (100, 100))
 
-        # Test setter
+        # A new position can be assigned
         new_position = (40, 79)
-        with patch.object(self.window, '_impl'):
-            self.window.position = new_position
-            self.window._impl.set_position.assert_called_once_with(new_position)
+        self.window.position = new_position
+        self.assertValueSet(self.window, 'position', new_position)
+
+        # New position can be retrieved
+        self.assertEqual(self.window.position, new_position)
+        self.assertValueGet(self.window, 'position')
 
     def test_full_screen_set(self):
         self.assertFalse(self.window.full_screen)

--- a/src/core/toga/app.py
+++ b/src/core/toga/app.py
@@ -543,18 +543,7 @@ class App:
         self._impl.set_on_exit(self._on_exit)
 
     def add_background_task(self, handler):
-        """Schedule a task to run in the background.
-
-        Schedules a coroutine or a generator to run in the background. Control will be
-        returned to the event loop during await or yield statements, respectively. Use
-        this to run background tasks without blocking the GUI. If a regular callable is
-        passed, it will be called as is and will still block the GUI until the call
-        returns.
-
-        Args:
-            handler (:obj:`callable`): Coroutine, generator or callable.
-        """
-        self._impl.add_background_task(wrapped_handler(self, handler))
+        self._impl.add_background_task(handler)
 
 
 class DocumentApp(App):

--- a/src/core/toga/window.py
+++ b/src/core/toga/window.py
@@ -31,8 +31,6 @@ class Window:
         self._impl = None
         self._app = None
         self._content = None
-        self._position = position
-        self._size = size
         self._is_full_screen = False
 
         self.resizeable = resizeable
@@ -40,7 +38,12 @@ class Window:
         self.minimizable = minimizable
 
         self.factory = get_platform_factory(factory)
-        self._impl = getattr(self.factory, self._WINDOW_CLASS)(interface=self)
+        self._impl = getattr(self.factory, self._WINDOW_CLASS)(
+            interface=self,
+            title='Toga' if title is None else title,
+            position=position,
+            size=size,
+        )
 
         self._toolbar = CommandSet(
             factory=self.factory,
@@ -48,9 +51,6 @@ class Window:
             on_change=self._impl.create_toolbar
         )
 
-        self.position = position
-        self.size = size
-        self.title = title
         self._on_close = None
         if on_close is not None:
             self.on_close = on_close
@@ -92,14 +92,13 @@ class Window:
         Returns:
             The current title of the window as a ``str``.
         """
-        return self._title
+        return self._impl.get_title()
 
     @title.setter
     def title(self, title):
         if not title:
             title = "Toga"
 
-        self._title = title
         self._impl.set_title(title)
 
     @property
@@ -146,11 +145,10 @@ class Window:
             A ``tuple`` of (``int``, ``int``) where the first value is
             the width and the second it the height of the window.
         """
-        return self._size
+        return self._impl.get_size()
 
     @size.setter
     def size(self, size):
-        self._size = size
         self._impl.set_size(size)
         if self.content:
             self.content.refresh()
@@ -162,11 +160,10 @@ class Window:
         Returns:
             A ``tuple`` of (``int``, ``int``) int the from (x, y).
         """
-        return self._position
+        return self._impl.get_position()
 
     @position.setter
     def position(self, position):
-        self._position = position
         self._impl.set_position(position)
 
     def show(self):

--- a/src/dummy/toga_dummy/window.py
+++ b/src/dummy/toga_dummy/window.py
@@ -2,12 +2,13 @@ from .utils import LoggedObject, not_required, not_required_on
 
 
 class Window(LoggedObject):
-    def __init__(self, interface):
+    def __init__(self, interface, title, position, size):
         super().__init__()
         self.interface = interface
 
-    def create(self):
-        self.action('create Window')
+        self.set_title(title)
+        self.set_position(position)
+        self.set_size(size)
 
     def create_toolbar(self):
         self._action('create toolbar')
@@ -15,13 +16,28 @@ class Window(LoggedObject):
     def set_content(self, widget):
         self._action('set content', widget=widget)
 
+    def get_title(self):
+        self._get_value('title')
+        return self._title
+
     def set_title(self, title):
+        self._title = title
         self._set_value('title', title)
 
+    def get_position(self):
+        self._get_value('position')
+        return self._position
+
     def set_position(self, position):
+        self._position = position
         self._set_value('position', position)
 
+    def get_size(self):
+        self._get_value('size')
+        return self._size
+
     def set_size(self, size):
+        self._size = size
         self._set_value('size', size)
 
     def set_app(self, app):

--- a/src/dummy/toga_dummy/window.py
+++ b/src/dummy/toga_dummy/window.py
@@ -17,27 +17,21 @@ class Window(LoggedObject):
         self._action('set content', widget=widget)
 
     def get_title(self):
-        self._get_value('title')
-        return self._title
+        return self._get_value('title')
 
     def set_title(self, title):
-        self._title = title
         self._set_value('title', title)
 
     def get_position(self):
-        self._get_value('position')
-        return self._position
+        return self._get_value('position')
 
     def set_position(self, position):
-        self._position = position
         self._set_value('position', position)
 
     def get_size(self):
-        self._get_value('size')
-        return self._size
+        return self._get_value('size')
 
     def set_size(self, size):
-        self._size = size
         self._set_value('size', size)
 
     def set_app(self, app):

--- a/src/gtk/toga_gtk/window.py
+++ b/src/gtk/toga_gtk/window.py
@@ -31,25 +31,28 @@ class GtkViewport:
 class Window:
     _IMPL_CLASS = Gtk.Window
 
-    def __init__(self, interface):
+    def __init__(self, interface, title, position, size):
         self.interface = interface
         self.interface._impl = self
-        self.create()
 
-    def create(self):
         self.layout = None
 
         self.native = self._IMPL_CLASS()
         self.native._impl = self
 
         self.native.connect("delete-event", self.gtk_delete_event)
-        self.native.set_default_size(self.interface.size[0], self.interface.size[1])
+        self.native.set_default_size(size[0], size[1])
+
+        self.set_position(position)
 
         # Set the window deletable/closeable.
         self.native.set_deletable(self.interface.closeable)
 
         self.toolbar_native = None
         self.toolbar_items = None
+
+    def get_title(self):
+        self.native.get_title()
 
     def set_title(self, title):
         self.native.set_title(title)
@@ -149,11 +152,17 @@ class Window:
     def close(self):
         self.native.close()
 
+    def get_position(self):
+        return self.native.get_position()
+
     def set_position(self, position):
-        pass
+        self.native.move(position[0], position[1])
+
+    def get_size(self):
+        self.native.get_size()
 
     def set_size(self, size):
-        pass
+        self.native.resize(size[0], size[1])
 
     def set_full_screen(self, is_full_screen):
         if is_full_screen:

--- a/src/gtk/toga_gtk/window.py
+++ b/src/gtk/toga_gtk/window.py
@@ -43,6 +43,7 @@ class Window:
         self.native.connect("delete-event", self.gtk_delete_event)
         self.native.set_default_size(size[0], size[1])
 
+        self.set_title(title)
         self.set_position(position)
 
         # Set the window deletable/closeable.
@@ -52,7 +53,7 @@ class Window:
         self.toolbar_items = None
 
     def get_title(self):
-        self.native.get_title()
+        return self.native.get_title()
 
     def set_title(self, title):
         self.native.set_title(title)
@@ -153,13 +154,15 @@ class Window:
         self.native.close()
 
     def get_position(self):
-        return self.native.get_position()
+        pos = self.native.get_position()
+        return (pos.root_x, pos.root_y)
 
     def set_position(self, position):
         self.native.move(position[0], position[1])
 
     def get_size(self):
-        self.native.get_size()
+        size = self.native.get_size()
+        return (size.width, size.height)
 
     def set_size(self, size):
         self.native.resize(size[0], size[1])

--- a/src/iOS/toga_iOS/app.py
+++ b/src/iOS/toga_iOS/app.py
@@ -14,12 +14,7 @@ from toga_iOS.window import Window
 
 
 class MainWindow(Window):
-    def __init__(self, interface):
-        super().__init__(interface)
-
-    # def startup(self):
-    #     super().startup()
-    #     self.native.setBackgroundColor_(UIColor.whiteColor())
+    pass
 
 
 class PythonAppDelegate(UIResponder):

--- a/src/iOS/toga_iOS/window.py
+++ b/src/iOS/toga_iOS/window.py
@@ -38,7 +38,6 @@ class Window:
 
         self.set_title(title)
 
-
     def set_content(self, widget):
         widget.viewport = iOSViewport(self.native)
 

--- a/src/iOS/toga_iOS/window.py
+++ b/src/iOS/toga_iOS/window.py
@@ -30,13 +30,14 @@ class iOSViewport:
 
 
 class Window:
-    def __init__(self, interface):
+    def __init__(self, interface, title, position, size):
         self.interface = interface
         self.interface._impl = self
-        self.create()
 
-    def create(self):
         self.native = UIWindow.alloc().initWithFrame(UIScreen.mainScreen.bounds)
+
+        self.set_title(title)
+
 
     def set_content(self, widget):
         widget.viewport = iOSViewport(self.native)
@@ -53,13 +54,25 @@ class Window:
         self.native.rootViewController = self.controller
         self.controller.view = widget.native
 
+    def get_title(self):
+        self.interface.factory.not_implemented("Window.get_title()")
+        return "?"
+
     def set_title(self, title):
-        pass
+        self.interface.factory.not_implemented("Window.set_title()")
+
+    def get_position(self):
+        return (0, 0)
 
     def set_position(self, position):
+        # Does nothing on mobile
         pass
 
+    def get_size(self):
+        return (UIScreen.mainScreen.bounds.size.width, UIScreen.mainScreen.bounds.size.height)
+
     def set_size(self, size):
+        # Does nothing on mobile
         pass
 
     def set_app(self, app):

--- a/src/web/toga_web/window.py
+++ b/src/web/toga_web/window.py
@@ -21,13 +21,11 @@ class WebViewport:
 
 
 class Window:
-    def __init__(self, interface):
+    def __init__(self, interface, title, position, size):
         self.interface = interface
         self.interface._impl = self
-        self.create()
 
-    def create(self):
-        pass
+        self.set_title(title)
 
     def __html__(self):
         return """
@@ -38,6 +36,10 @@ class Window:
             id=self.interface.id,
             content=self.interface.content._impl.__html__()
         )
+
+    def get_title(self):
+        self.interface.factory.not_implemented('Window.get_title()')
+        return "?"
 
     def set_title(self, title):
         self.interface.factory.not_implemented('Window.set_title()')
@@ -75,11 +77,19 @@ class Window:
     def close(self):
         self.interface.factory.not_implemented('Window.close()')
 
+    def get_position(self):
+        return (0, 0)
+
     def set_position(self, position):
-        self.interface.factory.not_implemented('Window.set_position()')
+        # Does nothing on web
+        pass
+
+    def get_size(self):
+        return (self.content.viewport.width, self.content.viewport.height)
 
     def set_size(self, size):
-        self.interface.factory.not_implemented('Window.set_size()')
+        # Does nothing on web
+        pass
 
     def set_full_screen(self, is_full_screen):
         self.interface.factory.not_implemented('Window.set_full_screen()')

--- a/src/winforms/toga_winforms/window.py
+++ b/src/winforms/toga_winforms/window.py
@@ -75,10 +75,10 @@ class Window:
         self.native.Location = Point(*position)
 
     def get_size(self):
-        return self.native.ClientSize
+        return (self.native.ClientSize.Width, self.native.ClientSize.Height)
 
     def set_size(self, size):
-        self.native.ClientSize = Size(*self.interface._size)
+        self.native.ClientSize = Size(*size)
 
     def set_app(self, app):
         if app is None:
@@ -116,6 +116,9 @@ class Window:
         # Add all children to the content widget.
         for child in widget.interface.children:
             child._impl.container = widget
+
+    def get_title(self):
+        return self.native.Text
 
     def set_title(self, title):
         self.native.Text = title

--- a/src/winforms/toga_winforms/window.py
+++ b/src/winforms/toga_winforms/window.py
@@ -36,7 +36,7 @@ class Window:
         self.interface = interface
         self.interface._impl = self
 
-        self.native = WinForms.Form(self)
+        self.native = WinForms.Form()
         self.native.interface = self.interface
 
         self.set_title(title)

--- a/src/winforms/toga_winforms/window.py
+++ b/src/winforms/toga_winforms/window.py
@@ -1,6 +1,6 @@
 from toga import GROUP_BREAK, SECTION_BREAK
 
-from .libs import Size, WinForms
+from .libs import Point, Size, WinForms
 
 
 class WinFormsViewport:
@@ -32,15 +32,17 @@ class WinFormsViewport:
 
 
 class Window:
-    def __init__(self, interface):
+    def __init__(self, interface, title, position, size):
         self.interface = interface
         self.interface._impl = self
-        self.create()
 
-    def create(self):
         self.native = WinForms.Form(self)
-        self.native.ClientSize = Size(*self.interface._size)
         self.native.interface = self.interface
+
+        self.set_title(title)
+        self.set_size(size)
+        self.set_position(position)
+
         self.toolbar_native = None
         self.toolbar_items = None
         if self.native.interface.resizeable:
@@ -66,8 +68,14 @@ class Window:
                 cmd._impl.native.append(item)
             self.toolbar_native.Items.Add(item)
 
+    def get_position(self):
+        return (self.native.Location.X, self.native.Location.Y)
+
     def set_position(self, position):
-        pass
+        self.native.Location = Point(*position)
+
+    def get_size(self):
+        return self.native.ClientSize
 
     def set_size(self, size):
         self.native.ClientSize = Size(*self.interface._size)


### PR DESCRIPTION
Window currently maintains an internal proxy of window title, size and position. This can lead to drift between the proxied value and the "true" value.

This PR moves to a "source of truth" model, where the interface interrogates the operating system APIs to obtain size, position and window title.

This requires initialization data to be passed to the implementation layer at time of construction; however, this also allows us to simplify the creation process. 

It also adds a test app to validate that these properties work as expected.

Supercedes (and includes portions of):
* #1395 (thanks to @eliteraspberries)
* #1023 (thanks to @t-arn)

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
