### PR TITLE
Improvements to GTK Webview

### DIFF
--- a/src/gtk/toga_gtk/widgets/webview.py
+++ b/src/gtk/toga_gtk/widgets/webview.py
@@ -12,14 +12,23 @@ class WebView(Widget):
     def create(self):
         if WebKit2 is None:
             raise RuntimeError(
-                "Import 'from gi.repository import WebKit' failed;" +
-                " may need to install gir1.2-webkit2-4.0 or gir1.2-webkit2-3.0.")
+                "Unable to import WebKit2. Ensure that the operating system GTK "
+                "WebKit bindings (e.g., gir1.2-webkit2-4.0 on Debian/Ubuntu) "
+                "have been installed."
+            )
 
         self.native = WebKit2.WebView()
         self.native.interface = self.interface
 
-        settings = self.native.get_settings();
+        settings = self.native.get_settings()
         settings.set_property("enable-developer-extras", True)
+
+        # The default cache model is WEB_BROWSER, which will
+        # use the backing cache to minimize hits on the web server.
+        # This can result in stale web content being served, even if
+        # the source document (and the web server response) changes.
+        context = self.native.get_context()
+        context.set_cache_model(WebKit2.CacheModel.DOCUMENT_VIEWER)
 
         self.native.connect('key-press-event', self.gtk_on_key)
         self._last_key_time = 0

--- a/src/gtk/toga_gtk/widgets/webview.py
+++ b/src/gtk/toga_gtk/widgets/webview.py
@@ -18,6 +18,9 @@ class WebView(Widget):
         self.native = WebKit2.WebView()
         self.native.interface = self.interface
 
+        settings = self.native.get_settings();
+        settings.set_property("enable-developer-extras", True)
+
         self.native.connect('key-press-event', self.gtk_on_key)
         self._last_key_time = 0
 


### PR DESCRIPTION
Small tweaks to the GTK web view:

* Enables the developer menu (so that you can work out why pages aren't rendering)
* Change the cache model to `DOCUMENT_VIEWER`. This ensures that every URL request loads the page; the default mode (`WEB_BROWSER`) has aggressive page caching, which means the content won't be redisplayed even if the web server changes.
* Tweaks the error message with Webkit2 bindings haven't been installed.
 
## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
