### PR TITLE
Android: update layout after rotation

### DIFF
--- a/src/android/toga_android/app.py
+++ b/src/android/toga_android/app.py
@@ -67,9 +67,7 @@ class TogaApp(IPythonApp):
             print("No intent matching request code {requestCode}")
 
     def onConfigurationChanged(self, new_config):
-        interface = self._impl.interface
-        if interface.main_window and interface.main_window.content:
-            interface.main_window.content.refresh()
+        pass
 
     def onOptionsItemSelected(self, menuitem):
         consumed = False

--- a/src/android/toga_android/app.py
+++ b/src/android/toga_android/app.py
@@ -66,6 +66,11 @@ class TogaApp(IPythonApp):
         except KeyError:
             print("No intent matching request code {requestCode}")
 
+    def onConfigurationChanged(self, new_config):
+        interface = self._impl.interface
+        if interface.main_window and interface.main_window.content:
+            interface.main_window.content.refresh()
+
     def onOptionsItemSelected(self, menuitem):
         consumed = False
         try:

--- a/src/android/toga_android/libs/android/__init__.py
+++ b/src/android/toga_android/libs/android/__init__.py
@@ -3,4 +3,5 @@ from rubicon.java import JavaClass
 R__attr = JavaClass("android/R$attr")
 R__color = JavaClass("android/R$color")
 R__drawable = JavaClass("android/R$drawable")
+R__id = JavaClass("android/R$id")
 R__layout = JavaClass("android/R$layout")

--- a/src/android/toga_android/libs/android/view.py
+++ b/src/android/toga_android/libs/android/view.py
@@ -10,3 +10,6 @@ View = JavaClass("android/view/View")
 ViewGroup__LayoutParams = JavaClass("android/view/ViewGroup$LayoutParams")
 View__MeasureSpec = JavaClass("android/view/View$MeasureSpec")
 View__OnTouchListener = JavaInterface("android/view/View$OnTouchListener")
+ViewTreeObserver__OnGlobalLayoutListener = JavaInterface(
+    "android/view/ViewTreeObserver$OnGlobalLayoutListener"
+)

--- a/src/android/toga_android/window.py
+++ b/src/android/toga_android/window.py
@@ -1,11 +1,11 @@
-from .libs.android import R__attr
-from .libs.android.util import TypedValue
+from .libs.android import R__id
+from .libs.android.view import ViewTreeObserver__OnGlobalLayoutListener
 
 
 class AndroidViewport:
-    def __init__(self, native):
-        self.native = native
-        self.dpi = self.native.getContext().getResources().getDisplayMetrics().densityDpi
+    def __init__(self, content_parent):
+        self.content_parent = content_parent
+        self.dpi = content_parent.getContext().getResources().getDisplayMetrics().densityDpi
         # Toga needs to know how the current DPI compares to the platform default,
         # which is 160: https://developer.android.com/training/multiscreen/screendensities
         self.baseline_dpi = 160
@@ -13,50 +13,41 @@ class AndroidViewport:
 
     @property
     def width(self):
-        return self.native.getContext().getResources().getDisplayMetrics().widthPixels
+        return self.content_parent.getWidth()
 
     @property
     def height(self):
-        screen_height = self.native.getContext().getResources().getDisplayMetrics().heightPixels
-        return screen_height - self._status_bar_height() - self._action_bar_height()
-
-    def _action_bar_height(self):
-        """
-        Get the size of the action bar. The action bar shows the app name and can provide some app actions.
-        """
-        tv = TypedValue()
-        has_action_bar_size = self.native.getContext().getTheme().resolveAttribute(R__attr.actionBarSize, tv, True)
-        if not has_action_bar_size:
-            return 0
-
-        return TypedValue.complexToDimensionPixelSize(
-            tv.data, self.native.getContext().getResources().getDisplayMetrics())
-
-    def _status_bar_height(self):
-        """
-        Get the size of the status bar. The status bar is typically rendered above the app,
-        showing the current time, battery level, etc.
-        """
-        resource_id = self.native.getContext().getResources().getIdentifier("status_bar_height", "dimen", "android")
-        if resource_id <= 0:
-            return 0
-
-        return self.native.getContext().getResources().getDimensionPixelSize(resource_id)
+        return self.content_parent.getHeight()
 
 
-class Window:
+class Window(ViewTreeObserver__OnGlobalLayoutListener):
     def __init__(self, interface, title, position, size):
+        super().__init__()
         self.interface = interface
         self.interface._impl = self
+        self.size = (None, None)
 
         # self.set_title(title)
 
     def set_app(self, app):
         self.app = app
+        content_parent = self.app.native.findViewById(R__id.content).__global__()
+        self.viewport = AndroidViewport(content_parent)
+        content_parent.getViewTreeObserver().addOnGlobalLayoutListener(self)
+
+    def onGlobalLayout(self):
+        """This listener is run after each native layout pass. If any view's size or position has
+        changed, the new values will be visible here.
+        """
+        new_size = (self.viewport.width, self.viewport.height)
+        if self.size != new_size:
+            self.size = new_size
+            if self.interface.content:
+                self.interface.content.refresh()
 
     def set_content(self, widget):
         # Set the widget's viewport to be based on the window's content.
-        widget.viewport = AndroidViewport(widget.native)
+        widget.viewport = self.viewport
         # Set the app's entire contentView to the desired widget. This means that
         # calling Window.set_content() on any Window object automatically updates
         # the app, meaning that every Window object acts as the MainWindow.

--- a/src/android/toga_android/window.py
+++ b/src/android/toga_android/window.py
@@ -3,6 +3,9 @@ from .libs.android.view import ViewTreeObserver__OnGlobalLayoutListener
 
 
 class AndroidViewport:
+    # `content_parent` should be the view that will become the parent of the widget passed to
+    # `Window.set_content`. This ensures that the viewport `width` and `height` attributes
+    # return the usable area of the app, not including the action bar or status bar.
     def __init__(self, content_parent):
         self.content_parent = content_parent
         self.dpi = content_parent.getContext().getResources().getDisplayMetrics().densityDpi
@@ -25,7 +28,7 @@ class Window(ViewTreeObserver__OnGlobalLayoutListener):
         super().__init__()
         self.interface = interface
         self.interface._impl = self
-        self.size = (None, None)
+        self.last_size = (None, None)
 
         # self.set_title(title)
 
@@ -40,8 +43,8 @@ class Window(ViewTreeObserver__OnGlobalLayoutListener):
         changed, the new values will be visible here.
         """
         new_size = (self.viewport.width, self.viewport.height)
-        if self.size != new_size:
-            self.size = new_size
+        if self.last_size != new_size:
+            self.last_size = new_size
             if self.interface.content:
                 self.interface.content.refresh()
 
@@ -71,8 +74,7 @@ class Window(ViewTreeObserver__OnGlobalLayoutListener):
         pass
 
     def get_size(self):
-        display_metrics = self.interface.content._impl.native.getContext().getResources().getDisplayMetrics()
-        return (display_metrics.widthPixels, display_metrics.heightPixels)
+        return self.last_size
 
     def set_size(self, size):
         # Does nothing on mobile


### PR DESCRIPTION
This is the Toga part of the fix described in https://github.com/beeware/briefcase-android-gradle-template/pull/50.  It mostly works, but the viewport height is slightly wrong after rotation because the action bar is narrower in landscape orientation. I'll look into this and add another commit.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
