### PR TITLE
Renamed 'initial' and 'default' init params to 'value'

### DIFF
--- a/examples/canvas/canvas/app.py
+++ b/examples/canvas/canvas/app.py
@@ -97,7 +97,7 @@ class ExampleCanvasApp(toga.App):
         )
         self.line_width_slider = toga.Slider(
             range=(1, 10),
-            default=1,
+            value=1,
             on_change=self.refresh_canvas
         )
         self.dash_pattern_selection = toga.Selection(
@@ -109,13 +109,13 @@ class ExampleCanvasApp(toga.App):
         self.rotation = 0
         self.scale_x_slider = toga.Slider(
             range=(0, 2),
-            default=1,
+            value=1,
             tick_count=10,
             on_change=self.refresh_canvas
         )
         self.scale_y_slider = toga.Slider(
             range=(0, 2),
-            default=1,
+            value=1,
             tick_count=10,
             on_change=self.refresh_canvas
         )
@@ -134,7 +134,7 @@ class ExampleCanvasApp(toga.App):
         self.font_size = toga.NumberInput(
             min_value=10,
             max_value=72,
-            default=20,
+            value=20,
             on_change=self.refresh_canvas
         )
         self.italic_switch = toga.Switch(

--- a/examples/date_and_time/date_and_time/app.py
+++ b/examples/date_and_time/date_and_time/app.py
@@ -20,7 +20,7 @@ class DateAndTimeApp(toga.App):
                 toga.Label("Any date:", style=Pack(width=150, text_align=RIGHT)),
                 toga.DatePicker(
                     id="Any",
-                    initial=None,
+                    value=None,
                     on_change=self.changed_date,
                 ),
             ],
@@ -31,7 +31,7 @@ class DateAndTimeApp(toga.App):
                 toga.Label("With min:", style=Pack(width=150, text_align=RIGHT)),
                 toga.DatePicker(
                     id="Min",
-                    initial=None,
+                    value=None,
                     on_change=self.changed_date,
                     min_date="2021-01-01",
                 ),
@@ -43,7 +43,7 @@ class DateAndTimeApp(toga.App):
                 toga.Label("With max:", style=Pack(width=150, text_align=RIGHT)),
                 toga.DatePicker(
                     id="Max",
-                    initial=date(2021, 4, 2),
+                    value=date(2021, 4, 2),
                     on_change=self.changed_date,
                     max_date=date(2022, 2, 1),
                 ),
@@ -57,7 +57,7 @@ class DateAndTimeApp(toga.App):
                 ),
                 toga.DatePicker(
                     id="Min-max",
-                    initial=date(2021, 4, 2),
+                    value=date(2021, 4, 2),
                     on_change=self.changed_date,
                     min_date=date(2021, 1, 1),
                     max_date=date(2022, 2, 1),
@@ -71,7 +71,7 @@ class DateAndTimeApp(toga.App):
                 toga.Label("Any time:", style=Pack(width=150, text_align=RIGHT)),
                 toga.TimePicker(
                     id="Any time",
-                    initial=None,
+                    value=None,
                     on_change=self.changed_time,
                 ),
             ],
@@ -82,7 +82,7 @@ class DateAndTimeApp(toga.App):
                 toga.Label("With min:", style=Pack(width=150, text_align=RIGHT)),
                 toga.TimePicker(
                     id="Min time",
-                    initial=None,
+                    value=None,
                     on_change=self.changed_time,
                     min_time="06:35:00",
                 ),
@@ -94,7 +94,7 @@ class DateAndTimeApp(toga.App):
                 toga.Label("With max:", style=Pack(width=150, text_align=RIGHT)),
                 toga.TimePicker(
                     id="Max time",
-                    initial=time(10, 42),
+                    value=time(10, 42),
                     on_change=self.changed_time,
                     max_time=time(21, 30),
                 ),
@@ -108,7 +108,7 @@ class DateAndTimeApp(toga.App):
                 ),
                 toga.TimePicker(
                     id="Min-max time",
-                    initial=time(10, 42),
+                    value=time(10, 42),
                     on_change=self.changed_time,
                     min_time=time(8, 15),
                     max_time=time(21, 30),

--- a/examples/multilinetextinput/multilinetextinput/app.py
+++ b/examples/multilinetextinput/multilinetextinput/app.py
@@ -29,7 +29,7 @@ class ExampleMultilineTextInputApp(toga.App):
 
         self.multiline_input = toga.MultilineTextInput(
             placeholder='Enter text here...',
-            initial='Initial value',
+            value='Initial value',
             style=Pack(flex=1, font_family='monospace', font_size=14),
             on_change=self.set_label
         )

--- a/examples/numberinput/numberinput/app.py
+++ b/examples/numberinput/numberinput/app.py
@@ -28,7 +28,7 @@ class ExampleNumberInputApp(toga.App):
         self.ni1 = toga.NumberInput(
             min_value=12,
             max_value=72,
-            default=12,
+            value=12,
             on_change=self.handle_numberinput,
         )
         box1 = toga.Box(

--- a/examples/slider/slider/app.py
+++ b/examples/slider/slider/app.py
@@ -52,7 +52,7 @@ class SliderApp(toga.App):
 
                     toga.Slider(
                         range=(1, 10),
-                        default=10,
+                        value=10,
                         style=Pack(width=150),
                         tick_count=10
                     ),

--- a/examples/tutorial3/tutorial/app.py
+++ b/examples/tutorial3/tutorial/app.py
@@ -8,7 +8,7 @@ class Graze(toga.App):
 
         self.webview = toga.WebView(on_webview_load=self.on_webview_loaded, style=Pack(flex=1))
         self.url_input = toga.TextInput(
-            initial='https://beeware.org/',
+            value='https://beeware.org/',
             style=Pack(flex=1)
         )
 

--- a/src/core/tests/widgets/test_datepicker.py
+++ b/src/core/tests/widgets/test_datepicker.py
@@ -76,3 +76,30 @@ class DatePickerTests(TestCase):
     def test_focus(self):
         self.date_picker.focus()
         self.assertActionPerformed(self.date_picker, "focus")
+
+    ######################################################################
+    # 2022-07: Backwards compatibility
+    ######################################################################
+
+    def test_init_with_deprecated(self):
+        value = datetime.date(2021, 2, 19)
+
+        # initial is a deprecated argument
+        with self.assertWarns(DeprecationWarning):
+            my_text_input = toga.DatePicker(
+                initial=value,
+                factory=toga_dummy.factory
+            )
+        self.assertEqual(my_text_input.value, value)
+
+        # can't specify both initial *and* value
+        with self.assertRaises(ValueError):
+            toga.DatePicker(
+                initial=value,
+                value=value,
+                factory=toga_dummy.factory
+            )
+
+    ######################################################################
+    # End backwards compatibility.
+    ######################################################################

--- a/src/core/tests/widgets/test_multilinetextinput.py
+++ b/src/core/tests/widgets/test_multilinetextinput.py
@@ -9,10 +9,10 @@ class MultilineTextInputTests(TestCase):
     def setUp(self):
         super().setUp()
 
-        self.initial = 'Super Multiline Text'
+        self.value = 'Super Multiline Text'
         self.on_change = mock.Mock()
         self.multiline = toga.MultilineTextInput(
-            initial=self.initial,
+            value=self.value,
             on_change=self.on_change,
             factory=toga_dummy.factory,
         )
@@ -24,7 +24,7 @@ class MultilineTextInputTests(TestCase):
 
     def test_multiline_properties_with_None(self):
         self.assertEqual(self.multiline.readonly, False)
-        self.assertEqual(self.multiline.value, self.initial)
+        self.assertEqual(self.multiline.value, self.value)
         self.assertEqual(self.multiline.placeholder, '')
 
     def test_multiline_values(self):
@@ -33,3 +33,30 @@ class MultilineTextInputTests(TestCase):
         self.assertEqual(self.multiline.value, new_value)
         self.multiline.clear()
         self.assertEqual(self.multiline.value, '')
+
+    ######################################################################
+    # 2022-07: Backwards compatibility
+    ######################################################################
+
+    def test_init_with_deprecated(self):
+        # initial is a deprecated argument
+        with self.assertWarns(DeprecationWarning):
+            my_text_input = toga.MultilineTextInput(
+                initial=self.value,
+                on_change=self.on_change,
+                factory=toga_dummy.factory
+            )
+        self.assertEqual(my_text_input.value, self.value)
+
+        # can't specify both initial *and* value
+        with self.assertRaises(ValueError):
+            toga.MultilineTextInput(
+                initial=self.value,
+                value=self.value,
+                on_change=self.on_change,
+                factory=toga_dummy.factory
+            )
+
+    ######################################################################
+    # End backwards compatibility.
+    ######################################################################

--- a/src/core/tests/widgets/test_numberinput.py
+++ b/src/core/tests/widgets/test_numberinput.py
@@ -73,11 +73,38 @@ class NumberInputTests(TestCase):
         self.nr_input.value = 2
         self.assertValueSet(self.nr_input, 'on_change', self.nr_input.on_change)
 
-    def test_default(self):
+    def test_value_init(self):
         value = 5
-        nr_input = toga.NumberInput(default=value, factory=toga_dummy.factory)
+        nr_input = toga.NumberInput(value=value, factory=toga_dummy.factory)
         self.assertEqual(nr_input.value, value)
 
     def test_focus(self):
         self.nr_input.focus()
         self.assertActionPerformed(self.nr_input, "focus")
+
+    ######################################################################
+    # 2022-07: Backwards compatibility
+    ######################################################################
+
+    def test_init_with_deprecated(self):
+        # default is a deprecated argument
+        value = 5
+        with self.assertWarns(DeprecationWarning):
+            my_nr_input = toga.NumberInput(
+                default=value,
+                factory=toga_dummy.factory
+            )
+        self.assertValueSet(my_nr_input, 'value', value)
+        self.assertEqual(my_nr_input.value, value)
+
+        # can't specify both default *and* value
+        with self.assertRaises(ValueError):
+            toga.NumberInput(
+                default=value,
+                value=value,
+                factory=toga_dummy.factory
+            )
+
+    ######################################################################
+    # End backwards compatibility.
+    ######################################################################

--- a/src/core/tests/widgets/test_slider.py
+++ b/src/core/tests/widgets/test_slider.py
@@ -9,7 +9,7 @@ class SliderTests(TestCase):
     def setUp(self):
         super().setUp()
 
-        self.default = 50
+        self.value = 50
         self.min_val = 0
         self.max_val = 100
         self.default_tick = 6
@@ -20,7 +20,7 @@ class SliderTests(TestCase):
         self.enabled = True
 
         self.slider = toga.Slider(
-            default=self.default,
+            value=self.value,
             range=self.range,
             on_change=self.on_change,
             enabled=self.enabled,
@@ -59,22 +59,22 @@ class SliderTests(TestCase):
     def test_set_value_to_be_too_small(self):
         with self.assertRaises(ValueError):
             self.slider.value = self.min_val - 1
-        self.assert_slider_value(tick_value=self.default_tick, value=self.default)
+        self.assert_slider_value(tick_value=self.default_tick, value=self.value)
 
     def test_set_value_to_be_too_big(self):
         with self.assertRaises(ValueError):
             self.slider.value = self.max_val + 1
-        self.assert_slider_value(tick_value=self.default_tick, value=self.default)
+        self.assert_slider_value(tick_value=self.default_tick, value=self.value)
 
     def test_set_tick_value_to_be_too_small(self):
         with self.assertRaises(ValueError):
             self.slider.tick_value = 0
-        self.assert_slider_value(tick_value=self.default_tick, value=self.default)
+        self.assert_slider_value(tick_value=self.default_tick, value=self.value)
 
     def test_set_tick_value_to_be_too_big(self):
         with self.assertRaises(ValueError):
             self.slider.tick_value = self.max_val + 1
-        self.assert_slider_value(tick_value=self.default_tick, value=self.default)
+        self.assert_slider_value(tick_value=self.default_tick, value=self.value)
 
     def test_new_value_is_None(self):
         self.slider.value = None
@@ -85,7 +85,7 @@ class SliderTests(TestCase):
         tick_delta = 2
         self.slider.value += delta
         self.assert_slider_value(
-            value=self.default + delta,
+            value=self.value + delta,
             tick_value=self.default_tick + tick_delta,
             on_change_call_count=1,
         )
@@ -95,7 +95,7 @@ class SliderTests(TestCase):
         tick_delta = 2
         self.slider.value -= delta
         self.assert_slider_value(
-            value=self.default - delta,
+            value=self.value - delta,
             tick_value=self.default_tick - tick_delta,
             on_change_call_count=1,
         )
@@ -105,7 +105,7 @@ class SliderTests(TestCase):
         tick_delta = 2
         self.slider.tick_value += tick_delta
         self.assert_slider_value(
-            value=self.default + delta,
+            value=self.value + delta,
             tick_value=self.default_tick + tick_delta,
             on_change_call_count=1,
         )
@@ -115,7 +115,7 @@ class SliderTests(TestCase):
         tick_delta = 2
         self.slider.tick_value -= tick_delta
         self.assert_slider_value(
-            value=self.default - delta,
+            value=self.value - delta,
             tick_value=self.default_tick - tick_delta,
             on_change_call_count=1,
         )
@@ -172,3 +172,36 @@ class SliderTests(TestCase):
         self.assertEqual(self.slider.max, max_val)
         self.assertEqual(self.slider.range, (min_val, max_val))
         self.assertValueSet(self.slider, "range", (min_val, max_val))
+
+    ######################################################################
+    # 2022-07: Backwards compatibility
+    ######################################################################
+
+    def test_init_with_deprecated(self):
+        # default is a deprecated argument
+        with self.assertWarns(DeprecationWarning):
+            my_slider = toga.Slider(
+                default=self.value,
+                range=self.range,
+                on_change=self.on_change,
+                enabled=self.enabled,
+                factory=toga_dummy.factory,
+                tick_count=self.tick_count,
+            )
+        self.assertEqual(my_slider.value, self.value)
+
+        # can't specify both default *and* value
+        with self.assertRaises(ValueError):
+            toga.Slider(
+                default=self.value,
+                value=self.value,
+                range=self.range,
+                on_change=self.on_change,
+                enabled=self.enabled,
+                factory=toga_dummy.factory,
+                tick_count=self.tick_count,
+            )
+
+    ######################################################################
+    # End backwards compatibility.
+    ######################################################################

--- a/src/core/tests/widgets/test_textinput.py
+++ b/src/core/tests/widgets/test_textinput.py
@@ -10,13 +10,13 @@ class TextInputTests(TestCase):
     def setUp(self):
         super().setUp()
 
-        self.initial = 'Initial Text'
+        self.value = 'Initial Text'
         self.placeholder = 'Placeholder Text'
         self.readonly = False
         self.on_gain_focus = mock.Mock()
         self.on_lose_focus = mock.Mock()
         self.text_input = toga.TextInput(
-            initial=self.initial,
+            value=self.value,
             placeholder=self.placeholder,
             readonly=self.readonly,
             on_gain_focus=self.on_gain_focus,
@@ -70,29 +70,62 @@ class TextInputTests(TestCase):
     def test_on_lose_focus(self):
         self.assertEqual(self.text_input.on_lose_focus._raw, self.on_lose_focus)
 
+    ######################################################################
+    # 2022-07: Backwards compatibility
+    ######################################################################
+
+    def test_init_with_deprecated(self):
+        # initial is a deprecated argument
+        with self.assertWarns(DeprecationWarning):
+            my_text_input = toga.TextInput(
+                initial=self.value,
+                placeholder=self.placeholder,
+                readonly=self.readonly,
+                on_gain_focus=self.on_gain_focus,
+                on_lose_focus=self.on_lose_focus,
+                factory=toga_dummy.factory
+            )
+        self.assertEqual(my_text_input.value, self.value)
+
+        # can't specify both initial *and* value
+        with self.assertRaises(ValueError):
+            toga.TextInput(
+                initial=self.value,
+                value=self.value,
+                placeholder=self.placeholder,
+                readonly=self.readonly,
+                on_gain_focus=self.on_gain_focus,
+                on_lose_focus=self.on_lose_focus,
+                factory=toga_dummy.factory
+            )
+
+    ######################################################################
+    # End backwards compatibility.
+    ######################################################################
+
 
 class ValidatedTextInputTests(TestCase):
     def setUp(self):
         super().setUp()
 
-        self.initial = 'Initial Text'
+        self.value = 'Initial Text'
 
     def test_validator_run_in_constructor(self):
         validator = Mock(return_value=None)
         text_input = toga.TextInput(
-            initial=self.initial,
+            value=self.value,
             validators=[validator],
             factory=toga_dummy.factory
         )
         self.assertValueNotSet(text_input, "error")
         self.assertActionPerformed(text_input, "clear_error")
-        validator.assert_called_once_with(self.initial)
+        validator.assert_called_once_with(self.value)
 
     def test_validator_run_after_set(self):
         message = "This is an error message"
         validator = Mock(return_value=message)
         text_input = toga.TextInput(
-            initial=self.initial,
+            value=self.value,
             factory=toga_dummy.factory
         )
 
@@ -101,11 +134,11 @@ class ValidatedTextInputTests(TestCase):
         text_input.validators = [validator]
 
         self.assertValueSet(text_input, "error", message)
-        validator.assert_called_once_with(self.initial)
+        validator.assert_called_once_with(self.value)
 
     def test_text_input_with_no_validator_is_valid(self):
         text_input = toga.TextInput(
-            initial=self.initial,
+            value=self.value,
             factory=toga_dummy.factory
         )
         self.assertTrue(text_input.validate())
@@ -113,7 +146,7 @@ class ValidatedTextInputTests(TestCase):
     def test_validate_true_when_valid(self):
         validator = Mock(return_value=None)
         text_input = toga.TextInput(
-            initial=self.initial,
+            value=self.value,
             validators=[validator],
             factory=toga_dummy.factory
         )
@@ -123,7 +156,7 @@ class ValidatedTextInputTests(TestCase):
         message = "This is an error message"
         validator = Mock(return_value=message)
         text_input = toga.TextInput(
-            initial=self.initial,
+            value=self.value,
             validators=[validator],
             factory=toga_dummy.factory
         )
@@ -132,7 +165,7 @@ class ValidatedTextInputTests(TestCase):
     def test_validate_passes(self):
         validator = Mock(side_effect=[None, None])
         text_input = toga.TextInput(
-            initial=self.initial,
+            value=self.value,
             validators=[validator],
             factory=toga_dummy.factory
         )
@@ -141,14 +174,14 @@ class ValidatedTextInputTests(TestCase):
         text_input.validate()
         self.assertValueNotSet(text_input, "error")
         self.assertEqual(
-            validator.call_args_list, [call(self.initial), call(self.initial)]
+            validator.call_args_list, [call(self.value), call(self.value)]
         )
 
     def test_validate_fails(self):
         message = "This is an error message"
         validator = Mock(side_effect=[None, message])
         text_input = toga.TextInput(
-            initial=self.initial,
+            value=self.value,
             validators=[validator],
             factory=toga_dummy.factory
         )
@@ -157,5 +190,5 @@ class ValidatedTextInputTests(TestCase):
         text_input.validate()
         self.assertValueSet(text_input, "error", message)
         self.assertEqual(
-            validator.call_args_list, [call(self.initial), call(self.initial)]
+            validator.call_args_list, [call(self.value), call(self.value)]
         )

--- a/src/core/tests/widgets/test_timepicker.py
+++ b/src/core/tests/widgets/test_timepicker.py
@@ -77,3 +77,30 @@ class TimePickerTests(TestCase):
     def test_focus(self):
         self.time_picker.focus()
         self.assertActionPerformed(self.time_picker, "focus")
+
+    ######################################################################
+    # 2022-07: Backwards compatibility
+    ######################################################################
+
+    def test_init_with_deprecated(self):
+        value = datetime.time(6, 7, 8)
+
+        # initial is a deprecated argument
+        with self.assertWarns(DeprecationWarning):
+            my_text_input = toga.TimePicker(
+                initial=value,
+                factory=toga_dummy.factory
+            )
+        self.assertEqual(my_text_input.value, value)
+
+        # can't specify both initial *and* value
+        with self.assertRaises(ValueError):
+            toga.TimePicker(
+                initial=value,
+                value=value,
+                factory=toga_dummy.factory
+            )
+
+    ######################################################################
+    # End backwards compatibility.
+    ######################################################################

--- a/src/core/toga/widgets/datepicker.py
+++ b/src/core/toga/widgets/datepicker.py
@@ -1,4 +1,5 @@
 import datetime
+import warnings
 
 from toga.handlers import wrapped_handler
 
@@ -18,11 +19,43 @@ class DatePicker(Widget):
     """
     MIN_WIDTH = 200
 
-    def __init__(self, id=None, style=None, factory=None, initial=None, min_date=None, max_date=None, on_change=None):
+    def __init__(
+        self,
+        id=None,
+        style=None,
+        factory=None,
+        value=None,
+        min_date=None,
+        max_date=None,
+        on_change=None,
+        initial=None,  # DEPRECATED!
+    ):
         super().__init__(id=id, style=style, factory=factory)
         # Create a platform specific implementation of a DatePicker
         self._impl = self.factory.DatePicker(interface=self)
-        self.value = initial
+
+        ##################################################################
+        # 2022-07: Backwards compatibility
+        ##################################################################
+
+        # initial replaced with value
+        if initial is not None:
+            if value is not None:
+                raise ValueError(
+                    "Cannot specify both `initial` and `value`; "
+                    "`initial` has been deprecated, use `value`"
+                )
+            else:
+                warnings.warn(
+                    "`initial` has been renamed `value`", DeprecationWarning
+                )
+            value = initial
+
+        ##################################################################
+        # End backwards compatibility.
+        ##################################################################
+
+        self.value = value
         self.min_date = min_date
         self.max_date = max_date
         self.on_change = on_change

--- a/src/core/toga/widgets/multilinetextinput.py
+++ b/src/core/toga/widgets/multilinetextinput.py
@@ -1,4 +1,7 @@
+import warnings
+
 from toga.handlers import wrapped_handler
+
 from .base import Widget
 
 
@@ -11,7 +14,7 @@ class MultilineTextInput(Widget):
             If no style is provided then a new one will be created for the widget.
         factory: Optional factory that must be able to return a implementation
             of a MulitlineTextInput Widget.
-        initial (str): The initial text of the widget.
+        value (str): The initial text of the widget.
         readonly (bool): Whether a user can write into the text input,
             defaults to `False`.
         placeholder (str): The placeholder text for the widget.
@@ -19,16 +22,45 @@ class MultilineTextInput(Widget):
     MIN_HEIGHT = 100
     MIN_WIDTH = 100
 
-    def __init__(self, id=None, style=None, factory=None,
-                 initial=None, readonly=False, placeholder=None,
-                 on_change=None):
+    def __init__(
+        self,
+        id=None,
+        style=None,
+        factory=None,
+        value=None,
+        readonly=False,
+        placeholder=None,
+        on_change=None,
+        initial=None,  # DEPRECATED!
+    ):
         super().__init__(id=id, style=style, factory=factory)
 
         # Create a platform specific implementation of a MultilineTextInput
         self._impl = self.factory.MultilineTextInput(interface=self)
 
+        ##################################################################
+        # 2022-07: Backwards compatibility
+        ##################################################################
+
+        # initial replaced with value
+        if initial is not None:
+            if value is not None:
+                raise ValueError(
+                    "Cannot specify both `initial` and `value`; "
+                    "`initial` has been deprecated, use `value`"
+                )
+            else:
+                warnings.warn(
+                    "`initial` has been renamed `value`", DeprecationWarning
+                )
+            value = initial
+
+        ##################################################################
+        # End backwards compatibility.
+        ##################################################################
+
         # Set all the properties
-        self.value = initial
+        self.value = value
         self.readonly = readonly
         self.placeholder = placeholder
         self.on_change = on_change

--- a/src/core/toga/widgets/numberinput.py
+++ b/src/core/toga/widgets/numberinput.py
@@ -1,4 +1,5 @@
 from decimal import Decimal, InvalidOperation
+import warnings
 
 from toga.handlers import wrapped_handler
 
@@ -22,19 +23,51 @@ class NumberInput(Widget):
         step (number): Step size of the adjustment buttons.
         min_value (number): The minimum bound for the widget's value.
         max_value (number): The maximum bound for the widget's value.
-        default (number): Default value for the widget
+        value (number): Initial value for the widget
         readonly (bool):  Whether a user can write/change the number input, defaults to `False`.
         on_change (``callable``): The handler to invoke when the value changes.
         **ex:
     """
     MIN_WIDTH = 100
 
-    def __init__(self, id=None, style=None, factory=None, step=1,
-                 min_value=None, max_value=None, default=None, readonly=False, on_change=None):
+    def __init__(
+        self,
+        id=None,
+        style=None,
+        factory=None,
+        step=1,
+        min_value=None,
+        max_value=None,
+        value=None,
+        readonly=False,
+        on_change=None,
+        default=None,  # DEPRECATED!
+    ):
         super().__init__(id=id, style=style, factory=factory)
         self._value = None
         self._on_change = None
         self._impl = self.factory.NumberInput(interface=self)
+
+        ##################################################################
+        # 2022-07: Backwards compatibility
+        ##################################################################
+
+        # default replaced with value
+        if default is not None:
+            if value is not None:
+                raise ValueError(
+                    "Cannot specify both `default` and `value`; "
+                    "`default` has been deprecated, use `value`"
+                )
+            else:
+                warnings.warn(
+                    "`default` has been renamed `value`", DeprecationWarning
+                )
+            value = default
+
+        ##################################################################
+        # End backwards compatibility.
+        ##################################################################
 
         self.readonly = readonly
         self.step = step
@@ -42,8 +75,8 @@ class NumberInput(Widget):
         self.max_value = max_value
         self.on_change = on_change
 
-        if default is not None:
-            self.value = default
+        if value is not None:
+            self.value = value
 
     @property
     def readonly(self):

--- a/src/core/toga/widgets/slider.py
+++ b/src/core/toga/widgets/slider.py
@@ -11,7 +11,7 @@ class Slider(Widget):
     Args:
         id: An identifier for this widget.
         style (:obj:`Style`):
-        default (float): Default value of the slider
+        value (float): Initial value of the slider
         range (``tuple``): Min and max values of the slider in this form (min, max).
         tick_count (``int``): How many ticks in range. if None, slider is continuous.
         on_change (``callable``): The handler to invoke when the slider value changes.
@@ -28,7 +28,7 @@ class Slider(Widget):
         self,
         id=None,
         style=None,
-        default=None,
+        value=None,
         range=None,
         tick_count=None,
         on_change=None,
@@ -36,7 +36,8 @@ class Slider(Widget):
         on_press=None,
         on_release=None,
         enabled=True,
-        factory=None
+        factory=None,
+        default=None,  # DEPRECATED!
     ):
         super().__init__(id=id, style=style, factory=factory)
 
@@ -46,12 +47,33 @@ class Slider(Widget):
 
         self._impl = self.factory.Slider(interface=self)
 
+        ##################################################################
+        # 2022-07: Backwards compatibility
+        ##################################################################
+
+        # default replaced with value
+        if default is not None:
+            if value is not None:
+                raise ValueError(
+                    "Cannot specify both `default` and `value`; "
+                    "`default` has been deprecated, use `value`"
+                )
+            else:
+                warnings.warn(
+                    "`default` has been renamed `value`", DeprecationWarning
+                )
+            value = default
+
+        ##################################################################
+        # End backwards compatibility.
+        ##################################################################
+
         self.range = range
         self.tick_count = tick_count
 
         # IMPORTANT NOTE: Setting value before on_change in order to not
         # call it in constructor. Please do not move it from here.
-        self.value = default
+        self.value = value
 
         if on_slide:
             self.on_slide = on_slide

--- a/src/core/toga/widgets/textinput.py
+++ b/src/core/toga/widgets/textinput.py
@@ -1,3 +1,5 @@
+import warnings
+
 from toga.handlers import wrapped_handler
 
 from .base import Widget
@@ -12,7 +14,7 @@ class TextInput(Widget):
             a new one will be created for the widget.
         factory (:obj:`module`): A python module that is capable to return a
             implementation of this class with the same name. (optional & normally not needed)
-        initial (str): The initial text for the input.
+        value (str): The initial text for the input.
         placeholder (str): If no input is present this text is shown.
         readonly (bool):  Whether a user can write into the text input, defaults to `False`.
         on_change (Callable): Method to be called when text is changed in text box
@@ -29,25 +31,47 @@ class TextInput(Widget):
         id=None,
         style=None,
         factory=None,
-        initial=None,
+        value=None,
         placeholder=None,
         readonly=False,
         on_change=None,
         on_gain_focus=None,
         on_lose_focus=None,
-        validators=None
+        validators=None,
+        initial=None,  # DEPRECATED!
     ):
         super().__init__(id=id, style=style, factory=factory)
 
         # Create a platform specific implementation of the widget
         self._create()
 
+        ##################################################################
+        # 2022-07: Backwards compatibility
+        ##################################################################
+
+        # initial replaced with value
+        if initial is not None:
+            if value is not None:
+                raise ValueError(
+                    "Cannot specify both `initial` and `value`; "
+                    "`initial` has been deprecated, use `value`"
+                )
+            else:
+                warnings.warn(
+                    "`initial` has been renamed `value`", DeprecationWarning
+                )
+            value = initial
+
+        ##################################################################
+        # End backwards compatibility.
+        ##################################################################
+
         self.on_change = on_change
         self.placeholder = placeholder
         self.readonly = readonly
 
         # Set the actual value after on_change, as it may trigger change events, etc.
-        self.value = initial
+        self.value = value
         self.validators = validators
         self.on_lose_focus = on_lose_focus
         self.on_gain_focus = on_gain_focus

--- a/src/core/toga/widgets/timepicker.py
+++ b/src/core/toga/widgets/timepicker.py
@@ -1,4 +1,5 @@
 import datetime
+import warnings
 
 from toga.handlers import wrapped_handler
 
@@ -15,23 +16,55 @@ class TimePicker(Widget):
             a new one will be created for the widget.
         factory (:obj:`module`): A python module that is capable to return a
             implementation of this class with the same name. (optional & normally not needed)
-        initial (str): The initial value to set the widget to. (Defaults to time of program execution)
+        value (str): The initial value to set the widget to. (Defaults to time of program execution)
         min_time (str): The minimum allowable time for the widget.
         max_time (str): The maximum allowable time for the widget.
         on_change (``callable``): Function that is invoked on time value change.
     """
     MIN_WIDTH = 100
 
-    def __init__(self, id=None, style=None, factory=None, initial=None, min_time=None, max_time=None, on_change=None):
+    def __init__(
+        self,
+        id=None,
+        style=None,
+        factory=None,
+        value=None,
+        min_time=None,
+        max_time=None,
+        on_change=None,
+        initial=None,  # DEPRECATED!
+    ):
         super().__init__(id=id, style=style, factory=factory)
         self._on_change = None
 
         # Create a platform specific implementation of a TimePicker
         self._impl = self.factory.TimePicker(interface=self)
+
+        ##################################################################
+        # 2022-07: Backwards compatibility
+        ##################################################################
+
+        # initial replaced with value
+        if initial is not None:
+            if value is not None:
+                raise ValueError(
+                    "Cannot specify both `initial` and `value`; "
+                    "`initial` has been deprecated, use `value`"
+                )
+            else:
+                warnings.warn(
+                    "`initial` has been renamed `value`", DeprecationWarning
+                )
+            value = initial
+
+        ##################################################################
+        # End backwards compatibility.
+        ##################################################################
+
         self.min_time = min_time
         self.max_time = max_time
         # Set the value after the min/max has been set
-        self.value = initial
+        self.value = value
         # Set the change handler after the initial value has been set
         self.on_change = on_change
 


### PR DESCRIPTION
Making the init param consistent with the widget property.

What I didn't do: re-use the 'default' param to implement actual default semantics (as was mentioned here: https://github.com/beeware/toga/discussions/1521#discussioncomment-3160501).

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
