### PR TITLE
Refs #1473 - Check for content before updating content size.

### DIFF
--- a/src/iOS/toga_iOS/widgets/scrollcontainer.py
+++ b/src/iOS/toga_iOS/widgets/scrollcontainer.py
@@ -130,7 +130,8 @@ class ScrollContainer(Widget):
             self.update_content_size()
 
     def rehint(self):
-        self.update_content_size()
+        if self.interface.content:
+            self.update_content_size()
 
     def set_on_scroll(self, on_scroll):
         self.interface.factory.not_implemented("ScrollContainer.set_on_scroll()")


### PR DESCRIPTION
On iOS, if a ScrollContainer widget doesn't have any content, the request to rehint the size of the widget will generate an error. This can happen if no content has been assigned to the widget; but it can also happen during app startup, as the first rehint occurs before any content is assigned.

Tested with the scrollcontainer demo app, plus the test case provided on #1473. The Scrollcontainer demo app raises errors associated with the use of Commands, but that doesn't stop the app from running.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
