### PR TITLE
API consistency: switch widget

### DIFF
--- a/examples/box/box/app.py
+++ b/examples/box/box/app.py
@@ -58,7 +58,7 @@ class ExampleBoxApp(toga.App):
                 self.inner_box,
                 toga.Label(text="Hello to my world!", style=Pack(text_align=CENTER)),
                 toga.Switch(
-                    "Enable yellow", value=True, on_toggle=self.toggle_yellow_button
+                    "Enable yellow", value=True, on_change=self.toggle_yellow_button
                 ),
             ],
         )

--- a/examples/box/box/app.py
+++ b/examples/box/box/app.py
@@ -58,7 +58,7 @@ class ExampleBoxApp(toga.App):
                 self.inner_box,
                 toga.Label(text="Hello to my world!", style=Pack(text_align=CENTER)),
                 toga.Switch(
-                    "Enable yellow", is_on=True, on_toggle=self.toggle_yellow_button
+                    "Enable yellow", value=True, on_toggle=self.toggle_yellow_button
                 ),
             ],
         )
@@ -85,7 +85,7 @@ class ExampleBoxApp(toga.App):
         self.outer_box.style.background_color = None
 
     def toggle_yellow_button(self, widget):
-        if widget.is_on:
+        if widget.value:
             self.inner_box.insert(1, self.yellow_button)
         else:
             self.inner_box.remove(self.yellow_button)

--- a/examples/canvas/canvas/app.py
+++ b/examples/canvas/canvas/app.py
@@ -138,11 +138,11 @@ class ExampleCanvasApp(toga.App):
             on_change=self.refresh_canvas
         )
         self.italic_switch = toga.Switch(
-            label="italic",
+            text="italic",
             on_change=self.refresh_canvas
         )
         self.bold_switch = toga.Switch(
-            label="bold",
+            text="bold",
             on_change=self.refresh_canvas
         )
         label_style = Pack(font_size=10, padding_left=5)

--- a/examples/canvas/canvas/app.py
+++ b/examples/canvas/canvas/app.py
@@ -539,12 +539,12 @@ class ExampleCanvasApp(toga.App):
         context.write_text(text, self.x_middle - width / 2, self.y_middle, font)
 
     def get_weight(self):
-        if self.bold_switch.is_on:
+        if self.bold_switch.value:
             return BOLD
         return NORMAL
 
     def get_style(self):
-        if self.italic_switch.is_on:
+        if self.italic_switch.value:
             return ITALIC
         return NORMAL
 

--- a/examples/canvas/canvas/app.py
+++ b/examples/canvas/canvas/app.py
@@ -139,11 +139,11 @@ class ExampleCanvasApp(toga.App):
         )
         self.italic_switch = toga.Switch(
             label="italic",
-            on_toggle=self.refresh_canvas
+            on_change=self.refresh_canvas
         )
         self.bold_switch = toga.Switch(
             label="bold",
-            on_toggle=self.refresh_canvas
+            on_change=self.refresh_canvas
         )
         label_style = Pack(font_size=10, padding_left=5)
 

--- a/examples/focus/focus/app.py
+++ b/examples/focus/focus/app.py
@@ -90,7 +90,7 @@ class ExampleFocusApp(toga.App):
         )
 
     def on_switch_toggle(self, widget: toga.Switch):
-        on_off = "on" if widget.is_on else "off"
+        on_off = "on" if widget.value else "off"
         self.info_label.text = "Switch turned {on_off}!".format(on_off=on_off)
 
     def on_textinput_gain_focus(self, widget: toga.TextInput):

--- a/examples/focus/focus/app.py
+++ b/examples/focus/focus/app.py
@@ -31,7 +31,7 @@ class ExampleFocusApp(toga.App):
             placeholder="A non-focussed text input.",
             style=Pack(height=25, width=200, font_size=10),
         )
-        self.switch = toga.Switch("Switch", on_toggle=self.on_switch_toggle)
+        self.switch = toga.Switch("Switch", on_change=self.on_switch_toggle)
         self.info_label = toga.Label(
             "Use keyboard shortcuts to focus on the different widgets",
             style=Pack(font_size=10)

--- a/examples/progressbar/progressbar/app.py
+++ b/examples/progressbar/progressbar/app.py
@@ -129,14 +129,14 @@ class ProgressBarApp(toga.App):
             self.progress_adder.value -= 0.1 * self.progress_adder.max
 
     def toggle_indeterminate(self, switch, **kw):
-        if switch.is_on:
+        if switch.value:
             self.progress_adder.max = None
         else:
             self.progress_adder.max = MAX_PROGRESSBAR_VALUE
         print("is determinate: " + str(self.progress_adder.is_determinate))
 
     def toggle_running(self, switch, **kw):
-        if switch.is_on:
+        if switch.value:
             self.progress_adder.start()
         else:
             self.progress_adder.stop()

--- a/examples/progressbar/progressbar/app.py
+++ b/examples/progressbar/progressbar/app.py
@@ -53,10 +53,10 @@ class ProgressBarApp(toga.App):
                         ),
                         toga.Switch(
                             "Toggle indeterminate mode",
-                            on_toggle=self.toggle_indeterminate,
+                            on_change=self.toggle_indeterminate,
                         ),
                         toga.Switch(
-                            "Toggle running mode", on_toggle=self.toggle_running
+                            "Toggle running mode", on_change=self.toggle_running
                         ),
                     ],
                 ),

--- a/examples/scrollcontainer/scrollcontainer/app.py
+++ b/examples/scrollcontainer/scrollcontainer/app.py
@@ -27,8 +27,8 @@ class ScrollContainerApp(toga.App):
         box.style.padding = 10
         self.scroller = toga.ScrollContainer(horizontal=self.hscrolling, vertical=self.vscrolling)
         switch_box = toga.Box(style=Pack(direction=ROW))
-        switch_box.add(toga.Switch('vertical scrolling', is_on=self.vscrolling, on_toggle=self.handle_vscrolling))
-        switch_box.add(toga.Switch('horizontal scrolling', is_on=self.hscrolling, on_toggle=self.handle_hscrolling))
+        switch_box.add(toga.Switch('vertical scrolling', value=self.vscrolling, on_toggle=self.handle_vscrolling))
+        switch_box.add(toga.Switch('horizontal scrolling', value=self.hscrolling, on_toggle=self.handle_hscrolling))
         box.add(switch_box)
 
         for x in range(100):
@@ -72,11 +72,11 @@ class ScrollContainerApp(toga.App):
         )
 
     def handle_hscrolling(self, widget):
-        self.hscrolling = widget.is_on
+        self.hscrolling = widget.value
         self.scroller.horizontal = self.hscrolling
 
     def handle_vscrolling(self, widget):
-        self.vscrolling = widget.is_on
+        self.vscrolling = widget.value
         self.scroller.vertical = self.vscrolling
 
     def toggle_up(self, widget):

--- a/examples/scrollcontainer/scrollcontainer/app.py
+++ b/examples/scrollcontainer/scrollcontainer/app.py
@@ -27,8 +27,8 @@ class ScrollContainerApp(toga.App):
         box.style.padding = 10
         self.scroller = toga.ScrollContainer(horizontal=self.hscrolling, vertical=self.vscrolling)
         switch_box = toga.Box(style=Pack(direction=ROW))
-        switch_box.add(toga.Switch('vertical scrolling', value=self.vscrolling, on_toggle=self.handle_vscrolling))
-        switch_box.add(toga.Switch('horizontal scrolling', value=self.hscrolling, on_toggle=self.handle_hscrolling))
+        switch_box.add(toga.Switch('vertical scrolling', value=self.vscrolling, on_change=self.handle_vscrolling))
+        switch_box.add(toga.Switch('horizontal scrolling', value=self.hscrolling, on_change=self.handle_hscrolling))
         box.add(switch_box)
 
         for x in range(100):

--- a/examples/switch_demo/switch_demo/app.py
+++ b/examples/switch_demo/switch_demo/app.py
@@ -14,7 +14,7 @@ class SwitchApp(toga.App):
         self.main_window.content = toga.Box(
             children=[
                 # Simple switch with label and callback function called toggled
-                toga.Switch('Change Label', on_toggle=self.callbackLabel),
+                toga.Switch('Change Label', on_change=self.callbackLabel),
 
                 # Switch with initial state
                 toga.Switch('Initial state', value=True, style=Pack(padding_top=24)),

--- a/examples/switch_demo/switch_demo/app.py
+++ b/examples/switch_demo/switch_demo/app.py
@@ -35,7 +35,7 @@ class SwitchApp(toga.App):
     def callbackLabel(self, switch):
         # Some action when you hit the switch
         #   In this case the label will change
-        switch.label = "switch is %s" % {0: "off", 1: "on"}[switch.value]
+        switch.text = "switch is %s" % {0: "off", 1: "on"}[switch.value]
 
 
 def main():

--- a/examples/switch_demo/switch_demo/app.py
+++ b/examples/switch_demo/switch_demo/app.py
@@ -17,7 +17,7 @@ class SwitchApp(toga.App):
                 toga.Switch('Change Label', on_toggle=self.callbackLabel),
 
                 # Switch with initial state
-                toga.Switch('Initial state', is_on=True, style=Pack(padding_top=24)),
+                toga.Switch('Initial state', value=True, style=Pack(padding_top=24)),
 
                 # Switch with label and enable option
                 toga.Switch('Disabled', enabled=False, style=Pack(padding_top=24)),
@@ -35,7 +35,7 @@ class SwitchApp(toga.App):
     def callbackLabel(self, switch):
         # Some action when you hit the switch
         #   In this case the label will change
-        switch.label = "switch is %s" % {0: "off", 1: "on"}[switch.is_on]
+        switch.label = "switch is %s" % {0: "off", 1: "on"}[switch.value]
 
 
 def main():

--- a/src/android/toga_android/widgets/switch.py
+++ b/src/android/toga_android/widgets/switch.py
@@ -24,14 +24,14 @@ class Switch(Widget):
         self.native = A_Switch(self._native_activity)
         self.native.setOnCheckedChangeListener(OnCheckedChangeListener(self))
 
-    def set_label(self, label):
+    def set_text(self, text):
         # When changing the text, Android needs a `setSingleLine(False)` call in order
         # to be willing to recompute the width of the text. Without the call, it will
         # constrain the new text to have the same line width as the old text, resulting
         # in unnecessary creation of new lines. In other words, `setSingleLine(False)`
         # is required to get the text to truly **use** one single line!
         self.native.setSingleLine(False)
-        self.native.setText(str(self.interface.label))
+        self.native.setText(str(self.interface.text))
         self.rehint()
 
     def set_value(self, value):

--- a/src/android/toga_android/widgets/switch.py
+++ b/src/android/toga_android/widgets/switch.py
@@ -34,10 +34,10 @@ class Switch(Widget):
         self.native.setText(str(self.interface.label))
         self.rehint()
 
-    def set_is_on(self, value):
+    def set_value(self, value):
         self.native.setChecked(bool(value))
 
-    def get_is_on(self):
+    def get_value(self):
         return self.native.isChecked()
 
     def set_font(self, font):

--- a/src/android/toga_android/widgets/switch.py
+++ b/src/android/toga_android/widgets/switch.py
@@ -15,8 +15,8 @@ class OnCheckedChangeListener(CompoundButton__OnCheckedChangeListener):
         self._impl = impl
 
     def onCheckedChanged(self, _button, _checked):
-        if self._impl.interface.on_toggle:
-            self._impl.interface.on_toggle(widget=self._impl.interface)
+        if self._impl.interface.on_change:
+            self._impl.interface.on_change(widget=self._impl.interface)
 
 
 class Switch(Widget):
@@ -46,7 +46,7 @@ class Switch(Widget):
             self.native.setTextSize(TypedValue.COMPLEX_UNIT_SP, font_impl.get_size())
             self.native.setTypeface(font_impl.get_typeface(), font_impl.get_style())
 
-    def set_on_toggle(self, handler):
+    def set_on_change(self, handler):
         # No special handling required
         pass
 

--- a/src/cocoa/toga_cocoa/widgets/switch.py
+++ b/src/cocoa/toga_cocoa/widgets/switch.py
@@ -46,20 +46,20 @@ class Switch(Widget):
         if font:
             self.native.font = font.bind(self.interface.factory).native
 
-    def set_is_on(self, value):
+    def set_value(self, value):
         if value is True:
             self.native.state = NSOnState
         elif value is False:
             self.native.state = NSOffState
 
-    def get_is_on(self):
-        is_on = self.native.state
-        if is_on == 1:
+    def get_value(self):
+        value = self.native.state
+        if value == 1:
             return True
-        elif is_on == 0:
+        elif value == 0:
             return False
         else:
-            raise Exception('Undefined value for is_on of {}'.format(__class__))
+            raise Exception('Undefined value for value of {}'.format(__class__))
 
     def rehint(self):
         content_size = self.native.intrinsicContentSize()

--- a/src/cocoa/toga_cocoa/widgets/switch.py
+++ b/src/cocoa/toga_cocoa/widgets/switch.py
@@ -21,8 +21,8 @@ class TogaSwitch(NSButton):
 
     @objc_method
     def onPress_(self, obj) -> None:
-        if self.interface.on_toggle:
-            self.interface.on_toggle(self.interface)
+        if self.interface.on_change:
+            self.interface.on_change(self.interface)
 
 
 class Switch(Widget):
@@ -66,5 +66,5 @@ class Switch(Widget):
         self.interface.intrinsic.height = content_size.height
         self.interface.intrinsic.width = at_least(content_size.width)
 
-    def set_on_toggle(self, handler):
+    def set_on_change(self, handler):
         pass

--- a/src/cocoa/toga_cocoa/widgets/switch.py
+++ b/src/cocoa/toga_cocoa/widgets/switch.py
@@ -39,8 +39,8 @@ class Switch(Widget):
         # Add the layout constraints
         self.add_constraints()
 
-    def set_label(self, label):
-        self.native.title = self.interface.label
+    def set_text(self, text):
+        self.native.title = self.interface.text
 
     def set_font(self, font):
         if font:

--- a/src/core/tests/testbed/bootstrap.py
+++ b/src/core/tests/testbed/bootstrap.py
@@ -1,0 +1,14 @@
+import importlib
+import sys
+# If the user provided a --app:<name> argument,
+# import that module as the app.
+app = [
+    arg.split(":")[1]
+    for arg in sys.argv
+    if arg.startswith("--app:")
+]
+main = importlib.import_module(f"{app[0]}.app").main
+
+
+if __name__ == "__main__":
+    main()

--- a/src/core/tests/testbed/subclassed/__main__.py
+++ b/src/core/tests/testbed/subclassed/__main__.py
@@ -1,0 +1,4 @@
+from subclassed.app import main
+
+if __name__ == '__main__':
+    main()

--- a/src/core/tests/testbed/subclassed/app.py
+++ b/src/core/tests/testbed/subclassed/app.py
@@ -1,0 +1,34 @@
+import importlib
+import sys
+
+import toga
+
+# If the user provided a --backend:<name> argument,
+# use that backend as the factory.
+backend = [
+    arg.split(":")[1]
+    for arg in sys.argv
+    if arg.startswith("--backend:")
+]
+try:
+    factory = importlib.import_module(f"toga_{backend[0]}").factory
+except IndexError:
+    factory = None
+
+
+class SubclassedApp(toga.App):
+    pass
+
+
+def main():
+    app = SubclassedApp('Subclassed App', 'org.testbed.subclassed-app', factory=factory)
+
+    print(f"app.paths.app={app.paths.app.resolve()}")
+    print(f"app.paths.data={app.paths.data.resolve()}")
+    print(f"app.paths.cache={app.paths.cache.resolve()}")
+    print(f"app.paths.logs={app.paths.logs.resolve()}")
+    print(f"app.paths.toga={app.paths.toga.resolve()}")
+
+
+if __name__ == '__main__':
+    main()

--- a/src/core/tests/widgets/test_switch.py
+++ b/src/core/tests/widgets/test_switch.py
@@ -12,11 +12,11 @@ class SwitchTests(TestCase):
         def callback(widget):
             pass
 
-        self.on_toggle = callback
+        self.on_change = callback
         self.value = True
         self.enabled = True
         self.switch = toga.Switch(self.label,
-                                  on_toggle=self.on_toggle,
+                                  on_change=self.on_change,
                                   value=self.value,
                                   enabled=self.enabled,
                                   factory=toga_dummy.factory)
@@ -28,7 +28,7 @@ class SwitchTests(TestCase):
     def test_arguments_are_all_set_properly(self):
         self.assertEqual(self.switch.label, self.label)
         self.assertEqual(self.switch._label, self.label)
-        self.assertEqual(self.switch.on_toggle._raw, self.on_toggle)
+        self.assertEqual(self.switch.on_change._raw, self.on_change)
         self.assertEqual(self.switch.enabled, self.enabled)
 
     def test_label_with_None(self):
@@ -77,5 +77,21 @@ class SwitchTests(TestCase):
     def test_get_is_on(self):
         with self.assertWarns(DeprecationWarning):
             self.switch.is_on
-        # self.assertWarns(DeprecationWarning, self.switch.is_on)
         self.assertValueGet(self.switch, 'value')
+
+    def test_on_change(self):
+        def my_callback(widget):
+            pass
+        
+        self.switch.on_change = my_callback
+        self.assertEqual(self.switch.on_change._raw, my_callback)
+
+    def test_on_toggle(self):
+        def my_callback(widget):
+            pass
+        
+        with self.assertWarns(DeprecationWarning):
+            self.switch.on_toggle = my_callback
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(self.switch.on_toggle._raw, my_callback)
+        self.assertEqual(self.switch.on_change._raw, my_callback)

--- a/src/core/tests/widgets/test_switch.py
+++ b/src/core/tests/widgets/test_switch.py
@@ -13,11 +13,11 @@ class SwitchTests(TestCase):
             pass
 
         self.on_toggle = callback
-        self.is_on = True
+        self.value = True
         self.enabled = True
         self.switch = toga.Switch(self.label,
                                   on_toggle=self.on_toggle,
-                                  is_on=self.is_on,
+                                  value=self.value,
                                   enabled=self.enabled,
                                   factory=toga_dummy.factory)
 
@@ -41,29 +41,41 @@ class SwitchTests(TestCase):
         self.switch.label = new_label
         self.assertValueSet(self.switch, 'label', new_label)
 
-    def test_setting_is_on_invokes_impl_method(self):
+    def test_setting_value_invokes_impl_method(self):
         new_value = False
-        self.switch.is_on = new_value
-        self.assertValueSet(self.switch, 'is_on', False)
+        self.switch.value = new_value
+        self.assertValueSet(self.switch, 'value', False)
 
-    def test_getting_is_on_invokes_impl_method(self):
-        self.switch.is_on
-        self.assertValueGet(self.switch, 'is_on')
+    def test_getting_value_invokes_impl_method(self):
+        self.switch.value
+        self.assertValueGet(self.switch, 'value')
 
     def test_focus(self):
         self.switch.focus()
         self.assertActionPerformed(self.switch, "focus")
 
     def test_toggle_from_true_to_false(self):
-        self.switch.is_on = True
+        self.switch.value = True
         self.switch.toggle()
-        self.assertValueSet(self.switch, 'is_on', False)
+        self.assertValueSet(self.switch, 'value', False)
 
     def test_toggle_from_false_to_true(self):
-        self.switch.is_on = False
+        self.switch.value = False
         self.switch.toggle()
-        self.assertValueSet(self.switch, 'is_on', True)
+        self.assertValueSet(self.switch, 'value', True)
 
-    def test_set_is_on_with_non_boolean(self):
+    def test_set_value_with_non_boolean(self):
         with self.assertRaises(ValueError):
-            self.switch.is_on = "on"
+            self.switch.value = "on"
+
+    def test_set_is_on(self):
+        new_value = False
+        with self.assertWarns(DeprecationWarning):
+            self.switch.is_on = new_value
+        self.assertValueSet(self.switch, 'value', False)
+
+    def test_get_is_on(self):
+        with self.assertWarns(DeprecationWarning):
+            self.switch.is_on
+        # self.assertWarns(DeprecationWarning, self.switch.is_on)
+        self.assertValueGet(self.switch, 'value')

--- a/src/core/tests/widgets/test_switch.py
+++ b/src/core/tests/widgets/test_switch.py
@@ -82,14 +82,14 @@ class SwitchTests(TestCase):
     def test_on_change(self):
         def my_callback(widget):
             pass
-        
+
         self.switch.on_change = my_callback
         self.assertEqual(self.switch.on_change._raw, my_callback)
 
     def test_on_toggle(self):
         def my_callback(widget):
             pass
-        
+
         with self.assertWarns(DeprecationWarning):
             self.switch.on_toggle = my_callback
         with self.assertWarns(DeprecationWarning):

--- a/src/core/tests/widgets/test_switch.py
+++ b/src/core/tests/widgets/test_switch.py
@@ -82,11 +82,11 @@ class SwitchTests(TestCase):
     def test_no_args(self):
         "A text label must be provided"
         with self.assertRaises(TypeError):
-            toga.Switch()
+            toga.Switch(factory=toga_dummy.factory)
 
     def test_default_value(self):
         "The switch value defaults to False"
-        switch = toga.Switch("My Switch")
+        switch = toga.Switch("My Switch", factory=toga_dummy.factory)
         self.assertEqual(switch.value, False)
 
     ######################################################################

--- a/src/core/tests/widgets/test_switch.py
+++ b/src/core/tests/widgets/test_switch.py
@@ -67,7 +67,17 @@ class SwitchTests(TestCase):
     def test_set_value_with_non_boolean(self):
         with self.assertRaises(ValueError):
             self.switch.value = "on"
+        with self.assertRaises(ValueError):
+            self.switch.value = None
 
+    def test_on_change(self):
+        def my_callback(widget):
+            pass
+
+        self.switch.on_change = my_callback
+        self.assertEqual(self.switch.on_change._raw, my_callback)
+
+    # 2022-07: Backwards compatibility
     def test_set_is_on(self):
         new_value = False
         with self.assertWarns(DeprecationWarning):
@@ -78,13 +88,6 @@ class SwitchTests(TestCase):
         with self.assertWarns(DeprecationWarning):
             self.switch.is_on
         self.assertValueGet(self.switch, 'value')
-
-    def test_on_change(self):
-        def my_callback(widget):
-            pass
-
-        self.switch.on_change = my_callback
-        self.assertEqual(self.switch.on_change._raw, my_callback)
 
     def test_on_toggle(self):
         def my_callback(widget):
@@ -103,3 +106,59 @@ class SwitchTests(TestCase):
         with self.assertWarns(DeprecationWarning):
             self.assertEqual(self.switch.label, new_text)
         self.assertValueSet(self.switch, 'text', new_text)
+
+    def test_init_with_deprecated(self):
+        with self.assertWarns(DeprecationWarning):
+            toga.Switch(
+                label=self.text,
+                on_change=self.on_change,
+                value=self.value,
+                enabled=self.enabled,
+                factory=toga_dummy.factory
+            )
+        with self.assertRaises(ValueError):
+            toga.Switch(
+                label=self.text,
+                text=self.text,
+                on_change=self.on_change,
+                value=self.value,
+                enabled=self.enabled,
+                factory=toga_dummy.factory
+            )
+        with self.assertWarns(DeprecationWarning):
+            toga.Switch(
+                self.text,
+                on_toggle=self.on_change,
+                value=self.value,
+                enabled=self.enabled,
+                factory=toga_dummy.factory
+            )
+        with self.assertRaises(ValueError):
+            toga.Switch(
+                self.text,
+                on_change=self.on_change,
+                on_toggle=self.on_change,
+                value=self.value,
+                enabled=self.enabled,
+                factory=toga_dummy.factory
+            )
+
+        with self.assertWarns(DeprecationWarning):
+            toga.Switch(
+                self.text,
+                on_change=self.on_change,
+                is_on=self.value,
+                enabled=self.enabled,
+                factory=toga_dummy.factory
+            )
+        with self.assertWarns(DeprecationWarning):
+            toga.Switch(
+                self.text,
+                on_change=self.on_change,
+                value=self.value,
+                is_on=self.value,
+                enabled=self.enabled,
+                factory=toga_dummy.factory
+            )
+
+    # end backwards compatibility.

--- a/src/core/tests/widgets/test_switch.py
+++ b/src/core/tests/widgets/test_switch.py
@@ -15,11 +15,13 @@ class SwitchTests(TestCase):
         self.on_change = callback
         self.value = True
         self.enabled = True
-        self.switch = toga.Switch(self.text,
-                                  on_change=self.on_change,
-                                  value=self.value,
-                                  enabled=self.enabled,
-                                  factory=toga_dummy.factory)
+        self.switch = toga.Switch(
+            self.text,
+            on_change=self.on_change,
+            value=self.value,
+            enabled=self.enabled,
+            factory=toga_dummy.factory
+        )
 
     def test_widget_created(self):
         self.assertEqual(self.switch._impl.interface, self.switch)
@@ -72,17 +74,30 @@ class SwitchTests(TestCase):
 
     def test_on_change(self):
         def my_callback(widget):
-            pass
+            pass  # pragma: no
 
         self.switch.on_change = my_callback
         self.assertEqual(self.switch.on_change._raw, my_callback)
 
+    def test_no_args(self):
+        "A text label must be provided"
+        with self.assertRaises(TypeError):
+            toga.Switch()
+
+    def test_default_value(self):
+        "The switch value defaults to False"
+        switch = toga.Switch("My Switch")
+        self.assertEqual(switch.value, False)
+
+    ######################################################################
     # 2022-07: Backwards compatibility
+    ######################################################################
+
     def test_set_is_on(self):
         new_value = False
         with self.assertWarns(DeprecationWarning):
             self.switch.is_on = new_value
-        self.assertValueSet(self.switch, 'value', False)
+        self.assertValueSet(self.switch, 'value', new_value)
 
     def test_get_is_on(self):
         with self.assertWarns(DeprecationWarning):
@@ -95,8 +110,10 @@ class SwitchTests(TestCase):
 
         with self.assertWarns(DeprecationWarning):
             self.switch.on_toggle = my_callback
+
         with self.assertWarns(DeprecationWarning):
             self.assertEqual(self.switch.on_toggle._raw, my_callback)
+
         self.assertEqual(self.switch.on_change._raw, my_callback)
 
     def test_label_deprecated(self):
@@ -108,6 +125,7 @@ class SwitchTests(TestCase):
         self.assertValueSet(self.switch, 'text', new_text)
 
     def test_init_with_deprecated(self):
+        # label is a deprecated argument
         with self.assertWarns(DeprecationWarning):
             toga.Switch(
                 label=self.text,
@@ -116,6 +134,8 @@ class SwitchTests(TestCase):
                 enabled=self.enabled,
                 factory=toga_dummy.factory
             )
+
+        # can't specify both label *and* text
         with self.assertRaises(ValueError):
             toga.Switch(
                 label=self.text,
@@ -125,6 +145,8 @@ class SwitchTests(TestCase):
                 enabled=self.enabled,
                 factory=toga_dummy.factory
             )
+
+        # on_toggle is deprecated
         with self.assertWarns(DeprecationWarning):
             toga.Switch(
                 self.text,
@@ -133,6 +155,8 @@ class SwitchTests(TestCase):
                 enabled=self.enabled,
                 factory=toga_dummy.factory
             )
+
+        # can't specify both on_toggle *and* on_change
         with self.assertRaises(ValueError):
             toga.Switch(
                 self.text,
@@ -143,6 +167,7 @@ class SwitchTests(TestCase):
                 factory=toga_dummy.factory
             )
 
+        # is_on is deprecated
         with self.assertWarns(DeprecationWarning):
             toga.Switch(
                 self.text,
@@ -151,7 +176,9 @@ class SwitchTests(TestCase):
                 enabled=self.enabled,
                 factory=toga_dummy.factory
             )
-        with self.assertWarns(DeprecationWarning):
+
+        # If is_on and value are both specified, warn about is_on;
+        with self.assertRaises(ValueError):
             toga.Switch(
                 self.text,
                 on_change=self.on_change,
@@ -161,4 +188,6 @@ class SwitchTests(TestCase):
                 factory=toga_dummy.factory
             )
 
-    # end backwards compatibility.
+    ######################################################################
+    # End backwards compatibility.
+    ######################################################################

--- a/src/core/tests/widgets/test_switch.py
+++ b/src/core/tests/widgets/test_switch.py
@@ -7,7 +7,7 @@ class SwitchTests(TestCase):
     def setUp(self):
         super().setUp()
 
-        self.label = 'Test Label'
+        self.text = 'Test Label'
 
         def callback(widget):
             pass
@@ -15,7 +15,7 @@ class SwitchTests(TestCase):
         self.on_change = callback
         self.value = True
         self.enabled = True
-        self.switch = toga.Switch(self.label,
+        self.switch = toga.Switch(self.text,
                                   on_change=self.on_change,
                                   value=self.value,
                                   enabled=self.enabled,
@@ -26,20 +26,20 @@ class SwitchTests(TestCase):
         self.assertActionPerformed(self.switch, 'create Switch')
 
     def test_arguments_are_all_set_properly(self):
-        self.assertEqual(self.switch.label, self.label)
-        self.assertEqual(self.switch._label, self.label)
+        self.assertEqual(self.switch.text, self.text)
+        self.assertEqual(self.switch._text, self.text)
         self.assertEqual(self.switch.on_change._raw, self.on_change)
         self.assertEqual(self.switch.enabled, self.enabled)
 
-    def test_label_with_None(self):
-        self.switch.label = None
-        self.assertEqual(self.switch.label, '')
-        self.assertEqual(self.switch._label, '')
+    def test_text_with_None(self):
+        self.switch.text = None
+        self.assertEqual(self.switch.text, '')
+        self.assertEqual(self.switch._text, '')
 
-    def test_setting_label_invokes_impl_method(self):
-        new_label = 'New Label'
-        self.switch.label = new_label
-        self.assertValueSet(self.switch, 'label', new_label)
+    def test_setting_text_invokes_impl_method(self):
+        new_text = 'New Label'
+        self.switch.text = new_text
+        self.assertValueSet(self.switch, 'text', new_text)
 
     def test_setting_value_invokes_impl_method(self):
         new_value = False
@@ -95,3 +95,11 @@ class SwitchTests(TestCase):
         with self.assertWarns(DeprecationWarning):
             self.assertEqual(self.switch.on_toggle._raw, my_callback)
         self.assertEqual(self.switch.on_change._raw, my_callback)
+
+    def test_label_deprecated(self):
+        new_text = 'New Label'
+        with self.assertWarns(DeprecationWarning):
+            self.switch.label = new_text
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(self.switch.label, new_text)
+        self.assertValueSet(self.switch, 'text', new_text)

--- a/src/core/toga/widgets/switch.py
+++ b/src/core/toga/widgets/switch.py
@@ -15,7 +15,7 @@ class Switch(Widget):
         id (str): AN identifier for this widget.
         style (:obj:`Style`): An optional style object.
             If no style is provided then a new one will be created for the widget.
-        on_toggle (``callable``): Function to execute when pressed.
+        on_change (``callable``): Function to execute when pressed.
         value (bool): Current on or off state of the switch.
         enabled (bool): Whether or not interaction with the button is possible, defaults to `True`.
         factory (:obj:`module`): A python module that is capable to return a
@@ -27,7 +27,8 @@ class Switch(Widget):
             label,
             id=None,
             style=None,
-            on_toggle=None,
+            on_change=None,
+            on_toggle=None, # DEPRECATED!
             value=False,
             enabled=True,
             factory=None,
@@ -37,7 +38,10 @@ class Switch(Widget):
         self._impl = self.factory.Switch(interface=self)
 
         self.label = label
-        self.on_toggle = on_toggle
+        if on_toggle:
+            self.on_toggle = on_toggle
+        else:
+            self.on_change = on_change
         self.value = value
         self.enabled = enabled
 
@@ -60,18 +64,39 @@ class Switch(Widget):
         self._impl.rehint()
 
     @property
+    def on_change(self):
+        """ The callable function for when the switch is pressed
+
+        Returns:
+            The ``callable`` on_change function.
+        """
+        return self._on_change
+
+    @on_change.setter
+    def on_change(self, handler):
+        self._on_change = wrapped_handler(self, handler)
+        self._impl.set_on_change(self._on_change)
+
+    @property
     def on_toggle(self):
         """ The callable function for when the switch is pressed
+
+        **DEPRECATED: renamed as on_change**
 
         Returns:
             The ``callable`` on_toggle function.
         """
-        return self._on_toggle
+        warnings.warn(
+            "Switch.on_toggle has been renamed Switch.on_change", DeprecationWarning
+        )
+        return self.on_change
 
     @on_toggle.setter
     def on_toggle(self, handler):
-        self._on_toggle = wrapped_handler(self, handler)
-        self._impl.set_on_toggle(self._on_toggle)
+        warnings.warn(
+            "Switch.on_toggle has been renamed Switch.on_change", DeprecationWarning
+        )
+        self.on_change = handler
 
     @property
     def is_on(self):

--- a/src/core/toga/widgets/switch.py
+++ b/src/core/toga/widgets/switch.py
@@ -28,7 +28,7 @@ class Switch(Widget):
             id=None,
             style=None,
             on_change=None,
-            on_toggle=None, # DEPRECATED!
+            on_toggle=None,  # DEPRECATED!
             value=False,
             enabled=True,
             factory=None,

--- a/src/core/toga/widgets/switch.py
+++ b/src/core/toga/widgets/switch.py
@@ -11,7 +11,7 @@ class Switch(Widget):
         and False (off, unchecked).
 
     Args:
-        label (str): Text to be shown next to the switch.
+        text (str): Text to be shown next to the switch.
         id (str): AN identifier for this widget.
         style (:obj:`Style`): An optional style object.
             If no style is provided then a new one will be created for the widget.
@@ -24,7 +24,7 @@ class Switch(Widget):
 
     def __init__(
             self,
-            label,
+            text,
             id=None,
             style=None,
             on_change=None,
@@ -38,7 +38,7 @@ class Switch(Widget):
 
         self._impl = self.factory.Switch(interface=self)
 
-        self.label = label
+        self.text = text
         if on_toggle:
             self.on_toggle = on_toggle
         else:
@@ -50,21 +50,21 @@ class Switch(Widget):
         self.enabled = enabled
 
     @property
-    def label(self):
+    def text(self):
         """ Accompanying text label of the Switch.
 
         Returns:
             The label text of the widget as a ``str``.
         """
-        return self._label
+        return self._text
 
-    @label.setter
-    def label(self, value):
+    @text.setter
+    def text(self, value):
         if value is None:
-            self._label = ''
+            self._text = ''
         else:
-            self._label = str(value)
-        self._impl.set_label(value)
+            self._text = str(value)
+        self._impl.set_text(value)
         self._impl.rehint()
 
     @property
@@ -143,3 +143,24 @@ class Switch(Widget):
         vice versa.
         """
         self.value = not self.value
+
+    @property
+    def label(self):
+        """ Button Off/On state.
+
+        **DEPRECATED: renamed as text**
+
+        Returns:
+            ``True`` if on and ``False`` if the switch is off.
+        """
+        warnings.warn(
+            "Switch.label has been renamed Switch.text", DeprecationWarning
+        )
+        return self.text
+
+    @label.setter
+    def label(self, label):
+        warnings.warn(
+            "Switch.label has been renamed Switch.text", DeprecationWarning
+        )
+        self.text = label

--- a/src/core/toga/widgets/switch.py
+++ b/src/core/toga/widgets/switch.py
@@ -29,6 +29,7 @@ class Switch(Widget):
             style=None,
             on_change=None,
             on_toggle=None,  # DEPRECATED!
+            is_on=None,
             value=False,
             enabled=True,
             factory=None,
@@ -42,7 +43,10 @@ class Switch(Widget):
             self.on_toggle = on_toggle
         else:
             self.on_change = on_change
-        self.value = value
+        if is_on is not None:
+            self.is_on = is_on
+        else:
+            self.value = value
         self.enabled = enabled
 
     @property

--- a/src/core/toga/widgets/switch.py
+++ b/src/core/toga/widgets/switch.py
@@ -1,3 +1,5 @@
+import warnings
+
 from toga.handlers import wrapped_handler
 
 from .base import Widget
@@ -14,7 +16,7 @@ class Switch(Widget):
         style (:obj:`Style`): An optional style object.
             If no style is provided then a new one will be created for the widget.
         on_toggle (``callable``): Function to execute when pressed.
-        is_on (bool): Current on or off state of the switch.
+        value (bool): Current on or off state of the switch.
         enabled (bool): Whether or not interaction with the button is possible, defaults to `True`.
         factory (:obj:`module`): A python module that is capable to return a
             implementation of this class with the same name. (optional & normally not needed)
@@ -26,7 +28,7 @@ class Switch(Widget):
             id=None,
             style=None,
             on_toggle=None,
-            is_on=False,
+            value=False,
             enabled=True,
             factory=None,
     ):
@@ -36,7 +38,7 @@ class Switch(Widget):
 
         self.label = label
         self.on_toggle = on_toggle
-        self.is_on = is_on
+        self.value = value
         self.enabled = enabled
 
     @property
@@ -75,19 +77,40 @@ class Switch(Widget):
     def is_on(self):
         """ Button Off/On state.
 
+        **DEPRECATED: renamed as value**
+
         Returns:
             ``True`` if on and ``False`` if the switch is off.
         """
-        return self._impl.get_is_on()
+        warnings.warn(
+            "Switch.is_on has been renamed Switch.value", DeprecationWarning
+        )
+        return self.value
 
     @is_on.setter
     def is_on(self, value):
+        warnings.warn(
+            "Switch.is_on has been renamed Switch.value", DeprecationWarning
+        )
+        self.value = value
+
+    @property
+    def value(self):
+        """ Button Off/On state.
+
+        Returns:
+            ``True`` if on and ``False`` if the switch is off.
+        """
+        return self._impl.get_value()
+
+    @value.setter
+    def value(self, value):
         if not isinstance(value, bool):
-            raise ValueError("Switch.is_on can only be set to true or false")
-        self._impl.set_is_on(value)
+            raise ValueError("Switch.value can only be set to true or false")
+        self._impl.set_value(value)
 
     def toggle(self):
-        """Reverse the value of `Slider.is_on` property from true to false and
+        """Reverse the value of `Switch.value` property from true to false and
         vice versa.
         """
-        self.is_on = not self.is_on
+        self.value = not self.value

--- a/src/dummy/toga_dummy/widgets/switch.py
+++ b/src/dummy/toga_dummy/widgets/switch.py
@@ -8,11 +8,11 @@ class Switch(Widget):
     def set_label(self, label):
         self._set_value('label', label)
 
-    def set_is_on(self, value):
-        self._set_value('is_on', value)
+    def set_value(self, value):
+        self._set_value('value', value)
 
-    def get_is_on(self):
-        return self._get_value('is_on')
+    def get_value(self):
+        return self._get_value('value')
 
     def rehint(self):
         self._action('rehint Switch')

--- a/src/dummy/toga_dummy/widgets/switch.py
+++ b/src/dummy/toga_dummy/widgets/switch.py
@@ -5,8 +5,8 @@ class Switch(Widget):
     def create(self):
         self._action('create Switch')
 
-    def set_label(self, label):
-        self._set_value('label', label)
+    def set_text(self, text):
+        self._set_value('text', text)
 
     def set_value(self, value):
         self._set_value('value', value)

--- a/src/dummy/toga_dummy/widgets/switch.py
+++ b/src/dummy/toga_dummy/widgets/switch.py
@@ -17,5 +17,5 @@ class Switch(Widget):
     def rehint(self):
         self._action('rehint Switch')
 
-    def set_on_toggle(self, handler):
-        self._set_value('on_toggle', handler)
+    def set_on_change(self, handler):
+        self._set_value('on_change', handler)

--- a/src/gtk/tests/widgets/test_switch.py
+++ b/src/gtk/tests/widgets/test_switch.py
@@ -38,7 +38,7 @@ class TestGtkSwitch(unittest.TestCase):
         self.assertEqual(self.switch.label, 'New')
         self.assertEqual(self.switch._label, 'New')
 
-    def test_set_is_on(self):
-        self.assertEqual(self.switch.is_on, False)
-        self.switch.is_on = True
-        self.assertEqual(self.switch.is_on, True)
+    def test_set_value(self):
+        self.assertEqual(self.switch.value, False)
+        self.switch.value = True
+        self.assertEqual(self.switch.value, True)

--- a/src/gtk/tests/widgets/test_switch.py
+++ b/src/gtk/tests/widgets/test_switch.py
@@ -24,7 +24,7 @@ def handle_events():
 @unittest.skipIf(Gtk is None, "Can't run GTK implementation tests on a non-Linux platform")
 class TestGtkSwitch(unittest.TestCase):
     def setUp(self):
-        self.switch = toga.Switch(label='A switch')
+        self.switch = toga.Switch(text='A switch')
 
         # make a shortcut for easy use
         self.gtk_switch = self.switch._impl
@@ -32,11 +32,11 @@ class TestGtkSwitch(unittest.TestCase):
         self.window = Gtk.Window()
         self.window.add(self.switch._impl.native)
 
-    def test_set_label(self):
-        self.assertEqual(self.switch.label, 'A switch')
-        self.switch.label = 'New'
-        self.assertEqual(self.switch.label, 'New')
-        self.assertEqual(self.switch._label, 'New')
+    def test_set_text(self):
+        self.assertEqual(self.switch.text, 'A switch')
+        self.switch.text = 'New'
+        self.assertEqual(self.switch.text, 'New')
+        self.assertEqual(self.switch._text, 'New')
 
     def test_set_value(self):
         self.assertEqual(self.switch.value, False)

--- a/src/gtk/toga_gtk/widgets/switch.py
+++ b/src/gtk/toga_gtk/widgets/switch.py
@@ -13,17 +13,17 @@ class Switch(Widget):
         self.label.set_line_wrap(True)
 
         self.switch = Gtk.Switch()
-        self.switch.connect("notify::active", self.gtk_on_toggle)
+        self.switch.connect("notify::active", self.gtk_on_change)
 
         self.native.pack_start(self.label, True, True, 0)
         self.native.pack_start(self.switch, False, False, 0)
         self.native.connect('show', lambda event: self.rehint())
 
-    def gtk_on_toggle(self, widget, state):
-        if self.interface.on_toggle:
-            self.interface.on_toggle(self.interface)
+    def gtk_on_change(self, widget, state):
+        if self.interface.on_change:
+            self.interface.on_change(self.interface)
 
-    def set_on_toggle(self, handler):
+    def set_on_change(self, handler):
         pass
 
     def set_label(self, label):

--- a/src/gtk/toga_gtk/widgets/switch.py
+++ b/src/gtk/toga_gtk/widgets/switch.py
@@ -29,10 +29,10 @@ class Switch(Widget):
     def set_label(self, label):
         self.label.set_text(self.interface.label)
 
-    def get_is_on(self):
+    def get_value(self):
         return self.switch.get_active()
 
-    def set_is_on(self, value):
+    def set_value(self, value):
         self.switch.set_active(value)
 
     def rehint(self):

--- a/src/gtk/toga_gtk/widgets/switch.py
+++ b/src/gtk/toga_gtk/widgets/switch.py
@@ -26,8 +26,8 @@ class Switch(Widget):
     def set_on_change(self, handler):
         pass
 
-    def set_label(self, label):
-        self.label.set_text(self.interface.label)
+    def set_text(self, text):
+        self.label.set_text(self.interface.text)
 
     def get_value(self):
         return self.switch.get_active()

--- a/src/iOS/toga_iOS/widgets/switch.py
+++ b/src/iOS/toga_iOS/widgets/switch.py
@@ -42,8 +42,8 @@ class Switch(Widget):
         # Add the layout constraints
         self.add_constraints()
 
-    def set_label(self, label):
-        self.native_label.text = str(self.interface.label)
+    def set_text(self, text):
+        self.native_label.text = str(self.interface.text)
         self.rehint()
 
     def set_value(self, value):

--- a/src/iOS/toga_iOS/widgets/switch.py
+++ b/src/iOS/toga_iOS/widgets/switch.py
@@ -46,10 +46,10 @@ class Switch(Widget):
         self.native_label.text = str(self.interface.label)
         self.rehint()
 
-    def set_is_on(self, value):
+    def set_value(self, value):
         self.native_switch.setOn_animated_(value, True)
 
-    def get_is_on(self):
+    def get_value(self):
         return self.native_switch.isOn()
 
     def set_on_toggle(self, handler):

--- a/src/iOS/toga_iOS/widgets/switch.py
+++ b/src/iOS/toga_iOS/widgets/switch.py
@@ -18,8 +18,8 @@ class TogaSwitch(UISwitch):
 
     @objc_method
     def onPress_(self, obj) -> None:
-        if self.interface.on_toggle:
-            self.interface.on_toggle(self.interface)
+        if self.interface.on_change:
+            self.interface.on_change(self.interface)
 
 
 class Switch(Widget):
@@ -52,7 +52,7 @@ class Switch(Widget):
     def get_value(self):
         return self.native_switch.isOn()
 
-    def set_on_toggle(self, handler):
+    def set_on_change(self, handler):
         # No special handling required
         pass
 

--- a/src/winforms/toga_winforms/widgets/switch.py
+++ b/src/winforms/toga_winforms/widgets/switch.py
@@ -12,8 +12,8 @@ class Switch(Widget):
 
     def winforms_checked_changed(self, sender, event):
         if self.container:
-            if self.interface.on_toggle:
-                self.interface.on_toggle(self.interface)
+            if self.interface.on_change:
+                self.interface.on_change(self.interface)
 
     def set_label(self, label):
         self.native.Text = self.interface.label
@@ -27,7 +27,7 @@ class Switch(Widget):
     def get_value(self):
         return self.native.Checked
 
-    def set_on_toggle(self, handler):
+    def set_on_change(self, handler):
         pass
 
     def rehint(self):

--- a/src/winforms/toga_winforms/widgets/switch.py
+++ b/src/winforms/toga_winforms/widgets/switch.py
@@ -15,8 +15,8 @@ class Switch(Widget):
             if self.interface.on_change:
                 self.interface.on_change(self.interface)
 
-    def set_label(self, label):
-        self.native.Text = self.interface.label
+    def set_text(self, text):
+        self.native.Text = self.interface.text
 
     def set_value(self, value):
         if value is True:

--- a/src/winforms/toga_winforms/widgets/switch.py
+++ b/src/winforms/toga_winforms/widgets/switch.py
@@ -18,13 +18,13 @@ class Switch(Widget):
     def set_label(self, label):
         self.native.Text = self.interface.label
 
-    def set_is_on(self, value):
+    def set_value(self, value):
         if value is True:
             self.native.Checked = True
         elif value is False:
             self.native.Checked = False
 
-    def get_is_on(self):
+    def get_value(self):
         return self.native.Checked
 
     def set_on_toggle(self, handler):


### PR DESCRIPTION
The Switch widget API becomes more consistent with other widgets by renaming some properties:
- label -> text
- is_on -> value
- on_toggle -> on_change

The legacy API still works, with deprecation warnings. Exceptions are raised if both the new and old init parameters are used. The label text parameter, now called `text`, was temporarily changed to keyword argument. It should be changed back to positional argument when the compatibility code is removed.


## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
