### PR TITLE
Fix select folder dialog on Windows

### DIFF
--- a/src/winforms/toga_winforms/dialogs.py
+++ b/src/winforms/toga_winforms/dialogs.py
@@ -173,15 +173,23 @@ class OpenFileDialog(FileDialog):
         )
 
 
-class SelectFolderDialog(FileDialog):
+class SelectFolderDialog(BaseDialog):
     def __init__(self, window, title, initial_directory, multiselect, on_result=None):
-        super().__init__(
-            dialog=WinForms.FolderBrowserDialog(),
-            window=window,
-            title=title,
-            filename=None,
-            initial_directory=initial_directory,
-            file_types=None,
-            multiselect=multiselect,
-            on_result=on_result,
-        )
+        super().__init__()
+        self.on_result = on_result
+
+        dialog = WinForms.FolderBrowserDialog()
+        dialog.Title = title
+        if initial_directory is not None:
+            dialog.InitialDirectory = str(initial_directory)
+
+        response = dialog.ShowDialog()
+        if response == WinForms.DialogResult.OK:
+            result = Path(dialog.SelectedPath)
+        else:
+            result = None
+
+        if self.on_result:
+            self.on_result(self, result)
+
+        self.future.set_result(result)


### PR DESCRIPTION
Calling `MainWindow.select_folder_dialog` would raise `AttributeError`
for `FileName`.
`OpenFileDialog` does not have a `FileName` or `FileNames` property
(nor does it support filtering nor multi-select)
so it cannot be handled the same way as the other two dialogs.

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
