### PR TITLE
fixes #1455 excessive decimals in numberinput

### DIFF
--- a/src/core/toga/widgets/numberinput.py
+++ b/src/core/toga/widgets/numberinput.py
@@ -72,7 +72,7 @@ class NumberInput(Widget):
     @step.setter
     def step(self, step):
         try:
-            self._step = Decimal(step)
+            self._step = Decimal(str(step))
         except (ValueError, TypeError, InvalidOperation):
             raise ValueError("step must be an number")
         self._impl.set_step(self._step)
@@ -90,7 +90,7 @@ class NumberInput(Widget):
     @min_value.setter
     def min_value(self, value):
         try:
-            self._min_value = Decimal(value)
+            self._min_value = Decimal(str(value))
         except (ValueError, InvalidOperation):
             raise ValueError("min_value must be a number")
         except TypeError:
@@ -110,7 +110,7 @@ class NumberInput(Widget):
     @max_value.setter
     def max_value(self, value):
         try:
-            self._max_value = Decimal(value)
+            self._max_value = Decimal(str(value))
         except (ValueError, InvalidOperation):
             raise ValueError("max_value must be a number")
         except TypeError:
@@ -130,7 +130,7 @@ class NumberInput(Widget):
     @value.setter
     def value(self, value):
         try:
-            self._value = Decimal(value)
+            self._value = Decimal(str(value))
 
             if self.min_value is not None and self._value < self.min_value:
                 self._value = self.min_value

--- a/src/core/toga/widgets/numberinput.py
+++ b/src/core/toga/widgets/numberinput.py
@@ -138,7 +138,7 @@ class NumberInput(Widget):
         else:
             self._value = None
 
-        self._impl.set_value(value)
+        self._impl.set_value(self._value)
 
     @property
     def on_change(self):

--- a/src/core/toga/widgets/numberinput.py
+++ b/src/core/toga/widgets/numberinput.py
@@ -90,11 +90,9 @@ class NumberInput(Widget):
     @min_value.setter
     def min_value(self, value):
         try:
-            self._min_value = Decimal(str(value))
+            self._min_value = Decimal(str(value)) if value is not None else None
         except (ValueError, InvalidOperation):
             raise ValueError("min_value must be a number")
-        except TypeError:
-            self._min_value = None
         self._impl.set_min_value(self._min_value)
 
     @property
@@ -110,11 +108,9 @@ class NumberInput(Widget):
     @max_value.setter
     def max_value(self, value):
         try:
-            self._max_value = Decimal(str(value))
+            self._max_value = Decimal(str(value)) if value is not None else None
         except (ValueError, InvalidOperation):
             raise ValueError("max_value must be a number")
-        except TypeError:
-            self._max_value = None
         self._impl.set_max_value(self._max_value)
 
     @property
@@ -129,16 +125,17 @@ class NumberInput(Widget):
 
     @value.setter
     def value(self, value):
-        try:
-            self._value = Decimal(str(value))
+        if value is not None:
+            try:
+                self._value = Decimal(str(value))
 
-            if self.min_value is not None and self._value < self.min_value:
-                self._value = self.min_value
-            elif self.max_value is not None and self._value > self.max_value:
-                self._value = self.max_value
-        except (ValueError, InvalidOperation):
-            raise ValueError("value must be a number")
-        except TypeError:
+                if self.min_value is not None and self._value < self.min_value:
+                    self._value = self.min_value
+                elif self.max_value is not None and self._value > self.max_value:
+                    self._value = self.max_value
+            except (ValueError, InvalidOperation):
+                raise ValueError("value must be a number")
+        else:
             self._value = None
 
         self._impl.set_value(value)


### PR DESCRIPTION
Extends @karthurdnt's work to fix #1455.
When using a NumberInput with a step of 0.1, annoying values appeared due to floating point imprecision.
This fixes that problem, plus adds some None handling to pass the test suite.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x]  All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
