### PR TITLE
WebView: Get the current URL from the implementation

### DIFF
--- a/examples/tutorial3/tutorial/app.py
+++ b/examples/tutorial3/tutorial/app.py
@@ -6,7 +6,7 @@ class Graze(toga.App):
     def startup(self):
         self.main_window = toga.MainWindow(title=self.name)
 
-        self.webview = toga.WebView(on_webview_load=self.on_webview_loaded,style=Pack(flex=1))
+        self.webview = toga.WebView(on_webview_load=self.on_webview_loaded, style=Pack(flex=1))
         self.url_input = toga.TextInput(
             initial='https://beeware.org/',
             style=Pack(flex=1)
@@ -43,6 +43,7 @@ class Graze(toga.App):
 
     def on_webview_loaded(self, widget):
         self.url_input.value = self.webview.url
+
 
 def main():
     return Graze('Graze', 'org.beeware.graze')

--- a/examples/tutorial3/tutorial/app.py
+++ b/examples/tutorial3/tutorial/app.py
@@ -6,7 +6,7 @@ class Graze(toga.App):
     def startup(self):
         self.main_window = toga.MainWindow(title=self.name)
 
-        self.webview = toga.WebView(style=Pack(flex=1))
+        self.webview = toga.WebView(on_webview_load=self.on_webview_loaded,style=Pack(flex=1))
         self.url_input = toga.TextInput(
             initial='https://beeware.org/',
             style=Pack(flex=1)
@@ -41,6 +41,8 @@ class Graze(toga.App):
     def load_page(self, widget):
         self.webview.url = self.url_input.value
 
+    def on_webview_loaded(self, widget):
+        self.url_input.value = self.webview.url
 
 def main():
     return Graze('Graze', 'org.beeware.graze')

--- a/src/android/toga_android/widgets/webview.py
+++ b/src/android/toga_android/widgets/webview.py
@@ -43,6 +43,9 @@ class WebView(Widget):
         # Android has no straightforward way to get the DOM from the browser synchronously.
         self.interface.factory.not_implemented('WebView.get_dom()')
 
+    def get_url(self):
+        return self.native.getUrl()
+
     def set_url(self, value):
         if value:
             self.native.loadUrl(str(value))

--- a/src/cocoa/toga_cocoa/libs/__init__.py
+++ b/src/cocoa/toga_cocoa/libs/__init__.py
@@ -18,9 +18,7 @@ from rubicon.objc import (  # noqa: F401
     objc_method,
     objc_property,
     send_super,
-    py_from_ns,
 )
-from rubicon.objc.runtime import objc_id  # noqa: F401
 
 from .appkit import *  # noqa: F401, F403
 from .core_graphics import *  # noqa: F401, F403

--- a/src/cocoa/toga_cocoa/widgets/webview.py
+++ b/src/cocoa/toga_cocoa/widgets/webview.py
@@ -3,27 +3,25 @@ from ctypes import c_void_p
 
 from travertino.size import at_least
 
+from rubicon.objc import objc_method, objc_property, py_from_ns
+from rubicon.objc.runtime import objc_id
+
 from .base import Widget
 from ..keys import toga_key
 from ..libs import (
     NSURL,
     NSURLRequest,
     WKWebView,
-    objc_method,
-    objc_property,
-    py_from_ns,
     send_super,
-    objc_id,
 )
 
 
 class TogaWebView(WKWebView):
-
     interface = objc_property(object, weak=True)
     impl = objc_property(object, weak=True)
 
     @objc_method
-    def webView_didFinish_navigation_(self, sender, wkNavigation) -> None:
+    def webView_didFinishNavigation_(self, navigation) -> None:
         if self.interface.on_webview_load:
             self.interface.on_webview_load(self.interface)
 
@@ -49,10 +47,7 @@ class WebView(Widget):
         self.native.interface = self.interface
         self.native.impl = self
 
-        self.native.downloadDelegate = self.native
-        self.native.frameLoadDelegate = self.native
-        self.native.policyDelegate = self.native
-        self.native.resourceLoadDelegate = self.native
+        self.native.navigationDelegate = self.native
         self.native.uIDelegate = self.native
 
         # Add the layout constraints
@@ -71,9 +66,14 @@ class WebView(Widget):
         html = self.native.mainframe.DOMDocument.documentElement.outerHTML
         return html
 
+    def get_url(self):
+        url = self.native.URL
+        if url:
+            return str(url)
+
     def set_url(self, value):
         if value:
-            request = NSURLRequest.requestWithURL(NSURL.URLWithString(self.interface.url))
+            request = NSURLRequest.requestWithURL(NSURL.URLWithString(value))
             self.native.loadRequest(request)
 
     def set_content(self, root_url, content):

--- a/src/core/toga/widgets/webview.py
+++ b/src/core/toga/widgets/webview.py
@@ -26,7 +26,6 @@ class WebView(Widget):
         super().__init__(id=id, style=style, factory=factory)
 
         # Prime some internal property-backing variables
-        self._url = None
         self._html_content = None
         self._user_agent = None
 
@@ -52,14 +51,10 @@ class WebView(Widget):
         Returns:
             The current URL as a ``str``.
         """
-        if hasattr(self._impl, 'get_url'):
-            self._url = self._impl.get_url()
-            # once get_url is implemented on all platforms, we can call it unconditionally and remove self._url
-        return self._url
+        return self._impl.get_url()
 
     @url.setter
     def url(self, value):
-        self._url = value
         self._html_content = None
         self._impl.set_url(value)
 
@@ -125,7 +120,6 @@ class WebView(Widget):
         Returns:
 
         """
-        self._url = root_url
         self._html_content = content
         self._impl.set_content(root_url, content)
 

--- a/src/core/toga/widgets/webview.py
+++ b/src/core/toga/widgets/webview.py
@@ -52,6 +52,9 @@ class WebView(Widget):
         Returns:
             The current URL as a ``str``.
         """
+        if hasattr(self._impl, 'get_url'):
+            self._url = self._impl.get_url()
+            # once get_url is implemented on all platforms, we can call it unconditionally and remove self._url
         return self._url
 
     @url.setter

--- a/src/dummy/toga_dummy/widgets/webview.py
+++ b/src/dummy/toga_dummy/widgets/webview.py
@@ -21,6 +21,9 @@ class WebView(Widget):
     def set_user_agent(self, value):
         self._set_value('user_agent', value)
 
+    def get_url(self):
+        return self._get_value('url')
+
     def set_url(self, value):
         self._set_value('url', value)
 

--- a/src/gtk/toga_gtk/widgets/webview.py
+++ b/src/gtk/toga_gtk/widgets/webview.py
@@ -30,6 +30,7 @@ class WebView(Widget):
         context = self.native.get_context()
         context.set_cache_model(WebKit2.CacheModel.DOCUMENT_VIEWER)
 
+        self.native.connect('load-changed', self.gtk_on_load_changed)
         self.native.connect('key-press-event', self.gtk_on_key)
         self._last_key_time = 0
 
@@ -38,6 +39,11 @@ class WebView(Widget):
 
     def set_on_webview_load(self, handler):
         pass
+
+    def gtk_on_load_changed(self, widget, load_event, *args):
+        if load_event == WebKit2.LoadEvent.FINISHED:
+            if self.interface.on_webview_load:
+                self.interface.on_webview_load(self.interface)
 
     def gtk_on_key(self, widget, event, *args):
         # key-press-event on WebKit on GTK double-sends events, but they have
@@ -48,9 +54,12 @@ class WebView(Widget):
             if toga_event:
                 self.interface.on_key_down(self.interface, **toga_event)
 
+    def get_url(self):
+        return self.native.get_uri()
+
     def set_url(self, value):
         if value:
-            self.native.load_uri(self.interface.url)
+            self.native.load_uri(value)
 
     def set_user_agent(self, value):
         # replace user agent of webview (webview has own one)

--- a/src/iOS/toga_iOS/widgets/webview.py
+++ b/src/iOS/toga_iOS/widgets/webview.py
@@ -1,16 +1,18 @@
-from rubicon.objc import objc_method, objc_property
+from asyncio import get_event_loop
+
+from rubicon.objc import objc_method, objc_property, py_from_ns
+from rubicon.objc.runtime import objc_id
 
 from toga_iOS.libs import NSURL, NSURLRequest, WKWebView
 from toga_iOS.widgets.base import Widget
 
 
 class TogaWebView(WKWebView):
-
     interface = objc_property(object, weak=True)
     impl = objc_property(object, weak=True)
 
     @objc_method
-    def webView_didFinishLoadForFrame_(self, sender, frame) -> None:
+    def webView_didFinishNavigation_(self, navigation) -> None:
         if self.interface.on_webview_load:
             self.interface.on_webview_load(self.interface)
 
@@ -29,7 +31,9 @@ class WebView(Widget):
         self.native = TogaWebView.alloc().init()
         self.native.interface = self.interface
         self.native.impl = self
-        self.native.delegate = self.native
+
+        self.native.navigationDelegate = self.native
+        self.native.uIDelegate = self.native
 
         # Add the layout constraints
         self.add_constraints()
@@ -44,25 +48,39 @@ class WebView(Widget):
         html = self.native.DOMDocument.documentElement.outerHTML
         return html
 
+    def get_url(self):
+        url = self.native.URL
+        if url:
+            return str(url)
+
     def set_url(self, value):
         if value:
-            if self.interface.url.startswith('file://'):
-                url = NSURL.fileURLWithPath(self.interface.url[7:])
-            else:
-                url = NSURL.URLWithString(self.interface.url)
-
-            request = NSURLRequest.requestWithURL_(url)
-            self.native.loadRequest_(request)
+            request = NSURLRequest.requestWithURL(NSURL.URLWithString(value))
+            self.native.loadRequest(request)
 
     def set_content(self, root_url, content):
-        self.native.loadHTMLString_baseURL_(content, NSURL.URLWithString_(root_url))
+        self.native.loadHTMLString(content, baseURL=NSURL.URLWithString(root_url))
 
     def set_user_agent(self, value):
         user_agent = value if value else "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/603.3.8 (KHTML, like Gecko) Version/10.1.2 Safari/603.3.8"  # NOQA
         self.native.customUserAgent = user_agent
 
     async def evaluate_javascript(self, javascript):
-        return self.native.stringByEvaluatingJavaScriptFromString_(javascript)
+        loop = get_event_loop()
+        future = loop.create_future()
+
+        def completion_handler(res: objc_id, error: objc_id) -> None:
+
+            if error:
+                error = py_from_ns(error)
+                exc = RuntimeError(str(error))
+                future.set_exception(exc)
+            else:
+                future.set_result(py_from_ns(res))
+
+        self.native.evaluateJavaScript(javascript, completionHandler=completion_handler)
+
+        return await future
 
     def invoke_javascript(self, javascript):
-        return self.native.stringByEvaluatingJavaScriptFromString_(javascript)
+        self.native.evaluateJavaScript(javascript, completionHandler=None)

--- a/src/winforms/toga_winforms/widgets/webview.py
+++ b/src/winforms/toga_winforms/widgets/webview.py
@@ -115,7 +115,7 @@ class WebView(Widget):
 
     def set_url(self, value):
         if value:
-            self.native.Source = Uri(self.interface._url)
+            self.native.Source = Uri(value)
 
     def set_content(self, root_url, content):
         if content and self.native.CoreWebView2:

--- a/src/winforms/toga_winforms/widgets/webview.py
+++ b/src/winforms/toga_winforms/widgets/webview.py
@@ -110,9 +110,12 @@ class WebView(Widget):
     def set_on_webview_load(self, handler):
         pass
 
+    def get_url(self):
+        return str(self.native.Source)
+
     def set_url(self, value):
         if value:
-            self.native.Source = Uri(self.interface.url)
+            self.native.Source = Uri(self.interface._url)
 
     def set_content(self, root_url, content):
         if content and self.native.CoreWebView2:


### PR DESCRIPTION
This PR implements WebView.get_url() for Winforms and Android, so the current URL can be fetched from the implementation.
The PR can be tested with tutorial3 which has been extended to always show the current URL in the url_input field (this updating the url_input field does not work on Android because on_webview_load does not work there. So, for Android, I tested the PR with a print debug statement).

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
