### PR TITLE
Run CI on macOS-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
   macOS:
     name: macOS backend tests
     needs: python-versions
-    runs-on: macOS-10.15
+    runs-on: macOS-latest
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.7
@@ -136,7 +136,7 @@ jobs:
   iOS:
     name: iOS backend tests
     needs: python-versions
-    runs-on: macOS-10.15
+    runs-on: macOS-latest
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.7


### PR DESCRIPTION
Github has [announced that they have deprecated the 10.15 runner, and will remove it by 30 Aug 2022](https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/). This moves macOS CI to macOS-latest.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
