### PR TITLE
Fix divider strech

### DIFF
--- a/examples/divider/divider/app.py
+++ b/examples/divider/divider/app.py
@@ -11,7 +11,7 @@ class DividerApp(toga.App):
         self.main_window = toga.MainWindow(title=self.name, size=(300, 150))
 
         style = Pack(padding_top=24)
-        substyle = Pack(padding_right=12, padding_left=12, flex=1)
+        substyle = Pack(padding_right=12, padding_left=12)
 
         # Add the content on the main window
         self.main_window.content = toga.Box(
@@ -27,7 +27,7 @@ class DividerApp(toga.App):
                         toga.Divider(direction=toga.Divider.VERTICAL, style=substyle),
                         toga.TextInput(placeholder="Second textbox"),
                     ],
-                    style=Pack(direction=ROW, padding=24, flex=1),
+                    style=Pack(direction=ROW, padding=24),
                 ),
             ],
             style=Pack(direction=COLUMN, padding=24)

--- a/src/cocoa/toga_cocoa/widgets/divider.py
+++ b/src/cocoa/toga_cocoa/widgets/divider.py
@@ -1,5 +1,3 @@
-from travertino.size import at_least
-
 from toga_cocoa.libs import NSBox, NSBoxType
 
 from .base import Widget

--- a/src/cocoa/toga_cocoa/widgets/divider.py
+++ b/src/cocoa/toga_cocoa/widgets/divider.py
@@ -1,3 +1,5 @@
+from travertino.size import at_least
+
 from toga_cocoa.libs import NSBox, NSBoxType
 
 from .base import Widget
@@ -16,9 +18,9 @@ class Divider(Widget):
 
         if self.interface.direction == self.interface.VERTICAL:
             self.interface.intrinsic.width = content_size.width
-            self.interface.intrinsic.height = 0
+            self.interface.intrinsic.height = at_least(content_size.height)
         else:
-            self.interface.intrinsic.width = 0
+            self.interface.intrinsic.width = at_least(content_size.width)
             self.interface.intrinsic.height = content_size.height
 
     def set_direction(self, value):

--- a/src/cocoa/toga_cocoa/widgets/divider.py
+++ b/src/cocoa/toga_cocoa/widgets/divider.py
@@ -18,9 +18,9 @@ class Divider(Widget):
 
         if self.interface.direction == self.interface.VERTICAL:
             self.interface.intrinsic.width = content_size.width
-            self.interface.intrinsic.height = at_least(content_size.height)
+            self.interface.intrinsic.height = 0
         else:
-            self.interface.intrinsic.width = at_least(content_size.width)
+            self.interface.intrinsic.width = 0
             self.interface.intrinsic.height = content_size.height
 
     def set_direction(self, value):

--- a/src/core/toga/style/pack.py
+++ b/src/core/toga/style/pack.py
@@ -323,6 +323,12 @@ class Pack(BaseStyle):
 
         # Pass 4: set vertical position of each child.
         for child in node.children:
+            if not self.height and not child.intrinsic.height:
+                child.layout.content_height = (
+                    height
+                    - scale(child.style.padding_top)
+                    - scale(child.style.padding_bottom)
+                )
             extra = (
                 height
                 - child.layout.content_height
@@ -461,6 +467,12 @@ class Pack(BaseStyle):
 
         # Pass 4: set horizontal position of each child.
         for child in node.children:
+            if not self.width and not child.intrinsic.width:
+                child.layout.content_width = (
+                    width
+                    - scale(child.style.padding_left)
+                    - scale(child.style.padding_right)
+                )
             extra = (
                 width
                 - child.layout.content_width

--- a/src/core/toga/style/pack.py
+++ b/src/core/toga/style/pack.py
@@ -27,7 +27,7 @@ from travertino.constants import (
 )
 from travertino.declaration import BaseStyle, Choices
 from travertino.layout import BaseBox
-from travertino.size import BaseIntrinsicSize
+from travertino.size import BaseIntrinsicSize, at_least
 
 from toga.fonts import SYSTEM_DEFAULT_FONT_SIZE, Font
 
@@ -321,9 +321,9 @@ class Pack(BaseStyle):
                 )
                 height = max(height, child_height)
 
-        # Pass 4: set vertical position of each child.
+        # Pass 4: set vertical position of each child, and extend flexible children to the full height.
         for child in node.children:
-            if not self.height and not child.intrinsic.height:
+            if child.style.flex or type(child.intrinsic.height) is at_least:
                 child.layout.content_height = (
                     height
                     - scale(child.style.padding_top)
@@ -467,9 +467,9 @@ class Pack(BaseStyle):
             )
             width = max(width, child_width)
 
-        # Pass 4: set horizontal position of each child.
+        # Pass 4: set horizontal position of each child, and extend flexible children to full width.
         for child in node.children:
-            if not self.width and not child.intrinsic.width:
+            if child.style.flex or type(child.intrinsic.width) is at_least:
                 child.layout.content_width = (
                     width
                     - scale(child.style.padding_left)

--- a/src/core/toga/style/pack.py
+++ b/src/core/toga/style/pack.py
@@ -329,12 +329,14 @@ class Pack(BaseStyle):
                     - scale(child.style.padding_top)
                     - scale(child.style.padding_bottom)
                 )
-            extra = (
-                height
-                - child.layout.content_height
-                + scale(child.style.padding_top)
-                + scale(child.style.padding_bottom)
-            )
+                extra = 0
+            else:
+                extra = (
+                    height
+                    - child.layout.content_height
+                    + scale(child.style.padding_top)
+                    + scale(child.style.padding_bottom)
+                )
             # self._debug("row extra height", extra)
             if self.alignment is BOTTOM:
                 child.layout.content_top = extra + scale(child.style.padding_top)
@@ -473,12 +475,14 @@ class Pack(BaseStyle):
                     - scale(child.style.padding_left)
                     - scale(child.style.padding_right)
                 )
-            extra = (
-                width
-                - child.layout.content_width
-                + scale(child.style.padding_left)
-                + scale(child.style.padding_right)
-            )
+                extra = 0
+            else:
+                extra = (
+                    width
+                    - child.layout.content_width
+                    + scale(child.style.padding_left)
+                    + scale(child.style.padding_right)
+                )
             # self._debug("row extra width", extra)
             if self.alignment is LEFT:
                 child.layout.content_left = extra + scale(child.style.padding_left)


### PR DESCRIPTION
Fixes #1529

Only dividers inside boxes with predefined size (like the the top-level box in a window) would stretch their child Dividers along their direction. In the other cases, a single 1x1 pixel (on macOS) would be drawn.

While I can't claim to fully grasp the pack layout code, a debug statement in `_layout_node` mentions that if `node.width` and `node.intrinsic.width` are falsy, the widget should "USE ALL AVAILABLE WIDTH" (https://github.com/beeware/toga/blob/b32e8bdf96048f5b3802da3a29f7b1719e51303f/src/core/toga/style/pack.py#L153).

But for this to be true in boxes without a predefined size, some code was missing. Those are my edits to the layout algorithm.
It also requires changing the widget implementation, to set `intrinsic.width` and `intrinsic.height` to 0 instead of `at_least(...)`

I only have a macOS, hence I only edited the cocoa widget. I _did_ update the example code, so the other platforms implementation should be updated as well before merging these changes.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
