### PR TITLE
Android: update toolbar after rotation

### DIFF
--- a/src/android/toga_android/libs/android/view.py
+++ b/src/android/toga_android/libs/android/view.py
@@ -7,9 +7,11 @@ MenuItem = JavaClass("android/view/MenuItem")
 MotionEvent = JavaClass("android/view/MotionEvent")
 SubMenu = JavaClass("android/view/SubMenu")
 View = JavaClass("android/view/View")
+ViewGroup = JavaClass("android/view/ViewGroup")
 ViewGroup__LayoutParams = JavaClass("android/view/ViewGroup$LayoutParams")
 View__MeasureSpec = JavaClass("android/view/View$MeasureSpec")
 View__OnTouchListener = JavaInterface("android/view/View$OnTouchListener")
 ViewTreeObserver__OnGlobalLayoutListener = JavaInterface(
     "android/view/ViewTreeObserver$OnGlobalLayoutListener"
 )
+Window = JavaClass("android/view/Window")

--- a/src/android/toga_android/libs/android/widget.py
+++ b/src/android/toga_android/libs/android/widget.py
@@ -11,6 +11,7 @@ CompoundButton__OnCheckedChangeListener = JavaInterface("android/widget/Compound
 DatePickerDialog = JavaClass("android/app/DatePickerDialog")
 DatePickerDialog__OnDateSetListener = JavaInterface("android/app/DatePickerDialog$OnDateSetListener")
 EditText = JavaClass("android/widget/EditText")
+FrameLayout = JavaClass("android/widget/FrameLayout")
 HorizontalScrollView = JavaClass("android/widget/HorizontalScrollView")
 ImageView = JavaClass("android/widget/ImageView")
 ImageView__ScaleType = JavaClass("android/widget/ImageView$ScaleType")

--- a/src/android/toga_android/libs/androidx/appcompat.py
+++ b/src/android/toga_android/libs/androidx/appcompat.py
@@ -1,0 +1,4 @@
+from rubicon.java import JavaClass
+
+
+Toolbar = JavaClass("androidx/appcompat/widget/Toolbar")

--- a/src/android/toga_android/window.py
+++ b/src/android/toga_android/window.py
@@ -1,4 +1,3 @@
-from .libs.android import R__id
 from .libs.android.view import ViewTreeObserver__OnGlobalLayoutListener
 
 
@@ -6,9 +5,9 @@ class AndroidViewport:
     # `content_parent` should be the view that will become the parent of the widget passed to
     # `Window.set_content`. This ensures that the viewport `width` and `height` attributes
     # return the usable area of the app, not including the action bar or status bar.
-    def __init__(self, content_parent):
-        self.content_parent = content_parent
-        self.dpi = content_parent.getContext().getResources().getDisplayMetrics().densityDpi
+    def __init__(self, app):
+        self.app = app
+        self.dpi = app.native.getResources().getDisplayMetrics().densityDpi
         # Toga needs to know how the current DPI compares to the platform default,
         # which is 160: https://developer.android.com/training/multiscreen/screendensities
         self.baseline_dpi = 160
@@ -16,11 +15,11 @@ class AndroidViewport:
 
     @property
     def width(self):
-        return self.content_parent.getWidth()
+        return self.app.content_parent.getWidth()
 
     @property
     def height(self):
-        return self.content_parent.getHeight()
+        return self.app.content_parent.getHeight()
 
 
 class Window(ViewTreeObserver__OnGlobalLayoutListener):
@@ -34,9 +33,8 @@ class Window(ViewTreeObserver__OnGlobalLayoutListener):
 
     def set_app(self, app):
         self.app = app
-        content_parent = self.app.native.findViewById(R__id.content).__global__()
-        self.viewport = AndroidViewport(content_parent)
-        content_parent.getViewTreeObserver().addOnGlobalLayoutListener(self)
+        self.viewport = AndroidViewport(app)
+        app.content_parent.getViewTreeObserver().addOnGlobalLayoutListener(self)
 
     def onGlobalLayout(self):
         """This listener is run after each native layout pass. If any view's size or position has
@@ -51,10 +49,11 @@ class Window(ViewTreeObserver__OnGlobalLayoutListener):
     def set_content(self, widget):
         # Set the widget's viewport to be based on the window's content.
         widget.viewport = self.viewport
-        # Set the app's entire contentView to the desired widget. This means that
-        # calling Window.set_content() on any Window object automatically updates
-        # the app, meaning that every Window object acts as the MainWindow.
-        self.app.native.setContentView(widget.native)
+
+        # Set the activity's entire content to the desired widget. This means that
+        # every Window object currently acts as the MainWindow.
+        self.app.content_parent.removeAllViews()
+        self.app.content_parent.addView(widget.native)
 
         # Attach child widgets to widget as their container.
         for child in widget.interface.children:


### PR DESCRIPTION
This is a follow-up to #1507.

The Android toolbar is supposed to respond to rotation in several ways:
* In landscape mode the toolbar should be slightly narrower.
* In landscape mode the toolbar should have a slightly smaller font size.
* The visble commands should adapt to the available space.

None of this is currently happening, because the built-in toolbar can apparently only change these things in response to an activity restart, which we've disabled. So this PR disables the built-in toolbar and adds one of our own.

In order for this to work, [these lines](https://github.com/beeware/briefcase-android-gradle-template/blob/78b576fa809762b5727fb3b7eb2a5ec12dbbdbfe/%7B%7B%20cookiecutter.safe_formal_name%20%7D%7D/app/src/main/java/org/beeware/android/MainActivity.java#L244-L245) have to be removed from the MainActivity:
```
        LinearLayout layout = new LinearLayout(this);
        this.setContentView(layout);
```
This LinearLayout was never actually used, because Toga's set_content method simply replaced it by calling setContentView again. However, setContentView is one of the things that can trigger the creation of the built-in toolbar, and once it's created there's no way to remove it.

To move this PR out of draft status, the new toolbar needs to be fixed to have the correct theme. This is awkward because Toga doesn't know what the name of the app's R class will be. One possible solution is to look up the theme resource by name, like [this](https://github.com/chaquo/chaquopy/blob/1c85eea61e1faa35ea9cca597895a083c447d31f/demo/app/src/utils/java/com/chaquo/python/utils/Utils.java#L7).

I won't be continuing with this in the near future, so anyone else is welcome to pick it up.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
