### PR TITLE
Improve coverage of OptionContainer

### DIFF
--- a/examples/optioncontainer/optioncontainer/app.py
+++ b/examples/optioncontainer/optioncontainer/app.py
@@ -29,6 +29,11 @@ class ExampleOptionContainerApp(toga.App):
         self.optioncontainer.add('New Option', toga.Box())
         self._refresh_select()
 
+    def on_insert_option(self, button):
+        index = self.optioncontainer.current_tab.index
+        self.optioncontainer.content.insert(index, 'New Option', toga.Box())
+        self._refresh_select()
+
     def on_enable_option(self, button):
         index = int(self.select_option.value)
         try:
@@ -39,6 +44,13 @@ class ExampleOptionContainerApp(toga.App):
     def on_change_option_title(self, button):
         index = int(self.select_option.value)
         self.optioncontainer.content[index].label = self.input_change_title.value
+
+    def on_activate_option(self, button):
+        try:
+            index = int(self.select_option.value)
+            self.optioncontainer.current_tab = index
+        except toga.OptionContainer.OptionException as e:
+            self.main_window.info_dialog('Oops', str(e))
 
     def on_remove_option(self, button):
         try:
@@ -68,13 +80,18 @@ class ExampleOptionContainerApp(toga.App):
         # styles
         style_flex = Pack(flex=1, padding=5)
         style_row = Pack(direction=ROW, flex=1)
-        style_select = Pack(direction=ROW, flex=1, padding_right=10)
+        style_select = Pack(direction=ROW, padding_right=10)
         style_col = Pack(direction=COLUMN, flex=1)
 
         # select
         label_select = toga.Label('Select an Option position:', style=style_flex)
-        self.select_option = toga.Selection(style=style_flex)
+        self.select_option = toga.Selection(style=Pack(padding=5, width=50))
         # buttons
+        btn_activate = toga.Button(
+            'Activate',
+            on_press=self.on_activate_option,
+            style=style_flex
+        )
         btn_remove = toga.Button(
             'Remove',
             on_press=self.on_remove_option,
@@ -99,7 +116,7 @@ class ExampleOptionContainerApp(toga.App):
         )
         box_actions_col1 = toga.Box(
             style=style_row,
-            children=[btn_remove, btn_enabled]
+            children=[btn_activate, btn_remove, btn_enabled]
         )
         box_actions_col2 = toga.Box(
             style=style_row,
@@ -121,10 +138,13 @@ class ExampleOptionContainerApp(toga.App):
         )
         self._create_options()
 
-        btn_add = toga.Button('Add Option', on_press=self.on_add_option)
+        btn_add = toga.Button('Append new option', style=Pack(padding=5), on_press=self.on_add_option)
+        btn_insert = toga.Button(
+            'Insert new option before active option', style=Pack(padding=5), on_press=self.on_insert_option
+        )
         box_general_actions = toga.Box(
             style=Pack(padding_bottom=10),
-            children=[btn_add]
+            children=[btn_add, btn_insert]
         )
 
         # Outermost box

--- a/examples/optioncontainer/optioncontainer/app.py
+++ b/examples/optioncontainer/optioncontainer/app.py
@@ -79,9 +79,6 @@ class ExampleOptionContainerApp(toga.App):
 
         # styles
         style_flex = Pack(flex=1, padding=5)
-        style_row = Pack(direction=ROW, flex=1)
-        style_select = Pack(direction=ROW, padding_right=10)
-        style_col = Pack(direction=COLUMN, flex=1)
 
         # select
         label_select = toga.Label('Select an Option position:', style=style_flex)
@@ -111,24 +108,16 @@ class ExampleOptionContainerApp(toga.App):
         )
 
         box_select = toga.Box(
-            style=style_select,
+            style=Pack(direction=ROW, padding_right=10, width=200),
             children=[label_select, self.select_option]
         )
-        box_actions_col1 = toga.Box(
-            style=style_row,
+        box_actions_1 = toga.Box(
+            style=Pack(direction=ROW, flex=1),
             children=[btn_activate, btn_remove, btn_enabled]
         )
-        box_actions_col2 = toga.Box(
-            style=style_row,
+        box_actions_2 = toga.Box(
+            style=Pack(direction=ROW, flex=1),
             children=[self.input_change_title, btn_change_title]
-        )
-        box_actions = toga.Box(
-            style=style_col,
-            children=[box_actions_col1, box_actions_col2]
-        )
-        box_container_actions = toga.Box(
-            style=style_row,
-            children=[box_select, box_actions]
         )
 
         self.selected_label = toga.Label("")
@@ -151,7 +140,9 @@ class ExampleOptionContainerApp(toga.App):
         outer_box = toga.Box(
             children=[
                 box_general_actions,
-                box_container_actions,
+                box_select,
+                box_actions_1,
+                box_actions_2,
                 self.selected_label,
                 self.optioncontainer,
             ],

--- a/src/cocoa/toga_cocoa/widgets/optioncontainer.py
+++ b/src/cocoa/toga_cocoa/widgets/optioncontainer.py
@@ -44,7 +44,7 @@ class OptionContainer(Widget):
         # Add the layout constraints
         self.add_constraints()
 
-    def add_content(self, label, widget):
+    def add_content(self, label, widget, index=None):
         """ Adds a new option to the option container.
 
         Args:
@@ -65,7 +65,10 @@ class OptionContainer(Widget):
         widget.native.translatesAutoresizingMaskIntoConstraints = True
 
         item.view = widget.native
-        self.native.addTabViewItem(item)
+        if index is None:
+            self.native.addTabViewItem(item)
+        else:
+            self.native.insertTabViewItem(item, atIndex=index)
 
     def remove_content(self, index):
         tabview = self.native.tabViewItemAtIndex(index)

--- a/src/cocoa/toga_cocoa/widgets/optioncontainer.py
+++ b/src/cocoa/toga_cocoa/widgets/optioncontainer.py
@@ -44,10 +44,11 @@ class OptionContainer(Widget):
         # Add the layout constraints
         self.add_constraints()
 
-    def add_content(self, label, widget, index):
+    def add_content(self, index, label, widget):
         """ Adds a new option to the option container.
 
         Args:
+            index: The index in the tab list where the tab should be added.
             label (str): The label for the option container
             widget: The widget or widget tree that belongs to the label.
         """

--- a/src/cocoa/toga_cocoa/widgets/optioncontainer.py
+++ b/src/cocoa/toga_cocoa/widgets/optioncontainer.py
@@ -44,7 +44,7 @@ class OptionContainer(Widget):
         # Add the layout constraints
         self.add_constraints()
 
-    def add_content(self, label, widget, index=None):
+    def add_content(self, label, widget, index):
         """ Adds a new option to the option container.
 
         Args:
@@ -65,10 +65,7 @@ class OptionContainer(Widget):
         widget.native.translatesAutoresizingMaskIntoConstraints = True
 
         item.view = widget.native
-        if index is None:
-            self.native.addTabViewItem(item)
-        else:
-            self.native.insertTabViewItem(item, atIndex=index)
+        self.native.insertTabViewItem(item, atIndex=index)
 
     def remove_content(self, index):
         tabview = self.native.tabViewItemAtIndex(index)

--- a/src/core/tests/widgets/test_optioncontainer.py
+++ b/src/core/tests/widgets/test_optioncontainer.py
@@ -191,3 +191,21 @@ class OptionContainerTests(TestCase):
         self.op_container.window = window
         for item in self.op_container.content:
             self.assertEqual(item._content.window, window)
+
+    def test_set_tab_title(self):
+        new_label = 'New Title'
+        self.op_container.content[0].label = new_label
+        self.assertEqual(self.op_container.content[0].label, new_label)
+
+    def test_insert_tab(self):
+        self.op_container.content.insert(0, label=self.label2, widget=self.widget2)
+        self.assertEqual(self.op_container.content[0].label, self.label2)
+
+    def test_swap_tabs(self):
+        self.add_widgets()
+        tab1 = self.op_container.content[1]
+        tab2 = self.op_container.content[2]
+        self.op_container.content[1] = tab2
+        self.op_container.content[2] = tab1
+        self.assertEqual(self.op_container.content[1], tab2)
+        self.assertEqual(self.op_container.content[2], tab1)

--- a/src/core/tests/widgets/test_optioncontainer.py
+++ b/src/core/tests/widgets/test_optioncontainer.py
@@ -201,15 +201,6 @@ class OptionContainerTests(TestCase):
         self.op_container.insert(0, label=self.label2, widget=self.widget2)
         self.assertEqual(self.op_container.content[0].label, self.label2)
 
-    def test_swap_tabs(self):
-        self.add_widgets()
-        tab1 = self.op_container.content[1]
-        tab2 = self.op_container.content[2]
-        self.op_container.content[1] = tab2
-        self.op_container.content[2] = tab1
-        self.assertEqual(self.op_container.content[1], tab2)
-        self.assertEqual(self.op_container.content[2], tab1)
-
     def test_set_app(self):
         app = mock.Mock()
         self.op_container.app = app

--- a/src/core/tests/widgets/test_optioncontainer.py
+++ b/src/core/tests/widgets/test_optioncontainer.py
@@ -198,7 +198,7 @@ class OptionContainerTests(TestCase):
         self.assertEqual(self.op_container.content[0].label, new_label)
 
     def test_insert_tab(self):
-        self.op_container.content.insert(0, label=self.label2, widget=self.widget2)
+        self.op_container.insert(0, label=self.label2, widget=self.widget2)
         self.assertEqual(self.op_container.content[0].label, self.label2)
 
     def test_swap_tabs(self):

--- a/src/core/toga/widgets/optioncontainer.py
+++ b/src/core/toga/widgets/optioncontainer.py
@@ -122,7 +122,7 @@ class OptionList:
 
         # Add the content to the implementation.
         # This will cause the native implementation to be created.
-        self.interface._impl.add_content(label, widget._impl, index=index)
+        self.interface._impl.add_content(label, widget._impl, index)
 
         # The option now exists on the implementation;
         # finalize the display properties that can't be resolved until the

--- a/src/core/toga/widgets/optioncontainer.py
+++ b/src/core/toga/widgets/optioncontainer.py
@@ -112,13 +112,13 @@ class OptionList:
 
     def _insert(self, index, label, widget, enabled=True):
         # Create an interface wrapper for the option.
-        option = OptionItem(self.interface, widget, index)
+        item = OptionItem(self.interface, widget, index)
 
         # Add the option to the list maintained on the interface,
         # and increment the index of all items after the one that was added.
-        self._options.insert(index, option)
-        for opt in self._options[index + 1:]:
-            opt._index += 1
+        self._options.insert(index, item)
+        for option in self._options[index + 1:]:
+            option._index += 1
 
         # Add the content to the implementation.
         # This will cause the native implementation to be created.
@@ -128,7 +128,7 @@ class OptionList:
         # finalize the display properties that can't be resolved until the
         # implementation exists.
         widget.refresh()
-        option.enabled = enabled
+        item.enabled = enabled
 
 
 class OptionContainer(Widget):

--- a/src/core/toga/widgets/optioncontainer.py
+++ b/src/core/toga/widgets/optioncontainer.py
@@ -117,8 +117,8 @@ class OptionList:
         # Add the option to the list maintained on the interface,
         # and increment the index of all items after the one that was added.
         self._options.insert(index, option)
-        for option in self._options[index + 1:]:
-            option._index += 1
+        for opt in self._options[index + 1:]:
+            opt._index += 1
 
         # Add the content to the implementation.
         # This will cause the native implementation to be created.

--- a/src/core/toga/widgets/optioncontainer.py
+++ b/src/core/toga/widgets/optioncontainer.py
@@ -212,6 +212,19 @@ class OptionContainer(Widget):
 
         self._content.append(label, widget)
 
+    def insert(self, index, label, widget):
+        """ Insert a new option at the specified index.
+
+        Args:
+            index (int): Index for the option.
+            label (str): The label for the option.
+            widget (:class:`toga.Widget`): The widget to add to the option.
+        """
+        widget.app = self.app
+        widget.window = self.window
+
+        self._content.insert(index, label, widget)
+
     def remove(self, index):
         del self._content[index]
 

--- a/src/core/toga/widgets/optioncontainer.py
+++ b/src/core/toga/widgets/optioncontainer.py
@@ -83,9 +83,10 @@ class OptionList:
         ])
         return repr_optionlist.format(self.__class__.__name__, repr_items)
 
-    def __setitem__(self, index, option):
-        self._options[index] = option
-        option._index = index
+    # def __setitem__(self, index, option):
+    #     TODO: replace tab content at the given index.
+    #     self._options[index] = option
+    #     option._index = index
 
     def __getitem__(self, index):
         return self._options[index]

--- a/src/core/toga/widgets/optioncontainer.py
+++ b/src/core/toga/widgets/optioncontainer.py
@@ -122,7 +122,7 @@ class OptionList:
 
         # Add the content to the implementation.
         # This will cause the native implementation to be created.
-        self.interface._impl.add_content(label, widget._impl)
+        self.interface._impl.add_content(label, widget._impl, index=index)
 
         # The option now exists on the implementation;
         # finalize the display properties that can't be resolved until the

--- a/src/core/toga/widgets/optioncontainer.py
+++ b/src/core/toga/widgets/optioncontainer.py
@@ -123,7 +123,7 @@ class OptionList:
 
         # Add the content to the implementation.
         # This will cause the native implementation to be created.
-        self.interface._impl.add_content(label, widget._impl, index)
+        self.interface._impl.add_content(index, label, widget._impl)
 
         # The option now exists on the implementation;
         # finalize the display properties that can't be resolved until the

--- a/src/dummy/toga_dummy/widgets/optioncontainer.py
+++ b/src/dummy/toga_dummy/widgets/optioncontainer.py
@@ -16,12 +16,9 @@ class OptionContainer(Widget):
         self._items = []
         self._current_index = 0
 
-    def add_content(self, label, widget, index=None):
+    def add_content(self, label, widget, index):
         self._action('add content', label=label, widget=widget)
-        if index is None:
-            self._items.append(Option(label, widget, True))
-        else:
-            self._items.insert(index, Option(label, widget, True))
+        self._items.insert(index, Option(label, widget, True))
 
     def remove_content(self, index):
         if index == self._current_index:

--- a/src/dummy/toga_dummy/widgets/optioncontainer.py
+++ b/src/dummy/toga_dummy/widgets/optioncontainer.py
@@ -16,8 +16,8 @@ class OptionContainer(Widget):
         self._items = []
         self._current_index = 0
 
-    def add_content(self, label, widget, index):
-        self._action('add content', label=label, widget=widget)
+    def add_content(self, index, label, widget):
+        self._action('add content', index=index, label=label, widget=widget)
         self._items.insert(index, Option(label, widget, True))
 
     def remove_content(self, index):

--- a/src/dummy/toga_dummy/widgets/optioncontainer.py
+++ b/src/dummy/toga_dummy/widgets/optioncontainer.py
@@ -16,9 +16,12 @@ class OptionContainer(Widget):
         self._items = []
         self._current_index = 0
 
-    def add_content(self, label, widget):
+    def add_content(self, label, widget, index=None):
         self._action('add content', label=label, widget=widget)
-        self._items.append(Option(label, widget, True))
+        if index is None:
+            self._items.append(Option(label, widget, True))
+        else:
+            self._items.insert(index, Option(label, widget, True))
 
     def remove_content(self, index):
         if index == self._current_index:

--- a/src/gtk/toga_gtk/widgets/optioncontainer.py
+++ b/src/gtk/toga_gtk/widgets/optioncontainer.py
@@ -17,18 +17,14 @@ class OptionContainer(Widget):
                 option=self.interface.content[page_num]
             )
 
-    def add_content(self, label, widget, index=None):
+    def add_content(self, label, widget, index):
         widget.viewport = GtkViewport(widget.native)
 
         # Add all children to the content widget.
         for child in widget.interface.children:
             child._impl.container = widget
 
-        if index is None:
-            self.native.append_page(widget.native, Gtk.Label(label=label))
-        else:
-            # FIXME: insert at correct position
-            self.native.append_page(widget.native, Gtk.Label(label=label))
+        self.native.insert_page(widget.native, Gtk.Label(label=label), index)
 
         # Tabs aren't visible by default;
         # tell the notebook to show all content.

--- a/src/gtk/toga_gtk/widgets/optioncontainer.py
+++ b/src/gtk/toga_gtk/widgets/optioncontainer.py
@@ -17,7 +17,7 @@ class OptionContainer(Widget):
                 option=self.interface.content[page_num]
             )
 
-    def add_content(self, label, widget, index):
+    def add_content(self, index, label, widget):
         widget.viewport = GtkViewport(widget.native)
 
         # Add all children to the content widget.

--- a/src/gtk/toga_gtk/widgets/optioncontainer.py
+++ b/src/gtk/toga_gtk/widgets/optioncontainer.py
@@ -17,14 +17,19 @@ class OptionContainer(Widget):
                 option=self.interface.content[page_num]
             )
 
-    def add_content(self, label, widget):
+    def add_content(self, label, widget, index=None):
         widget.viewport = GtkViewport(widget.native)
 
         # Add all children to the content widget.
         for child in widget.interface.children:
             child._impl.container = widget
 
-        self.native.append_page(widget.native, Gtk.Label(label=label))
+        if index is None:
+            self.native.append_page(widget.native, Gtk.Label(label=label))
+        else:
+            # FIXME: insert at correct position
+            self.native.append_page(widget.native, Gtk.Label(label=label))
+
         # Tabs aren't visible by default;
         # tell the notebook to show all content.
         self.native.show_all()

--- a/src/winforms/toga_winforms/widgets/optioncontainer.py
+++ b/src/winforms/toga_winforms/widgets/optioncontainer.py
@@ -9,7 +9,7 @@ class OptionContainer(Widget):
         self.native = WinForms.TabControl()
         self.native.Selected += self.winforms_selected
 
-    def add_content(self, label, widget, index):
+    def add_content(self, index, label, widget):
         widget.viewport = WinFormsViewport(self.native, self)
         widget.frame = self
         # Add all children to the content widget.

--- a/src/winforms/toga_winforms/widgets/optioncontainer.py
+++ b/src/winforms/toga_winforms/widgets/optioncontainer.py
@@ -9,7 +9,7 @@ class OptionContainer(Widget):
         self.native = WinForms.TabControl()
         self.native.Selected += self.winforms_selected
 
-    def add_content(self, label, widget, index=None):
+    def add_content(self, label, widget, index):
         widget.viewport = WinFormsViewport(self.native, self)
         widget.frame = self
         # Add all children to the content widget.
@@ -24,11 +24,7 @@ class OptionContainer(Widget):
         widget.AutoSize = True
 
         item.Controls.Add(widget.native)
-        if index is None:
-            self.native.TabPages.Add(item)
-        else:
-            # FIXME: insert at correct position
-            self.native.TabPages.Add(item)
+        self.native.TabPages.Insert(index, item)
 
     def remove_content(self, index):
         tab_page = self.native.TabPages[index]

--- a/src/winforms/toga_winforms/widgets/optioncontainer.py
+++ b/src/winforms/toga_winforms/widgets/optioncontainer.py
@@ -24,7 +24,10 @@ class OptionContainer(Widget):
         widget.AutoSize = True
 
         item.Controls.Add(widget.native)
-        self.native.TabPages.Insert(index, item)
+        if index < self.native.TabPages.Count:
+            self.native.TabPages.Insert(index, item)
+        else:
+            self.native.TabPages.Add(item)
 
     def remove_content(self, index):
         tab_page = self.native.TabPages[index]

--- a/src/winforms/toga_winforms/widgets/optioncontainer.py
+++ b/src/winforms/toga_winforms/widgets/optioncontainer.py
@@ -9,7 +9,7 @@ class OptionContainer(Widget):
         self.native = WinForms.TabControl()
         self.native.Selected += self.winforms_selected
 
-    def add_content(self, label, widget):
+    def add_content(self, label, widget, index=None):
         widget.viewport = WinFormsViewport(self.native, self)
         widget.frame = self
         # Add all children to the content widget.
@@ -24,7 +24,11 @@ class OptionContainer(Widget):
         widget.AutoSize = True
 
         item.Controls.Add(widget.native)
-        self.native.TabPages.Add(item)
+        if index is None:
+            self.native.TabPages.Add(item)
+        else:
+            # FIXME: insert at correct position
+            self.native.TabPages.Add(item)
 
     def remove_content(self, index):
         tab_page = self.native.TabPages[index]


### PR DESCRIPTION
Added a few tests to increase coverage of OptionContainer.

There was a bug: inserting a tab (not adding it after existing tabs) was not working. 
Fixed for toga_cocoa, I left `FIXME` comments for other platforms.

Maybe a convenience `insert` method should be added to OptionContainer, instead of calling `.content.insert()`
Or `.add()` could have an optional `index` parameter?

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
