### PR TITLE
Pack layout system: fixing two bugs

### DIFF
--- a/src/core/tests/style/test_pack.py
+++ b/src/core/tests/style/test_pack.py
@@ -148,51 +148,13 @@ class PackLayoutTests(TestCase):
             ]}
         )
 
-        # HiDPI normal size
+        # HiDPI Normal size
         root.style.layout(root, TestViewport(640, 480, dpi=144))
         self.assertLayout(
             root,
             (640, 180),
             {'origin': (0, 0), 'content': (640, 180), 'children': [
                 {'origin': (75, 75), 'content': (490, 30)}
-            ]}
-        )
-
-    def test_tutorial_0_vertical(self):
-        root = TestNode(
-            'app', style=Pack(direction=COLUMN), children=[
-                # TestNode('button', style=Pack(flex=1), size=(30, at_least(120))),
-                TestNode('button', style=Pack(flex=1, padding=50), size=(30, at_least(120))),
-            ]
-        )
-
-        # Minimum size
-        root.style.layout(root, TestViewport(0, 0, dpi=96))
-        self.assertLayout(
-            root,
-            (130, 220),
-            {'origin': (0, 0), 'content': (130, 220), 'children': [
-                {'origin': (50, 50), 'content': (30, 120)}
-            ]}
-        )
-
-        # Normal size
-        root.style.layout(root, TestViewport(480, 640, dpi=96))
-        self.assertLayout(
-            root,
-            (130, 640),
-            {'origin': (0, 0), 'content': (130, 640), 'children': [
-                {'origin': (50, 50), 'content': (30, 540)}
-            ]}
-        )
-
-        # HiDPI normal size
-        root.style.layout(root, TestViewport(480, 640, dpi=144))
-        self.assertLayout(
-            root,
-            (180, 640),
-            {'origin': (0, 0), 'content': (180, 640), 'children': [
-                {'origin': (75, 75), 'content': (30, 490)}
             ]}
         )
 
@@ -412,87 +374,14 @@ class PackLayoutTests(TestCase):
             ]}
         )
 
-    def test_alignment_with_padding(self):
+    def test_row_alignment_top(self):
         root = TestNode(
-            'app', style=Pack(), children=[
-                TestNode('row_e_box', style=Pack(direction=COLUMN), children=[
-                    TestNode('top_alignment_row_box', style=Pack(direction=ROW, alignment=TOP), children=[
-                        TestNode('row_top_stretched', style=Pack(
-                            height=120, width=30, padding_top=0, padding_bottom=0)),
-                        TestNode('row_top_padded_0', style=Pack(
-                            height=30, width=30, padding_top=0, padding_bottom=0)),
-                        TestNode('row_top_padded_1', style=Pack(
-                            height=30, width=30, padding_top=30, padding_bottom=0)),
-                        TestNode('row_top_padded_2', style=Pack(
-                            height=30, width=30, padding_top=0, padding_bottom=30)),
-                        TestNode('row_top_padded_3', style=Pack(
-                            height=30, width=30, padding_top=30, padding_bottom=30)),
-                    ]),
-                    TestNode('center_alignment_row_box', style=Pack(direction=ROW, alignment=CENTER), children=[
-                        TestNode('row_center_stretched', style=Pack(
-                            height=120, width=30, padding_top=0, padding_bottom=0)),
-                        TestNode('row_center_padded_0', style=Pack(
-                            height=30, width=30, padding_top=0, padding_bottom=0)),
-                        TestNode('row_center_padded_1', style=Pack(
-                            height=30, width=30, padding_top=30, padding_bottom=0)),
-                        TestNode('row_center_padded_2', style=Pack(
-                            height=30, width=30, padding_top=0, padding_bottom=30)),
-                        TestNode('row_center_padded_3', style=Pack(
-                            height=30, width=30, padding_top=30, padding_bottom=30)),
-                    ]),
-                    TestNode('bottom_alignment_row_box', style=Pack(direction=ROW, alignment=BOTTOM), children=[
-                        TestNode('row_bottom_stretched', style=Pack(
-                            height=120, width=30, padding_top=0, padding_bottom=0)),
-                        TestNode('row_bottom_padded_0', style=Pack(
-                            height=30, width=30, padding_top=0, padding_bottom=0)),
-                        TestNode('row_bottom_padded_1', style=Pack(
-                            height=30, width=30, padding_top=30, padding_bottom=0)),
-                        TestNode('row_bottom_padded_2', style=Pack(
-                            height=30, width=30, padding_top=0, padding_bottom=30)),
-                        TestNode('row_bottom_padded_3', style=Pack(
-                            height=30, width=30, padding_top=30, padding_bottom=30)),
-                    ]),
+            'root', style=Pack(direction=ROW, alignment=TOP, width=300), children=[
+                TestNode('space_filler', style=Pack(width=100, height=540)),
+                TestNode('container', style=Pack(direction=COLUMN, padding_top=110, padding_bottom=120), children=[
+                    TestNode('widget_a', style=Pack(height=30, padding_top=32, padding_bottom=34)),
+                    TestNode('widget_b', style=Pack(height=36, padding_top=38, padding_bottom=40)),
                 ]),
-                TestNode('spacer_between', style=Pack(width=30)),
-                TestNode('column_e_box', style=Pack(direction=ROW), children=[
-                    TestNode('left_alignment_column_box', style=Pack(direction=COLUMN, alignment=LEFT), children=[
-                        TestNode('column_left_stretched', style=Pack(
-                            width=120, height=30, padding_left=0, padding_right=0)),
-                        TestNode('column_left_padded_0', style=Pack(
-                            width=30, height=30, padding_left=0, padding_right=0)),
-                        TestNode('column_left_padded_1', style=Pack(
-                            width=30, height=30, padding_left=30, padding_right=0)),
-                        TestNode('column_left_padded_2', style=Pack(
-                            width=30, height=30, padding_left=0, padding_right=30)),
-                        TestNode('column_left_padded_3', style=Pack(
-                            width=30, height=30, padding_left=30, padding_right=30)),
-                    ]),
-                    TestNode('center_alignment_column_box', style=Pack(direction=COLUMN, alignment=CENTER), children=[
-                        TestNode('column_center_stretched', style=Pack(
-                            width=120, height=30, padding_left=0, padding_right=0)),
-                        TestNode('column_center_padded_0', style=Pack(
-                            width=30, height=30, padding_left=0, padding_right=0)),
-                        TestNode('column_center_padded_1', style=Pack(
-                            width=30, height=30, padding_left=30, padding_right=0)),
-                        TestNode('column_center_padded_2', style=Pack(
-                            width=30, height=30, padding_left=0, padding_right=30)),
-                        TestNode('column_center_padded_3', style=Pack(
-                            width=30, height=30, padding_left=30, padding_right=30)),
-                    ]),
-                    TestNode('right_alignment_column_box', style=Pack(direction=COLUMN, alignment=RIGHT), children=[
-                        TestNode('column_right_stretched', style=Pack(
-                            width=120, height=30, padding_left=0, padding_right=0)),
-                        TestNode('column_right_padded_0', style=Pack(
-                            width=30, height=30, padding_left=0, padding_right=0)),
-                        TestNode('column_right_padded_1', style=Pack(
-                            width=30, height=30, padding_left=30, padding_right=0)),
-                        TestNode('column_right_padded_2', style=Pack(
-                            width=30, height=30, padding_left=0, padding_right=30)),
-                        TestNode('column_right_padded_3', style=Pack(
-                            width=30, height=30, padding_left=30, padding_right=30)),
-                    ]),
-                ]),
-                TestNode('spacer_after', style=Pack(width=30)),
             ]
         )
 
@@ -500,56 +389,13 @@ class PackLayoutTests(TestCase):
         root.style.layout(root, TestViewport(0, 0, dpi=96))
         self.assertLayout(
             root,
-            (570, 360),
-            {'origin': (0, 0), 'content': (570, 360), 'children': [
-                {'origin': (0, 0), 'content': (150, 360), 'children': [
-                    {'origin': (0, 0), 'content': (150, 120), 'children': [
-                        {'origin': (0, 0), 'content': (30, 120)},
-                        {'origin': (30, 0), 'content': (30, 30)},
-                        {'origin': (60, 30), 'content': (30, 30)},
-                        {'origin': (90, 0), 'content': (30, 30)},
-                        {'origin': (120, 30), 'content': (30, 30)},
-                    ]},
-                    {'origin': (0, 120), 'content': (150, 120), 'children': [
-                        {'origin': (0, 120), 'content': (30, 120)},
-                        {'origin': (30, 165), 'content': (30, 30)},
-                        {'origin': (60, 180), 'content': (30, 30)},
-                        {'origin': (90, 150), 'content': (30, 30)},
-                        {'origin': (120, 165), 'content': (30, 30)},
-                    ]},
-                    {'origin': (0, 240), 'content': (150, 120), 'children': [
-                        {'origin': (0, 240), 'content': (30, 120)},
-                        {'origin': (30, 330), 'content': (30, 30)},
-                        {'origin': (60, 330), 'content': (30, 30)},
-                        {'origin': (90, 300), 'content': (30, 30)},
-                        {'origin': (120, 300), 'content': (30, 30)},
-                    ]},
+            (300, 540),
+            {'origin': (0, 0), 'content': (300, 540), 'children': [
+                {'origin': (0, 0), 'content': (100, 540)},
+                {'origin': (100, 110), 'content': (200, 210), 'children': [
+                    {'origin': (100, 142), 'content': (200, 30)},
+                    {'origin': (100, 244), 'content': (200, 36)},
                 ]},
-                {'origin': (150, 0), 'content': (30, 0)},
-                {'origin': (180, 0), 'content': (360, 150), 'children': [
-                    {'origin': (180, 0), 'content': (120, 150), 'children': [
-                        {'origin': (180, 0), 'content': (120, 30)},
-                        {'origin': (180, 30), 'content': (30, 30)},
-                        {'origin': (210, 60), 'content': (30, 30)},
-                        {'origin': (180, 90), 'content': (30, 30)},
-                        {'origin': (210, 120), 'content': (30, 30)},
-                    ]},
-                    {'origin': (300, 0), 'content': (120, 150), 'children': [
-                        {'origin': (300, 0), 'content': (120, 30)},
-                        {'origin': (345, 30), 'content': (30, 30)},
-                        {'origin': (360, 60), 'content': (30, 30)},
-                        {'origin': (330, 90), 'content': (30, 30)},
-                        {'origin': (345, 120), 'content': (30, 30)},
-                    ]},
-                    {'origin': (420, 0), 'content': (120, 150), 'children': [
-                        {'origin': (420, 0), 'content': (120, 30)},
-                        {'origin': (510, 30), 'content': (30, 30)},
-                        {'origin': (510, 60), 'content': (30, 30)},
-                        {'origin': (480, 90), 'content': (30, 30)},
-                        {'origin': (480, 120), 'content': (30, 30)},
-                    ]},
-                ]},
-                {'origin': (540, 0), 'content': (30, 0)},
             ]}
         )
 
@@ -557,56 +403,13 @@ class PackLayoutTests(TestCase):
         root.style.layout(root, TestViewport(640, 480, dpi=96))
         self.assertLayout(
             root,
-            (570, 480),
-            {'origin': (0, 0), 'content': (570, 480), 'children': [
-                {'origin': (0, 0), 'content': (150, 360), 'children': [
-                    {'origin': (0, 0), 'content': (150, 120), 'children': [
-                        {'origin': (0, 0), 'content': (30, 120)},
-                        {'origin': (30, 0), 'content': (30, 30)},
-                        {'origin': (60, 30), 'content': (30, 30)},
-                        {'origin': (90, 0), 'content': (30, 30)},
-                        {'origin': (120, 30), 'content': (30, 30)},
-                    ]},
-                    {'origin': (0, 120), 'content': (150, 120), 'children': [
-                        {'origin': (0, 120), 'content': (30, 120)},
-                        {'origin': (30, 165), 'content': (30, 30)},
-                        {'origin': (60, 180), 'content': (30, 30)},
-                        {'origin': (90, 150), 'content': (30, 30)},
-                        {'origin': (120, 165), 'content': (30, 30)},
-                    ]},
-                    {'origin': (0, 240), 'content': (150, 120), 'children': [
-                        {'origin': (0, 240), 'content': (30, 120)},
-                        {'origin': (30, 330), 'content': (30, 30)},
-                        {'origin': (60, 330), 'content': (30, 30)},
-                        {'origin': (90, 300), 'content': (30, 30)},
-                        {'origin': (120, 300), 'content': (30, 30)},
-                    ]},
+            (300, 540),
+            {'origin': (0, 0), 'content': (300, 540), 'children': [
+                {'origin': (0, 0), 'content': (100, 540)},
+                {'origin': (100, 110), 'content': (200, 210), 'children': [
+                    {'origin': (100, 142), 'content': (200, 30)},
+                    {'origin': (100, 244), 'content': (200, 36)},
                 ]},
-                {'origin': (150, 0), 'content': (30, 480)},
-                {'origin': (180, 0), 'content': (360, 150), 'children': [
-                    {'origin': (180, 0), 'content': (120, 150), 'children': [
-                        {'origin': (180, 0), 'content': (120, 30)},
-                        {'origin': (180, 30), 'content': (30, 30)},
-                        {'origin': (210, 60), 'content': (30, 30)},
-                        {'origin': (180, 90), 'content': (30, 30)},
-                        {'origin': (210, 120), 'content': (30, 30)},
-                    ]},
-                    {'origin': (300, 0), 'content': (120, 150), 'children': [
-                        {'origin': (300, 0), 'content': (120, 30)},
-                        {'origin': (345, 30), 'content': (30, 30)},
-                        {'origin': (360, 60), 'content': (30, 30)},
-                        {'origin': (330, 90), 'content': (30, 30)},
-                        {'origin': (345, 120), 'content': (30, 30)},
-                    ]},
-                    {'origin': (420, 0), 'content': (120, 150), 'children': [
-                        {'origin': (420, 0), 'content': (120, 30)},
-                        {'origin': (510, 30), 'content': (30, 30)},
-                        {'origin': (510, 60), 'content': (30, 30)},
-                        {'origin': (480, 90), 'content': (30, 30)},
-                        {'origin': (480, 120), 'content': (30, 30)},
-                    ]},
-                ]},
-                {'origin': (540, 0), 'content': (30, 480)},
             ]}
         )
 
@@ -614,55 +417,711 @@ class PackLayoutTests(TestCase):
         root.style.layout(root, TestViewport(640, 480, dpi=144))
         self.assertLayout(
             root,
-            (855, 540),
-            {'origin': (0, 0), 'content': (855, 540), 'children': [
-                {'origin': (0, 0), 'content': (225, 540), 'children': [
-                    {'origin': (0, 0), 'content': (225, 180), 'children': [
-                        {'origin': (0, 0), 'content': (45, 180)},
-                        {'origin': (45, 0), 'content': (45, 45)},
-                        {'origin': (90, 45), 'content': (45, 45)},
-                        {'origin': (135, 0), 'content': (45, 45)},
-                        {'origin': (180, 45), 'content': (45, 45)},
-                    ]},
-                    {'origin': (0, 180), 'content': (225, 180), 'children': [
-                        {'origin': (0, 180), 'content': (45, 180)},
-                        {'origin': (45, 247), 'content': (45, 45)},
-                        {'origin': (90, 270), 'content': (45, 45)},
-                        {'origin': (135, 225), 'content': (45, 45)},
-                        {'origin': (180, 247), 'content': (45, 45)},
-                    ]},
-                    {'origin': (0, 360), 'content': (225, 180), 'children': [
-                        {'origin': (0, 360), 'content': (45, 180)},
-                        {'origin': (45, 495), 'content': (45, 45)},
-                        {'origin': (90, 495), 'content': (45, 45)},
-                        {'origin': (135, 450), 'content': (45, 45)},
-                        {'origin': (180, 450), 'content': (45, 45)},
-                    ]},
-                ]},
-                {'origin': (225, 0), 'content': (45, 480)},
-                {'origin': (270, 0), 'content': (540, 225), 'children': [
-                    {'origin': (270, 0), 'content': (180, 225), 'children': [
-                        {'origin': (270, 0), 'content': (180, 45)},
-                        {'origin': (270, 45), 'content': (45, 45)},
-                        {'origin': (315, 90), 'content': (45, 45)},
-                        {'origin': (270, 135), 'content': (45, 45)},
-                        {'origin': (315, 180), 'content': (45, 45)},
-                    ]},
-                    {'origin': (450, 0), 'content': (180, 225), 'children': [
-                        {'origin': (450, 0), 'content': (180, 45)},
-                        {'origin': (517, 45), 'content': (45, 45)},
-                        {'origin': (540, 90), 'content': (45, 45)},
-                        {'origin': (495, 135), 'content': (45, 45)},
-                        {'origin': (517, 180), 'content': (45, 45)},
-                    ]},
-                    {'origin': (630, 0), 'content': (180, 225), 'children': [
-                        {'origin': (630, 0), 'content': (180, 45)},
-                        {'origin': (765, 45), 'content': (45, 45)},
-                        {'origin': (765, 90), 'content': (45, 45)},
-                        {'origin': (720, 135), 'content': (45, 45)},
-                        {'origin': (720, 180), 'content': (45, 45)},
-                    ]},
-                ]},
-                {'origin': (810, 0), 'content': (45, 480)},
+            (450, 810),
+            {'origin': (0, 0), 'content': (450, 810), 'children': [
+                {'origin': (0, 0), 'content': (150, 810)},
+                {'origin': (150, 165), 'content': (300, 315), 'children': [
+                    {'origin': (150, 213), 'content': (300, 45)},
+                    {'origin': (150, 366), 'content': (300, 54)},
+                ]}
             ]}
+        )
+
+    def test_row_alignment_center(self):
+        root = TestNode(
+            'root', style=Pack(direction=ROW, alignment=CENTER, width=300), children=[
+                TestNode('space_filler', style=Pack(width=100, height=540)),
+                TestNode('container', style=Pack(direction=COLUMN, padding_top=110, padding_bottom=120), children=[
+                    TestNode('widget_a', style=Pack(height=30, padding_top=32, padding_bottom=34)),
+                    TestNode('widget_b', style=Pack(height=36, padding_top=38, padding_bottom=40)),
+                ]),
+            ]
+        )
+
+        # Minimum size
+        root.style.layout(root, TestViewport(0, 0, dpi=96))
+        self.assertLayout(
+            root,
+            (300, 540),
+            {'origin': (0, 0), 'content': (300, 540), 'children': [
+                {'origin': (0, 0), 'content': (100, 540)},
+                {'origin': (100, 160), 'content': (200, 210), 'children': [
+                    {'origin': (100, 192), 'content': (200, 30)},
+                    {'origin': (100, 294), 'content': (200, 36)},
+                ]},
+            ]}
+        )
+
+        # Normal size
+        root.style.layout(root, TestViewport(640, 480, dpi=96))
+        self.assertLayout(
+            root,
+            (300, 540),
+            {'origin': (0, 0), 'content': (300, 540), 'children': [
+                {'origin': (0, 0), 'content': (100, 540)},
+                {'origin': (100, 160), 'content': (200, 210), 'children': [
+                    {'origin': (100, 192), 'content': (200, 30)},
+                    {'origin': (100, 294), 'content': (200, 36)},
+                ]},
+            ]}
+        )
+
+        # HiDPI Normal size
+        root.style.layout(root, TestViewport(640, 480, dpi=144))
+        self.assertLayout(
+            root,
+            (450, 810),
+            {'origin': (0, 0), 'content': (450, 810), 'children': [
+                {'origin': (0, 0), 'content': (150, 810)},
+                {'origin': (150, 240), 'content': (300, 315), 'children': [
+                    {'origin': (150, 288), 'content': (300, 45)},
+                    {'origin': (150, 441), 'content': (300, 54)},
+                ]}
+            ]}
+        )
+
+    def test_row_alignment_bottom(self):
+        root = TestNode(
+            'root', style=Pack(direction=ROW, alignment=BOTTOM, width=300), children=[
+                TestNode('space_filler', style=Pack(width=100, height=540)),
+                TestNode('container', style=Pack(direction=COLUMN, padding_top=110, padding_bottom=120), children=[
+                    TestNode('widget_a', style=Pack(height=30, padding_top=32, padding_bottom=34)),
+                    TestNode('widget_b', style=Pack(height=36, padding_top=38, padding_bottom=40)),
+                ]),
+            ]
+        )
+
+        # Minimum size
+        root.style.layout(root, TestViewport(0, 0, dpi=96))
+        self.assertLayout(
+            root,
+            (300, 540),
+            {'origin': (0, 0), 'content': (300, 540), 'children': [
+                {'origin': (0, 0), 'content': (100, 540)},
+                {'origin': (100, 210), 'content': (200, 210), 'children': [
+                    {'origin': (100, 242), 'content': (200, 30)},
+                    {'origin': (100, 344), 'content': (200, 36)},
+                ]},
+            ]}
+        )
+
+        # Normal size
+        root.style.layout(root, TestViewport(640, 480, dpi=96))
+        self.assertLayout(
+            root,
+            (300, 540),
+            {'origin': (0, 0), 'content': (300, 540), 'children': [
+                {'origin': (0, 0), 'content': (100, 540)},
+                {'origin': (100, 210), 'content': (200, 210), 'children': [
+                    {'origin': (100, 242), 'content': (200, 30)},
+                    {'origin': (100, 344), 'content': (200, 36)},
+                ]},
+            ]}
+        )
+
+        # HiDPI Normal size
+        root.style.layout(root, TestViewport(640, 480, dpi=144))
+        self.assertLayout(
+            root,
+            (450, 810),
+            {'origin': (0, 0), 'content': (450, 810), 'children': [
+                {'origin': (0, 0), 'content': (150, 810)},
+                {'origin': (150, 315), 'content': (300, 315), 'children': [
+                    {'origin': (150, 363), 'content': (300, 45)},
+                    {'origin': (150, 516), 'content': (300, 54)},
+                ]}
+            ]}
+        )
+
+    def test_column_alignment_left(self):
+        root = TestNode(
+            'root', style=Pack(direction=COLUMN, alignment=LEFT, height=300), children=[
+                TestNode('space_filler', style=Pack(width=540, height=100)),
+                TestNode('container', style=Pack(direction=ROW, padding_left=110, padding_right=120), children=[
+                    TestNode('widget_a', style=Pack(width=30, padding_left=32, padding_right=34)),
+                    TestNode('widget_b', style=Pack(width=36, padding_left=38, padding_right=40)),
+                ]),
+            ]
+        )
+
+        # Minimum size
+        root.style.layout(root, TestViewport(0, 0, dpi=96))
+        self.assertLayout(
+            root,
+            (540, 300),
+            {'origin': (0, 0), 'content': (540, 300), 'children': [
+                {'origin': (0, 0), 'content': (540, 100)},
+                {'origin': (110, 100), 'content': (210, 200), 'children': [
+                    {'origin': (142, 100), 'content': (30, 200)},
+                    {'origin': (244, 100), 'content': (36, 200)},
+                ]},
+            ]}
+        )
+
+        # Normal size
+        root.style.layout(root, TestViewport(640, 480, dpi=96))
+        self.assertLayout(
+            root,
+            (540, 300),
+            {'origin': (0, 0), 'content': (540, 300), 'children': [
+                {'origin': (0, 0), 'content': (540, 100)},
+                {'origin': (110, 100), 'content': (210, 200), 'children': [
+                    {'origin': (142, 100), 'content': (30, 200)},
+                    {'origin': (244, 100), 'content': (36, 200)},
+                ]},
+            ]}
+        )
+
+        # HiDPI Normal size
+        root.style.layout(root, TestViewport(640, 480, dpi=144))
+        self.assertLayout(
+            root,
+            (810, 450),
+            {'origin': (0, 0), 'content': (810, 450), 'children': [
+                {'origin': (0, 0), 'content': (810, 150)},
+                {'origin': (165, 150), 'content': (315, 300), 'children': [
+                    {'origin': (213, 150), 'content': (45, 300)},
+                    {'origin': (366, 150), 'content': (54, 300)},
+                ]}
+            ]}
+        )
+
+    def test_column_alignment_center(self):
+        root = TestNode(
+            'root', style=Pack(direction=COLUMN, alignment=CENTER, height=300), children=[
+                TestNode('space_filler', style=Pack(width=540, height=100)),
+                TestNode('container', style=Pack(direction=ROW, padding_left=110, padding_right=120), children=[
+                    TestNode('widget_a', style=Pack(width=30, padding_left=32, padding_right=34)),
+                    TestNode('widget_b', style=Pack(width=36, padding_left=38, padding_right=40)),
+                ]),
+            ]
+        )
+
+        # Minimum size
+        root.style.layout(root, TestViewport(0, 0, dpi=96))
+        self.assertLayout(
+            root,
+            (540, 300),
+            {'origin': (0, 0), 'content': (540, 300), 'children': [
+                {'origin': (0, 0), 'content': (540, 100)},
+                {'origin': (160, 100), 'content': (210, 200), 'children': [
+                    {'origin': (192, 100), 'content': (30, 200)},
+                    {'origin': (294, 100), 'content': (36, 200)},
+                ]},
+            ]}
+        )
+
+        # Normal size
+        root.style.layout(root, TestViewport(640, 480, dpi=96))
+        self.assertLayout(
+            root,
+            (540, 300),
+            {'origin': (0, 0), 'content': (540, 300), 'children': [
+                {'origin': (0, 0), 'content': (540, 100)},
+                {'origin': (160, 100), 'content': (210, 200), 'children': [
+                    {'origin': (192, 100), 'content': (30, 200)},
+                    {'origin': (294, 100), 'content': (36, 200)},
+                ]},
+            ]}
+        )
+
+        # HiDPI Normal size
+        root.style.layout(root, TestViewport(640, 480, dpi=144))
+        self.assertLayout(
+            root,
+            (810, 450),
+            {'origin': (0, 0), 'content': (810, 450), 'children': [
+                {'origin': (0, 0), 'content': (810, 150)},
+                {'origin': (240, 150), 'content': (315, 300), 'children': [
+                    {'origin': (288, 150), 'content': (45, 300)},
+                    {'origin': (441, 150), 'content': (54, 300)},
+                ]}
+            ]}
+        )
+
+    def test_column_alignment_right(self):
+        root = TestNode(
+            'root', style=Pack(direction=COLUMN, alignment=RIGHT, height=300), children=[
+                TestNode('space_filler', style=Pack(width=540, height=100)),
+                TestNode('container', style=Pack(direction=ROW, padding_left=110, padding_right=120), children=[
+                    TestNode('widget_a', style=Pack(width=30, padding_left=32, padding_right=34)),
+                    TestNode('widget_b', style=Pack(width=36, padding_left=38, padding_right=40)),
+                ]),
+            ]
+        )
+
+        # Minimum size
+        root.style.layout(root, TestViewport(0, 0, dpi=96))
+        self.assertLayout(
+            root,
+            (540, 300),
+            {'origin': (0, 0), 'content': (540, 300), 'children': [
+                {'origin': (0, 0), 'content': (540, 100)},
+                {'origin': (210, 100), 'content': (210, 200), 'children': [
+                    {'origin': (242, 100), 'content': (30, 200)},
+                    {'origin': (344, 100), 'content': (36, 200)},
+                ]},
+            ]}
+        )
+
+        # Normal size
+        root.style.layout(root, TestViewport(640, 480, dpi=96))
+        self.assertLayout(
+            root,
+            (540, 300),
+            {'origin': (0, 0), 'content': (540, 300), 'children': [
+                {'origin': (0, 0), 'content': (540, 100)},
+                {'origin': (210, 100), 'content': (210, 200), 'children': [
+                    {'origin': (242, 100), 'content': (30, 200)},
+                    {'origin': (344, 100), 'content': (36, 200)},
+                ]},
+            ]}
+        )
+
+        # HiDPI Normal size
+        root.style.layout(root, TestViewport(640, 480, dpi=144))
+        self.assertLayout(
+            root,
+            (810, 450),
+            {'origin': (0, 0), 'content': (810, 450), 'children': [
+                {'origin': (0, 0), 'content': (810, 150)},
+                {'origin': (315, 150), 'content': (315, 300), 'children': [
+                    {'origin': (363, 150), 'content': (45, 300)},
+                    {'origin': (516, 150), 'content': (54, 300)},
+                ]}
+            ]}
+        )
+
+    def test_row_alignment_no_padding(self):
+        root = TestNode(
+            'root', style=Pack(direction=ROW, alignment=CENTER, width=300), children=[
+                TestNode('space_filler', style=Pack(width=100, height=540)),
+                TestNode('widget', style=Pack(height=440)),
+            ]
+        )
+
+        # Minimum size
+        root.style.layout(root, TestViewport(0, 0, dpi=96))
+        self.assertLayout(
+            root,
+            (300, 540),
+            {'origin': (0, 0), 'content': (300, 540), 'children': [
+                {'origin': (0, 0), 'content': (100, 540)},
+                {'origin': (100, 50), 'content': (200, 440)},
+            ]}
+        )
+
+        # Normal size
+        root.style.layout(root, TestViewport(640, 480, dpi=96))
+        self.assertLayout(
+            root,
+            (300, 540),
+            {'origin': (0, 0), 'content': (300, 540), 'children': [
+                {'origin': (0, 0), 'content': (100, 540)},
+                {'origin': (100, 50), 'content': (200, 440)},
+            ]}
+        )
+
+        # HiDPI Normal size
+        root.style.layout(root, TestViewport(640, 480, dpi=144))
+        self.assertLayout(
+            root,
+            (450, 810),
+            {'origin': (0, 0), 'content': (450, 810), 'children': [
+                {'origin': (0, 0), 'content': (150, 810)},
+                {'origin': (150, 75), 'content': (300, 660)}
+            ]}
+        )
+
+    def test_column_alignment_no_padding(self):
+        root = TestNode(
+            'root', style=Pack(direction=COLUMN, alignment=CENTER, height=300), children=[
+                TestNode('space_filler', style=Pack(width=540, height=100)),
+                TestNode('widget', style=Pack(width=440)),
+            ]
+        )
+
+        # Minimum size
+        root.style.layout(root, TestViewport(0, 0, dpi=96))
+        self.assertLayout(
+            root,
+            (540, 300),
+            {'origin': (0, 0), 'content': (540, 300), 'children': [
+                {'origin': (0, 0), 'content': (540, 100)},
+                {'origin': (50, 100), 'content': (440, 200)},
+            ]}
+        )
+
+        # Normal size
+        root.style.layout(root, TestViewport(640, 480, dpi=96))
+        self.assertLayout(
+            root,
+            (540, 300),
+            {'origin': (0, 0), 'content': (540, 300), 'children': [
+                {'origin': (0, 0), 'content': (540, 100)},
+                {'origin': (50, 100), 'content': (440, 200)},
+            ]}
+        )
+
+        # HiDPI Normal size
+        root.style.layout(root, TestViewport(640, 480, dpi=144))
+        self.assertLayout(
+            root,
+            (810, 450),
+            {'origin': (0, 0), 'content': (810, 450), 'children': [
+                {'origin': (0, 0), 'content': (810, 150)},
+                {'origin': (75, 150), 'content': (660, 300)}
+            ]}
+        )
+
+    def test_row_alignment_row_box(self):
+        root = TestNode(
+            'root', style=Pack(direction=ROW, alignment=CENTER), children=[
+                TestNode('space_filler', style=Pack(width=100, height=430)),
+                TestNode('container', style=Pack(direction=ROW, padding_top=110, padding_bottom=120), children=[
+                    TestNode('widget_a', style=Pack(width=30, height=100, padding_left=32, padding_right=34)),
+                    TestNode('widget_b', style=Pack(width=36, height=100, padding_left=38, padding_right=40)),
+                ]),
+            ]
+        )
+
+        # Minimum size
+        root.style.layout(root, TestViewport(0, 0, dpi=96))
+        self.assertLayout(
+            root,
+            (310, 430),
+            {'origin': (0, 0), 'content': (310, 430), 'children': [
+                {'origin': (0, 0), 'content': (100, 430)},
+                {'origin': (100, 160), 'content': (210, 100), 'children': [
+                    {'origin': (132, 160), 'content': (30, 100)},
+                    {'origin': (234, 160), 'content': (36, 100)},
+                ]},
+            ]}
+        )
+
+        # Normal size
+        root.style.layout(root, TestViewport(640, 480, dpi=96))
+        self.assertLayout(
+            root,
+            (310, 430),
+            {'origin': (0, 0), 'content': (310, 430), 'children': [
+                {'origin': (0, 0), 'content': (100, 430)},
+                {'origin': (100, 160), 'content': (210, 100), 'children': [
+                    {'origin': (132, 160), 'content': (30, 100)},
+                    {'origin': (234, 160), 'content': (36, 100)},
+                ]},
+            ]}
+        )
+
+        # HiDPI Normal size
+        root.style.layout(root, TestViewport(640, 480, dpi=144))
+        self.assertLayout(
+            root,
+            (465, 645),
+            {'origin': (0, 0), 'content': (465, 645), 'children': [
+                {'origin': (0, 0), 'content': (150, 645)},
+                {'origin': (150, 240), 'content': (315, 150), 'children': [
+                    {'origin': (198, 240), 'content': (45, 150)},
+                    {'origin': (351, 240), 'content': (54, 150)},
+                ]},
+            ]}
+        )
+
+    def test_column_alignment_column_box(self):
+        root = TestNode(
+            'root', style=Pack(direction=COLUMN, alignment=CENTER), children=[
+                TestNode('space_filler', style=Pack(width=430, height=100)),
+                TestNode('container', style=Pack(direction=COLUMN, padding_left=110, padding_right=120), children=[
+                    TestNode('widget_a', style=Pack(width=100, height=30, padding_top=32, padding_bottom=34)),
+                    TestNode('widget_b', style=Pack(width=100, height=36, padding_top=38, padding_bottom=40)),
+                ]),
+            ]
+        )
+
+        # Minimum size
+        root.style.layout(root, TestViewport(0, 0, dpi=96))
+        self.assertLayout(
+            root,
+            (430, 310),
+            {'origin': (0, 0), 'content': (430, 310), 'children': [
+                {'origin': (0, 0), 'content': (430, 100)},
+                {'origin': (160, 100), 'content': (100, 210), 'children': [
+                    {'origin': (160, 132), 'content': (100, 30)},
+                    {'origin': (160, 234), 'content': (100, 36)},
+                ]},
+            ]}
+        )
+
+        # Normal size
+        root.style.layout(root, TestViewport(640, 480, dpi=96))
+        self.assertLayout(
+            root,
+            (430, 310),
+            {'origin': (0, 0), 'content': (430, 310), 'children': [
+                {'origin': (0, 0), 'content': (430, 100)},
+                {'origin': (160, 100), 'content': (100, 210), 'children': [
+                    {'origin': (160, 132), 'content': (100, 30)},
+                    {'origin': (160, 234), 'content': (100, 36)},
+                ]},
+            ]}
+        )
+
+        # HiDPI Normal size
+        root.style.layout(root, TestViewport(640, 480, dpi=144))
+        self.assertLayout(
+            root,
+            (645, 465),
+            {'origin': (0, 0), 'content': (645, 465), 'children': [
+                {'origin': (0, 0), 'content': (645, 150)},
+                {'origin': (240, 150), 'content': (150, 315), 'children': [
+                    {'origin': (240, 198), 'content': (150, 45)},
+                    {'origin': (240, 351), 'content': (150, 54)},
+                ]},
+            ]}
+        )
+
+    def test_rtl_row_box_child_layout(self):
+        root = TestNode(
+            'container', style=Pack(text_direction=RTL, direction=ROW), children=[
+                TestNode('widget_a', style=Pack(width=30, height=100, padding_left=32, padding_right=34)),
+                TestNode('widget_b', style=Pack(width=36, height=100, padding_left=38, padding_right=40)),
+            ]
+        )
+
+        # Minimum size
+        root.style.layout(root, TestViewport(0, 0, dpi=96))
+        self.assertLayout(
+            root,
+            (210, 100),
+            {'origin': (0, 0), 'content': (210, 100), 'children': [
+                {'origin': (146, 0), 'content': (30, 100)},
+                {'origin': (38, 0), 'content': (36, 100)},
+            ]},
+        )
+
+        # Normal size
+        root.style.layout(root, TestViewport(640, 480, dpi=96))
+        self.assertLayout(
+            root,
+            (210, 100),
+            {'origin': (0, 0), 'content': (210, 100), 'children': [
+                {'origin': (146, 0), 'content': (30, 100)},
+                {'origin': (38, 0), 'content': (36, 100)},
+            ]},
+        )
+
+        # HiDPI Normal size
+        root.style.layout(root, TestViewport(640, 480, dpi=144))
+        self.assertLayout(
+            root,
+            (315, 150),
+            {'origin': (0, 0), 'content': (315, 150), 'children': [
+                {'origin': (219, 0), 'content': (45, 150)},
+                {'origin': (57, 0), 'content': (54, 150)},
+            ]},
+        )
+
+    def test_rtl_column_box_child_layout(self):
+        root = TestNode(
+            'container', style=Pack(text_direction=RTL, direction=COLUMN), children=[
+                TestNode('widget_a', style=Pack(width=100, height=30, padding_top=32, padding_bottom=34)),
+                TestNode('widget_b', style=Pack(width=100, height=36, padding_top=38, padding_bottom=40)),
+            ]
+        )
+
+        # Minimum size
+        root.style.layout(root, TestViewport(0, 0, dpi=96))
+        self.assertLayout(
+            root,
+            (100, 210),
+            {'origin': (0, 0), 'content': (100, 210), 'children': [
+                {'origin': (0, 32), 'content': (100, 30)},
+                {'origin': (0, 134), 'content': (100, 36)},
+            ]},
+        )
+
+        # Normal size
+        root.style.layout(root, TestViewport(640, 480, dpi=96))
+        self.assertLayout(
+            root,
+            (100, 210),
+            {'origin': (0, 0), 'content': (100, 210), 'children': [
+                {'origin': (0, 32), 'content': (100, 30)},
+                {'origin': (0, 134), 'content': (100, 36)},
+            ]},
+        )
+
+        # HiDPI Normal size
+        root.style.layout(root, TestViewport(640, 480, dpi=144))
+        self.assertLayout(
+            root,
+            (150, 315),
+            {'origin': (0, 0), 'content': (150, 315), 'children': [
+                {'origin': (0, 48), 'content': (150, 45)},
+                {'origin': (0, 201), 'content': (150, 54)},
+            ]},
+        )
+
+    def test_rtl_alignment_top(self):
+        root = TestNode(
+            'root', style=Pack(text_direction=RTL, direction=ROW, alignment=TOP), children=[
+                TestNode('space_filler', style=Pack(width=30, height=100)),
+                TestNode('widget', style=Pack(width=30, height=30)),
+            ]
+        )
+
+        # Minimum size
+        root.style.layout(root, TestViewport(0, 0, dpi=96))
+        self.assertLayout(
+            root,
+            (60, 100),
+            {'origin': (0, 0), 'content': (60, 100), 'children': [
+                {'origin': (30, 0), 'content': (30, 100)},
+                {'origin': (0, 0), 'content': (30, 30)},
+            ]},
+        )
+
+        # Normal size
+        root.style.layout(root, TestViewport(640, 480, dpi=96))
+        self.assertLayout(
+            root,
+            (60, 100),
+            {'origin': (0, 0), 'content': (60, 100), 'children': [
+                {'origin': (30, 0), 'content': (30, 100)},
+                {'origin': (0, 0), 'content': (30, 30)},
+            ]},
+        )
+
+        # HiDPI Normal size
+        root.style.layout(root, TestViewport(640, 480, dpi=144))
+        self.assertLayout(
+            root,
+            (90, 150),
+            {'origin': (0, 0), 'content': (90, 150), 'children': [
+                {'origin': (45, 0), 'content': (45, 150)},
+                {'origin': (0, 0), 'content': (45, 45)},
+            ]},
+        )
+
+    def test_rtl_alignment_bottom(self):
+        root = TestNode(
+            'root', style=Pack(text_direction=RTL, direction=ROW, alignment=BOTTOM), children=[
+                TestNode('space_filler', style=Pack(width=30, height=100)),
+                TestNode('widget', style=Pack(width=30, height=30)),
+            ]
+        )
+
+        # Minimum size
+        root.style.layout(root, TestViewport(0, 0, dpi=96))
+        self.assertLayout(
+            root,
+            (60, 100),
+            {'origin': (0, 0), 'content': (60, 100), 'children': [
+                {'origin': (30, 0), 'content': (30, 100)},
+                {'origin': (0, 70), 'content': (30, 30)},
+            ]},
+        )
+
+        # Normal size
+        root.style.layout(root, TestViewport(640, 480, dpi=96))
+        self.assertLayout(
+            root,
+            (60, 100),
+            {'origin': (0, 0), 'content': (60, 100), 'children': [
+                {'origin': (30, 0), 'content': (30, 100)},
+                {'origin': (0, 70), 'content': (30, 30)},
+            ]},
+        )
+
+        # HiDPI Normal size
+        root.style.layout(root, TestViewport(640, 480, dpi=144))
+        self.assertLayout(
+            root,
+            (90, 150),
+            {'origin': (0, 0), 'content': (90, 150), 'children': [
+                {'origin': (45, 0), 'content': (45, 150)},
+                {'origin': (0, 105), 'content': (45, 45)},
+            ]},
+        )
+
+    def test_rtl_alignment_left(self):
+        root = TestNode(
+            'root', style=Pack(text_direction=RTL, direction=COLUMN, alignment=LEFT), children=[
+                TestNode('space_filler', style=Pack(width=100, height=30)),
+                TestNode('widget', style=Pack(width=30, height=30)),
+            ]
+        )
+
+        # Minimum size
+        root.style.layout(root, TestViewport(0, 0, dpi=96))
+        self.assertLayout(
+            root,
+            (100, 60),
+            {'origin': (0, 0), 'content': (100, 60), 'children': [
+                {'origin': (0, 0), 'content': (100, 30)},
+                {'origin': (0, 30), 'content': (30, 30)},
+            ]},
+        )
+
+        # Normal size
+        root.style.layout(root, TestViewport(640, 480, dpi=96))
+        self.assertLayout(
+            root,
+            (100, 60),
+            {'origin': (0, 0), 'content': (100, 60), 'children': [
+                {'origin': (0, 0), 'content': (100, 30)},
+                {'origin': (0, 30), 'content': (30, 30)},
+            ]},
+        )
+
+        # HiDPI Normal size
+        root.style.layout(root, TestViewport(640, 480, dpi=144))
+        self.assertLayout(
+            root,
+            (150, 90),
+            {'origin': (0, 0), 'content': (150, 90), 'children': [
+                {'origin': (0, 0), 'content': (150, 45)},
+                {'origin': (0, 45), 'content': (45, 45)},
+            ]},
+        )
+
+    def test_rtl_alignment_right(self):
+        root = TestNode(
+            'root', style=Pack(text_direction=RTL, direction=COLUMN, alignment=RIGHT), children=[
+                TestNode('space_filler', style=Pack(width=100, height=30)),
+                TestNode('widget', style=Pack(width=30, height=30)),
+            ]
+        )
+
+        # Minimum size
+        root.style.layout(root, TestViewport(0, 0, dpi=96))
+        self.assertLayout(
+            root,
+            (100, 60),
+            {'origin': (0, 0), 'content': (100, 60), 'children': [
+                {'origin': (0, 0), 'content': (100, 30)},
+                {'origin': (70, 30), 'content': (30, 30)},
+            ]},
+        )
+
+        # Normal size
+        root.style.layout(root, TestViewport(640, 480, dpi=96))
+        self.assertLayout(
+            root,
+            (100, 60),
+            {'origin': (0, 0), 'content': (100, 60), 'children': [
+                {'origin': (0, 0), 'content': (100, 30)},
+                {'origin': (70, 30), 'content': (30, 30)},
+            ]},
+        )
+
+        # HiDPI Normal size
+        root.style.layout(root, TestViewport(640, 480, dpi=144))
+        self.assertLayout(
+            root,
+            (150, 90),
+            {'origin': (0, 0), 'content': (150, 90), 'children': [
+                {'origin': (0, 0), 'content': (150, 45)},
+                {'origin': (105, 45), 'content': (45, 45)},
+            ]},
         )

--- a/src/core/tests/style/test_pack.py
+++ b/src/core/tests/style/test_pack.py
@@ -7,7 +7,7 @@ from travertino.size import at_least
 from toga.colors import rgb
 from toga.fonts import Font
 from toga.style.applicator import TogaApplicator
-from toga.style.pack import CENTER, COLUMN, HIDDEN, LEFT, RIGHT, ROW, RTL, Pack
+from toga.style.pack import BOTTOM, CENTER, COLUMN, HIDDEN, LEFT, RIGHT, ROW, RTL, Pack, TOP
 
 
 class TestNode(Node):
@@ -409,5 +409,260 @@ class PackLayoutTests(TestCase):
                     {'origin': (7, 458), 'content': (572, 15)},
                     {'origin': (593, 458), 'content': (40, 10)},
                 ]},
+            ]}
+        )
+
+    def test_alignment_with_padding(self):
+        root = TestNode(
+            'app', style=Pack(), children=[
+                TestNode('row_e_box', style=Pack(direction=COLUMN), children=[
+                    TestNode('top_alignment_row_box', style=Pack(direction=ROW, alignment=TOP), children=[
+                        TestNode('row_top_stretched', style=Pack(
+                            height=120, width=30, padding_top=0, padding_bottom=0)),
+                        TestNode('row_top_padded_0', style=Pack(
+                            height=30, width=30, padding_top=0, padding_bottom=0)),
+                        TestNode('row_top_padded_1', style=Pack(
+                            height=30, width=30, padding_top=30, padding_bottom=0)),
+                        TestNode('row_top_padded_2', style=Pack(
+                            height=30, width=30, padding_top=0, padding_bottom=30)),
+                        TestNode('row_top_padded_3', style=Pack(
+                            height=30, width=30, padding_top=30, padding_bottom=30)),
+                    ]),
+                    TestNode('center_alignment_row_box', style=Pack(direction=ROW, alignment=CENTER), children=[
+                        TestNode('row_center_stretched', style=Pack(
+                            height=120, width=30, padding_top=0, padding_bottom=0)),
+                        TestNode('row_center_padded_0', style=Pack(
+                            height=30, width=30, padding_top=0, padding_bottom=0)),
+                        TestNode('row_center_padded_1', style=Pack(
+                            height=30, width=30, padding_top=30, padding_bottom=0)),
+                        TestNode('row_center_padded_2', style=Pack(
+                            height=30, width=30, padding_top=0, padding_bottom=30)),
+                        TestNode('row_center_padded_3', style=Pack(
+                            height=30, width=30, padding_top=30, padding_bottom=30)),
+                    ]),
+                    TestNode('bottom_alignment_row_box', style=Pack(direction=ROW, alignment=BOTTOM), children=[
+                        TestNode('row_bottom_stretched', style=Pack(
+                            height=120, width=30, padding_top=0, padding_bottom=0)),
+                        TestNode('row_bottom_padded_0', style=Pack(
+                            height=30, width=30, padding_top=0, padding_bottom=0)),
+                        TestNode('row_bottom_padded_1', style=Pack(
+                            height=30, width=30, padding_top=30, padding_bottom=0)),
+                        TestNode('row_bottom_padded_2', style=Pack(
+                            height=30, width=30, padding_top=0, padding_bottom=30)),
+                        TestNode('row_bottom_padded_3', style=Pack(
+                            height=30, width=30, padding_top=30, padding_bottom=30)),
+                    ]),
+                ]),
+                TestNode('spacer_between', style=Pack(width=30)),
+                TestNode('column_e_box', style=Pack(direction=ROW), children=[
+                    TestNode('left_alignment_column_box', style=Pack(direction=COLUMN, alignment=LEFT), children=[
+                        TestNode('column_left_stretched', style=Pack(
+                            width=120, height=30, padding_left=0, padding_right=0)),
+                        TestNode('column_left_padded_0', style=Pack(
+                            width=30, height=30, padding_left=0, padding_right=0)),
+                        TestNode('column_left_padded_1', style=Pack(
+                            width=30, height=30, padding_left=30, padding_right=0)),
+                        TestNode('column_left_padded_2', style=Pack(
+                            width=30, height=30, padding_left=0, padding_right=30)),
+                        TestNode('column_left_padded_3', style=Pack(
+                            width=30, height=30, padding_left=30, padding_right=30)),
+                    ]),
+                    TestNode('center_alignment_column_box', style=Pack(direction=COLUMN, alignment=CENTER), children=[
+                        TestNode('column_center_stretched', style=Pack(
+                            width=120, height=30, padding_left=0, padding_right=0)),
+                        TestNode('column_center_padded_0', style=Pack(
+                            width=30, height=30, padding_left=0, padding_right=0)),
+                        TestNode('column_center_padded_1', style=Pack(
+                            width=30, height=30, padding_left=30, padding_right=0)),
+                        TestNode('column_center_padded_2', style=Pack(
+                            width=30, height=30, padding_left=0, padding_right=30)),
+                        TestNode('column_center_padded_3', style=Pack(
+                            width=30, height=30, padding_left=30, padding_right=30)),
+                    ]),
+                    TestNode('right_alignment_column_box', style=Pack(direction=COLUMN, alignment=RIGHT), children=[
+                        TestNode('column_right_stretched', style=Pack(
+                            width=120, height=30, padding_left=0, padding_right=0)),
+                        TestNode('column_right_padded_0', style=Pack(
+                            width=30, height=30, padding_left=0, padding_right=0)),
+                        TestNode('column_right_padded_1', style=Pack(
+                            width=30, height=30, padding_left=30, padding_right=0)),
+                        TestNode('column_right_padded_2', style=Pack(
+                            width=30, height=30, padding_left=0, padding_right=30)),
+                        TestNode('column_right_padded_3', style=Pack(
+                            width=30, height=30, padding_left=30, padding_right=30)),
+                    ]),
+                ]),
+                TestNode('spacer_after', style=Pack(width=30)),
+            ]
+        )
+
+        # Minimum size
+        root.style.layout(root, TestViewport(0, 0, dpi=96))
+        self.assertLayout(
+            root,
+            (570, 360),
+            {'origin': (0, 0), 'content': (570, 360), 'children': [
+                {'origin': (0, 0), 'content': (150, 360), 'children': [
+                    {'origin': (0, 0), 'content': (150, 120), 'children': [
+                        {'origin': (0, 0), 'content': (30, 120)},
+                        {'origin': (30, 0), 'content': (30, 30)},
+                        {'origin': (60, 30), 'content': (30, 30)},
+                        {'origin': (90, 0), 'content': (30, 30)},
+                        {'origin': (120, 30), 'content': (30, 30)},
+                    ]},
+                    {'origin': (0, 120), 'content': (150, 120), 'children': [
+                        {'origin': (0, 120), 'content': (30, 120)},
+                        {'origin': (30, 165), 'content': (30, 30)},
+                        {'origin': (60, 180), 'content': (30, 30)},
+                        {'origin': (90, 150), 'content': (30, 30)},
+                        {'origin': (120, 165), 'content': (30, 30)},
+                    ]},
+                    {'origin': (0, 240), 'content': (150, 120), 'children': [
+                        {'origin': (0, 240), 'content': (30, 120)},
+                        {'origin': (30, 330), 'content': (30, 30)},
+                        {'origin': (60, 330), 'content': (30, 30)},
+                        {'origin': (90, 300), 'content': (30, 30)},
+                        {'origin': (120, 300), 'content': (30, 30)},
+                    ]},
+                ]},
+                {'origin': (150, 0), 'content': (30, 0)},
+                {'origin': (180, 0), 'content': (360, 150), 'children': [
+                    {'origin': (180, 0), 'content': (120, 150), 'children': [
+                        {'origin': (180, 0), 'content': (120, 30)},
+                        {'origin': (180, 30), 'content': (30, 30)},
+                        {'origin': (210, 60), 'content': (30, 30)},
+                        {'origin': (180, 90), 'content': (30, 30)},
+                        {'origin': (210, 120), 'content': (30, 30)},
+                    ]},
+                    {'origin': (300, 0), 'content': (120, 150), 'children': [
+                        {'origin': (300, 0), 'content': (120, 30)},
+                        {'origin': (345, 30), 'content': (30, 30)},
+                        {'origin': (360, 60), 'content': (30, 30)},
+                        {'origin': (330, 90), 'content': (30, 30)},
+                        {'origin': (345, 120), 'content': (30, 30)},
+                    ]},
+                    {'origin': (420, 0), 'content': (120, 150), 'children': [
+                        {'origin': (420, 0), 'content': (120, 30)},
+                        {'origin': (510, 30), 'content': (30, 30)},
+                        {'origin': (510, 60), 'content': (30, 30)},
+                        {'origin': (480, 90), 'content': (30, 30)},
+                        {'origin': (480, 120), 'content': (30, 30)},
+                    ]},
+                ]},
+                {'origin': (540, 0), 'content': (30, 0)},
+            ]}
+        )
+
+        # Normal size
+        root.style.layout(root, TestViewport(640, 480, dpi=96))
+        self.assertLayout(
+            root,
+            (570, 480),
+            {'origin': (0, 0), 'content': (570, 480), 'children': [
+                {'origin': (0, 0), 'content': (150, 360), 'children': [
+                    {'origin': (0, 0), 'content': (150, 120), 'children': [
+                        {'origin': (0, 0), 'content': (30, 120)},
+                        {'origin': (30, 0), 'content': (30, 30)},
+                        {'origin': (60, 30), 'content': (30, 30)},
+                        {'origin': (90, 0), 'content': (30, 30)},
+                        {'origin': (120, 30), 'content': (30, 30)},
+                    ]},
+                    {'origin': (0, 120), 'content': (150, 120), 'children': [
+                        {'origin': (0, 120), 'content': (30, 120)},
+                        {'origin': (30, 165), 'content': (30, 30)},
+                        {'origin': (60, 180), 'content': (30, 30)},
+                        {'origin': (90, 150), 'content': (30, 30)},
+                        {'origin': (120, 165), 'content': (30, 30)},
+                    ]},
+                    {'origin': (0, 240), 'content': (150, 120), 'children': [
+                        {'origin': (0, 240), 'content': (30, 120)},
+                        {'origin': (30, 330), 'content': (30, 30)},
+                        {'origin': (60, 330), 'content': (30, 30)},
+                        {'origin': (90, 300), 'content': (30, 30)},
+                        {'origin': (120, 300), 'content': (30, 30)},
+                    ]},
+                ]},
+                {'origin': (150, 0), 'content': (30, 480)},
+                {'origin': (180, 0), 'content': (360, 150), 'children': [
+                    {'origin': (180, 0), 'content': (120, 150), 'children': [
+                        {'origin': (180, 0), 'content': (120, 30)},
+                        {'origin': (180, 30), 'content': (30, 30)},
+                        {'origin': (210, 60), 'content': (30, 30)},
+                        {'origin': (180, 90), 'content': (30, 30)},
+                        {'origin': (210, 120), 'content': (30, 30)},
+                    ]},
+                    {'origin': (300, 0), 'content': (120, 150), 'children': [
+                        {'origin': (300, 0), 'content': (120, 30)},
+                        {'origin': (345, 30), 'content': (30, 30)},
+                        {'origin': (360, 60), 'content': (30, 30)},
+                        {'origin': (330, 90), 'content': (30, 30)},
+                        {'origin': (345, 120), 'content': (30, 30)},
+                    ]},
+                    {'origin': (420, 0), 'content': (120, 150), 'children': [
+                        {'origin': (420, 0), 'content': (120, 30)},
+                        {'origin': (510, 30), 'content': (30, 30)},
+                        {'origin': (510, 60), 'content': (30, 30)},
+                        {'origin': (480, 90), 'content': (30, 30)},
+                        {'origin': (480, 120), 'content': (30, 30)},
+                    ]},
+                ]},
+                {'origin': (540, 0), 'content': (30, 480)},
+            ]}
+        )
+
+        # HiDPI Normal size
+        root.style.layout(root, TestViewport(640, 480, dpi=144))
+        self.assertLayout(
+            root,
+            (855, 540),
+            {'origin': (0, 0), 'content': (855, 540), 'children': [
+                {'origin': (0, 0), 'content': (225, 540), 'children': [
+                    {'origin': (0, 0), 'content': (225, 180), 'children': [
+                        {'origin': (0, 0), 'content': (45, 180)},
+                        {'origin': (45, 0), 'content': (45, 45)},
+                        {'origin': (90, 45), 'content': (45, 45)},
+                        {'origin': (135, 0), 'content': (45, 45)},
+                        {'origin': (180, 45), 'content': (45, 45)},
+                    ]},
+                    {'origin': (0, 180), 'content': (225, 180), 'children': [
+                        {'origin': (0, 180), 'content': (45, 180)},
+                        {'origin': (45, 247), 'content': (45, 45)},
+                        {'origin': (90, 270), 'content': (45, 45)},
+                        {'origin': (135, 225), 'content': (45, 45)},
+                        {'origin': (180, 247), 'content': (45, 45)},
+                    ]},
+                    {'origin': (0, 360), 'content': (225, 180), 'children': [
+                        {'origin': (0, 360), 'content': (45, 180)},
+                        {'origin': (45, 495), 'content': (45, 45)},
+                        {'origin': (90, 495), 'content': (45, 45)},
+                        {'origin': (135, 450), 'content': (45, 45)},
+                        {'origin': (180, 450), 'content': (45, 45)},
+                    ]},
+                ]},
+                {'origin': (225, 0), 'content': (45, 480)},
+                {'origin': (270, 0), 'content': (540, 225), 'children': [
+                    {'origin': (270, 0), 'content': (180, 225), 'children': [
+                        {'origin': (270, 0), 'content': (180, 45)},
+                        {'origin': (270, 45), 'content': (45, 45)},
+                        {'origin': (315, 90), 'content': (45, 45)},
+                        {'origin': (270, 135), 'content': (45, 45)},
+                        {'origin': (315, 180), 'content': (45, 45)},
+                    ]},
+                    {'origin': (450, 0), 'content': (180, 225), 'children': [
+                        {'origin': (450, 0), 'content': (180, 45)},
+                        {'origin': (517, 45), 'content': (45, 45)},
+                        {'origin': (540, 90), 'content': (45, 45)},
+                        {'origin': (495, 135), 'content': (45, 45)},
+                        {'origin': (517, 180), 'content': (45, 45)},
+                    ]},
+                    {'origin': (630, 0), 'content': (180, 225), 'children': [
+                        {'origin': (630, 0), 'content': (180, 45)},
+                        {'origin': (765, 45), 'content': (45, 45)},
+                        {'origin': (765, 90), 'content': (45, 45)},
+                        {'origin': (720, 135), 'content': (45, 45)},
+                        {'origin': (720, 180), 'content': (45, 45)},
+                    ]},
+                ]},
+                {'origin': (810, 0), 'content': (45, 480)},
             ]}
         )

--- a/src/core/tests/style/test_pack.py
+++ b/src/core/tests/style/test_pack.py
@@ -158,6 +158,44 @@ class PackLayoutTests(TestCase):
             ]}
         )
 
+    def test_tutorial_0_vertical(self):
+        root = TestNode(
+            'app', style=Pack(direction=COLUMN), children=[
+                # TestNode('button', style=Pack(flex=1), size=(30, at_least(120))),
+                TestNode('button', style=Pack(flex=1, padding=50), size=(30, at_least(120))),
+            ]
+        )
+
+        # Minimum size
+        root.style.layout(root, TestViewport(0, 0, dpi=96))
+        self.assertLayout(
+            root,
+            (130, 220),
+            {'origin': (0, 0), 'content': (130, 220), 'children': [
+                {'origin': (50, 50), 'content': (30, 120)}
+            ]}
+        )
+
+        # Normal size
+        root.style.layout(root, TestViewport(480, 640, dpi=96))
+        self.assertLayout(
+            root,
+            (130, 640),
+            {'origin': (0, 0), 'content': (130, 640), 'children': [
+                {'origin': (50, 50), 'content': (30, 540)}
+            ]}
+        )
+
+        # HiDPI normal size
+        root.style.layout(root, TestViewport(480, 640, dpi=144))
+        self.assertLayout(
+            root,
+            (180, 640),
+            {'origin': (0, 0), 'content': (180, 640), 'children': [
+                {'origin': (75, 75), 'content': (30, 490)}
+            ]}
+        )
+
     def test_tutorial_0_high_baseline_dpi(self):
         root = TestNode(
             'app', style=Pack(), children=[

--- a/src/core/toga/style/pack.py
+++ b/src/core/toga/style/pack.py
@@ -324,9 +324,8 @@ class Pack(BaseStyle):
 
         # Pass 4: set vertical position of each child.
         for child in node.children:
-            extra = (
-                height
-                - child.layout.content_height
+            extra = height - (
+                child.layout.content_height
                 + scale(child.style.padding_top)
                 + scale(child.style.padding_bottom)
             )
@@ -462,14 +461,13 @@ class Pack(BaseStyle):
 
         # Pass 4: set horizontal position of each child.
         for child in node.children:
-            extra = (
-                width
-                - child.layout.content_width
+            extra = width - (
+                child.layout.content_width
                 + scale(child.style.padding_left)
                 + scale(child.style.padding_right)
             )
             # self._debug("row extra width", extra)
-            if self.alignment is LEFT:
+            if self.alignment is RIGHT:
                 child.layout.content_left = extra + scale(child.style.padding_left)
                 # self._debug("align to right", child, child.layout.content_left)
             elif self.alignment is CENTER:


### PR DESCRIPTION
This pull request aims to fix the two bugs in the layout code that I pointed out on Discord: alignment taking padding into account incorrectly, and left alignment and right alignment being switched from how they should be.

More work is likely needed regarding tests for this behaviour, so this pull request is not yet ready for review.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
