### PR TITLE
Renamed 'label' to 'text' for Command and Group

### DIFF
--- a/examples/command/command/app.py
+++ b/examples/command/command/app.py
@@ -58,21 +58,21 @@ class ExampleTestCommandApp(toga.App):
         things = toga.Group('Things')
         cmd0 = toga.Command(
             self.action0,
-            label='Action 0',
+            text='Action 0',
             tooltip='Perform action 0',
             icon=brutus_icon_256,
             group=things
         )
         cmd1 = toga.Command(
             self.action1,
-            label='Action 1',
+            text='Action 1',
             tooltip='Perform action 1',
             icon=brutus_icon_256,
             group=things
         )
         cmd2 = toga.Command(
             self.action2,
-            label='TB Action 2',
+            text='TB Action 2',
             tooltip='Perform toolbar action 2',
             icon=brutus_icon_256,
             group=things
@@ -83,7 +83,7 @@ class ExampleTestCommandApp(toga.App):
         # alphabetical ordering
         cmd3 = toga.Command(
             self.action3,
-            label='Action 3',
+            text='Action 3',
             tooltip='Perform action 3',
             shortcut=toga.Key.MOD_1 + 'k',
             icon=cricket_icon_256,
@@ -98,14 +98,14 @@ class ExampleTestCommandApp(toga.App):
         sub_menu = toga.Group("Sub Menu", parent=toga.Group.COMMANDS, order=1)
         cmd5 = toga.Command(
             self.action5,
-            label='TB Action 5',
+            text='TB Action 5',
             tooltip='Perform toolbar action 5',
             order=2,
             group=sub_menu
         )  # there is deliberately no icon to show that a toolbar action also works with text
         cmd6 = toga.Command(
             self.action6,
-            label='Action 6',
+            text='Action 6',
             tooltip='Perform action 6',
             order=1,
             icon=cricket_icon_256,
@@ -113,7 +113,7 @@ class ExampleTestCommandApp(toga.App):
         )
         cmd7 = toga.Command(
             self.action7,
-            label='TB action 7',
+            text='TB action 7',
             tooltip='Perform toolbar action 7',
             order=30,
             icon=tiberius_icon_256,
@@ -127,7 +127,7 @@ class ExampleTestCommandApp(toga.App):
 
         cmd4 = toga.Command(
             action4,
-            label='Action 4',
+            text='Action 4',
             tooltip='Perform action 4',
             icon=brutus_icon_256,
             order=3

--- a/examples/focus/focus/app.py
+++ b/examples/focus/focus/app.py
@@ -50,31 +50,31 @@ class ExampleFocusApp(toga.App):
         self.commands.add(
             toga.Command(
                 lambda widget: self.focus_with_label(self.a_button),
-                label="Focus on A",
+                text="Focus on A",
                 shortcut=toga.Key.MOD_1 + "a",
                 group=WIDGETS_GROUP
             ),
             toga.Command(
                 lambda widget: self.focus_with_label(self.b_button),
-                label="Focus on B",
+                text="Focus on B",
                 shortcut=toga.Key.MOD_1 + "b",
                 group=WIDGETS_GROUP
             ),
             toga.Command(
                 lambda widget: self.focus_with_label(self.c_button),
-                label="Focus on C",
+                text="Focus on C",
                 shortcut=toga.Key.MOD_1 + "c",
                 group=WIDGETS_GROUP
             ),
             toga.Command(
                 lambda widget: self.text_input.focus(),
-                label="Focus on text input",
+                text="Focus on text input",
                 shortcut=toga.Key.MOD_1 + "t",
                 group=WIDGETS_GROUP
             ),
             toga.Command(
                 lambda widget: self.focus_with_label(self.switch),
-                label="Focus on switch",
+                text="Focus on switch",
                 shortcut=toga.Key.MOD_1 + "s",
                 group=WIDGETS_GROUP
             )

--- a/examples/tutorial2/tutorial/app.py
+++ b/examples/tutorial2/tutorial/app.py
@@ -83,21 +83,21 @@ def build(app):
     things = toga.Group('Things')
     cmd0 = toga.Command(
         action0,
-        label='Action 0',
+        text='Action 0',
         tooltip='Perform action 0',
         icon=brutus_icon,
         group=things
     )
     cmd1 = toga.Command(
         action1,
-        label='Action 1',
+        text='Action 1',
         tooltip='Perform action 1',
         icon=brutus_icon,
         group=things
     )
     cmd2 = toga.Command(
         action2,
-        label='Action 2',
+        text='Action 2',
         tooltip='Perform action 2',
         icon=toga.Icon.TOGA_ICON,
         group=things
@@ -108,7 +108,7 @@ def build(app):
     # alphabetical ordering
     cmd3 = toga.Command(
         action3,
-        label='Action 3',
+        text='Action 3',
         tooltip='Perform action 3',
         shortcut=toga.Key.MOD_1 + 'k',
         icon=cricket_icon,
@@ -122,14 +122,14 @@ def build(app):
     sub_menu = toga.Group("Sub Menu", parent=toga.Group.COMMANDS, order=2)
     cmd5 = toga.Command(
         action5,
-        label='Action 5',
+        text='Action 5',
         tooltip='Perform action 5',
         order=2,
         group=sub_menu
     )
     cmd6 = toga.Command(
         action6,
-        label='Action 6',
+        text='Action 6',
         tooltip='Perform action 6',
         order=1,
         group=sub_menu
@@ -141,7 +141,7 @@ def build(app):
 
     cmd4 = toga.Command(
         action4,
-        label='Action 4',
+        text='Action 4',
         tooltip='Perform action 4',
         icon=brutus_icon,
         order=1

--- a/src/android/toga_android/app.py
+++ b/src/android/toga_android/app.py
@@ -108,20 +108,20 @@ class TogaApp(IPythonApp):
                     if groupkey in menulist:
                         menugroup = menulist[groupkey]
                     else:
-                        if group.label == toga.Group.COMMANDS.label:
+                        if group.text == toga.Group.COMMANDS.text:
                             menulist[groupkey] = menu
                             menugroup = menu
                         else:
                             itemid += 1
                             order = Menu.NONE if group.order is None else group.order
                             menugroup = parentmenu.addSubMenu(Menu.NONE, itemid, order,
-                                                              group.label)  # groupId, itemId, order, title
+                                                              group.text)  # groupId, itemId, order, title
                             menulist[groupkey] = menugroup
                     parentmenu = menugroup
             # create menu item
             itemid += 1
             order = Menu.NONE if cmd.order is None else cmd.order
-            menuitem = menugroup.add(Menu.NONE, itemid, order, cmd.label)  # groupId, itemId, order, title
+            menuitem = menugroup.add(Menu.NONE, itemid, order, cmd.text)  # groupId, itemId, order, title
             menuitem.setShowAsActionFlags(MenuItem.SHOW_AS_ACTION_NEVER)
             menuitem.setEnabled(cmd.enabled)
             self.menuitem_mapping[itemid] = cmd  # store itemid for use in onOptionsItemSelected
@@ -133,7 +133,7 @@ class TogaApp(IPythonApp):
                     continue
                 itemid += 1
                 order = Menu.NONE if cmd.order is None else cmd.order
-                menuitem = menu.add(Menu.NONE, itemid, order, cmd.label)  # groupId, itemId, order, title
+                menuitem = menu.add(Menu.NONE, itemid, order, cmd.text)  # groupId, itemId, order, title
                 menuitem.setShowAsActionFlags(
                     MenuItem.SHOW_AS_ACTION_IF_ROOM)  # toolbar button / item in options menu on overflow
                 menuitem.setEnabled(cmd.enabled)

--- a/src/cocoa/toga_cocoa/app.py
+++ b/src/cocoa/toga_cocoa/app.py
@@ -298,7 +298,7 @@ class App:
                     action = cmd.action
 
                 item = NSMenuItem.alloc().initWithTitle(
-                    cmd.label,
+                    cmd.text,
                     action=action,
                     keyEquivalent=key,
                 )
@@ -329,9 +329,9 @@ class App:
                 parent_menu = self._submenu(group.parent, menubar)
 
                 menu_item = parent_menu.addItemWithTitle(
-                    group.label, action=None, keyEquivalent=''
+                    group.text, action=None, keyEquivalent=''
                 )
-                submenu = NSMenu.alloc().initWithTitle(group.label)
+                submenu = NSMenu.alloc().initWithTitle(group.text)
                 parent_menu.setSubmenu(submenu, forItem=menu_item)
 
             # Install the item in the group cache.
@@ -429,7 +429,7 @@ class DocumentApp(App):
         self.interface.commands.add(
             toga.Command(
                 lambda _: self.select_file(),
-                label='Open...',
+                text='Open...',
                 shortcut=toga.Key.MOD_1 + 'o',
                 group=toga.Group.FILE,
                 section=0

--- a/src/cocoa/toga_cocoa/window.py
+++ b/src/cocoa/toga_cocoa/window.py
@@ -100,9 +100,9 @@ class WindowDelegate(NSObject):
         native = NSToolbarItem.alloc().initWithItemIdentifier_(identifier)
         try:
             item = self.impl._toolbar_items[str(identifier)]
-            if item.label:
-                native.setLabel(item.label)
-                native.setPaletteLabel(item.label)
+            if item.text:
+                native.setLabel(item.text)
+                native.setPaletteLabel(item.text)
             if item.tooltip:
                 native.setToolTip(item.tooltip)
             if item.icon:

--- a/src/core/tests/command/test_command.py
+++ b/src/core/tests/command/test_command.py
@@ -105,6 +105,14 @@ class TestCommand(TestCase):
     )
     test_order_commands_by_groups = order_test(*COMMANDS_IN_ORDER)
 
+    def test_missing_argument(self):
+        "If the no text is provided for the group, an error is raised"
+        # This test is only required as part of the backwards compatibility
+        # path renaming label->text; when that shim is removed, this teset
+        # validates default Python behavior
+        with self.assertRaises(TypeError):
+            toga.Command(lambda x: print('Hello World'), factory=toga_dummy.factory)
+
     ######################################################################
     # 2022-07: Backwards compatibility
     ######################################################################

--- a/src/core/tests/command/test_command.py
+++ b/src/core/tests/command/test_command.py
@@ -17,7 +17,7 @@ class TestCommand(TestCase):
 
     def test_command_init_defaults(self):
         cmd = toga.Command(lambda x: print('Hello World'), 'test', factory=toga_dummy.factory)
-        self.assertEqual(cmd.label, 'test')
+        self.assertEqual(cmd.text, 'test')
         self.assertEqual(cmd.shortcut, None)
         self.assertEqual(cmd.tooltip, None)
         self.assertEqual(cmd.icon, None)
@@ -30,7 +30,7 @@ class TestCommand(TestCase):
         grp = toga.Group('Test group', order=10)
         cmd = toga.Command(
             lambda x: print('Hello World'),
-            label='test',
+            text='test',
             tooltip='test command',
             shortcut='t',
             icon='icons/none.png',
@@ -39,7 +39,7 @@ class TestCommand(TestCase):
             order=1,
             factory=toga_dummy.factory
         )
-        self.assertEqual(cmd.label, 'test')
+        self.assertEqual(cmd.text, 'test')
         self.assertEqual(cmd.shortcut, 't')
         self.assertEqual(cmd.tooltip, 'test command')
         self.assertEqual(cmd.icon.path, 'icons/none.png')
@@ -56,7 +56,7 @@ class TestCommand(TestCase):
         grp = toga.Group('Test group', order=10)
         cmd = toga.Command(
             lambda x: print('Hello World'),
-            label='test',
+            text='test',
             tooltip='test command',
             shortcut='t',
             icon='icons/none.png',
@@ -72,7 +72,7 @@ class TestCommand(TestCase):
         grp = toga.Group('Test group', order=10)
         cmd = toga.Command(
             lambda x: print('Hello World'),
-            label='test',
+            text='test',
             tooltip='test command',
             shortcut='t',
             icon='icons/none.png',
@@ -90,10 +90,10 @@ class TestCommand(TestCase):
     def test_command_repr(self):
         self.assertEqual(
             repr(toga.Command(None, "A", group=PARENT_GROUP1, order=1, section=4)),
-            "<Command label=A group=<Group label=P order=1 parent=None> section=4 order=1>"
+            "<Command text=A group=<Group text=P order=1 parent=None> section=4 order=1>"
         )
 
-    test_order_commands_by_label = order_test(
+    test_order_commands_by_text = order_test(
         toga.Command(None, "A"), toga.Command(None, "B")
     )
     test_order_commands_by_number = order_test(
@@ -104,3 +104,38 @@ class TestCommand(TestCase):
         toga.Command(None, "A", group=PARENT_GROUP1, section=2, order=1)
     )
     test_order_commands_by_groups = order_test(*COMMANDS_IN_ORDER)
+
+    ######################################################################
+    # 2022-07: Backwards compatibility
+    ######################################################################
+
+    def test_label_deprecated(self):
+        cmd = toga.Command(lambda x: print('Hello World'), label='test', factory=toga_dummy.factory)
+        new_text = 'New Text'
+        with self.assertWarns(DeprecationWarning):
+            cmd.label = new_text
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(cmd.label, new_text)
+        self.assertEqual(cmd.text, new_text)
+
+    def test_init_with_deprecated(self):
+        # label is a deprecated argument
+        with self.assertWarns(DeprecationWarning):
+            toga.Command(
+                lambda x: print('Hello World'),
+                label='test',
+                factory=toga_dummy.factory
+            )
+
+        # can't specify both label *and* text
+        with self.assertRaises(ValueError):
+            toga.Command(
+                lambda x: print('Hello World'),
+                label='test',
+                text='test',
+                factory=toga_dummy.factory
+            )
+
+    ######################################################################
+    # End backwards compatibility.
+    ######################################################################

--- a/src/core/tests/command/test_commands_group.py
+++ b/src/core/tests/command/test_commands_group.py
@@ -149,6 +149,14 @@ class TestCommandsGroup(unittest.TestCase):
         self.assertEqual(group.parent, parent)
         self.assertEqual(group.root, root)
 
+    def test_missing_argument(self):
+        "If the no text is provided for the group, an error is raised"
+        # This test is only required as part of the backwards compatibility
+        # path renaming label->text; when that shim is removed, this teset
+        # validates default Python behavior
+        with self.assertRaises(TypeError):
+            toga.Group()
+
     ######################################################################
     # 2022-07: Backwards compatibility
     ######################################################################

--- a/src/core/tests/command/test_commands_group.py
+++ b/src/core/tests/command/test_commands_group.py
@@ -9,24 +9,24 @@ from tests.command.constants import PARENT_GROUP1, PARENT_GROUP2
 class TestCommandsGroup(unittest.TestCase):
 
     def test_group_init_no_order(self):
-        grp = toga.Group('label')
-        self.assertEqual(grp.label, 'label')
+        grp = toga.Group('text')
+        self.assertEqual(grp.text, 'text')
         self.assertEqual(grp.order, 0)
 
     def test_group_init_with_order(self):
-        grp = toga.Group('label', 2)
-        self.assertEqual(grp.label, 'label')
+        grp = toga.Group('text', 2)
+        self.assertEqual(grp.text, 'text')
         self.assertEqual(grp.order, 2)
 
     def test_hashable(self):
-        grp1 = toga.Group('label 1')
-        grp2 = toga.Group('label 2')
+        grp1 = toga.Group('text 1')
+        grp2 = toga.Group('text 2')
 
-        # The hash is based on the full path, not just the label.
-        # This allows labels to be non-unique, as long as they're in
+        # The hash is based on the full path, not just the text.
+        # This allows texts to be non-unique, as long as they're in
         # different groups
-        grp1_child = toga.Group('label', parent=grp1)
-        grp2_child = toga.Group('label', parent=grp2)
+        grp1_child = toga.Group('text', parent=grp1)
+        grp2_child = toga.Group('text', parent=grp2)
 
         # Insert the groups as keys in a dict. This is
         # only possible if Group is hashable.
@@ -96,8 +96,8 @@ class TestCommandsGroup(unittest.TestCase):
         self.assertEqual(bottom.root, top)
 
     test_order_by_number = order_test(toga.Group('A', 1), toga.Group('A', 2))
-    test_order_ignore_label = order_test(toga.Group('B', 1), toga.Group('A', 2))
-    test_order_by_label = order_test(toga.Group('A'), toga.Group('B'))
+    test_order_ignore_text = order_test(toga.Group('B', 1), toga.Group('A', 2))
+    test_order_by_text = order_test(toga.Group('A'), toga.Group('B'))
     test_order_by_groups = order_test(
         PARENT_GROUP1,
         toga.Group('C', parent=PARENT_GROUP1),
@@ -110,11 +110,11 @@ class TestCommandsGroup(unittest.TestCase):
     def test_group_repr(self):
         parent = toga.Group("P")
         self.assertEqual(
-            repr(toga.Group("A")), "<Group label=A order=0 parent=None>"
+            repr(toga.Group("A")), "<Group text=A order=0 parent=None>"
         )
         self.assertEqual(
             repr(toga.Group("A", parent=parent)),
-            "<Group label=A order=0 parent=P>"
+            "<Group text=A order=0 parent=P>"
         )
 
     def test_set_section_without_parent(self):
@@ -148,3 +148,32 @@ class TestCommandsGroup(unittest.TestCase):
     def assert_parent_and_root(self, group, parent, root):
         self.assertEqual(group.parent, parent)
         self.assertEqual(group.root, root)
+
+    ######################################################################
+    # 2022-07: Backwards compatibility
+    ######################################################################
+
+    def test_label_deprecated(self):
+        grp = toga.Group(label='text')
+        new_text = 'New Text'
+        with self.assertWarns(DeprecationWarning):
+            grp.label = new_text
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(grp.label, new_text)
+        self.assertEqual(grp.text, new_text)
+
+    def test_init_with_deprecated(self):
+        # label is a deprecated argument
+        with self.assertWarns(DeprecationWarning):
+            toga.Group(label='test')
+
+        # can't specify both label *and* text
+        with self.assertRaises(ValueError):
+            toga.Group(
+                label='test',
+                text='test',
+            )
+
+    ######################################################################
+    # End backwards compatibility.
+    ######################################################################

--- a/src/core/tests/command/test_commands_set.py
+++ b/src/core/tests/command/test_commands_set.py
@@ -30,7 +30,7 @@ class TestCommandSet(unittest.TestCase):
         grp = toga.Group('Test group', order=10)
         cmd = toga.Command(
             lambda x: print('Hello World'),
-            label='test',
+            text='test',
             tooltip='test command',
             shortcut='t',
             icon='icons/none.png',

--- a/src/core/toga/command.py
+++ b/src/core/toga/command.py
@@ -21,7 +21,7 @@ class Group:
         self,
         text=NOT_PROVIDED,  # BACKWARDS COMPATIBILITY: The default value
                             # can be removed when the handling for
-                            # `label`` is removed
+                            # `label` is removed
         order=None,
         section=None,
         parent=None,
@@ -196,7 +196,7 @@ class Command:
         action,
         text=NOT_PROVIDED,  # BACKWARDS COMPATIBILITY: The default value
                             # can be removed when the handling for
-                            # `label`` is removed
+                            # `label` is removed
         shortcut=None,
         tooltip=None,
         icon=None,

--- a/src/core/toga/command.py
+++ b/src/core/toga/command.py
@@ -142,8 +142,12 @@ class Group:
     # label replaced with text
     @property
     def label(self):
-        """
+        """Group text
+
         **DEPRECATED: renamed as text**
+
+        Returns:
+            The button text as a ``str``
         """
         warnings.warn(
             "Group.label has been renamed Group.text", DeprecationWarning
@@ -316,8 +320,12 @@ class Command:
     # label replaced with text
     @property
     def label(self):
-        """
+        """ Command text.
+
         **DEPRECATED: renamed as text**
+
+        Returns:
+            The command text as a ``str``
         """
         warnings.warn(
             "Command.label has been renamed Command.text", DeprecationWarning

--- a/src/core/toga/widgets/button.py
+++ b/src/core/toga/widgets/button.py
@@ -30,7 +30,7 @@ class Button(Widget):
             self,
             text=NOT_PROVIDED,  # BACKWARDS COMPATIBILITY: The default value
                                 # can be removed when the handling for
-                                # `label`` is removed
+                                # `label` is removed
             id=None,
             style=None,
             on_press=None,

--- a/src/core/toga/widgets/switch.py
+++ b/src/core/toga/widgets/switch.py
@@ -31,7 +31,7 @@ class Switch(Widget):
             self,
             text=NOT_PROVIDED,  # BACKWARDS COMPATIBILITY: The default value
                                 # can be removed when the handling for
-                                # `label`` is removed
+                                # `label` is removed
             id=None,
             style=None,
             on_change=None,

--- a/src/gtk/toga_gtk/app.py
+++ b/src/gtk/toga_gtk/app.py
@@ -161,7 +161,7 @@ class App:
                 self._menu_items[action] = cmd
                 self.native.add_action(action)
 
-                item = Gio.MenuItem.new(cmd.label, 'app.' + cmd_id)
+                item = Gio.MenuItem.new(cmd.text, 'app.' + cmd_id)
                 if cmd.shortcut:
                     item.set_attribute_value('accel', GLib.Variant('s', gtk_accel(cmd.shortcut)))
 
@@ -182,11 +182,11 @@ class App:
                 submenu = Gio.Menu()
                 self._menu_groups[group] = submenu
 
-                label = group.label
-                if label == '*':
-                    label = self.interface.name
+                text = group.text
+                if text == '*':
+                    text = self.interface.name
 
-                parent_menu.append_submenu(label, submenu)
+                parent_menu.append_submenu(text, submenu)
 
             # Install the item in the group cache.
             self._menu_groups[group] = submenu
@@ -254,7 +254,7 @@ class DocumentApp(App):
         self.interface.commands.add(
             toga.Command(
                 self.open_file,
-                label='Open...',
+                text='Open...',
                 shortcut=toga.Key.MOD_1 + 'o',
                 group=toga.Group.FILE,
                 section=0

--- a/src/gtk/toga_gtk/window.py
+++ b/src/gtk/toga_gtk/window.py
@@ -83,7 +83,7 @@ class Window:
                 item_impl = Gtk.ToolButton()
                 icon_impl = cmd.icon.bind(self.interface.factory)
                 item_impl.set_icon_widget(icon_impl.native_32)
-                item_impl.set_label(cmd.label)
+                item_impl.set_label(cmd.text)
                 item_impl.set_tooltip_text(cmd.tooltip)
                 item_impl.connect("clicked", wrapped_handler(cmd, cmd.action))
                 cmd._impl.native.append(item_impl)

--- a/src/winforms/toga_winforms/app.py
+++ b/src/winforms/toga_winforms/app.py
@@ -129,7 +129,7 @@ class App:
             else:
                 submenu = self._submenu(cmd.group, menubar)
 
-                item = WinForms.ToolStripMenuItem(cmd.label)
+                item = WinForms.ToolStripMenuItem(cmd.text)
 
                 if cmd.action:
                     item.Click += cmd._impl.as_handler()
@@ -158,7 +158,7 @@ class App:
             else:
                 parent_menu = self._submenu(group.parent, menubar)
 
-                submenu = WinForms.ToolStripMenuItem(group.label)
+                submenu = WinForms.ToolStripMenuItem(group.text)
 
                 # Top level menus are added in a different way to submenus
                 if group.parent is None:
@@ -309,7 +309,7 @@ class DocumentApp(App):
         self.interface.commands.add(
             toga.Command(
                 lambda w: self.open_file,
-                label='Open...',
+                text='Open...',
                 shortcut=Key.MOD_1 + 'o',
                 group=toga.Group.FILE,
                 section=0

--- a/src/winforms/toga_winforms/window.py
+++ b/src/winforms/toga_winforms/window.py
@@ -72,9 +72,9 @@ class Window:
             else:
                 if cmd.icon is not None:
                     native_icon = cmd.icon._impl.native
-                    item = WinForms.ToolStripMenuItem(cmd.label, native_icon.ToBitmap())
+                    item = WinForms.ToolStripMenuItem(cmd.text, native_icon.ToBitmap())
                 else:
-                    item = WinForms.ToolStripMenuItem(cmd.label)
+                    item = WinForms.ToolStripMenuItem(cmd.text)
                 item.Click += cmd._impl.as_handler()
                 cmd._impl.native.append(item)
             self.toolbar_native.Items.Add(item)


### PR DESCRIPTION
As discussed in https://github.com/beeware/toga/discussions/1521

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
