### PR TITLE
Windows: remove unused window message mechanism from event loop

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ keywords =
 
 [options]
 zip_safe = False
-python_requires = >= 3.6
+python_requires = >= 3.7
 
 [flake8]
 # https://flake8.readthedocs.org/en/latest/

--- a/src/winforms/toga_winforms/libs/proactor.py
+++ b/src/winforms/toga_winforms/libs/proactor.py
@@ -3,7 +3,7 @@ import sys
 import threading
 from asyncio import events
 
-from .winforms import Action, Task, WinForms, user32
+from .winforms import Action, Task, WinForms
 
 
 class WinformsProactorEventLoop(asyncio.ProactorEventLoop):

--- a/src/winforms/toga_winforms/libs/proactor.py
+++ b/src/winforms/toga_winforms/libs/proactor.py
@@ -121,9 +121,3 @@ class WinformsProactorEventLoop(asyncio.ProactorEventLoop):
             # queue, the select() call will block, locking the app.
             self.enqueue_tick()
             self.call_soon(self._loop_self_reading)
-
-
-# Python 3.7 changed the name of an internal wrapper function.
-# Install an alias for the old name at the new name.
-if sys.version_info < (3, 7):
-    WinformsProactorEventLoop._set_coroutine_origin_tracking = WinformsProactorEventLoop._set_coroutine_wrapper


### PR DESCRIPTION
I've noticed that every time I run a BeeWare app on Windows, my laptop fan spins up. I've also noticed that whenever a BeeWare app is running, my VcXsrv X server locks up, preventing me from using any graphical Linux apps at the same time.

This was caused by the `PostMessageA` line in the event loop. `0xffff` doesn't just send the message to every window in the current app, it sends it to every window in *every* running app, 200 times per second.

As I understand it, this window message mechanism is a partially-disabled implementation left over from #741, which was intended to address #750 but was blocked by a bug in python.net.

I could comment out the rest of the window message code, but I think it's confusing having fragments of two different implementations mixed together in the file, so I've just removed it all. If this PR is merged, I'll post a comment in #750 explaining where to find it in the future.

After doing this, the X server lockup no longer happens, and my CPU temperature with a BeeWare app running has reduced from 67 to 57C.

Tested by running examples/handlers.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
