### PR TITLE
Add explicit casts to float in Winforms canvas.

### DIFF
--- a/src/winforms/toga_winforms/widgets/canvas.py
+++ b/src/winforms/toga_winforms/widgets/canvas.py
@@ -273,10 +273,12 @@ class Canvas(Box):
         draw_context.matrix.Rotate(math.degrees(radians))
 
     def scale(self, sx, sy, draw_context, *args, **kwargs):
-        draw_context.matrix.Scale(sx, sy)
+        # Workaround for Pythonnet#1833 requires an explicit cast to float
+        draw_context.matrix.Scale(float(sx), float(sy))
 
     def translate(self, tx, ty, draw_context, *args, **kwargs):
-        draw_context.matrix.Translate(tx, ty)
+        # Workaround for Pythonnet#1833 requires an explicit cast to float
+        draw_context.matrix.Translate(float(tx), float(ty))
 
     def reset_transform(self, draw_context, *args, **kwargs):
         draw_context.matrix = None


### PR DESCRIPTION
pythonnet/pythonnet#1833 reveals a problem passing float-like numpy types to Winforms APIs. This causes problems with toga-chart, as it uses numpy types internally.

Adding explicit casts to float avoids these problems. Eventually, we'll be able to remove these casts; but for now it doesn't hurt.

Fixes beeware/toga-chart#16.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
