### PR TITLE
Fix typo in the cocoa stack trace dialog

### DIFF
--- a/src/cocoa/toga_cocoa/dialogs.py
+++ b/src/cocoa/toga_cocoa/dialogs.py
@@ -148,7 +148,7 @@ class StackTraceDialog(NSAlertDialog):
         trace = NSTextView.alloc().init()
         trace.insertText(content)
         trace.editable = False
-        trace.werticallyResizable = True
+        trace.verticallyResizable = True
         trace.horizontallyResizable = True
         trace.font = NSFont.fontWithName("Menlo", size=12)
 


### PR DESCRIPTION
Fixes setting the NSTextView in the stack trace dialog being vertically resizable.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
