### PR TITLE
remove name from windows default paths

### DIFF
--- a/src/winforms/toga_winforms/paths.py
+++ b/src/winforms/toga_winforms/paths.py
@@ -30,15 +30,15 @@ class Paths:
 
     @property
     def data(self):
-        return Path.home() / 'AppData' / 'Local' / self.author / App.app.formal_name
+        return Path.home() / 'AppData' / 'Local' / self.app_id / App.app.formal_name
 
     @property
     def cache(self):
-        return Path.home() / 'AppData' / 'Local' / self.author / App.app.formal_name / 'Cache'
+        return Path.home() / 'AppData' / 'Local' / self.app_id / App.app.formal_name / 'Cache'
 
     @property
     def logs(self):
-        return Path.home() / 'AppData' / 'Local' / self.author / App.app.formal_name / 'Logs'
+        return Path.home() / 'AppData' / 'Local' / self.app_id / App.app.formal_name / 'Logs'
 
     @property
     def toga(self):


### PR DESCRIPTION
Update windows default paths: data, cache, logs.
Why use the App Author name? I find it strange to have a Author folder as a save location for files.
I think we can better remove this name or change it to the app_id from the app.

<!--- Describe your changes in detail -->
Removing real names (Author) from the default storage locations for the app in windows.

<!--- What problem does this change solve? -->
It is strange when releasing an app to add your name in a foldername.

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
