### PR TITLE
API consistency: Button widget

### DIFF
--- a/examples/activityindicator/activityindicator/app.py
+++ b/examples/activityindicator/activityindicator/app.py
@@ -9,10 +9,10 @@ class ExampleActivityIndicatorApp(toga.App):
 
         if self.spinner.is_running:
             self.spinner.stop()
-            self.button.label = 'Start'
+            self.button.text = 'Start'
         else:
             self.spinner.start()
-            self.button.label = 'Stop'
+            self.button.text = 'Stop'
 
     def startup(self):
         # Set up main window

--- a/examples/box/box/app.py
+++ b/examples/box/box/app.py
@@ -21,7 +21,7 @@ class ExampleBoxApp(toga.App):
             title=self.name, size=(800, 500), resizeable=False, minimizable=False
         )
         self.yellow_button = toga.Button(
-            label="Set yellow color",
+            text="Set yellow color",
             on_press=self.set_yellow_color,
             style=Pack(background_color=YELLOW),
         )
@@ -29,23 +29,23 @@ class ExampleBoxApp(toga.App):
             style=Pack(direction=ROW),
             children=[
                 toga.Button(
-                    label="Set red color",
+                    text="Set red color",
                     on_press=self.set_red_color,
                     style=Pack(background_color=RED),
                 ),
                 self.yellow_button,
                 toga.Button(
-                    label="Set blue color",
+                    text="Set blue color",
                     on_press=self.set_blue_color,
                     style=Pack(background_color=BLUE),
                 ),
                 toga.Button(
-                    label="Set green color",
+                    text="Set green color",
                     on_press=self.set_green_color,
                     style=Pack(background_color=GREEN),
                 ),
                 toga.Button(
-                    label="Reset color",
+                    text="Reset color",
                     on_press=self.reset_color,
                     style=Pack(background_color=WHITE),
                 ),

--- a/examples/button/button/app.py
+++ b/examples/button/button/app.py
@@ -20,29 +20,29 @@ class ExampleButtonApp(toga.App):
         style_inner_box = Pack(direction=ROW)
 
         # Button class
-        #   Simple button with label and callback function called when
+        #   Simple button with text and callback function called when
         #   hit the button
         button1 = toga.Button(
-            'Change Label',
-            on_press=self.callbackLabel,
+            'Change Text',
+            on_press=self.callback_text,
             style=Pack(flex=1),
         )
 
-        # Button with label and enable option
+        # Button with text and enable option
         # Keep a reference to it so it can be enabled by another button.
         self.button2 = toga.Button(
             'Button is disabled!',
             enabled=False,
             style=Pack(flex=1),
-            on_press=self.callbackDisable,
+            on_press=self.callback_disable,
         )
 
-        # Button with label and style option
+        # Button with text and style option
         button3 = toga.Button('Bigger', style=Pack(width=200))
 
-        # Button with label and callback function called
-        button4a = toga.Button('Make window larger', on_press=self.callbackLarger)
-        button4b = toga.Button('Make window smaller', on_press=self.callbackSmaller)
+        # Button with text and callback function called
+        button4a = toga.Button('Make window larger', on_press=self.callback_larger)
+        button4b = toga.Button('Make window smaller', on_press=self.callback_smaller)
 
         # Box class
         # Container of components
@@ -58,16 +58,16 @@ class ExampleButtonApp(toga.App):
             ]
         )
 
-        # Button with label and margin style
+        # Button with text and margin style
         button5 = toga.Button('Far from home', style=Pack(padding=50, color=BLUE))
 
-        # Button with label and RGB color
+        # Button with text and RGB color
         button6 = toga.Button('RGB : Fashion', style=Pack(background_color=RED))
 
-        # Button with label and string color
+        # Button with text and string color
         button7 = toga.Button('String : Fashion', style=Pack(background_color=BLUE))
 
-        # Button with label and string color
+        # Button with text and string color
         button8 = toga.Button('Big Font', style=Pack(font_family='serif', font_size=20, font_weight='bold'))
 
         # Add components for the second row of the outer box
@@ -93,26 +93,26 @@ class ExampleButtonApp(toga.App):
         # Show the main window
         self.main_window.show()
 
-    def callbackLabel(self, button):
+    def callback_text(self, button):
         # Some action when you hit the button
-        #   In this case the label will change
-        button.label = 'Magic {val}!!'.format(val=random.randint(0, 100))
+        #   In this case the text will change
+        button.text = 'Magic {val}!!'.format(val=random.randint(0, 100))
 
         # If the disabled button isn't enabled, enable it.
         if not self.button2.enabled:
             self.button2.enabled = True
-            self.button2.label = 'Disable button'
+            self.button2.text = 'Disable button'
 
-    def callbackDisable(self, button):
+    def callback_disable(self, button):
         button.enabled = False
-        button.label = 'Button is disabled!'
+        button.text = 'Button is disabled!'
 
-    def callbackLarger(self, button):
+    def callback_larger(self, button):
         # Some action when you hit the button
         #   In this case the window size will change
         self.main_window.size = (1000, 600)
 
-    def callbackSmaller(self, button):
+    def callback_smaller(self, button):
         # Some action when you hit the button
         #   In this case the window size will change
         self.main_window.size = (200, 200)

--- a/examples/canvas/canvas/app.py
+++ b/examples/canvas/canvas/app.py
@@ -176,7 +176,7 @@ class ExampleCanvasApp(toga.App):
                         toga.Label("Y Scale:", style=label_style),
                         self.scale_y_slider,
                         toga.Button(
-                            label="Reset transform",
+                            text="Reset transform",
                             on_press=self.reset_transform
                         )
                     ]

--- a/examples/focus/focus/app.py
+++ b/examples/focus/focus/app.py
@@ -85,8 +85,8 @@ class ExampleFocusApp(toga.App):
         self.text_input.focus()
 
     def on_button_press(self, widget: toga.Button):
-        self.info_label.text = "{widget_label} was pressed!".format(
-            widget_label=widget.label
+        self.info_label.text = "{widget_text} was pressed!".format(
+            widget_text=widget.text
         )
 
     def on_switch_toggle(self, widget: toga.Switch):
@@ -104,7 +104,7 @@ class ExampleFocusApp(toga.App):
 
     def focus_with_label(self, widget: toga.Widget):
         widget.focus()
-        self.info_label.text = "{name} is focused!".format(name=widget.label)
+        self.info_label.text = "{name} is focused!".format(name=widget.text)
 
 
 def main():

--- a/examples/font/font/app.py
+++ b/examples/font/font/app.py
@@ -11,7 +11,7 @@ class ExampleFontExampleApp(toga.App):
         self.textpanel.value = ""
 
     def do_monospace_button(self, widget):
-        self.textpanel.value += widget.label + "\n"
+        self.textpanel.value += widget.text + "\n"
 
     def do_icon_button(self, widget):
         self.textpanel.value += widget.id + "\n"

--- a/examples/layout/layout/app.py
+++ b/examples/layout/layout/app.py
@@ -8,39 +8,39 @@ class ExampleLayoutApp(toga.App):
     def startup(self):
 
         self.button_hide = toga.Button(
-            label='Hide label',
+            text='Hide label',
             style=Pack(padding=10, width=120),
             on_press=self.hide_label,
         )
 
         self.button_add = toga.Button(
-            label='Add image',
+            text='Add image',
             style=Pack(padding=10, width=120),
             on_press=self.add_image,
         )
 
         self.button_remove = toga.Button(
-            label='Remove image',
+            text='Remove image',
             style=Pack(padding=10, width=120),
             on_press=self.remove_image,
             enabled=False,
         )
 
         self.button_insert = toga.Button(
-            label='Insert image',
+            text='Insert image',
             style=Pack(padding=10, width=120),
             on_press=self.insert_image,
         )
 
         self.button_reparent = toga.Button(
-            label='Reparent image',
+            text='Reparent image',
             style=Pack(padding=10, width=120),
             on_press=self.reparent_image,
             enabled=False,
         )
 
         self.button_add_to_scroll = toga.Button(
-            label='Add new label',
+            text='Add new label',
             style=Pack(padding=10, width=120),
             on_press=self.add_label,
         )
@@ -84,10 +84,10 @@ class ExampleLayoutApp(toga.App):
     def hide_label(self, sender):
         if self.labels[0].style.visibility == HIDDEN:
             self.labels[0].style.visibility = VISIBLE
-            self.button_hide.label = "Hide label"
+            self.button_hide.text = "Hide label"
         else:
             self.labels[0].style.visibility = HIDDEN
-            self.button_hide.label = "Show label"
+            self.button_hide.text = "Show label"
 
     def add_image(self, sender):
         self.content_box.add(self.image_view)

--- a/examples/selection/selection/app.py
+++ b/examples/selection/selection/app.py
@@ -36,9 +36,9 @@ class SelectionApp(toga.App):
                             "Selection value can be set by property setter",
                             style=label_style,
                         ),
-                        toga.Button(label="Set Carbon", on_press=self.set_carbon),
-                        toga.Button(label="Set Ytterbium", on_press=self.set_ytterbium),
-                        toga.Button(label="Set THULIUM", on_press=self.set_thulium),
+                        toga.Button(text="Set Carbon", on_press=self.set_carbon),
+                        toga.Button(text="Set Ytterbium", on_press=self.set_ytterbium),
+                        toga.Button(text="Set THULIUM", on_press=self.set_thulium),
                     ],
                 ),
                 toga.Box(

--- a/src/android/toga_android/dialogs.py
+++ b/src/android/toga_android/dialogs.py
@@ -47,8 +47,8 @@ class TextDialog(BaseDialog):
         - window: Toga Window
         - title: Title of dialog
         - message: Message of dialog
-        - positive_text: Button label where clicking it returns True (or None to skip)
-        - negative_text: Button label where clicking it returns False (or None to skip)
+        - positive_text: Button text where clicking it returns True (or None to skip)
+        - negative_text: Button text where clicking it returns False (or None to skip)
         - icon: Integer used as an Android resource ID number for dialog icon (or None to skip)
         """
         super().__init__()

--- a/src/android/toga_android/widgets/button.py
+++ b/src/android/toga_android/widgets/button.py
@@ -24,8 +24,8 @@ class Button(Widget):
         self.native = A_Button(self._native_activity)
         self.native.setOnClickListener(TogaOnClickListener(button_impl=self))
 
-    def set_label(self, label):
-        self.native.setText(self.interface.label)
+    def set_text(self, text):
+        self.native.setText(self.interface.text)
 
     def set_enabled(self, value):
         self.native.setEnabled(value)

--- a/src/cocoa/toga_cocoa/widgets/button.py
+++ b/src/cocoa/toga_cocoa/widgets/button.py
@@ -43,8 +43,8 @@ class Button(Widget):
         if font:
             self.native.font = font.bind(self.interface.factory).native
 
-    def set_label(self, label):
-        self.native.title = self.interface.label
+    def set_text(self, text):
+        self.native.title = self.interface.text
 
     def set_on_press(self, handler):
         # No special handling required

--- a/src/core/tests/widgets/test_button.py
+++ b/src/core/tests/widgets/test_button.py
@@ -8,25 +8,25 @@ class ButtonTests(TestCase):
         super().setUp()
 
         # Create a button with the dummy factory
-        self.initial_label = 'Test Button'
-        self.btn = toga.Button(self.initial_label, factory=toga_dummy.factory)
+        self.initial_text = 'Test Button'
+        self.btn = toga.Button(self.initial_text, factory=toga_dummy.factory)
 
     def test_widget_created(self):
         self.assertEqual(self.btn._impl.interface, self.btn)
         self.assertActionPerformed(self.btn, 'create Button')
 
-    def test_button_label(self):
-        self.assertEqual(self.btn._label, self.initial_label)
-        self.btn.label = 'New Label'
-        self.assertEqual(self.btn.label, 'New Label')
+    def test_button_text(self):
+        self.assertEqual(self.btn._text, self.initial_text)
+        self.btn.text = 'New Text'
+        self.assertEqual(self.btn.text, 'New Text')
 
-        # test if backend gets called with the right label
-        self.assertValueSet(self.btn, 'label', 'New Label')
+        # test if backend gets called with the right text
+        self.assertValueSet(self.btn, 'text', 'New Text')
 
-    def test_button_label_with_None(self):
-        self.btn.label = None
-        self.assertEqual(self.btn.label, '')
-        self.assertValueSet(self.btn, 'label', '')
+    def test_button_text_with_None(self):
+        self.btn.text = None
+        self.assertEqual(self.btn.text, '')
+        self.assertValueSet(self.btn, 'text', '')
 
     def test_button_on_press(self):
         self.assertIsNone(self.btn._on_press)
@@ -46,3 +46,41 @@ class ButtonTests(TestCase):
     def test_focus(self):
         self.btn.focus()
         self.assertActionPerformed(self.btn, "focus")
+
+    ######################################################################
+    # 2022-07: Backwards compatibility
+    ######################################################################
+
+    def test_label_deprecated(self):
+        new_text = 'New Label'
+        with self.assertWarns(DeprecationWarning):
+            self.btn.label = new_text
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(self.btn.label, new_text)
+        self.assertValueSet(self.btn, 'text', new_text)
+
+    def test_init_with_deprecated(self):
+        # label is a deprecated argument
+        with self.assertWarns(DeprecationWarning):
+            toga.Button(
+                label='Test Button',
+                factory=toga_dummy.factory
+            )
+
+        # can't specify both label *and* text
+        with self.assertRaises(ValueError):
+            toga.Button(
+                label='Test Button',
+                text='Test Button',
+                factory=toga_dummy.factory
+            )
+
+        # label/text is mandatory
+        with self.assertRaises(TypeError):
+            toga.Button(
+                factory=toga_dummy.factory
+            )
+
+    ######################################################################
+    # End backwards compatibility.
+    ######################################################################

--- a/src/core/toga/widgets/button.py
+++ b/src/core/toga/widgets/button.py
@@ -1,13 +1,20 @@
+import warnings
+
 from toga.handlers import wrapped_handler
 
 from .base import Widget
+
+# BACKWARDS COMPATIBILITY: a token object that can be used to differentiate
+# between an explicitly provided ``None``, and a unspecified value falling
+# back to a default.
+NOT_PROVIDED = object()
 
 
 class Button(Widget):
     """A clickable button widget.
 
     Args:
-        label (str): Text to be shown on the button.
+        text (str): Text to be shown on the button.
         id (str): An identifier for this widget.
         style (:obj:`Style`): An optional style object. If no style is provided then
             a new one will be created for the widget.
@@ -20,33 +27,69 @@ class Button(Widget):
     """
 
     def __init__(
-            self, label, id=None, style=None, on_press=None, enabled=True, factory=None
+            self,
+            text=NOT_PROVIDED,  # BACKWARDS COMPATIBILITY: The default value
+                                # can be removed when the handling for
+                                # `label`` is removed
+            id=None,
+            style=None,
+            on_press=None,
+            enabled=True,
+            factory=None,
+            label=None,  # DEPRECATED!
     ):
         super().__init__(id=id, style=style, enabled=enabled, factory=factory)
 
         # Create a platform specific implementation of a Button
         self._impl = self.factory.Button(interface=self)
 
+        ##################################################################
+        # 2022-07: Backwards compatibility
+        ##################################################################
+        # When deleting this block, also delete the NOT_PROVIDED
+        # placeholder, and replace it's usage in default values.
+
+        # label replaced with text
+        if label is not None:
+            if text is not NOT_PROVIDED:
+                raise ValueError(
+                    "Cannot specify both `label` and `text`; "
+                    "`label` has been deprecated, use `text`"
+                )
+            else:
+                warnings.warn(
+                    "Button.label has been renamed Button.text", DeprecationWarning
+                )
+                text = label
+        elif text is NOT_PROVIDED:
+            # This would be raised by Python itself; however, we need to use a placeholder
+            # value as part of the migration from text->value.
+            raise TypeError("Button.__init__ missing 1 required positional argument: 'text'")
+
+        ##################################################################
+        # End backwards compatibility.
+        ##################################################################
+
         # Set all the properties
-        self.label = label
+        self.text = text
         self.on_press = on_press
         self.enabled = enabled
 
     @property
-    def label(self):
+    def text(self):
         """
         Returns:
-            The button label as a ``str``
+            The button text as a ``str``
         """
-        return self._label
+        return self._text
 
-    @label.setter
-    def label(self, value):
+    @text.setter
+    def text(self, value):
         if value is None:
-            self._label = ''
+            self._text = ''
         else:
-            self._label = str(value)
-        self._impl.set_label(value)
+            self._text = str(value)
+        self._impl.set_text(value)
         self._impl.rehint()
 
     @property
@@ -67,3 +110,31 @@ class Button(Widget):
         """
         self._on_press = wrapped_handler(self, handler)
         self._impl.set_on_press(self._on_press)
+
+    ######################################################################
+    # 2022-07: Backwards compatibility
+    ######################################################################
+    # label replaced with text
+    @property
+    def label(self):
+        """ Button text.
+
+        **DEPRECATED: renamed as text**
+
+        Returns:
+            The button text as a ``str``
+        """
+        warnings.warn(
+            "Button.label has been renamed Button.text", DeprecationWarning
+        )
+        return self.text
+
+    @label.setter
+    def label(self, label):
+        warnings.warn(
+            "Button.label has been renamed Button.text", DeprecationWarning
+        )
+        self.text = label
+    ######################################################################
+    # End backwards compatibility.
+    ######################################################################

--- a/src/dummy/toga_dummy/widgets/button.py
+++ b/src/dummy/toga_dummy/widgets/button.py
@@ -5,8 +5,8 @@ class Button(Widget):
     def create(self):
         self._action('create Button')
 
-    def set_label(self, label):
-        self._set_value('label', self.interface.label)
+    def set_text(self, text):
+        self._set_value('text', self.interface.text)
 
     def set_on_press(self, handler):
         self._set_value('on_press', handler)

--- a/src/gtk/toga_gtk/widgets/button.py
+++ b/src/gtk/toga_gtk/widgets/button.py
@@ -13,8 +13,8 @@ class Button(Widget):
         self.native.connect('show', lambda event: self.rehint())
         self.native.connect('clicked', self.gtk_on_press)
 
-    def set_label(self, label):
-        self.native.set_label(self.interface.label)
+    def set_text(self, text):
+        self.native.set_label(self.interface.text)
         self.rehint()
 
     def set_enabled(self, value):

--- a/src/iOS/toga_iOS/widgets/button.py
+++ b/src/iOS/toga_iOS/widgets/button.py
@@ -35,8 +35,8 @@ class Button(Widget):
         # Add the layout constraints
         self.add_constraints()
 
-    def set_label(self, label):
-        self.native.setTitle(self.interface.label, forState=UIControlStateNormal)
+    def set_text(self, text):
+        self.native.setTitle(self.interface.text, forState=UIControlStateNormal)
 
     def set_on_press(self, handler):
         # No special handling required.

--- a/src/web/toga_web/widgets/button.py
+++ b/src/web/toga_web/widgets/button.py
@@ -5,18 +5,18 @@ class Button(Widget):
     def __html__(self):
         return """
             <button id="toga_{id}" class="toga button btn-block" style="{style}">
-            {label}
+            {text}
             </button>
         """.format(
             id=self.interface.id,
-            label=self.interface.label,
+            text=self.interface.text,
             style='',
         )
 
     def create(self):
         pass
 
-    def set_label(self, label):
+    def set_text(self, text):
         pass
 
     def set_enabled(self, value):

--- a/src/winforms/toga_winforms/widgets/button.py
+++ b/src/winforms/toga_winforms/widgets/button.py
@@ -18,8 +18,8 @@ class Button(Widget):
             if self.interface.on_press:
                 self.interface.on_press(self.interface)
 
-    def set_label(self, label):
-        self.native.Text = self.interface.label
+    def set_text(self, text):
+        self.native.Text = self.interface.text
         self.rehint()
 
     def set_font(self, font):


### PR DESCRIPTION
Used the same approach as the Switch.label rename

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
