### PR TITLE
Correct winfont loading in Briefcase packaged apps

### DIFF
--- a/examples/font/font/app.py
+++ b/examples/font/font/app.py
@@ -105,7 +105,10 @@ class ExampleFontExampleApp(toga.App):
                 font_style=ITALIC,
             ),
         )
-
+        lbl9 = toga.Label(
+            "Unknown font",
+            style=Pack(font_family="Unknown", font_size=14)
+        )
         self.textpanel = toga.MultilineTextInput(
             readonly=False, style=Pack(flex=1), placeholder="Ready."
         )
@@ -122,6 +125,7 @@ class ExampleFontExampleApp(toga.App):
                 lbl6,
                 lbl7,
                 lbl8,
+                lbl9,
                 self.textpanel,
             ],
             style=Pack(flex=1, direction=COLUMN, padding=10),

--- a/src/winforms/toga_winforms/fonts.py
+++ b/src/winforms/toga_winforms/fonts.py
@@ -36,36 +36,30 @@ class Font:
                 style=self.interface.style,
                 variant=self.interface.variant,
             )
-            if font_key in _REGISTERED_FONT_CACHE:
+            try:
                 font_path = str(
                     self.interface.factory.paths.app / _REGISTERED_FONT_CACHE[font_key]
                 )
                 try:
                     self._pfc = PrivateFontCollection()
                     self._pfc.AddFontFile(font_path)
-                    font_size = win_font_size(self.interface.size)
-                    font_style = win_font_style(
-                        self.interface.weight,
-                        self.interface.style,
-                        self._pfc.Families[0],
-                    )
-                    font = WinFont(self._pfc.Families[0], float(font_size), font_style)
+                    font_family = self._pfc.Families[0]
                 except FileNotFoundException as e:
                     print(f"Registered font path {font_path!r} could not be found: {e}")
                 except ExternalException as e:
                     print(f"Registered font path {font_path!r} could not be loaded: {e}")
                 except IndexError as e:
                     print(f"Registered font {font_key} could not be loaded: {e}")
-
-            if font is None:
+            except KeyError:
                 font_family = win_font_family(self.interface.family)
-                font_style = win_font_style(
-                    self.interface.weight, self.interface.style, font_family
-                )
-                font_size = win_font_size(self.interface.size)
-                font = WinFont.Overloads[FontFamily, Single, FontStyle](
-                    font_family, font_size, font_style
-                )
+
+            font_style = win_font_style(
+                self.interface.weight,
+                self.interface.style,
+                font_family,
+            )
+            font_size = win_font_size(self.interface.size)
+            font = WinFont(font_family, font_size, font_style)
             _FONT_CACHE[self.interface] = font
 
         self.native = font


### PR DESCRIPTION
When Winforms apps are packaged with Briefcase, loading a system font would raise an error around the constructor for WinFont. It turns out the Overloads[] call wasn't required, and avoided the error. 

This also provided an opportunity to simplify the implementation of font loading so that there is a single path that constructs a font.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [ ] I have read the **CONTRIBUTING.md** file
- [ ] I will abide by the code of conduct
