### PR TITLE
Explicitly define allowed Winforms TLS protocols.

### DIFF
--- a/src/winforms/toga_winforms/app.py
+++ b/src/winforms/toga_winforms/app.py
@@ -7,7 +7,15 @@ import toga
 from toga import Key
 from .keys import toga_to_winforms_key
 
-from .libs import Threading, WinForms, shcore, user32, win_version
+from .libs import (
+    SecurityProtocolType,
+    ServicePointManager,
+    Threading,
+    WinForms,
+    shcore,
+    user32,
+    win_version
+)
 from .libs.proactor import WinformsProactorEventLoop
 from .window import Window
 
@@ -68,6 +76,14 @@ class App:
 
         self.native.EnableVisualStyles()
         self.native.SetCompatibleTextRenderingDefault(False)
+
+        # Ensure that TLS1.2 and TLS1.3 are enabled for HTTPS connections.
+        # For some reason, some Windows installs have these protocols
+        # turned off by default. SSL3, TLS1.0 and TLS1.1 are *not* enabled
+        # as they are deprecated protocols and their use should *not* be
+        # encouraged.
+        ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12
+        ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls13
 
         self.interface.commands.add(
             toga.Command(

--- a/src/winforms/toga_winforms/libs/__init__.py
+++ b/src/winforms/toga_winforms/libs/__init__.py
@@ -20,6 +20,8 @@ from .winforms import (  # noqa: F401
     PointF,
     Rectangle,
     RectangleF,
+    SecurityProtocolType,
+    ServicePointManager,
     Single,
     Size,
     SolidBrush,

--- a/src/winforms/toga_winforms/libs/winforms.py
+++ b/src/winforms/toga_winforms/libs/winforms.py
@@ -55,6 +55,7 @@ from System.Runtime.InteropServices import ExternalException  # noqa: F401, E402
 
 from System.Threading.Tasks import Task, TaskScheduler  # noqa: F401, E402
 
+from System.Net import SecurityProtocolType, ServicePointManager  # noqa: F401, E402
 
 user32 = ctypes.windll.user32
 # shcore dll not exist on some Windows versions

--- a/src/winforms/toga_winforms/widgets/imageview.py
+++ b/src/winforms/toga_winforms/widgets/imageview.py
@@ -8,7 +8,7 @@ class ImageView(Widget):
     def create(self):
         self.native = WinForms.PictureBox()
         self.native.interface = self.interface
-        self.native.SizeMode = WinForms.PictureBoxSizeMode.StretchImage
+        self.native.SizeMode = WinForms.PictureBoxSizeMode.Zoom
 
     def set_image(self, image):
         # If an image already exists, ensure it is destroyed


### PR DESCRIPTION
Some installs seem to disable TLS1.2 and TLS1.3; this ensures those protocols are enabled for Winforms-derived requests.

Also fixes #1416, correcting aspect ratio for images.

Thanks to @rmartin16 for the diagnosis and .NET assistance on this.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
