### PR TITLE
Improve top-level exception handling in Windows apps.

### DIFF
--- a/src/winforms/toga_winforms/app.py
+++ b/src/winforms/toga_winforms/app.py
@@ -215,17 +215,30 @@ class App:
         try:
             self.create()
 
+            # This catches errors in handlers, and prints them
+            # in a usable form.
             self.native.ThreadException += self.winforms_thread_exception
 
             self.loop.run_forever(self.app_context)
-        except:  # NOQA
-            traceback.print_exc()
+        except Exception as e:
+            # In case of an unhandled error at the level of the app,
+            # preserve the Python stacktrace
+            self._exception = e
+        else:
+            self._exception = None
 
     def main_loop(self):
         thread = Threading.Thread(Threading.ThreadStart(self.run_app))
         thread.SetApartmentState(Threading.ApartmentState.STA)
         thread.Start()
         thread.Join()
+
+        # If the thread has exited, the _exception attribute will exist.
+        # If it's non-None, raise it, as it indicates the underlying
+        # app thread had a problem; this is effectibely a re-raise over
+        # a thread boundary.
+        if self._exception:
+            raise self._exception
 
     def show_about_dialog(self):
         message_parts = []

--- a/src/winforms/toga_winforms/app.py
+++ b/src/winforms/toga_winforms/app.py
@@ -1,7 +1,6 @@
 import asyncio
 import re
 import sys
-import traceback
 
 import toga
 from toga import Key


### PR DESCRIPTION
If the app thread raises an exception, re-raise in the main thread context.

At present, if an app-terminating exception raised, it is caught inside the thread, printed, and then swallowed. This causes the application to terminate, but from the perspective of the main thread, the application completed successfully. This makes it difficult to identify at a process level when apps are failing.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
