### PR TITLE
Tutorial2 load images

### DIFF
--- a/docs/tutorial/tutorial-2.rst
+++ b/docs/tutorial/tutorial-2.rst
@@ -27,10 +27,15 @@ Here's the source code:
 .. literalinclude:: /../examples/tutorial2/tutorial/app.py
    :language: python
 
-In order to render the icons, you will need to move the icons folder into the
-same directory as your app file.
+In order to render the icons, you will need to have the icon files inside a
+``icons`` folder in the same directory as your app file.
 
 Here are the :download:`Icons <./resources/icons.zip>`
+
+The ``rebase_path`` function handles two cases: when your application is
+launched as a single file module, Toga needs an absolute file path; but when
+launched as a package module, or through briefcase, it should be a relative
+file path. On a real world scenario, you would be using only relative paths.
 
 In this example, we see a couple of new Toga widgets - :class:`.Table`,
 :class:`.SplitContainer`, and :class:`.ScrollContainer`. You can also see that

--- a/examples/tutorial2/tutorial/app.py
+++ b/examples/tutorial2/tutorial/app.py
@@ -1,3 +1,5 @@
+import os
+
 import toga
 from toga.style.pack import COLUMN, Pack
 
@@ -34,9 +36,16 @@ def action6(widget):
     print("action 6")
 
 
+def rebase_path(path):
+    if __name__ == '__main__':
+        return os.path.abspath(path)
+    else:
+        return path
+
+
 def build(app):
-    brutus_icon = "icons/brutus"
-    cricket_icon = "icons/cricket-72.png"
+    brutus_icon = rebase_path("icons/brutus")
+    cricket_icon = rebase_path("icons/cricket-72.png")
 
     data = [
         ('root%s' % i, 'value %s' % i)


### PR DESCRIPTION
When running an application as a single file, as a module, i.e:
`python -m app` on a app.py file, Toga will not assume the working directory to resolve relative paths.

This PR solves the frustration that arises from following the tutorial instructions but failing to load the images.

Fixes #990 and #1387.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
