### PR TITLE
Return the correct factory.paths.app, even when launched as a single file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v3.1.2
       with:
         python-version: "3.7"
     - name: Install dependencies
@@ -40,7 +40,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v3.1.2
       with:
         python-version: "3.7"
     - name: Install dependencies
@@ -73,7 +73,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v3.1.2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -92,7 +92,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.9
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v3.1.2
       with:
         # Py3.9 is the first Python version for which
         # a wheel of pythonnet isn't available on PyPI.
@@ -117,7 +117,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v3.1.2
       with:
         python-version: "3.7"
     - name: Install dependencies
@@ -140,7 +140,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v3.1.2
       with:
         python-version: "3.7"
     - name: Install dependencies
@@ -163,7 +163,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v3.1.2
       with:
         python-version: "3.7"
     - name: Install dependencies
@@ -188,7 +188,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v3.1.2
       with:
         python-version: "3.7"
     - name: Install dependencies
@@ -211,7 +211,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v3.1.2
       with:
         python-version: "3.7"
     - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
     - name: Test
       run: |
         cd src/winforms
-        python setup.py test
+        pytest
 
   macOS:
     name: macOS backend tests
@@ -131,7 +131,7 @@ jobs:
     - name: Test
       run: |
         cd src/cocoa
-        python setup.py test
+        pytest
 
   iOS:
     name: iOS backend tests
@@ -154,7 +154,7 @@ jobs:
     - name: Test
       run: |
         cd src/iOS
-        python setup.py test
+        pytest
 
   gtk:
     name: GTK+ backend tests
@@ -179,7 +179,7 @@ jobs:
     - name: Test
       run: |
         cd src/gtk
-        xvfb-run -a -s '-screen 0 2048x1536x24' python setup.py test
+        xvfb-run -a -s '-screen 0 2048x1536x24' pytest
 
   android:
     name: Android backend tests
@@ -202,7 +202,7 @@ jobs:
     - name: Test
       run: |
         cd src/android
-        python setup.py test
+        pytest
 
   web:
     name: Web backend tests
@@ -225,4 +225,4 @@ jobs:
     - name: Test
       run: |
         cd src/web
-        python setup.py test
+        pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11.0-alpha - 3.11.0"]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.xml
+        file: ./src/core/coverage.xml
         flags: unittests
         fail_ci_if_error: true
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -53,3 +53,5 @@ recursive-include src/winforms/toga_winforms/libs/WebView2 *.dll
 prune src/*/build
 prune src/*/.eggs
 
+include src/core/tests/testbed/installed.dist-info/INSTALLER
+include src/core/tests/testbed/installed.dist-info/METADATA

--- a/src/android/toga_android/paths.py
+++ b/src/android/toga_android/paths.py
@@ -17,8 +17,12 @@ class Paths:
     def app(self):
         try:
             return Path(sys.modules["__main__"].__file__).parent
+        except KeyError:
+            # If we're running in test conditions,
+            # there is no __main__ module.
+            return Path.cwd()
         except AttributeError:
-            # If we're running in a test suite, or at an interactive prompt,
+            # If we're running at an interactive prompt,
             # the __main__ module isn't file-based.
             return Path.cwd()
 

--- a/src/android/toga_android/paths.py
+++ b/src/android/toga_android/paths.py
@@ -1,6 +1,6 @@
+import sys
 from pathlib import Path
 
-import __main__
 import toga
 from toga import App
 
@@ -15,7 +15,12 @@ class Paths:
 
     @property
     def app(self):
-        return Path(__main__.__file__).parent
+        try:
+            return Path(sys.modules["__main__"].__file__).parent
+        except AttributeError:
+            # If we're running in a test suite, or at an interactive prompt,
+            # the __main__ module isn't file-based.
+            return Path.cwd()
 
     @property
     def data(self):

--- a/src/android/toga_android/paths.py
+++ b/src/android/toga_android/paths.py
@@ -1,6 +1,6 @@
-import sys
 from pathlib import Path
 
+import __main__
 import toga
 from toga import App
 
@@ -15,7 +15,7 @@ class Paths:
 
     @property
     def app(self):
-        return Path(sys.modules[App.app.module_name].__file__).parent
+        return Path(__main__.__file__).parent
 
     @property
     def data(self):

--- a/src/cocoa/tests/test_paths.py
+++ b/src/cocoa/tests/test_paths.py
@@ -11,6 +11,14 @@ TESTBED_PATH = Path(__file__).parent.parent.parent / "core" / "tests" / "testbed
 
 
 class TestPaths(unittest.TestCase):
+    def setUp(self):
+        # We use the existence of a __main__ module as a proxy for being in test
+        # conditions. This isn't *great*, but the __main__ module isn't meaningful
+        # during tests, and removing it allows us to avoid having explicit "if
+        # under test conditions" checks in paths.py.
+        if "__main__" in sys.modules:
+            del sys.modules["__main__"]
+
     def test_as_test(self):
         "During test conditions, the app path is the current working directory"
         app = toga.App(

--- a/src/cocoa/tests/test_paths.py
+++ b/src/cocoa/tests/test_paths.py
@@ -1,0 +1,130 @@
+import unittest
+import subprocess
+
+import sys
+from pathlib import Path
+
+import toga
+
+
+TESTBED_PATH = Path(__file__).parent.parent.parent / "core" / 'tests' / 'testbed'
+
+
+class TestPaths(unittest.TestCase):
+    def test_as_test(self):
+        "During test conditions, the app path is the current working directory"
+        app = toga.App(
+            formal_name="Test App",
+            app_id="org.beeware.test-app",
+            author="Jane Developer",
+        )
+
+        self.assertEqual(app.paths.app, Path.cwd())
+        self.assertEqual(app.paths.data, Path.home() / "Library" / "Application Support" / "org.beeware.test-app")
+        self.assertEqual(app.paths.cache, Path.home() / "Library" / "Caches" / "org.beeware.test-app")
+        self.assertEqual(app.paths.logs, Path.home() / "Library" / "Logs" / "org.beeware.test-app")
+        self.assertEqual(app.paths.toga, Path(toga.__file__).parent)
+
+    def assert_standalone_paths(self, output):
+        "Assert the paths for the standalone app are consistent"
+        results = output.splitlines()
+        self.assertIn(f"app.paths.app={TESTBED_PATH}", results)
+        self.assertIn(f"app.paths.data={Path.home() / 'Library' / 'Application Support' / 'org.testbed.standalone-app'}", results)
+        self.assertIn(f"app.paths.cache={Path.home() / 'Library' / 'Caches' / 'org.testbed.standalone-app'}", results)
+        self.assertIn(f"app.paths.logs={Path.home() / 'Library' / 'Logs' / 'org.testbed.standalone-app'}", results)
+        self.assertIn(f"app.paths.toga={Path(toga.__file__).parent}", results)
+
+    def test_as_interactive(self):
+        "At an interactive prompt, the app path is the current working directory"
+        # Spawn the standalone app using the interactive-mode mocking entry point
+        output = subprocess.check_output(
+            [sys.executable, "standalone.py", "--interactive"],
+            cwd=TESTBED_PATH,
+            text=True,
+        )
+        self.assert_standalone_paths(output)
+
+    def test_as_file(self):
+        "When started as `python app.py`, the app path is the folder holding app.py"
+        # Spawn the standalone app using `app.py`
+        output = subprocess.check_output(
+            [sys.executable, "standalone.py"],
+            cwd=TESTBED_PATH,
+            text=True,
+        )
+        self.assert_standalone_paths(output)
+
+    def test_as_module(self):
+        "When started as `python -m app`, the app path is the folder holding app.py"
+        # Spawn the standalone app using `-m app`
+        output = subprocess.check_output(
+            [sys.executable, "-m", "standalone"],
+            cwd=TESTBED_PATH,
+            text=True,
+        )
+        self.assert_standalone_paths(output)
+
+    def assert_simple_paths(self, output):
+        "Assert the paths for the simple app are consistent"
+        results = output.splitlines()
+        self.assertIn(f"app.paths.app={TESTBED_PATH / 'simple'}", results)
+        self.assertIn(f"app.paths.data={Path.home() / 'Library' / 'Application Support' / 'org.testbed.simple-app'}", results)
+        self.assertIn(f"app.paths.cache={Path.home() / 'Library' / 'Caches' / 'org.testbed.simple-app'}", results)
+        self.assertIn(f"app.paths.logs={Path.home() / 'Library' / 'Logs' / 'org.testbed.simple-app'}", results)
+        self.assertIn(f"app.paths.toga={Path(toga.__file__).parent}", results)
+
+    def test_simple_as_file_in_module(self):
+        "When a simple app is started as `python app.py` inside a runnable module, the app path is the folder holding app.py"
+        # Spawn the simple testbed app using `app.py`
+        output = subprocess.check_output(
+            [sys.executable, "app.py"],
+            cwd=TESTBED_PATH / "simple",
+            text=True,
+        )
+        self.assert_simple_paths(output)
+
+    def test_simple_as_module(self):
+        "When a simple app is started as `python -m app` inside a runnable module, the app path is the folder holding app.py"
+        # Spawn the simple testbed app using `-m app`
+        output = subprocess.check_output(
+            [sys.executable, "-m", "app"],
+            cwd=TESTBED_PATH / "simple",
+            text=True,
+        )
+        self.assert_simple_paths(output)
+
+    def test_simple_as_deep_file(self):
+        "When a simple app is started as `python simple/app.py`, the app path is the folder holding app.py"
+        # Spawn the simple testbed app using `-m simple`
+        output = subprocess.check_output(
+            [sys.executable, "simple/app.py"],
+            cwd=TESTBED_PATH,
+            text=True,
+        )
+        self.assert_simple_paths(output)
+
+    def test_simple_as_deep_module(self):
+        "When a simple app is started as `python -m simple`, the app path is the folder hodling app.py"
+        # Spawn the simple testbed app using `-m simple`
+        output = subprocess.check_output(
+            [sys.executable, "-m", "simple"],
+            cwd=TESTBED_PATH,
+            text=True,
+        )
+        self.assert_simple_paths(output)
+
+    def test_installed_as_module(self):
+        "When the installed app is started, the app path is the folder holding app.py"
+        # Spawn the installed testbed app using `-m app`
+        output = subprocess.check_output(
+            [sys.executable, "-m", "installed"],
+            cwd=TESTBED_PATH,
+            text=True,
+        )
+
+        results = output.splitlines()
+        self.assertIn(f"app.paths.app={TESTBED_PATH / 'installed'}", results)
+        self.assertIn(f"app.paths.data={Path.home() / 'Library' / 'Application Support' / 'org.testbed.installed'}", results)
+        self.assertIn(f"app.paths.cache={Path.home() / 'Library' / 'Caches' / 'org.testbed.installed'}", results)
+        self.assertIn(f"app.paths.logs={Path.home() / 'Library' / 'Logs' / 'org.testbed.installed'}", results)
+        self.assertIn(f"app.paths.toga={Path(toga.__file__).parent}", results)

--- a/src/cocoa/tests/test_paths.py
+++ b/src/cocoa/tests/test_paths.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import toga
 
 
-TESTBED_PATH = Path(__file__).parent.parent.parent / "core" / 'tests' / 'testbed'
+TESTBED_PATH = Path(__file__).parent.parent.parent / "core" / "tests" / "testbed"
 
 
 class TestPaths(unittest.TestCase):
@@ -19,20 +19,50 @@ class TestPaths(unittest.TestCase):
             author="Jane Developer",
         )
 
-        self.assertEqual(app.paths.app, Path.cwd())
-        self.assertEqual(app.paths.data, Path.home() / "Library" / "Application Support" / "org.beeware.test-app")
-        self.assertEqual(app.paths.cache, Path.home() / "Library" / "Caches" / "org.beeware.test-app")
-        self.assertEqual(app.paths.logs, Path.home() / "Library" / "Logs" / "org.beeware.test-app")
-        self.assertEqual(app.paths.toga, Path(toga.__file__).parent)
+        self.assertEqual(
+            app.paths.app,
+            Path.cwd(),
+        )
+        self.assertEqual(
+            app.paths.data,
+            Path.home() / "Library" / "Application Support" / "org.beeware.test-app",
+        )
+        self.assertEqual(
+            app.paths.cache,
+            Path.home() / "Library" / "Caches" / "org.beeware.test-app",
+        )
+        self.assertEqual(
+            app.paths.logs,
+            Path.home() / "Library" / "Logs" / "org.beeware.test-app",
+        )
+        self.assertEqual(
+            app.paths.toga,
+            Path(toga.__file__).parent,
+        )
 
     def assert_standalone_paths(self, output):
         "Assert the paths for the standalone app are consistent"
         results = output.splitlines()
-        self.assertIn(f"app.paths.app={TESTBED_PATH}", results)
-        self.assertIn(f"app.paths.data={Path.home() / 'Library' / 'Application Support' / 'org.testbed.standalone-app'}", results)
-        self.assertIn(f"app.paths.cache={Path.home() / 'Library' / 'Caches' / 'org.testbed.standalone-app'}", results)
-        self.assertIn(f"app.paths.logs={Path.home() / 'Library' / 'Logs' / 'org.testbed.standalone-app'}", results)
-        self.assertIn(f"app.paths.toga={Path(toga.__file__).parent}", results)
+        self.assertIn(
+            f"app.paths.app={TESTBED_PATH}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.data={Path.home() / 'Library' / 'Application Support' / 'org.testbed.standalone-app'}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.cache={Path.home() / 'Library' / 'Caches' / 'org.testbed.standalone-app'}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.logs={Path.home() / 'Library' / 'Logs' / 'org.testbed.standalone-app'}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.toga={Path(toga.__file__).parent}",
+            results,
+        )
 
     def test_as_interactive(self):
         "At an interactive prompt, the app path is the current working directory"
@@ -67,14 +97,30 @@ class TestPaths(unittest.TestCase):
     def assert_simple_paths(self, output):
         "Assert the paths for the simple app are consistent"
         results = output.splitlines()
-        self.assertIn(f"app.paths.app={TESTBED_PATH / 'simple'}", results)
-        self.assertIn(f"app.paths.data={Path.home() / 'Library' / 'Application Support' / 'org.testbed.simple-app'}", results)
-        self.assertIn(f"app.paths.cache={Path.home() / 'Library' / 'Caches' / 'org.testbed.simple-app'}", results)
-        self.assertIn(f"app.paths.logs={Path.home() / 'Library' / 'Logs' / 'org.testbed.simple-app'}", results)
-        self.assertIn(f"app.paths.toga={Path(toga.__file__).parent}", results)
+        self.assertIn(
+            f"app.paths.app={TESTBED_PATH / 'simple'}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.data={Path.home() / 'Library' / 'Application Support' / 'org.testbed.simple-app'}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.cache={Path.home() / 'Library' / 'Caches' / 'org.testbed.simple-app'}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.logs={Path.home() / 'Library' / 'Logs' / 'org.testbed.simple-app'}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.toga={Path(toga.__file__).parent}",
+            results,
+        )
 
     def test_simple_as_file_in_module(self):
-        "When a simple app is started as `python app.py` inside a runnable module, the app path is the folder holding app.py"
+        """When a simple app is started as `python app.py` inside a runnable module,
+        the app path is the folder holding app.py"""
         # Spawn the simple testbed app using `app.py`
         output = subprocess.check_output(
             [sys.executable, "app.py"],
@@ -84,7 +130,8 @@ class TestPaths(unittest.TestCase):
         self.assert_simple_paths(output)
 
     def test_simple_as_module(self):
-        "When a simple app is started as `python -m app` inside a runnable module, the app path is the folder holding app.py"
+        """When a simple app is started as `python -m app` inside a runnable module,
+        the app path is the folder holding app.py"""
         # Spawn the simple testbed app using `-m app`
         output = subprocess.check_output(
             [sys.executable, "-m", "app"],
@@ -123,8 +170,23 @@ class TestPaths(unittest.TestCase):
         )
 
         results = output.splitlines()
-        self.assertIn(f"app.paths.app={TESTBED_PATH / 'installed'}", results)
-        self.assertIn(f"app.paths.data={Path.home() / 'Library' / 'Application Support' / 'org.testbed.installed'}", results)
-        self.assertIn(f"app.paths.cache={Path.home() / 'Library' / 'Caches' / 'org.testbed.installed'}", results)
-        self.assertIn(f"app.paths.logs={Path.home() / 'Library' / 'Logs' / 'org.testbed.installed'}", results)
-        self.assertIn(f"app.paths.toga={Path(toga.__file__).parent}", results)
+        self.assertIn(
+            f"app.paths.app={TESTBED_PATH / 'installed'}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.data={Path.home() / 'Library' / 'Application Support' / 'org.testbed.installed'}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.cache={Path.home() / 'Library' / 'Caches' / 'org.testbed.installed'}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.logs={Path.home() / 'Library' / 'Logs' / 'org.testbed.installed'}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.toga={Path(toga.__file__).parent}",
+            results,
+        )

--- a/src/cocoa/toga_cocoa/paths.py
+++ b/src/cocoa/toga_cocoa/paths.py
@@ -1,6 +1,6 @@
+import sys
 from pathlib import Path
 
-import __main__
 import toga
 from toga import App
 
@@ -11,7 +11,12 @@ class Paths:
 
     @property
     def app(self):
-        return Path(__main__.__file__).parent
+        try:
+            return Path(sys.modules["__main__"].__file__).parent
+        except AttributeError:
+            # If we're running in a test suite, or at an interactive prompt,
+            # the __main__ module isn't file-based.
+            return Path.cwd()
 
     @property
     def data(self):

--- a/src/cocoa/toga_cocoa/paths.py
+++ b/src/cocoa/toga_cocoa/paths.py
@@ -1,6 +1,6 @@
-import sys
 from pathlib import Path
 
+import __main__
 import toga
 from toga import App
 
@@ -11,7 +11,7 @@ class Paths:
 
     @property
     def app(self):
-        return Path(sys.modules[App.app.module_name].__file__).parent
+        return Path(__main__.__file__).parent
 
     @property
     def data(self):

--- a/src/cocoa/toga_cocoa/paths.py
+++ b/src/cocoa/toga_cocoa/paths.py
@@ -13,8 +13,12 @@ class Paths:
     def app(self):
         try:
             return Path(sys.modules["__main__"].__file__).parent
+        except KeyError:
+            # If we're running in test conditions,
+            # there is no __main__ module.
+            return Path.cwd()
         except AttributeError:
-            # If we're running in a test suite, or at an interactive prompt,
+            # If we're running at an interactive prompt,
             # the __main__ module isn't file-based.
             return Path.cwd()
 

--- a/src/core/MANIFEST.in
+++ b/src/core/MANIFEST.in
@@ -6,3 +6,5 @@ recursive-include toga/resources *.png
 recursive-include toga/resources *.icns
 recursive-include toga/resources *.ico
 recursive-include tests *.py
+include tests/testbed/installed.dist-info/INSTALLER
+include tests/testbed/installed.dist-info/METADATA

--- a/src/core/tests/test_paths.py
+++ b/src/core/tests/test_paths.py
@@ -8,6 +8,14 @@ import toga_dummy
 
 
 class TestPaths(unittest.TestCase):
+    def setUp(self):
+        # We use the existence of a __main__ module as a proxy for being in test
+        # conditions. This isn't *great*, but the __main__ module isn't meaningful
+        # during tests, and removing it allows us to avoid having explicit "if
+        # under test conditions" checks in paths.py.
+        if '__main__' in sys.modules:
+            del sys.modules['__main__']
+
     def test_as_test(self):
         "During test conditions, the app path is the current working directory"
         app = toga.App(

--- a/src/core/tests/test_paths.py
+++ b/src/core/tests/test_paths.py
@@ -1,0 +1,127 @@
+import unittest
+import subprocess
+import sys
+from pathlib import Path
+
+import toga
+import toga_dummy
+
+
+class TestPaths(unittest.TestCase):
+    def test_as_test(self):
+        "During test conditions, the app path is the current working directory"
+        app = toga.App(
+            formal_name="Test App",
+            app_id="org.beeware.test-app",
+            factory=toga_dummy.factory,
+        )
+
+        self.assertEqual(app.paths.app, Path.cwd())
+        self.assertEqual(app.paths.data, Path.home() / "user_data" / "org.beeware.test-app")
+        self.assertEqual(app.paths.cache, Path.home() / "cache" / "org.beeware.test-app")
+        self.assertEqual(app.paths.logs, Path.home() / "logs" / "org.beeware.test-app")
+        self.assertEqual(app.paths.toga, Path(toga.__file__).parent)
+
+    def assert_standalone_paths(self, output):
+        "Assert the paths for the standalone app are consistent"
+        results = output.splitlines()
+        self.assertIn(f"app.paths.app={Path.cwd() / 'tests' / 'testbed'}", results)
+        self.assertIn(f"app.paths.data={Path.home() / 'user_data' / 'org.testbed.standalone-app'}", results)
+        self.assertIn(f"app.paths.cache={Path.home() / 'cache' / 'org.testbed.standalone-app'}", results)
+        self.assertIn(f"app.paths.logs={Path.home() / 'logs' / 'org.testbed.standalone-app'}", results)
+        self.assertIn(f"app.paths.toga={Path(toga.__file__).parent}", results)
+
+    def test_as_interactive(self):
+        "At an interactive prompt, the app path is the current working directory"
+        # Spawn the standalone app using the interactive-mode mocking entry point
+        output = subprocess.check_output(
+            [sys.executable, "standalone.py", "--backend:dummy", "--interactive"],
+            cwd=Path(__file__).parent / "testbed",
+            text=True,
+        )
+        self.assert_standalone_paths(output)
+
+    def test_as_file(self):
+        "When started as `python app.py`, the app path is the folder holding app.py"
+        # Spawn the standalone app using `standalone.py`
+        output = subprocess.check_output(
+            [sys.executable, "standalone.py", "--backend:dummy"],
+            cwd=Path(__file__).parent / "testbed",
+            text=True,
+        )
+        self.assert_standalone_paths(output)
+
+    def test_as_module(self):
+        "When started as `python -m app`, the app path is the folder holding app.py"
+        # Spawn the standalone app app using `-m standalone`
+        output = subprocess.check_output(
+            [sys.executable, "-m", "standalone", "--backend:dummy"],
+            cwd=Path(__file__).parent / "testbed",
+            text=True,
+        )
+        self.assert_standalone_paths(output)
+
+    def assert_simple_paths(self, output):
+        "Assert the paths for the simple app are consistent"
+        results = output.splitlines()
+        self.assertIn(f"app.paths.app={Path.cwd() / 'tests' / 'testbed' / 'simple'}", results)
+        self.assertIn(f"app.paths.data={Path.home() / 'user_data' / 'org.testbed.simple-app'}", results)
+        self.assertIn(f"app.paths.cache={Path.home() / 'cache' / 'org.testbed.simple-app'}", results)
+        self.assertIn(f"app.paths.logs={Path.home() / 'logs' / 'org.testbed.simple-app'}", results)
+        self.assertIn(f"app.paths.toga={Path(toga.__file__).parent}", results)
+
+    def test_simple_as_file_in_module(self):
+        "When a simple app is started as `python app.py` inside a runnable module, the app path is the folder holding app.py"
+        # Spawn the simple testbed app using `app.py`
+        output = subprocess.check_output(
+            [sys.executable, "app.py", "--backend:dummy"],
+            cwd=Path(__file__).parent / "testbed" / "simple",
+            text=True,
+        )
+        self.assert_simple_paths(output)
+
+    def test_simple_as_module(self):
+        "When a simple apps is started as `python -m app` inside a runnable module, the app path is the folder holding app.py"
+        # Spawn the simple testbed app using `-m app`
+        output = subprocess.check_output(
+            [sys.executable, "-m", "app", "--backend:dummy"],
+            cwd=Path(__file__).parent / "testbed" / "simple",
+            text=True,
+        )
+        self.assert_simple_paths(output)
+
+    def test_simple_as_deep_file(self):
+        "When a simple app is started as `python simple/app.py`, the app path is the folder holding app.py"
+        # Spawn the simple testbed app using `-m simple`
+        output = subprocess.check_output(
+            [sys.executable, "simple/app.py", "--backend:dummy"],
+            cwd=Path(__file__).parent / "testbed",
+            text=True,
+        )
+        self.assert_simple_paths(output)
+
+    def test_simple_as_deep_module(self):
+        "When a simple app is started as `python -m simple`, the app path is the folder holding app.py"
+        # Spawn the simple testbed app using `-m simple`
+        output = subprocess.check_output(
+            [sys.executable, "-m", "simple", "--backend:dummy"],
+            cwd=Path(__file__).parent / "testbed",
+            text=True,
+        )
+        self.assert_simple_paths(output)
+
+    def test_installed_as_module(self):
+        "When the installed app is started, the app path is the folder holding app.py"
+        # Spawn the installed testbed app using `-m app`
+        output = subprocess.check_output(
+            [sys.executable, "-m", "installed", "--backend:dummy"],
+            cwd=Path(__file__).parent / "testbed",
+            text=True,
+        )
+
+        results = output.splitlines()
+        self.assertIn(f"app.paths.app={Path.cwd() / 'tests' / 'testbed' / 'installed'}", results)
+        self.assertIn(f"app.paths.data={Path.home() / 'user_data' / 'org.testbed.installed'}", results)
+        self.assertIn(f"app.paths.cache={Path.home() / 'cache' / 'org.testbed.installed'}", results)
+        self.assertIn(f"app.paths.logs={Path.home() / 'logs' / 'org.testbed.installed'}", results)
+        self.assertIn(f"app.paths.toga={Path(toga.__file__).parent}", results)

--- a/src/core/tests/test_paths.py
+++ b/src/core/tests/test_paths.py
@@ -16,20 +16,50 @@ class TestPaths(unittest.TestCase):
             factory=toga_dummy.factory,
         )
 
-        self.assertEqual(app.paths.app, Path.cwd())
-        self.assertEqual(app.paths.data, Path.home() / "user_data" / "org.beeware.test-app")
-        self.assertEqual(app.paths.cache, Path.home() / "cache" / "org.beeware.test-app")
-        self.assertEqual(app.paths.logs, Path.home() / "logs" / "org.beeware.test-app")
-        self.assertEqual(app.paths.toga, Path(toga.__file__).parent)
+        self.assertEqual(
+            app.paths.app,
+            Path.cwd(),
+        )
+        self.assertEqual(
+            app.paths.data,
+            Path.home() / "user_data" / "org.beeware.test-app",
+        )
+        self.assertEqual(
+            app.paths.cache,
+            Path.home() / "cache" / "org.beeware.test-app",
+        )
+        self.assertEqual(
+            app.paths.logs,
+            Path.home() / "logs" / "org.beeware.test-app",
+        )
+        self.assertEqual(
+            app.paths.toga,
+            Path(toga.__file__).parent,
+        )
 
     def assert_standalone_paths(self, output):
         "Assert the paths for the standalone app are consistent"
         results = output.splitlines()
-        self.assertIn(f"app.paths.app={Path.cwd() / 'tests' / 'testbed'}", results)
-        self.assertIn(f"app.paths.data={Path.home() / 'user_data' / 'org.testbed.standalone-app'}", results)
-        self.assertIn(f"app.paths.cache={Path.home() / 'cache' / 'org.testbed.standalone-app'}", results)
-        self.assertIn(f"app.paths.logs={Path.home() / 'logs' / 'org.testbed.standalone-app'}", results)
-        self.assertIn(f"app.paths.toga={Path(toga.__file__).parent}", results)
+        self.assertIn(
+            f"app.paths.app={Path.cwd() / 'tests' / 'testbed'}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.data={Path.home() / 'user_data' / 'org.testbed.standalone-app'}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.cache={Path.home() / 'cache' / 'org.testbed.standalone-app'}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.logs={Path.home() / 'logs' / 'org.testbed.standalone-app'}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.toga={Path(toga.__file__).parent}",
+            results,
+        )
 
     def test_as_interactive(self):
         "At an interactive prompt, the app path is the current working directory"
@@ -64,14 +94,29 @@ class TestPaths(unittest.TestCase):
     def assert_simple_paths(self, output):
         "Assert the paths for the simple app are consistent"
         results = output.splitlines()
-        self.assertIn(f"app.paths.app={Path.cwd() / 'tests' / 'testbed' / 'simple'}", results)
-        self.assertIn(f"app.paths.data={Path.home() / 'user_data' / 'org.testbed.simple-app'}", results)
-        self.assertIn(f"app.paths.cache={Path.home() / 'cache' / 'org.testbed.simple-app'}", results)
-        self.assertIn(f"app.paths.logs={Path.home() / 'logs' / 'org.testbed.simple-app'}", results)
-        self.assertIn(f"app.paths.toga={Path(toga.__file__).parent}", results)
+        self.assertIn(
+            f"app.paths.app={Path.cwd() / 'tests' / 'testbed' / 'simple'}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.data={Path.home() / 'user_data' / 'org.testbed.simple-app'}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.cache={Path.home() / 'cache' / 'org.testbed.simple-app'}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.logs={Path.home() / 'logs' / 'org.testbed.simple-app'}", results
+        )
+        self.assertIn(
+            f"app.paths.toga={Path(toga.__file__).parent}",
+            results,
+        )
 
     def test_simple_as_file_in_module(self):
-        "When a simple app is started as `python app.py` inside a runnable module, the app path is the folder holding app.py"
+        """When a simple app is started as `python app.py` inside a runnable module,
+        the app path is the folder holding app.py"""
         # Spawn the simple testbed app using `app.py`
         output = subprocess.check_output(
             [sys.executable, "app.py", "--backend:dummy"],
@@ -81,7 +126,8 @@ class TestPaths(unittest.TestCase):
         self.assert_simple_paths(output)
 
     def test_simple_as_module(self):
-        "When a simple apps is started as `python -m app` inside a runnable module, the app path is the folder holding app.py"
+        """When a simple apps is started as `python -m app` inside a runnable module,
+        the app path is the folder holding app.py"""
         # Spawn the simple testbed app using `-m app`
         output = subprocess.check_output(
             [sys.executable, "-m", "app", "--backend:dummy"],
@@ -120,8 +166,20 @@ class TestPaths(unittest.TestCase):
         )
 
         results = output.splitlines()
-        self.assertIn(f"app.paths.app={Path.cwd() / 'tests' / 'testbed' / 'installed'}", results)
-        self.assertIn(f"app.paths.data={Path.home() / 'user_data' / 'org.testbed.installed'}", results)
-        self.assertIn(f"app.paths.cache={Path.home() / 'cache' / 'org.testbed.installed'}", results)
-        self.assertIn(f"app.paths.logs={Path.home() / 'logs' / 'org.testbed.installed'}", results)
+        self.assertIn(
+            f"app.paths.app={Path.cwd() / 'tests' / 'testbed' / 'installed'}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.data={Path.home() / 'user_data' / 'org.testbed.installed'}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.cache={Path.home() / 'cache' / 'org.testbed.installed'}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.logs={Path.home() / 'logs' / 'org.testbed.installed'}",
+            results,
+        )
         self.assertIn(f"app.paths.toga={Path(toga.__file__).parent}", results)

--- a/src/core/tests/testbed/installed.dist-info/INSTALLER
+++ b/src/core/tests/testbed/installed.dist-info/INSTALLER
@@ -1,0 +1,1 @@
+briefcase

--- a/src/core/tests/testbed/installed.dist-info/METADATA
+++ b/src/core/tests/testbed/installed.dist-info/METADATA
@@ -1,0 +1,10 @@
+Metadata-Version: 2.1
+Briefcase-Version: 0.3.8
+Name: installed
+Formal-Name: Installed App
+App-ID: org.testbed.installed
+Version: 1.2.3
+Home-page: https://beeware.org
+Author: Tiberius Yak
+Author-email: tiberius@beeware.org
+Summary: A testing app

--- a/src/core/tests/testbed/installed/__main__.py
+++ b/src/core/tests/testbed/installed/__main__.py
@@ -1,0 +1,4 @@
+from installed.app import main
+
+if __name__ == '__main__':
+    main()

--- a/src/core/tests/testbed/installed/app.py
+++ b/src/core/tests/testbed/installed/app.py
@@ -19,11 +19,11 @@ except IndexError:
 def main():
     app = toga.App(factory=factory)
 
-    print(f"app.paths.app={app.paths.app}")
-    print(f"app.paths.data={app.paths.data}")
-    print(f"app.paths.cache={app.paths.cache}")
-    print(f"app.paths.logs={app.paths.logs}")
-    print(f"app.paths.toga={app.paths.toga}")
+    print(f"app.paths.app={app.paths.app.resolve()}")
+    print(f"app.paths.data={app.paths.data.resolve()}")
+    print(f"app.paths.cache={app.paths.cache.resolve()}")
+    print(f"app.paths.logs={app.paths.logs.resolve()}")
+    print(f"app.paths.toga={app.paths.toga.resolve()}")
 
 
 if __name__ == '__main__':

--- a/src/core/tests/testbed/installed/app.py
+++ b/src/core/tests/testbed/installed/app.py
@@ -1,0 +1,30 @@
+import importlib
+import sys
+
+import toga
+
+# If the user provided a --backend:<name> argument,
+# use that backend as the factory.
+backend = [
+    arg.split(":")[1]
+    for arg in sys.argv
+    if arg.startswith("--backend:")
+]
+try:
+    factory = importlib.import_module(f"toga_{backend[0]}").factory
+except IndexError:
+    factory = None
+
+
+def main():
+    app = toga.App(factory=factory)
+
+    print(f"app.paths.app={app.paths.app}")
+    print(f"app.paths.data={app.paths.data}")
+    print(f"app.paths.cache={app.paths.cache}")
+    print(f"app.paths.logs={app.paths.logs}")
+    print(f"app.paths.toga={app.paths.toga}")
+
+
+if __name__ == '__main__':
+    main()

--- a/src/core/tests/testbed/simple/__main__.py
+++ b/src/core/tests/testbed/simple/__main__.py
@@ -1,0 +1,4 @@
+from simple.app import main
+
+if __name__ == '__main__':
+    main()

--- a/src/core/tests/testbed/simple/app.py
+++ b/src/core/tests/testbed/simple/app.py
@@ -17,7 +17,7 @@ except IndexError:
 
 
 def main():
-    app = toga.App('Testbed App', 'org.testbed.simple-app', factory=factory)
+    app = toga.App('Simple App', 'org.testbed.simple-app', factory=factory)
 
     print(f"app.paths.app={app.paths.app.resolve()}")
     print(f"app.paths.data={app.paths.data.resolve()}")

--- a/src/core/tests/testbed/simple/app.py
+++ b/src/core/tests/testbed/simple/app.py
@@ -1,0 +1,30 @@
+import importlib
+import sys
+
+import toga
+
+# If the user provided a --backend:<name> argument,
+# use that backend as the factory.
+backend = [
+    arg.split(":")[1]
+    for arg in sys.argv
+    if arg.startswith("--backend:")
+]
+try:
+    factory = importlib.import_module(f"toga_{backend[0]}").factory
+except IndexError:
+    factory = None
+
+
+def main():
+    app = toga.App('Testbed App', 'org.testbed.simple-app', factory=factory)
+
+    print(f"app.paths.app={app.paths.app}")
+    print(f"app.paths.data={app.paths.data}")
+    print(f"app.paths.cache={app.paths.cache}")
+    print(f"app.paths.logs={app.paths.logs}")
+    print(f"app.paths.toga={app.paths.toga}")
+
+
+if __name__ == '__main__':
+    main()

--- a/src/core/tests/testbed/simple/app.py
+++ b/src/core/tests/testbed/simple/app.py
@@ -19,11 +19,11 @@ except IndexError:
 def main():
     app = toga.App('Testbed App', 'org.testbed.simple-app', factory=factory)
 
-    print(f"app.paths.app={app.paths.app}")
-    print(f"app.paths.data={app.paths.data}")
-    print(f"app.paths.cache={app.paths.cache}")
-    print(f"app.paths.logs={app.paths.logs}")
-    print(f"app.paths.toga={app.paths.toga}")
+    print(f"app.paths.app={app.paths.app.resolve()}")
+    print(f"app.paths.data={app.paths.data.resolve()}")
+    print(f"app.paths.cache={app.paths.cache.resolve()}")
+    print(f"app.paths.logs={app.paths.logs.resolve()}")
+    print(f"app.paths.toga={app.paths.toga.resolve()}")
 
 
 if __name__ == '__main__':

--- a/src/core/tests/testbed/standalone.py
+++ b/src/core/tests/testbed/standalone.py
@@ -1,0 +1,37 @@
+import importlib
+import sys
+import types
+
+# Before we import toga, check for the --interactive flag
+# If that flag exists, mock the behavior of an interactive shell
+# - replace the __main__ module with an in-memory representation.
+if "--interactive" in sys.argv:
+    sys.modules['__main__'] = types.ModuleType('__main__')
+
+import toga
+
+# If the user provided a --backend:<name> argument,
+# use that backend as the factory.
+backend = [
+    arg.split(":")[1]
+    for arg in sys.argv
+    if arg.startswith("--backend:")
+]
+try:
+    factory = importlib.import_module(f"toga_{backend[0]}").factory
+except IndexError:
+    factory = None
+
+
+def main():
+    app = toga.App('Testbed App', 'org.testbed.standalone-app', factory=factory)
+
+    print(f"app.paths.app={app.paths.app}")
+    print(f"app.paths.data={app.paths.data}")
+    print(f"app.paths.cache={app.paths.cache}")
+    print(f"app.paths.logs={app.paths.logs}")
+    print(f"app.paths.toga={app.paths.toga}")
+
+
+if __name__ == '__main__':
+    main()

--- a/src/core/tests/testbed/standalone.py
+++ b/src/core/tests/testbed/standalone.py
@@ -24,7 +24,7 @@ except IndexError:
 
 
 def main():
-    app = toga.App('Testbed App', 'org.testbed.standalone-app', factory=factory)
+    app = toga.App('Standalone App', 'org.testbed.standalone-app', factory=factory)
 
     print(f"app.paths.app={app.paths.app.resolve()}")
     print(f"app.paths.data={app.paths.data.resolve()}")

--- a/src/core/tests/testbed/standalone.py
+++ b/src/core/tests/testbed/standalone.py
@@ -26,11 +26,11 @@ except IndexError:
 def main():
     app = toga.App('Testbed App', 'org.testbed.standalone-app', factory=factory)
 
-    print(f"app.paths.app={app.paths.app}")
-    print(f"app.paths.data={app.paths.data}")
-    print(f"app.paths.cache={app.paths.cache}")
-    print(f"app.paths.logs={app.paths.logs}")
-    print(f"app.paths.toga={app.paths.toga}")
+    print(f"app.paths.app={app.paths.app.resolve()}")
+    print(f"app.paths.data={app.paths.data.resolve()}")
+    print(f"app.paths.cache={app.paths.cache.resolve()}")
+    print(f"app.paths.logs={app.paths.logs.resolve()}")
+    print(f"app.paths.toga={app.paths.toga.resolve()}")
 
 
 if __name__ == '__main__':

--- a/src/core/toga/app.py
+++ b/src/core/toga/app.py
@@ -178,14 +178,20 @@ class App:
             # If the code is contained in a folder, and you start the app
             # using `python -m appname`, the main module will report as the
             # name of the folder.
-            main_module_pkg = sys.modules['__main__'].__package__
-            if main_module_pkg == '':
+            try:
+                main_module_pkg = sys.modules['__main__'].__package__
+                if main_module_pkg == '':
+                    self._app_name = None
+                else:
+                    self._app_name = main_module_pkg
+            except KeyError:
+                # We use the existence of a __main__ module as a proxy for
+                # being in test conditions. This isn't *great*, but the __main__
+                # module isn't meaningful during tests, and removing it allows
+                # us to avoid having explicit "if under test conditions" checks.
+                # If there's no __main__ module, we're in a test, and we can't
+                # imply an app name from that module name.
                 self._app_name = None
-            else:
-                self._app_name = main_module_pkg
-
-            # During tests, and when running from a prompt, there won't be
-            # a __main__ module.
 
             # Try deconstructing the app name from the app ID
             if self._app_name is None and app_id:

--- a/src/dummy/toga_dummy/paths.py
+++ b/src/dummy/toga_dummy/paths.py
@@ -1,6 +1,6 @@
+import sys
 from pathlib import Path
 
-import __main__
 import toga
 from toga import App
 
@@ -11,7 +11,12 @@ class Paths:
 
     @property
     def app(self):
-        return Path(__main__.__file__).parent
+        try:
+            return Path(sys.modules["__main__"].__file__).parent
+        except AttributeError:
+            # If we're running in a test suite, or at an interactive prompt,
+            # the __main__ module isn't file-based.
+            return Path.cwd()
 
     @property
     def data(self):

--- a/src/dummy/toga_dummy/paths.py
+++ b/src/dummy/toga_dummy/paths.py
@@ -13,8 +13,12 @@ class Paths:
     def app(self):
         try:
             return Path(sys.modules["__main__"].__file__).parent
+        except KeyError:
+            # If we're running in a test suite,
+            # there isn't a __main__ module
+            return Path.cwd()
         except AttributeError:
-            # If we're running in a test suite, or at an interactive prompt,
+            # If we're running at an interactive prompt,
             # the __main__ module isn't file-based.
             return Path.cwd()
 

--- a/src/dummy/toga_dummy/paths.py
+++ b/src/dummy/toga_dummy/paths.py
@@ -1,6 +1,6 @@
-import sys
 from pathlib import Path
 
+import __main__
 import toga
 from toga import App
 
@@ -11,7 +11,7 @@ class Paths:
 
     @property
     def app(self):
-        return Path(sys.modules[App.app.module_name].__file__).parent
+        return Path(__main__.__file__).parent
 
     @property
     def data(self):

--- a/src/dummy/toga_dummy/utils.py
+++ b/src/dummy/toga_dummy/utils.py
@@ -1,3 +1,4 @@
+import sys
 import unittest
 
 from travertino.declaration import BaseStyle
@@ -184,6 +185,12 @@ class TestStyle(BaseStyle):
 class TestCase(unittest.TestCase):
     def setUp(self):
         EventLog.reset()
+        # We use the existence of a __main__ module as a proxy for being in test
+        # conditions. This isn't *great*, but the __main__ module isn't meaningful
+        # during tests, and removing it allows us to avoid having explicit "if
+        # under test conditions" checks in paths.py.
+        if '__main__' in sys.modules:
+            del sys.modules['__main__']
 
     def reset_event_log(self):
         EventLog.reset()

--- a/src/gtk/tests/test_paths.py
+++ b/src/gtk/tests/test_paths.py
@@ -1,0 +1,200 @@
+import unittest
+import subprocess
+
+import sys
+from pathlib import Path
+
+import toga
+
+
+TESTBED_PATH = Path(__file__).parent.parent.parent / "core" / "tests" / "testbed"
+
+
+class TestPaths(unittest.TestCase):
+    def setUp(self):
+        # We use the existence of a __main__ module as a proxy for being in test
+        # conditions. This isn't *great*, but the __main__ module isn't meaningful
+        # during tests, and removing it allows us to avoid having explicit "if
+        # under test conditions" checks in paths.py.
+        if "__main__" in sys.modules:
+            del sys.modules["__main__"]
+
+    def test_as_test(self):
+        "During test conditions, the app path is the current working directory"
+        app = toga.App(
+            formal_name="Test App",
+            app_id="org.beeware.test-app",
+            author="Jane Developer",
+        )
+
+        self.assertEqual(
+            app.paths.app,
+            Path.cwd(),
+        )
+        self.assertEqual(
+            app.paths.data,
+            Path.home() / ".local" / "share" / "toga",
+        )
+        self.assertEqual(
+            app.paths.cache,
+            Path.home() / ".cache" / "toga",
+        )
+        self.assertEqual(
+            app.paths.logs,
+            Path.home() / ".cache" / "toga" / "log",
+        )
+        self.assertEqual(
+            app.paths.toga,
+            Path(toga.__file__).parent,
+        )
+
+    def assert_standalone_paths(self, output):
+        "Assert the paths for the standalone app are consistent"
+        results = output.splitlines()
+        self.assertIn(
+            f"app.paths.app={TESTBED_PATH}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.data={Path.home() / '.local' / 'share' / 'toga'}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.cache={Path.home() / '.cache' / 'toga'}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.logs={Path.home() / '.cache' / 'toga' / 'log'}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.toga={Path(toga.__file__).parent}",
+            results,
+        )
+
+    def test_as_interactive(self):
+        "At an interactive prompt, the app path is the current working directory"
+        # Spawn the standalone app using the interactive-mode mocking entry point
+        output = subprocess.check_output(
+            [sys.executable, "standalone.py", "--interactive"],
+            cwd=TESTBED_PATH,
+            text=True,
+        )
+        self.assert_standalone_paths(output)
+
+    def test_as_file(self):
+        "When started as `python app.py`, the app path is the folder holding app.py"
+        # Spawn the standalone app using `app.py`
+        output = subprocess.check_output(
+            [sys.executable, "standalone.py"],
+            cwd=TESTBED_PATH,
+            text=True,
+        )
+        self.assert_standalone_paths(output)
+
+    def test_as_module(self):
+        "When started as `python -m app`, the app path is the folder holding app.py"
+        # Spawn the standalone app using `-m app`
+        output = subprocess.check_output(
+            [sys.executable, "-m", "standalone"],
+            cwd=TESTBED_PATH,
+            text=True,
+        )
+        self.assert_standalone_paths(output)
+
+    def assert_simple_paths(self, output, module_name="toga"):
+        "Assert the paths for the simple app are consistent"
+        results = output.splitlines()
+        self.assertIn(
+            f"app.paths.app={TESTBED_PATH / 'simple'}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.data={Path.home() / '.local' / 'share' / module_name}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.cache={Path.home() / '.cache' / module_name}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.logs={Path.home() / '.cache' / module_name / 'log'}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.toga={Path(toga.__file__).parent}",
+            results,
+        )
+
+    def test_simple_as_file_in_module(self):
+        """When a simple app is started as `python app.py` inside a runnable module,
+        the app path is the folder holding app.py"""
+        # Spawn the simple testbed app using `app.py`
+        output = subprocess.check_output(
+            [sys.executable, "app.py"],
+            cwd=TESTBED_PATH / "simple",
+            text=True,
+        )
+        self.assert_simple_paths(output)
+
+    def test_simple_as_module(self):
+        """When a simple app is started as `python -m app` inside a runnable module,
+        the app path is the folder holding app.py"""
+        # Spawn the simple testbed app using `-m app`
+        output = subprocess.check_output(
+            [sys.executable, "-m", "app"],
+            cwd=TESTBED_PATH / "simple",
+            text=True,
+        )
+        self.assert_simple_paths(output)
+
+    def test_simple_as_deep_file(self):
+        "When a simple app is started as `python simple/app.py`, the app path is the folder holding app.py"
+        # Spawn the simple testbed app using `-m simple`
+        output = subprocess.check_output(
+            [sys.executable, "simple/app.py"],
+            cwd=TESTBED_PATH,
+            text=True,
+        )
+        self.assert_simple_paths(output)
+
+    def test_simple_as_deep_module(self):
+        "When a simple app is started as `python -m simple`, the app path is the folder hodling app.py"
+        # Spawn the simple testbed app using `-m simple`
+        output = subprocess.check_output(
+            [sys.executable, "-m", "simple"],
+            cwd=TESTBED_PATH,
+            text=True,
+        )
+        self.assert_simple_paths(output, module_name="simple")
+
+    def test_installed_as_module(self):
+        "When the installed app is started, the app path is the folder holding app.py"
+        # Spawn the installed testbed app using `-m app`
+        output = subprocess.check_output(
+            [sys.executable, "-m", "installed"],
+            cwd=TESTBED_PATH,
+            text=True,
+        )
+
+        results = output.splitlines()
+        self.assertIn(
+            f"app.paths.app={TESTBED_PATH / 'installed'}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.data={Path.home() / '.local' / 'share' / 'installed'}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.cache={Path.home() / '.cache' / 'installed'}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.logs={Path.home() / '.cache' / 'installed' / 'log'}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.toga={Path(toga.__file__).parent}",
+            results,
+        )

--- a/src/gtk/toga_gtk/paths.py
+++ b/src/gtk/toga_gtk/paths.py
@@ -1,6 +1,6 @@
+import sys
 from pathlib import Path
 
-import __main__
 import toga
 from toga import App
 
@@ -11,7 +11,12 @@ class Paths:
 
     @property
     def app(self):
-        return Path(__main__.__file__).parent
+        try:
+            return Path(sys.modules["__main__"].__file__).parent
+        except AttributeError:
+            # If we're running in a test suite, or at an interactive prompt,
+            # the __main__ module isn't file-based.
+            return Path.cwd()
 
     @property
     def data(self):

--- a/src/gtk/toga_gtk/paths.py
+++ b/src/gtk/toga_gtk/paths.py
@@ -1,6 +1,6 @@
-import sys
 from pathlib import Path
 
+import __main__
 import toga
 from toga import App
 
@@ -11,7 +11,7 @@ class Paths:
 
     @property
     def app(self):
-        return Path(sys.modules[App.app.module_name].__file__).parent
+        return Path(__main__.__file__).parent
 
     @property
     def data(self):

--- a/src/gtk/toga_gtk/paths.py
+++ b/src/gtk/toga_gtk/paths.py
@@ -13,8 +13,12 @@ class Paths:
     def app(self):
         try:
             return Path(sys.modules["__main__"].__file__).parent
+        except KeyError:
+            # If we're running in test conditions,
+            # there is no __main__ module.
+            return Path.cwd()
         except AttributeError:
-            # If we're running in a test suite, or at an interactive prompt,
+            # If we're running at an interactive prompt,
             # the __main__ module isn't file-based.
             return Path.cwd()
 

--- a/src/iOS/toga_iOS/paths.py
+++ b/src/iOS/toga_iOS/paths.py
@@ -1,6 +1,6 @@
+import sys
 from pathlib import Path
 
-import __main__
 import toga
 from toga import App
 
@@ -11,7 +11,12 @@ class Paths:
 
     @property
     def app(self):
-        return Path(__main__.__file__).parent
+        try:
+            return Path(sys.modules["__main__"].__file__).parent
+        except AttributeError:
+            # If we're running in a test suite, or at an interactive prompt,
+            # the __main__ module isn't file-based.
+            return Path.cwd()
 
     @property
     def data(self):

--- a/src/iOS/toga_iOS/paths.py
+++ b/src/iOS/toga_iOS/paths.py
@@ -1,6 +1,6 @@
-import sys
 from pathlib import Path
 
+import __main__
 import toga
 from toga import App
 
@@ -11,7 +11,7 @@ class Paths:
 
     @property
     def app(self):
-        return Path(sys.modules[App.app.module_name].__file__).parent
+        return Path(__main__.__file__).parent
 
     @property
     def data(self):

--- a/src/iOS/toga_iOS/paths.py
+++ b/src/iOS/toga_iOS/paths.py
@@ -13,8 +13,12 @@ class Paths:
     def app(self):
         try:
             return Path(sys.modules["__main__"].__file__).parent
+        except KeyError:
+            # If we're running in test conditions,
+            # there is no __main__ module.
+            return Path.cwd()
         except AttributeError:
-            # If we're running in a test suite, or at an interactive prompt,
+            # If we're running at an interactive prompt,
             # the __main__ module isn't file-based.
             return Path.cwd()
 

--- a/src/web/toga_web/paths.py
+++ b/src/web/toga_web/paths.py
@@ -1,6 +1,6 @@
-import sys
 from pathlib import Path
 
+import __main__
 import toga
 from toga import App
 
@@ -11,7 +11,7 @@ class Paths:
 
     @property
     def app(self):
-        return Path(sys.modules[App.app.module_name].__file__).parent
+        return Path(__main__.__file__).parent
 
     @property
     def data(self):

--- a/src/winforms/tests/test_paths.py
+++ b/src/winforms/tests/test_paths.py
@@ -55,16 +55,17 @@ class TestPaths(unittest.TestCase):
             f"app.paths.app={TESTBED_PATH.resolve()}",
             results,
         )
+        win_app_path = (Path.home() / 'AppData' / 'Local' / 'Toga' / 'Standalone App').resolve()
         self.assertIn(
-            f"app.paths.data={(Path.home() / 'AppData' / 'Local' / 'Toga' / 'Standalone App').resolve()}",
+            f"app.paths.data={win_app_path}",
             results,
         )
         self.assertIn(
-            f"app.paths.cache={(Path.home() / 'AppData' / 'Local' / 'Toga' / 'Standalone App' / 'Cache').resolve()}",
+            f"app.paths.cache={win_app_path / 'Cache'}",
             results,
         )
         self.assertIn(
-            f"app.paths.logs={(Path.home() / 'AppData' / 'Local' / 'Toga' / 'Standalone App' / 'Logs').resolve()}",
+            f"app.paths.logs={win_app_path / 'Logs'}",
             results,
         )
         self.assertIn(
@@ -109,16 +110,17 @@ class TestPaths(unittest.TestCase):
             f"app.paths.app={(TESTBED_PATH / 'simple').resolve()}",
             results,
         )
+        win_app_path = (Path.home() / 'AppData' / 'Local' / 'Toga' / 'Simple App').resolve()
         self.assertIn(
-            f"app.paths.data={(Path.home() / 'AppData' / 'Local' / 'Toga' / 'Simple App').resolve()}",
+            f"app.paths.data={win_app_path}",
             results,
         )
         self.assertIn(
-            f"app.paths.cache={(Path.home() / 'AppData' / 'Local' / 'Toga' / 'Simple App' / 'Cache').resolve()}",
+            f"app.paths.cache={win_app_path / 'Cache'}",
             results,
         )
         self.assertIn(
-            f"app.paths.logs={(Path.home() / 'AppData' / 'Local' / 'Toga' / 'Simple App' / 'Logs').resolve()}",
+            f"app.paths.logs={win_app_path / 'Logs'}",
             results,
         )
         self.assertIn(
@@ -182,16 +184,17 @@ class TestPaths(unittest.TestCase):
             f"app.paths.app={(TESTBED_PATH / 'installed').resolve()}",
             results,
         )
+        win_app_path = (Path.home() / 'AppData' / 'Local' / 'Tiberius Yak' / 'Installed App').resolve()
         self.assertIn(
-            f"app.paths.data={(Path.home() / 'AppData' / 'Local' / 'Tiberius Yak' / 'Installed App').resolve()}",
+            f"app.paths.data={win_app_path}",
             results,
         )
         self.assertIn(
-            f"app.paths.cache={(Path.home() / 'AppData' / 'Local' / 'Tiberius Yak' / 'Installed App' / 'Cache').resolve()}",
+            f"app.paths.cache={win_app_path / 'Cache'}",
             results,
         )
         self.assertIn(
-            f"app.paths.logs={(Path.home() / 'AppData' / 'Local' / 'Tiberius Yak' / 'Installed App' / 'Logs').resolve()}",
+            f"app.paths.logs={win_app_path / 'Logs'}",
             results,
         )
         self.assertIn(

--- a/src/winforms/tests/test_paths.py
+++ b/src/winforms/tests/test_paths.py
@@ -1,0 +1,200 @@
+import unittest
+import subprocess
+
+import sys
+from pathlib import Path
+
+import toga
+
+
+TESTBED_PATH = Path(__file__).parent.parent.parent / "core" / "tests" / "testbed"
+
+
+class TestPaths(unittest.TestCase):
+    def setUp(self):
+        # We use the existence of a __main__ module as a proxy for being in test
+        # conditions. This isn't *great*, but the __main__ module isn't meaningful
+        # during tests, and removing it allows us to avoid having explicit "if
+        # under test conditions" checks in paths.py.
+        if "__main__" in sys.modules:
+            del sys.modules["__main__"]
+
+    def test_as_test(self):
+        "During test conditions, the app path is the current working directory"
+        app = toga.App(
+            formal_name="Test App",
+            app_id="org.beeware.test-app",
+            author="Jane Developer",
+        )
+
+        self.assertEqual(
+            app.paths.app,
+            Path.cwd(),
+        )
+        self.assertEqual(
+            app.paths.data,
+            Path.home() / "AppData" / "Local" / "Jane Developer" / "Test App",
+        )
+        self.assertEqual(
+            app.paths.cache,
+            Path.home() / "AppData" / "Local" / "Jane Developer" / "Test App" / "Cache",
+        )
+        self.assertEqual(
+            app.paths.logs,
+            Path.home() / "AppData" / "Local" / "Jane Developer" / "Test App" / "Logs",
+        )
+        self.assertEqual(
+            app.paths.toga,
+            Path(toga.__file__).parent,
+        )
+
+    def assert_standalone_paths(self, output):
+        "Assert the paths for the standalone app are consistent"
+        results = output.splitlines()
+        self.assertIn(
+            f"app.paths.app={TESTBED_PATH.resolve()}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.data={(Path.home() / 'AppData' / 'Local' / 'Toga' / 'Standalone App').resolve()}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.cache={(Path.home() / 'AppData' / 'Local' / 'Toga' / 'Standalone App' / 'Cache').resolve()}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.logs={(Path.home() / 'AppData' / 'Local' / 'Toga' / 'Standalone App' / 'Logs').resolve()}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.toga={(Path(toga.__file__).parent).resolve()}",
+            results,
+        )
+
+    def test_as_interactive(self):
+        "At an interactive prompt, the app path is the current working directory"
+        # Spawn the standalone app using the interactive-mode mocking entry point
+        output = subprocess.check_output(
+            [sys.executable, "standalone.py", "--interactive"],
+            cwd=TESTBED_PATH,
+            text=True,
+        )
+        self.assert_standalone_paths(output)
+
+    def test_as_file(self):
+        "When started as `python app.py`, the app path is the folder holding app.py"
+        # Spawn the standalone app using `app.py`
+        output = subprocess.check_output(
+            [sys.executable, "standalone.py"],
+            cwd=TESTBED_PATH,
+            text=True,
+        )
+        self.assert_standalone_paths(output)
+
+    def test_as_module(self):
+        "When started as `python -m app`, the app path is the folder holding app.py"
+        # Spawn the standalone app using `-m app`
+        output = subprocess.check_output(
+            [sys.executable, "-m", "standalone"],
+            cwd=TESTBED_PATH,
+            text=True,
+        )
+        self.assert_standalone_paths(output)
+
+    def assert_simple_paths(self, output):
+        "Assert the paths for the simple app are consistent"
+        results = output.splitlines()
+        self.assertIn(
+            f"app.paths.app={(TESTBED_PATH / 'simple').resolve()}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.data={(Path.home() / 'AppData' / 'Local' / 'Toga' / 'Simple App').resolve()}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.cache={(Path.home() / 'AppData' / 'Local' / 'Toga' / 'Simple App' / 'Cache').resolve()}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.logs={(Path.home() / 'AppData' / 'Local' / 'Toga' / 'Simple App' / 'Logs').resolve()}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.toga={Path(toga.__file__).parent.resolve()}",
+            results,
+        )
+
+    def test_simple_as_file_in_module(self):
+        """When a simple app is started as `python app.py` inside a runnable module,
+        the app path is the folder holding app.py"""
+        # Spawn the simple testbed app using `app.py`
+        output = subprocess.check_output(
+            [sys.executable, "app.py"],
+            cwd=TESTBED_PATH / "simple",
+            text=True,
+        )
+        self.assert_simple_paths(output)
+
+    def test_simple_as_module(self):
+        """When a simple app is started as `python -m app` inside a runnable module,
+        the app path is the folder holding app.py"""
+        # Spawn the simple testbed app using `-m app`
+        output = subprocess.check_output(
+            [sys.executable, "-m", "app"],
+            cwd=TESTBED_PATH / "simple",
+            text=True,
+        )
+        self.assert_simple_paths(output)
+
+    def test_simple_as_deep_file(self):
+        "When a simple app is started as `python simple/app.py`, the app path is the folder holding app.py"
+        # Spawn the simple testbed app using `-m simple`
+        output = subprocess.check_output(
+            [sys.executable, "simple/app.py"],
+            cwd=TESTBED_PATH,
+            text=True,
+        )
+        self.assert_simple_paths(output)
+
+    def test_simple_as_deep_module(self):
+        "When a simple app is started as `python -m simple`, the app path is the folder hodling app.py"
+        # Spawn the simple testbed app using `-m simple`
+        output = subprocess.check_output(
+            [sys.executable, "-m", "simple"],
+            cwd=TESTBED_PATH,
+            text=True,
+        )
+        self.assert_simple_paths(output)
+
+    def test_installed_as_module(self):
+        "When the installed app is started, the app path is the folder holding app.py"
+        # Spawn the installed testbed app using `-m app`
+        output = subprocess.check_output(
+            [sys.executable, "-m", "installed"],
+            cwd=TESTBED_PATH,
+            text=True,
+        )
+
+        results = output.splitlines()
+        self.assertIn(
+            f"app.paths.app={(TESTBED_PATH / 'installed').resolve()}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.data={(Path.home() / 'AppData' / 'Local' / 'Tiberius Yak' / 'Installed App').resolve()}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.cache={(Path.home() / 'AppData' / 'Local' / 'Tiberius Yak' / 'Installed App' / 'Cache').resolve()}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.logs={(Path.home() / 'AppData' / 'Local' / 'Tiberius Yak' / 'Installed App' / 'Logs').resolve()}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.toga={Path(toga.__file__).parent.resolve()}",
+            results,
+        )

--- a/src/winforms/toga_winforms/paths.py
+++ b/src/winforms/toga_winforms/paths.py
@@ -1,6 +1,6 @@
-import sys
 from pathlib import Path
 
+import __main__
 import toga
 from toga import App
 
@@ -11,7 +11,7 @@ class Paths:
 
     @property
     def app(self):
-        return Path(sys.modules[App.app.module_name].__file__).parent
+        return Path(__main__.__file__).parent
 
     @property
     def author(self):

--- a/src/winforms/toga_winforms/paths.py
+++ b/src/winforms/toga_winforms/paths.py
@@ -25,7 +25,7 @@ class Paths:
     @property
     def author(self):
         if App.app.author is None:
-            return "Unknown Developer"
+            return "Toga"
         return App.app.author
 
     @property
@@ -34,11 +34,11 @@ class Paths:
 
     @property
     def cache(self):
-        return Path.home() / 'Library' / 'Local' / self.author / App.app.formal_name / 'Cache'
+        return Path.home() / 'AppData' / 'Local' / self.author / App.app.formal_name / 'Cache'
 
     @property
     def logs(self):
-        return Path.home() / 'Library' / 'Local' / self.author / App.app.formal_name / 'Logs'
+        return Path.home() / 'AppData' / 'Local' / self.author / App.app.formal_name / 'Logs'
 
     @property
     def toga(self):

--- a/src/winforms/toga_winforms/paths.py
+++ b/src/winforms/toga_winforms/paths.py
@@ -1,6 +1,6 @@
+import sys
 from pathlib import Path
 
-import __main__
 import toga
 from toga import App
 
@@ -11,7 +11,12 @@ class Paths:
 
     @property
     def app(self):
-        return Path(__main__.__file__).parent
+        try:
+            return Path(sys.modules["__main__"].__file__).parent
+        except AttributeError:
+            # If we're running in a test suite, or at an interactive prompt,
+            # the __main__ module isn't file-based.
+            return Path.cwd()
 
     @property
     def author(self):

--- a/src/winforms/toga_winforms/paths.py
+++ b/src/winforms/toga_winforms/paths.py
@@ -13,8 +13,12 @@ class Paths:
     def app(self):
         try:
             return Path(sys.modules["__main__"].__file__).parent
+        except KeyError:
+            # If we're running in test conditions,
+            # there is no __main__ module.
+            return Path.cwd()
         except AttributeError:
-            # If we're running in a test suite, or at an interactive prompt,
+            # If we're running at an interactive prompt,
             # the __main__ module isn't file-based.
             return Path.cwd()
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,11 +13,13 @@ deps =
     setuptools
     pytest-tldr
     pytest-cov
+allowlist_externals =
+    cd
 commands:
     python -m pip install -e src/core
     python -m pip install -e src/dummy
-    pytest src/core/tests --cov
-    coverage xml
+    cd src/core && pytest --cov
+    cd src/core && coverage xml
 
 [testenv:flake8]
 skip_install = True

--- a/tox.ini
+++ b/tox.ini
@@ -13,13 +13,12 @@ deps =
     setuptools
     pytest-tldr
     pytest-cov
-allowlist_externals =
-    cd
+changedir = {toxinidir}/src/core
 commands:
-    python -m pip install -e src/core
-    python -m pip install -e src/dummy
-    cd src/core && pytest --cov
-    cd src/core && coverage xml
+    python -m pip install -e .
+    python -m pip install -e ../dummy
+    pytest --cov
+    coverage xml
 
 [testenv:flake8]
 skip_install = True

--- a/tox.ini
+++ b/tox.ini
@@ -24,12 +24,14 @@ commands:
 skip_install = True
 deps =
     flake8
+changedir = {toxinidir}
 commands = flake8 {posargs}
 
 # [testenv:towncrier-check]
 # skip_install = True
 # deps =
 #     {[testenv:towncrier]deps}
+# changedir = {toxinidir}
 # commands =
 #     python -m towncrier.check
 
@@ -37,6 +39,7 @@ commands = flake8 {posargs}
 # skip_install = True
 # deps =
 #     towncrier >= 18.5.0
+# changedir = {toxinidir}
 # commands =
 #     towncrier {posargs}
 
@@ -45,6 +48,7 @@ skip_install = True
 deps =
     -r{toxinidir}/docs/requirements.txt
     src/core
+changedir = {toxinidir}
 commands =
     python setup.py build_sphinx -W
 
@@ -56,5 +60,6 @@ deps =
     twine
 whitelist_externals =
     release.sh
+changedir = {toxinidir}
 commands =
     ./release.sh package


### PR DESCRIPTION
When running an application as a single file, as a module, e.g:
`python -m app` on a `app.py` file,
Toga would not assume the working directory to resolve relative paths, and would fail to load local app resources.

`factory.paths.app` is now built using `__main__.__file__`.
This works both for:
- apps inside packages: `__main__.__file__` returns the path for the app package `__main__.py`.
- when the app is launched from single startup script: `__main__.__file__` returns the path for the single startup script.

The old method used  `sys.modules[App.app.module_name].__file__)`,  which returns the path for the app package `__init__.py`.
But for apps launched from a single startup script, `App.app.module_name` is set to `toga`. In that case, only resources on the `toga` package could be loaded.

Fixes #990 and #1387.

Tested on macOS.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
