### PR TITLE
Fix containers app

### DIFF
--- a/src/android/toga_android/widgets/base.py
+++ b/src/android/toga_android/widgets/base.py
@@ -35,6 +35,9 @@ class Widget:
         # they have been added to a container.
         self.interface.style.reapply()
 
+    def create(self):
+        pass
+
     def set_app(self, app):
         pass
 

--- a/src/core/tests/widgets/test_optioncontainer.py
+++ b/src/core/tests/widgets/test_optioncontainer.py
@@ -191,3 +191,9 @@ class OptionContainerTests(TestCase):
         self.op_container.window = window
         for item in self.op_container.content:
             self.assertEqual(item._content.window, window)
+
+    def test_set_app(self):
+        app = mock.Mock()
+        self.op_container.app = app
+        for item in self.op_container.content:
+            self.assertEqual(item._content.app, app)

--- a/src/core/tests/widgets/test_scrollcontainer.py
+++ b/src/core/tests/widgets/test_scrollcontainer.py
@@ -87,3 +87,13 @@ class ScrollContainerTests(TestCase):
             ValueError, "^Cannot set vertical position when vertical is not set.$"
         ):
             self.sc.vertical_position = 0.5
+
+    def test_set_app(self):
+
+        new_content = toga.Box(style=TestStyle(), factory=toga_dummy.factory)
+        self.sc.content = new_content
+        self.assertIsNone(new_content.app)
+
+        app = mock.Mock()
+        self.sc.app = app
+        self.assertEqual(new_content.app, app)

--- a/src/core/tests/widgets/test_splitcontainer.py
+++ b/src/core/tests/widgets/test_splitcontainer.py
@@ -92,7 +92,29 @@ class SplitContainerTests(TestCase):
         with self.assertRaises(ValueError):
             self.split.content = new_content
 
-    def test_set_app(self):
+    def test_set_window_without_content(self):
+        window = mock.Mock()
+        self.split.window = window
+        self.assertEqual(self.split.window, window)
+
+    def test_set_window_with_content(self):
+        self.split.content = self.content
+        for content in self.content:
+            self.assertIsNone(content.window)
+
+        window = mock.Mock()
+        self.split.window = window
+
+        self.assertEqual(self.split.window, window)
+        for content in self.content:
+            self.assertEqual(content.window, window)
+
+    def test_set_app_without_content(self):
+        app = mock.Mock()
+        self.split.app = app
+        self.assertEqual(self.split.app, app)
+
+    def test_set_app_with_content(self):
         self.split.content = self.content
         for content in self.content:
             self.assertIsNone(content.app)
@@ -100,5 +122,27 @@ class SplitContainerTests(TestCase):
         app = mock.Mock()
         self.split.app = app
 
+        self.assertEqual(self.split.app, app)
         for content in self.content:
             self.assertEqual(content.app, app)
+
+    def test_refresh_without_content(self):
+        self.split.refresh()
+        self.assertActionPerformedWith(
+            self.split, 'set bounds', x=0, y=0, width=0, height=0
+        )
+
+    def test_refresh_with_content(self):
+        for content in self.content:
+            self.assertActionNotPerformed(content, "set bound")
+
+        self.split.content = self.content
+
+        self.split.refresh()
+        self.assertActionPerformedWith(
+            self.split, 'set bounds', x=0, y=0, width=0, height=0
+        )
+        for content in self.content:
+            self.assertActionPerformedWith(
+                content, 'set bounds', x=0, y=0, width=0, height=0
+            )

--- a/src/core/tests/widgets/test_splitcontainer.py
+++ b/src/core/tests/widgets/test_splitcontainer.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import toga
 import toga_dummy
 from toga_dummy.utils import TestCase, TestStyle
@@ -89,3 +91,14 @@ class SplitContainerTests(TestCase):
         ]
         with self.assertRaises(ValueError):
             self.split.content = new_content
+
+    def test_set_app(self):
+        self.split.content = self.content
+        for content in self.content:
+            self.assertIsNone(content.app)
+
+        app = mock.Mock()
+        self.split.app = app
+
+        for content in self.content:
+            self.assertEqual(content.app, app)

--- a/src/core/toga/widgets/base.py
+++ b/src/core/toga/widgets/base.py
@@ -153,15 +153,7 @@ class Widget(Node):
 
     @app.setter
     def app(self, app):
-        # raise an error when we already have an app and attempt to override it
-        # with a different app
-        if self._app and app and self._app != app:
-            raise ValueError("Widget %s is already associated with an App" % self)
-        elif self._impl:
-            self._app = app
-            self._impl.set_app(app)
-            for child in self.children:
-                child.app = app
+        self._set_app(app)
 
     @property
     def window(self):
@@ -213,3 +205,14 @@ class Widget(Node):
 
     def _set_window(self, window):
         pass
+
+    def _set_app(self, app):
+        # raise an error when we already have an app and attempt to override it
+        # with a different app
+        if self._app and app and self._app != app:
+            raise ValueError("Widget %s is already associated with an App" % self)
+        elif self._impl:
+            self._app = app
+            self._impl.set_app(app)
+            for child in self.children:
+                child.app = app

--- a/src/core/toga/widgets/base.py
+++ b/src/core/toga/widgets/base.py
@@ -153,7 +153,22 @@ class Widget(Node):
 
     @app.setter
     def app(self, app):
+        # raise an error when we already have an app and attempt to override it
+        # with a different app
+        if self._app and app and self._app != app:
+            raise ValueError("Widget %s is already associated with an App" % self)
+        elif self._impl:
+            self._app = app
+            self._impl.set_app(app)
+            for child in self.children:
+                child.app = app
+
+        # Provide an extension point for widgets with
+        # more complex widget heirarchies
         self._set_app(app)
+
+    def _set_app(self, app):
+        pass
 
     @property
     def window(self):
@@ -176,7 +191,12 @@ class Widget(Node):
             for child in self._children:
                 child.window = window
 
+        # Provide an extension point for widgets with
+        # more complex widget heirarchies
         self._set_window(window)
+
+    def _set_window(self, window):
+        pass
 
     @property
     def enabled(self):
@@ -202,17 +222,3 @@ class Widget(Node):
     def focus(self):
         if self._impl is not None:
             self._impl.focus()
-
-    def _set_window(self, window):
-        pass
-
-    def _set_app(self, app):
-        # raise an error when we already have an app and attempt to override it
-        # with a different app
-        if self._app and app and self._app != app:
-            raise ValueError("Widget %s is already associated with an App" % self)
-        elif self._impl:
-            self._app = app
-            self._impl.set_app(app)
-            for child in self.children:
-                child.app = app

--- a/src/core/toga/widgets/optioncontainer.py
+++ b/src/core/toga/widgets/optioncontainer.py
@@ -234,3 +234,8 @@ class OptionContainer(Widget):
         """
         self._on_select = wrapped_handler(self, handler)
         self._impl.set_on_select(self._on_select)
+
+    def _set_app(self, app):
+        super()._set_app(app)
+        for item in self.content:
+            item.content.app = app

--- a/src/core/toga/widgets/optioncontainer.py
+++ b/src/core/toga/widgets/optioncontainer.py
@@ -190,10 +190,15 @@ class OptionContainer(Widget):
             current_tab = current_tab.index
         self._impl.set_current_tab_index(current_tab)
 
+    def _set_app(self, app):
+        # Also assign the app to the content in the container
+        for item in self._content:
+            item._content.app = app
+
     def _set_window(self, window):
-        if self._content:
-            for content in self._content:
-                content._content.window = window
+        # Also assign the window to the content in the container
+        for item in self._content:
+            item._content.window = window
 
     def add(self, label, widget):
         """ Add a new option to the option container.
@@ -234,8 +239,3 @@ class OptionContainer(Widget):
         """
         self._on_select = wrapped_handler(self, handler)
         self._impl.set_on_select(self._on_select)
-
-    def _set_app(self, app):
-        super()._set_app(app)
-        for item in self.content:
-            item.content.app = app

--- a/src/core/toga/widgets/scrollcontainer.py
+++ b/src/core/toga/widgets/scrollcontainer.py
@@ -125,3 +125,8 @@ class ScrollContainer(Widget):
                 "Cannot set vertical position when vertical is not set."
             )
         self._impl.set_vertical_position(vertical_position)
+
+    def _set_app(self, app):
+        super()._set_app(app)
+        if self.content:
+            self.content.app = app

--- a/src/core/toga/widgets/scrollcontainer.py
+++ b/src/core/toga/widgets/scrollcontainer.py
@@ -34,7 +34,13 @@ class ScrollContainer(Widget):
         self.content = content
         self.on_scroll = on_scroll
 
+    def _set_app(self, app):
+        # Also assign the app to the content in the container
+        if self.content:
+            self.content.app = app
+
     def _set_window(self, window):
+        # Also assign the window to the content in the container
         if self._content:
             self._content.window = window
 
@@ -125,8 +131,3 @@ class ScrollContainer(Widget):
                 "Cannot set vertical position when vertical is not set."
             )
         self._impl.set_vertical_position(vertical_position)
-
-    def _set_app(self, app):
-        super()._set_app(app)
-        if self.content:
-            self.content.app = app

--- a/src/core/toga/widgets/splitcontainer.py
+++ b/src/core/toga/widgets/splitcontainer.py
@@ -89,7 +89,9 @@ class SplitContainer(Widget):
 
     def refresh_sublayouts(self):
         """Refresh the layout and appearance of this widget."""
-        for widget in self._content:
+        if self.content is None:
+            return
+        for widget in self.content:
             widget.refresh()
 
     @property

--- a/src/core/toga/widgets/splitcontainer.py
+++ b/src/core/toga/widgets/splitcontainer.py
@@ -106,3 +106,8 @@ class SplitContainer(Widget):
         self._direction = value
         self._impl.set_direction(value)
         self._impl.rehint()
+
+    def _set_app(self, app):
+        super()._set_app(app)
+        for content in self.content:
+            content.app = app

--- a/src/core/toga/widgets/splitcontainer.py
+++ b/src/core/toga/widgets/splitcontainer.py
@@ -82,7 +82,14 @@ class SplitContainer(Widget):
             self._impl.add_content(position, widget._impl, flex)
             widget.refresh()
 
+    def _set_app(self, app):
+        # Also assign the app to the content in the container
+        if self.content:
+            for content in self.content:
+                content.app = app
+
     def _set_window(self, window):
+        # Also assign the window to the content in the container
         if self._content:
             for content in self._content:
                 content.window = window
@@ -108,10 +115,3 @@ class SplitContainer(Widget):
         self._direction = value
         self._impl.set_direction(value)
         self._impl.rehint()
-
-    def _set_app(self, app):
-        super()._set_app(app)
-        if self.content is None:
-            return
-        for content in self.content:
-            content.app = app

--- a/src/core/toga/widgets/splitcontainer.py
+++ b/src/core/toga/widgets/splitcontainer.py
@@ -109,5 +109,7 @@ class SplitContainer(Widget):
 
     def _set_app(self, app):
         super()._set_app(app)
+        if self.content is None:
+            return
         for content in self.content:
             content.app = app

--- a/src/dummy/toga_dummy/factory.py
+++ b/src/dummy/toga_dummy/factory.py
@@ -8,6 +8,7 @@ from .paths import paths
 from . import dialogs
 
 from .widgets.activityindicator import ActivityIndicator
+from .widgets.base import Widget
 from .widgets.box import Box
 from .widgets.button import Button
 from .widgets.canvas import Canvas
@@ -78,4 +79,8 @@ __all__ = [
     'Tree',
     'WebView',
     'Window',
+
+    # Widget is also required for testing purposes
+    # Real backends shouldn't expose Widget.
+    'Widget'
 ]

--- a/src/dummy/toga_dummy/widgets/base.py
+++ b/src/dummy/toga_dummy/widgets/base.py
@@ -9,6 +9,9 @@ class Widget(LoggedObject):
         self.viewport = None
         self.create()
 
+    def create(self):
+        pass
+
     def set_app(self, app):
         self._set_value('app', app)
 
@@ -51,6 +54,12 @@ class Widget(LoggedObject):
 
     def add_child(self, child):
         self._action('add child', child=child)
+
+    def insert_child(self, index, child):
+        self._action('insert child', index=index, child=child)
+
+    def remove_child(self, child):
+        self._action('remove child', child=child)
 
     @not_required_on('gtk', 'winforms', 'android', 'web')
     def add_constraints(self):

--- a/src/gtk/toga_gtk/widgets/base.py
+++ b/src/gtk/toga_gtk/widgets/base.py
@@ -18,6 +18,9 @@ class Widget:
         self.create()
         self.interface.style.reapply()
 
+    def create(self):
+        pass
+
     def set_app(self, app):
         pass
 

--- a/src/iOS/toga_iOS/widgets/base.py
+++ b/src/iOS/toga_iOS/widgets/base.py
@@ -13,6 +13,9 @@ class Widget:
         self.interface.style.reapply()
         self.set_enabled(self.interface.enabled)
 
+    def create(self):
+        pass
+
     def set_app(self, app):
         pass
 
@@ -97,12 +100,14 @@ class Widget:
     # INTERFACE
 
     def add_child(self, child):
-
         if self.viewport:
             # we are the the top level UIView
             child.container = self
         else:
             child.container = self.container
+
+    def insert_child(self, index, child):
+        self.add_child(child)
 
     def remove_child(self, child):
         child.container = None

--- a/src/winforms/toga_winforms/widgets/base.py
+++ b/src/winforms/toga_winforms/widgets/base.py
@@ -12,6 +12,9 @@ class Widget:
         self.create()
         self.interface.style.reapply()
 
+    def create(self):
+        pass
+
     def set_app(self, app):
         # No special handling required
         pass

--- a/src/winforms/toga_winforms/widgets/scrollcontainer.py
+++ b/src/winforms/toga_winforms/widgets/scrollcontainer.py
@@ -39,10 +39,6 @@ class ScrollContainer(Widget):
         self.native.VerticalScroll.Visible = value
         self.native.AutoScroll = True
 
-    def set_app(self, app):
-        if self.interface.content:
-            self.interface.content.app = app
-
     def set_window(self, window):
         if self.interface.content:
             self.interface.content.window = window


### PR DESCRIPTION
Fixes #833 

Now, for every container, app is set for it's content once it is set for the container.
Done for `OptionContainer`, `SplitContainer` and `ScrollContainer`.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
