### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/how-to/contribute.rst
+++ b/docs/how-to/contribute.rst
@@ -399,7 +399,7 @@ One error you might see...
 --------------------------
 
 When you're running these tests - especially when you submit your PR, and the
-tests run on our continous integration (CI) server - it's possible you might get
+tests run on our continuous integration (CI) server - it's possible you might get
 an error that reads::
 
     ModuleNotFoundError: No module named 'toga_gtk'.

--- a/src/core/toga/widgets/progressbar.py
+++ b/src/core/toga/widgets/progressbar.py
@@ -17,7 +17,7 @@ class ProgressBar(Widget):
                 new one will be created for the widget.
             max (float): The maximum value of the progressbar.
             value (float): To define the current progress of the progressbar.
-            running (bool): Set the inital running mode.
+            running (bool): Set the initial running mode.
             factory (:obj:`module`): A python module that is capable to return a
                 implementation of this class with the same name. (optional & normally not needed)
         """

--- a/src/django/README.rst
+++ b/src/django/README.rst
@@ -21,7 +21,7 @@ Usage
 
 Toga Django defines a ``TogaApp`` class that can be used to mount a Toga Web
 instance in a Django app. If you have Toga application named `myapp`, Django
-deployment is acheived by putting the following into your project's
+deployment is achieved by putting the following into your project's
 ``urls.py``::
 
     from django.conf import settings

--- a/src/flask/README.rst
+++ b/src/flask/README.rst
@@ -21,7 +21,7 @@ Usage
 
 Toga Flask defines a ``TogaApp`` class that can be used to mount a Toga Web
 instance in a Flask app. If you have Toga application named `myapp`, Flask
-deployment is acheived by putting the following into ``flaskapp.py``::
+deployment is achieved by putting the following into ``flaskapp.py``::
 
     from flask import Flask
     flask_app = Flask(__name__)

--- a/src/winforms/toga_winforms/widgets/slider.py
+++ b/src/winforms/toga_winforms/widgets/slider.py
@@ -23,7 +23,7 @@ class Slider(Widget):
     and maximum, we trnaslate the value linearly to the desired interval.
 
     When tick_count is not defined, we use 100 as the default number of ticks since
-    it is big enough to make the TrackBar feel continous.
+    it is big enough to make the TrackBar feel continuous.
     """
     def create(self):
         self.native = WinForms.TrackBar()


### PR DESCRIPTION
There are small typos in:
- docs/how-to/contribute.rst
- src/core/toga/widgets/progressbar.py
- src/django/README.rst
- src/flask/README.rst
- src/winforms/toga_winforms/widgets/slider.py

Fixes:
- Should read `continuous` rather than `continous`.
- Should read `achieved` rather than `acheived`.
- Should read `initial` rather than `inital`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md