### PR TITLE
Correct the handling of screen origin in window placement on Cocoa

### DIFF
--- a/src/cocoa/toga_cocoa/window.py
+++ b/src/cocoa/toga_cocoa/window.py
@@ -226,14 +226,15 @@ class Window:
         if len(NSScreen.screens) == 0:
             return (0, 0)
 
+        # The "primary" screen has index 0 and origin (0, 0).
         primary_screen = NSScreen.screens[0].frame
         window_frame = self.native.frame
 
         # macOS origin is bottom left of screen, and the screen might be
         # offset relative to other screens. Adjust for this.
         return (
-            primary_screen.origin.x + window_frame.origin.x,
-            primary_screen.origin.y + primary_screen.size.height - (
+            window_frame.origin.x,
+            primary_screen.size.height - (
                 window_frame.origin.y + window_frame.size.height
             )
         )
@@ -243,13 +244,13 @@ class Window:
         if len(NSScreen.screens) == 0:
             return
 
-        # The "principal" screen has index 0 and origin (0, 0).
+        # The "primary" screen has index 0 and origin (0, 0).
         primary_screen = NSScreen.screens[0].frame
 
         # macOS origin is bottom left of screen, and the screen might be
         # offset relative to other screens. Adjust for this.
-        x = primary_screen.origin.x + position[0]
-        y = primary_screen.origin.y + primary_screen.size.height - position[1]
+        x = position[0]
+        y = primary_screen.size.height - position[1]
 
         self.native.setFrameTopLeftPoint(NSPoint(x, y))
 


### PR DESCRIPTION
Following on from #1461 (and a comment from @samschott), Removes the adjustment for the primary screen origin, as it will always be 0,0. 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
