### PR TITLE
Pack algorithm documentation: typo & grammar corrections

### DIFF
--- a/docs/reference/style/pack.rst
+++ b/docs/reference/style/pack.rst
@@ -356,14 +356,14 @@ specifying the allocated width and allocated height.
       The extra height for a child is defined as the difference between the
       parent elements final height and the child's full height.
 
-      If the parent element has a ``alignment`` value of ``top``, the
+      If the parent element has an ``alignment`` value of ``top``, the
       vertical position of the child is set to 0, relative to the parent.
 
-      If the parent element has a ``alignment`` value of ``bottom``, the
+      If the parent element has an ``alignment`` value of ``bottom``, the
       vertical position of the child is set to the extra height, relative to
       the parent.
 
-      If the parent element has a ``alignment`` value of ``center``, the
+      If the parent element has an ``alignment`` value of ``center``, the
       vertical position of the child is set to 1/2 of the extra height,
       relative to the parent.
 
@@ -438,13 +438,13 @@ specifying the allocated width and allocated height.
       The extra width for a child is defined as the difference between the
       parent element's final width and the child's full width.
 
-      If the parent element has a ``alignment`` value of ``left``, the
+      If the parent element has an ``alignment`` value of ``left``, the
       horizontal position of the child is set to 0, relative to the parent.
 
-      If the parent element has a ``alignment`` value of ``right``, the
+      If the parent element has an ``alignment`` value of ``right``, the
       horizontal position of the child is set to the extra width, relative to
       the parent.
 
-      If the parent element has a ``text_align`` value of ``center``, the
+      If the parent element has an ``alignment`` value of ``center``, the
       horizontal position of the child is set to 1/2 of the extra width,
       relative to the parent.


### PR DESCRIPTION
Two minor edits:
* Corrected a typo: "``text_align`` value of ``center``" -> "``alignment`` value of ``center``"
* Changed all instances of "a ``alignment``" to "an ``alignment``"

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [N/A] All new features have been tested
- [N/A] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
