### PR TITLE
Allow widgets to be assigned to Window.content multiple times

### DIFF
--- a/src/winforms/toga_winforms/widgets/base.py
+++ b/src/winforms/toga_winforms/widgets/base.py
@@ -27,15 +27,10 @@ class Widget:
     @container.setter
     def container(self, container):
         if self.container:
-            if container:
-                raise RuntimeError('Already have a container')
-            else:
-                # container is set to None, removing self from the container.native
-                self._container.native.Controls.Remove(self.native)
-                self._container = None
-        elif container:
-            # setting container, adding self to container.native
-            self._container = container
+            self._container.native.Controls.Remove(self.native)
+
+        self._container = container
+        if container:
             self._container.native.Controls.Add(self.native)
             self.native.BringToFront()
 

--- a/src/winforms/toga_winforms/window.py
+++ b/src/winforms/toga_winforms/window.py
@@ -54,6 +54,7 @@ class Window:
         self.set_size(size)
         self.set_position(position)
 
+        self.content = None
         self.toolbar_native = None
         self.toolbar_items = None
         if self.native.interface.resizeable:
@@ -114,13 +115,12 @@ class Window:
         return result
 
     def set_content(self, widget):
-        for control in self.native.Controls:
-            self.native.Controls.Remove(control)
-
         if self.toolbar_native:
             self.native.Controls.Add(self.toolbar_native)
-            # Create the lookup table of menu items,
-            # then force the creation of the menus.
+
+        if self.content:
+            self.native.Controls.Remove(self.content.native)
+        self.content = widget
         self.native.Controls.Add(widget.native)
 
         # Set the widget's viewport to be based on the window's content.


### PR DESCRIPTION
Fixes #1509, but only on Windows so far. If this is the correct approach, it should be applied to all the other platforms as well.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
