### PR TITLE
Add support for select_folder_dialog initial_directory on Windows

### DIFF
--- a/src/winforms/toga_winforms/dialogs.py
+++ b/src/winforms/toga_winforms/dialogs.py
@@ -210,6 +210,7 @@ class FileDialog(BaseDialog):
             dialog.FileName = filename
 
         if initial_directory is not None:
+            dialog.SelectedPath = str(initial_directory)
             dialog.InitialDirectory = str(initial_directory)
 
         if file_types is not None:

--- a/src/winforms/toga_winforms/dialogs.py
+++ b/src/winforms/toga_winforms/dialogs.py
@@ -210,8 +210,13 @@ class FileDialog(BaseDialog):
             dialog.FileName = filename
 
         if initial_directory is not None:
-            dialog.SelectedPath = str(initial_directory)
-            dialog.InitialDirectory = str(initial_directory)
+            # On Windows, FolderBrowserDialog works in a different way than
+            # other file dialogs, so a different attribute needs to be set
+            # when specifying the initial directory.
+            if isinstance(dialog, WinForms.FolderBrowserDialog):
+                dialog.SelectedPath = str(initial_directory)
+            else:
+                dialog.InitialDirectory = str(initial_directory)
 
         if file_types is not None:
             filters = [f"{ext} files (*.{ext})|*.{ext}" for ext in file_types] + ["All files (*.*)|*.*"]

--- a/src/winforms/toga_winforms/dialogs.py
+++ b/src/winforms/toga_winforms/dialogs.py
@@ -210,13 +210,7 @@ class FileDialog(BaseDialog):
             dialog.FileName = filename
 
         if initial_directory is not None:
-            # On Windows, FolderBrowserDialog works in a different way than
-            # other file dialogs, so a different attribute needs to be set
-            # when specifying the initial directory.
-            if isinstance(dialog, WinForms.FolderBrowserDialog):
-                dialog.SelectedPath = str(initial_directory)
-            else:
-                dialog.InitialDirectory = str(initial_directory)
+            self._set_initial_directory(dialog, str(initial_directory))
 
         if file_types is not None:
             filters = [f"{ext} files (*.{ext})|*.{ext}" for ext in file_types] + ["All files (*.*)|*.*"]
@@ -248,6 +242,22 @@ class FileDialog(BaseDialog):
             return [Path(filename) for filename in dialog.FileNames]
         else:
             return Path(dialog.FileName)
+
+    @classmethod
+    def _set_initial_directory(cls, dialog, initial_directory):
+        """Set the initial directory of the given dialog.
+
+        On Windows, not all file/folder dialogs work the same way,
+        so this method is overridden when a subclass needs to
+        set the initial directory in some other fashion.
+
+        Args:
+            dialog (WinForms.CommonDialog): the dialog to set the
+                initial directory on.
+            initial_directory (str): the path of the initial directory.
+
+        """
+        dialog.InitialDirectory = initial_directory
 
 
 class SaveFileDialog(FileDialog):
@@ -295,3 +305,7 @@ class SelectFolderDialog(FileDialog):
     def _get_filenames(cls, dialog, multiselect):
         filename = Path(dialog.SelectedPath)
         return [filename] if multiselect else filename
+
+    @classmethod
+    def _set_initial_directory(cls, dialog, initial_directory):
+        dialog.SelectedPath = initial_directory


### PR DESCRIPTION
This PR aims to add functionality for the `initial_directory` argument of `select_folder_dialog` on Windows, fixing #1244.
The way that this is currently done in this PR is through the `SelectedPath` property of `FolderBrowserDialog`s. The initial directory will now be preselected in the dialog -- this does not match up perfectly with the behaviour of `initial_directory` for `open_file_dialog`, but it will still provide a useful, roughly equivalent function.

The changes to code may or may not be complete already, but more testing (and potentially documentation) is likely still needed right now.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
