### PR TITLE
Fix minimizable=False on Windows.

### DIFF
--- a/src/winforms/toga_winforms/window.py
+++ b/src/winforms/toga_winforms/window.py
@@ -48,6 +48,8 @@ class Window:
         self.native.interface = self.interface
         self.native.FormClosing += self.winforms_FormClosing
 
+        self.native.MinimizeBox = self.native.interface.minimizable
+
         self.set_title(title)
         self.set_size(size)
         self.set_position(position)


### PR DESCRIPTION
Fixes #1420.

The winforms Window constructor wasn't doing anything with the `toga.Window.minimizable` attribute. This PR sets the `Form.MinimizeBox` to the value of `interface.minimizable` which Windows respects. Found the attribute for the Form object here: https://stackoverflow.com/questions/3025923/disabling-minimize-maximize-on-winform

The resizable and closeable attributes were both being respected when I tested.

Tested on Windows 10, build 19044.1706 with Python 3.8.10 and Python 3.10.0

Short video demonstrating fix using the sample application from #1420:

![fix-demo](https://user-images.githubusercontent.com/6393101/172084511-88d5836d-6cef-467e-b93b-fe60db9b5407.gif)

Welcome to feedback on how to test this in an automated fashion.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
