### PR TITLE
Fixes #1482 - If a secondary window doesn't have a close handler, it can still be closed

### DIFF
--- a/examples/window/window/app.py
+++ b/examples/window/window/app.py
@@ -51,6 +51,17 @@ class WindowDemoApp(toga.App):
         self.app.windows += non_close_window
         non_close_window.show()
 
+        no_close_handler_window = toga.Window(
+            "No close handler",
+            position=(400, 400),
+            size=(300, 300),
+        )
+        no_close_handler_window.content = toga.Box(
+            children=[toga.Label("This window has no close handler")]
+        )
+        self.app.windows += no_close_handler_window
+        no_close_handler_window.show()
+
     def do_report(self, widget, **kwargs):
         self.label.text = (
             f"Window {self.main_window.title!r} "

--- a/src/cocoa/toga_cocoa/window.py
+++ b/src/cocoa/toga_cocoa/window.py
@@ -289,8 +289,13 @@ class Window:
 
     def cocoa_windowShouldClose(self):
         if self.interface.on_close:
-            return self.interface.on_close(self)
-        return True
+            # The on_close handler has a cleanup method that will enforce
+            # the close if the on_close handler requests it; this initial
+            # "should close" request can always return False.
+            self.interface.on_close(self)
+            return False
+        else:
+            return True
 
     def close(self):
         self.native.close()

--- a/src/cocoa/toga_cocoa/window.py
+++ b/src/cocoa/toga_cocoa/window.py
@@ -289,8 +289,8 @@ class Window:
 
     def cocoa_windowShouldClose(self):
         if self.interface.on_close:
-            self.interface.on_close(self)
-        return False
+            return self.interface.on_close(self)
+        return True
 
     def close(self):
         self.native.close()

--- a/src/core/toga/window.py
+++ b/src/core/toga/window.py
@@ -18,6 +18,7 @@ class Window:
         resizeable (bool): Toggle if the window is resizable by the user, defaults to `True`.
         closeable (bool): Toggle if the window is closable by the user, defaults to `True`.
         minimizable (bool): Toggle if the window is minimizable by the user, defaults to `True`.
+        on_close: A callback to invoke when the user makes a request to close the window.
         factory (:obj:`module`): A python module that is capable to return a
             implementation of this class with the same name. (optional; normally not needed)
     """

--- a/src/winforms/toga_winforms/window.py
+++ b/src/winforms/toga_winforms/window.py
@@ -151,7 +151,7 @@ class Window:
         self.interface.content.refresh()
 
         if self.interface is not self.interface.app._main_window:
-            self.native.Icon = self.interface.app.icon._impl.native
+            self.native.Icon = self.interface.app.icon.bind(self.interface.factory).native
             self.native.Show()
 
     def winforms_FormClosing(self, sender, event):


### PR DESCRIPTION
Corrects an oversight from #1464; analogous to #1466, but with secondary windows.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
