### PR TITLE
Account for app exit with no on_exit handler.

### DIFF
--- a/src/core/toga/app.py
+++ b/src/core/toga/app.py
@@ -514,11 +514,9 @@ class App:
         """ Quit the application gracefully.
         """
         if self.on_exit:
-            should_exit = self.on_exit(self)
+            self.on_exit(self)
         else:
-            should_exit = True
-
-        return should_exit
+            self._impl.exit()
 
     @property
     def on_exit(self):


### PR DESCRIPTION
The changes for #1463 altered how the exit paths worked to allow for on_exit handlers to be asynchronous - but didn't account for the case when there isn't an on_exit handler at all.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
