### PR TITLE
Fix setting main_window.content acts as noop on windows.

### DIFF
--- a/src/winforms/toga_winforms/window.py
+++ b/src/winforms/toga_winforms/window.py
@@ -112,6 +112,9 @@ class Window:
         return result
 
     def set_content(self, widget):
+        for control in self.native.Controls:
+            self.native.Controls.Remove(control)
+
         if self.toolbar_native:
             self.native.Controls.Add(self.toolbar_native)
             # Create the lookup table of menu items,


### PR DESCRIPTION
Ref #1439

Replacing main_window.content was acting as a no op on Windows. By removing the existing controls, then adding the new widget, this fixes that problem. I'm personally concerned that there may be some subtlety I'm missing in the way winforms works here, but it works in the example from the ticket.

Would like to know if anyone is aware of a toga app where this approach would break it and I'll dive back into researching to see if I can use a lighter touch.

Things I did attempt:

* Tried moving setting the content until after the call to set_content, but that caused a number of failures (primarily on startup.)
* identity comparisons of controls don't work the way you would assume in Python. There may be some other kind of identity check I could do that I missed.

Video of the fix on windows:

![1439-fix-demo](https://user-images.githubusercontent.com/6393101/172089200-acf5d619-ba21-4f15-beba-2a88c379e42e.gif)


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
