### PR TITLE
New Pack test: transposed layout

### DIFF
--- a/docs/reference/style/pack.rst
+++ b/docs/reference/style/pack.rst
@@ -243,7 +243,7 @@ specifying the allocated width and allocated height.
    value less than 0, the adjusted view width is set to 0.
 
    If the element has a fixed intrinsic width, the available width is set to
-   the minimum of the adjusted view width and the intrinsic width.
+   the intrinsic width.
 
    If the element has a minimum intrinsic width, the available width is fixed
    to the maximum of the adjusted view width and the intrinsic minimum width.
@@ -261,7 +261,7 @@ specifying the allocated width and allocated height.
    value less than 0, the adjusted view height is set to 0.
 
    If the element has a fixed intrinsic height, the available height is set to
-   the minimum of the adjusted view height and the intrinsic height.
+   the intrinsic height.
 
    If the element has a minimum intrinsic height, the available height is
    fixed to the maximum of the adjusted view height and the intrinsic minimum

--- a/src/core/tests/style/test_pack.py
+++ b/src/core/tests/style/test_pack.py
@@ -293,16 +293,16 @@ class PackLayoutTests(TestCase):
             root,
             (640, 142),
             {'origin': (0, 10), 'content': (640, 132), 'children': [
-                {'origin': (7, 15), 'content': (626, 15), 'children': [
-                    {'origin': (247, 15), 'content': (221, 15)},
-                    {'origin': (483, 15), 'content': (150, 10)},
+                {'origin': (7, 17), 'content': (626, 15), 'children': [
+                    {'origin': (247, 17), 'content': (221, 15)},
+                    {'origin': (483, 17), 'content': (150, 10)},
                 ]},
-                {'origin': (7, 42), 'content': (626, 15), 'children': [
-                    {'origin': (7, 42), 'content': (225, 10)},
-                    {'origin': (247, 42), 'content': (221, 15)},
-                    {'origin': (483, 42), 'content': (150, 10)},
+                {'origin': (7, 46), 'content': (626, 15), 'children': [
+                    {'origin': (7, 46), 'content': (225, 10)},
+                    {'origin': (247, 46), 'content': (221, 15)},
+                    {'origin': (483, 46), 'content': (150, 10)},
                 ]},
-                {'origin': (22, 79), 'content': (596, 30)}
+                {'origin': (22, 90), 'content': (596, 30)}
             ]}
         )
 

--- a/src/core/tests/style/test_pack.py
+++ b/src/core/tests/style/test_pack.py
@@ -158,6 +158,44 @@ class PackLayoutTests(TestCase):
             ]}
         )
 
+    def test_tutorial_0_vertical(self):
+        root = TestNode(
+            'app', style=Pack(direction=COLUMN), children=[
+                # TestNode('button', style=Pack(flex=1), size=(30, at_least(120))),
+                TestNode('button', style=Pack(flex=1, padding=50), size=(30, at_least(120))),
+            ]
+        )
+
+        # Minimum size
+        root.style.layout(root, TestViewport(0, 0, dpi=96))
+        self.assertLayout(
+            root,
+            (130, 220),
+            {'origin': (0, 0), 'content': (130, 220), 'children': [
+                {'origin': (50, 50), 'content': (30, 120)}
+            ]}
+        )
+
+        # Normal size
+        root.style.layout(root, TestViewport(480, 640, dpi=96))
+        self.assertLayout(
+            root,
+            (130, 640),
+            {'origin': (0, 0), 'content': (130, 640), 'children': [
+                {'origin': (50, 50), 'content': (30, 540)}
+            ]}
+        )
+
+        # HiDPI normal size
+        root.style.layout(root, TestViewport(480, 640, dpi=144))
+        self.assertLayout(
+            root,
+            (180, 640),
+            {'origin': (0, 0), 'content': (180, 640), 'children': [
+                {'origin': (75, 75), 'content': (30, 490)}
+            ]}
+        )
+
     def test_tutorial_0_high_baseline_dpi(self):
         root = TestNode(
             'app', style=Pack(), children=[

--- a/src/core/toga/style/pack.py
+++ b/src/core/toga/style/pack.py
@@ -449,7 +449,7 @@ class Pack(BaseStyle):
         width = 0
         for child in node.children:
             # self._debug("START CHILD AT VERTICAL OFFSET", offset)
-            offset += child.style.padding_top
+            offset += scale(child.style.padding_top)
             child.layout.content_top = offset
             offset += child.layout.content_height + scale(child.style.padding_bottom)
             child_width = (

--- a/src/core/toga/style/pack.py
+++ b/src/core/toga/style/pack.py
@@ -146,7 +146,7 @@ class Pack(BaseStyle):
                 try:
                     available_width = max(available_width, node.intrinsic.width.value)
                 except AttributeError:
-                    available_width = min(available_width, node.intrinsic.width)
+                    available_width = node.intrinsic.width
 
                 # self._debug("ADJUSTED WIDTH", available_width)
             else:

--- a/src/core/toga/style/pack.py
+++ b/src/core/toga/style/pack.py
@@ -139,7 +139,8 @@ class Pack(BaseStyle):
             available_width = max(0, (
                 alloc_width -
                 scale(self.padding_left) -
-                scale(self.padding_right)))
+                scale(self.padding_right))
+            )
             # self._debug("INITIAL AVAILABLE WIDTH", available_width)
             if node.intrinsic.width:
                 # self._debug("INTRINSIC WIDTH", node.intrinsic.width)


### PR DESCRIPTION
I am trying to get a deeper understanding of the Pack layout. As an exercise, I copied one of the tests and swapped the horizontal and vertical dimensions. This exposed (I believe) two bugs in the algorithm.

In both cases, the symmetry of the code was broken. My changes bring back the symmetry.

My case is purely synthetic, and those changes in symmetry might be features, not bugs. But in that case, they should be documented. 


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
