### PR TITLE
Cast pathlib.Path to string in Image()

### DIFF
--- a/examples/imageview/imageview/app.py
+++ b/examples/imageview/imageview/app.py
@@ -11,7 +11,7 @@ class ImageViewApp(toga.App):
         box.style.update(alignment=CENTER)
         box.style.update(direction=COLUMN)
 
-        # image from local path (string)
+        # image from local path
         # load brutus.png from the package
         # We set the style width/height parameters for this one
         image_from_path = toga.Image('resources/pride-brutus.png')
@@ -19,7 +19,7 @@ class ImageViewApp(toga.App):
         imageview_from_path.style.update(height=72)
         box.add(imageview_from_path)
 
-        # image from local path (pathlib.Path)
+        # image from pathlib.Path object
         # same as the above image, just with a different argument type
         image_from_pathlib_path = toga.Image(self.paths.app / 'resources/pride-brutus.png')
         imageview_from_pathlib_path = toga.ImageView(image_from_pathlib_path)

--- a/examples/imageview/imageview/app.py
+++ b/examples/imageview/imageview/app.py
@@ -11,13 +11,20 @@ class ImageViewApp(toga.App):
         box.style.update(alignment=CENTER)
         box.style.update(direction=COLUMN)
 
-        # image from local path
+        # image from local path (string)
         # load brutus.png from the package
         # We set the style width/height parameters for this one
         image_from_path = toga.Image('resources/pride-brutus.png')
         imageview_from_path = toga.ImageView(image_from_path)
         imageview_from_path.style.update(height=72)
         box.add(imageview_from_path)
+
+        # image from local path (pathlib.Path)
+        # same as the above image, just with a different argument type
+        image_from_pathlib_path = toga.Image(self.paths.app / 'resources/pride-brutus.png')
+        imageview_from_pathlib_path = toga.ImageView(image_from_pathlib_path)
+        imageview_from_pathlib_path.style.update(height=72)
+        box.add(imageview_from_pathlib_path)
 
         # image from remote URL
         # no style parameters - we let Pack determine how to allocate

--- a/src/core/tests/test_image.py
+++ b/src/core/tests/test_image.py
@@ -58,7 +58,6 @@ class ImageTests(TestCase):
         self.assertEqual(self.url_image._impl.interface, self.url_image)
         self.assertActionPerformedWith(self.url_image, 'load image url', url=self.url_path)
 
-
     def test_path_file_image_path(self):
         self.assertEqual(self.path_file_image.path, self.file_path)
 

--- a/src/core/tests/test_image.py
+++ b/src/core/tests/test_image.py
@@ -32,7 +32,7 @@ class ImageTests(TestCase):
             pass
 
         # self.assertEqual(self.path_file_image._impl.interface, self.path_file_image)
-        # self.assertActionPerformedWith(self.path_file_image, 'load image', path=self.file_path)
+        # self.assertActionPerformedWith(self.path_file_image, 'load image file', path=self.file_path)
 
     def test_str_file_image_binding(self):
         # Image is initially unbound
@@ -46,7 +46,18 @@ class ImageTests(TestCase):
             pass
 
         # self.assertEqual(self.str_file_image._impl.interface, self.str_file_image)
-        # self.assertActionPerformedWith(self.str_file_image, 'load image', path=str(self.file_path))
+        # self.assertActionPerformedWith(self.str_file_image, 'load image file', path=self.file_path)
+
+    def test_url_image_binding(self):
+        # Image is initially unbound
+        self.assertIsNone(self.url_image._impl)
+
+        # Bind the image
+        self.url_image.bind(factory=toga_dummy.factory)
+
+        self.assertEqual(self.url_image._impl.interface, self.url_image)
+        self.assertActionPerformedWith(self.url_image, 'load image url', url=self.url_path)
+
 
     def test_path_file_image_path(self):
         self.assertEqual(self.path_file_image.path, self.file_path)

--- a/src/core/tests/test_image.py
+++ b/src/core/tests/test_image.py
@@ -14,22 +14,45 @@ class ImageTests(TestCase):
         toga.App(formal_name='Image Test App',
                  app_id='org.beeware.test_image',
                  factory=toga_dummy.factory)
-        self.path = 'path/to/image.jpg'
-        self.image = toga.Image(path=self.path)
+        self.file_path = Path('path/to/image.jpg')
+        self.url_path = 'http://website.com/image.jpg'
+        self.path_file_image = toga.Image(path=self.file_path)
+        self.str_file_image = toga.Image(path=str(self.file_path))
+        self.url_image = toga.Image(path=self.url_path)
 
-    def test_object_created(self):
+    def test_path_file_image_binding(self):
         # Image is initially unbound
-        self.assertIsNone(self.image._impl)
+        self.assertIsNone(self.path_file_image._impl)
 
         # Bind the image; the file doesn't exist, so it raises an error.
         try:
-            self.image.bind(factory=toga_dummy.factory)
+            self.path_file_image.bind(factory=toga_dummy.factory)
             self.fail('The image should not bind')
         except FileNotFoundError:
             pass
 
-        # self.assertEqual(self.image._impl.interface, self.image)
-        # self.assertActionPerformedWith(self.image, 'load image', path=self.path)
+        # self.assertEqual(self.path_file_image._impl.interface, self.path_file_image)
+        # self.assertActionPerformedWith(self.path_file_image, 'load image', path=self.file_path)
 
-    def test_path(self):
-        self.assertEqual(self.image.path, Path(self.path))
+    def test_str_file_image_binding(self):
+        # Image is initially unbound
+        self.assertIsNone(self.str_file_image._impl)
+
+        # Bind the image; the file doesn't exist, so it raises an error.
+        try:
+            self.str_file_image.bind(factory=toga_dummy.factory)
+            self.fail('The image should not bind')
+        except FileNotFoundError:
+            pass
+
+        # self.assertEqual(self.str_file_image._impl.interface, self.str_file_image)
+        # self.assertActionPerformedWith(self.str_file_image, 'load image', path=str(self.file_path))
+
+    def test_path_file_image_path(self):
+        self.assertEqual(self.path_file_image.path, self.file_path)
+
+    def test_str_file_image_path(self):
+        self.assertEqual(self.str_file_image.path, self.file_path)
+
+    def test_url_image_path(self):
+        self.assertEqual(self.url_image.path, self.url_path)

--- a/src/core/tests/test_image.py
+++ b/src/core/tests/test_image.py
@@ -27,12 +27,12 @@ class ImageTests(TestCase):
         # Bind the image; the file doesn't exist, so it raises an error.
         try:
             self.path_file_image.bind(factory=toga_dummy.factory)
-            self.fail('The image should not bind')
+            self.fail('The image should not bind')  # pragma: nocover
         except FileNotFoundError:
             pass
 
-        # self.assertEqual(self.path_file_image._impl.interface, self.path_file_image)
-        # self.assertActionPerformedWith(self.path_file_image, 'load image file', path=self.file_path)
+        # Image remains unbound
+        self.assertIsNone(self.path_file_image._impl)
 
     def test_str_file_image_binding(self):
         # Image is initially unbound
@@ -41,12 +41,12 @@ class ImageTests(TestCase):
         # Bind the image; the file doesn't exist, so it raises an error.
         try:
             self.str_file_image.bind(factory=toga_dummy.factory)
-            self.fail('The image should not bind')
+            self.fail('The image should not bind')  # pragma: nocover
         except FileNotFoundError:
             pass
 
-        # self.assertEqual(self.str_file_image._impl.interface, self.str_file_image)
-        # self.assertActionPerformedWith(self.str_file_image, 'load image file', path=self.file_path)
+        # Image remains unbound
+        self.assertIsNone(self.str_file_image._impl)
 
     def test_url_image_binding(self):
         # Image is initially unbound
@@ -55,6 +55,7 @@ class ImageTests(TestCase):
         # Bind the image
         self.url_image.bind(factory=toga_dummy.factory)
 
+        # Image is bound correctly
         self.assertEqual(self.url_image._impl.interface, self.url_image)
         self.assertActionPerformedWith(self.url_image, 'load image url', url=self.url_path)
 

--- a/src/core/tests/test_image.py
+++ b/src/core/tests/test_image.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import toga
 import toga_dummy
 from toga_dummy.utils import TestCase
@@ -30,4 +32,4 @@ class ImageTests(TestCase):
         # self.assertActionPerformedWith(self.image, 'load image', path=self.path)
 
     def test_path(self):
-        self.assertEqual(self.image.path, self.path)
+        self.assertEqual(self.image.path, Path(self.path))

--- a/src/core/toga/images.py
+++ b/src/core/toga/images.py
@@ -1,3 +1,6 @@
+import pathlib
+
+
 class Image:
     """
     A representation of graphical content.
@@ -7,7 +10,12 @@ class Image:
         will be interpreted relative to the application module directory.
     """
     def __init__(self, path):
-        self.path = str(path)
+        if isinstance(path, pathlib.Path):
+            self.path = path
+        elif path.startswith('http://') or path.startswith('https://'):
+            self.path = path
+        else:
+            self.path = pathlib.Path(path)
 
         # Resource is late bound.
         self._impl = None
@@ -23,10 +31,8 @@ class Image:
         :returns: The platform implementation
         """
         if self._impl is None:
-            if self.path.startswith('http://') or self.path.startswith('https://'):
-                self._impl = factory.Image(interface=self, url=self.path)
-            else:
-                full_path = factory.paths.app / factory.paths.Path(self.path)
+            if isinstance(self.path, pathlib.Path):
+                full_path = factory.paths.app / self.path
                 if not full_path.exists():
                     raise FileNotFoundError(
                         'Image file {full_path!r} does not exist'.format(
@@ -34,5 +40,7 @@ class Image:
                         )
                     )
                 self._impl = factory.Image(interface=self, path=full_path)
+            else:
+                self._impl = factory.Image(interface=self, url=self.path)
 
         return self._impl

--- a/src/core/toga/images.py
+++ b/src/core/toga/images.py
@@ -7,7 +7,7 @@ class Image:
         will be interpreted relative to the application module directory.
     """
     def __init__(self, path):
-        self.path = path
+        self.path = str(path)
 
         # Resource is late bound.
         self._impl = None


### PR DESCRIPTION
I probably should have announced my intentions to work on this before actually working on it, but ah well.

This pull request aims to implement the functionality described in issue #1294. Currently, `toga.Image` expects to be given a string, and will error if given a `pathlib.Path` object. Under this PR, it will convert the given `path` argument to a string, allowing `pathlib.Path` objects to be used to construct images without having to manually convert to a string.

The `imageview` example has also been modified to add a test case for passing in `pathlib.Path` objects to `toga.Image`.

Potential concerns:
- The PR currently does not do any type checking of the `path` argument, though Toga in general does not do much type checking and it's hard for me to imagine a situation where converting something to a string without type checking could turn out to be a disaster.
- For the example, I just copied the code for the local path and made minor modifications to it. Currently, both image views show the same image `pride-brutus.png`. It might be appropriate to use a different image for the `pathlib.Path` image view.
- I have not updated any documentation, though I'm not sure if there is any documentation to update. The way things are worded in https://toga.readthedocs.io/en/latest/reference/api/resources/images.html, it doesn't actually specify that the path has to be a string.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [?] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
