### PR TITLE
Fix bug in windows `DashPattern`

### DIFF
--- a/src/winforms/toga_winforms/widgets/canvas.py
+++ b/src/winforms/toga_winforms/widgets/canvas.py
@@ -141,7 +141,7 @@ class Canvas(Box):
         if line_width is not None:
             pen.Width = line_width
         if line_dash is not None:
-            pen.DashPattern = line_dash
+            pen.DashPattern = tuple(map(float, line_dash))
         return pen
 
     def create_brush(self, color):


### PR DESCRIPTION
Fix the same bug described in #1559 
Now the problem is with setting `Pen.DashPattern`:

```
Traceback (most recent call last):
  File "c:\users\sagi\pycharmprojects\toga\src\winforms\toga_winforms\widgets\canvas.py", line 144, in create_pen
    pen.DashPattern = line_dash
  File "c:\users\sagi\pycharmprojects\toga\src\winforms\toga_winforms\widgets\canvas.py", line 272, in stroke
    pen = self.create_pen(color=color, line_width=line_width, line_dash=line_dash)
  File "c:\users\sagi\pycharmprojects\toga\src\core\toga\widgets\canvas.py", line 474, in _draw
    impl.stroke(self.color, self.line_width, self.line_dash, *args, **kwargs)
  File "c:\users\sagi\pycharmprojects\toga\src\core\toga\widgets\canvas.py", line 43, in _draw
    obj._draw(impl, *args, **kwargs)
  File "c:\users\sagi\pycharmprojects\toga\src\winforms\toga_winforms\widgets\canvas.py", line 93, in winforms_paint
    self.interface._draw(self, draw_context=context)
   at Python.Runtime.PythonException.ThrowLastAsClrException()
   at Python.Runtime.Dispatcher.TrueDispatch(Object[] args)
   at Python.Runtime.Dispatcher.Dispatch(Object[] args)
   at __System_Windows_Forms_PaintEventHandlerDispatcher.Invoke(Object , PaintEventArgs )
   at System.Windows.Forms.Control.OnPaint(PaintEventArgs e)
   at System.Windows.Forms.Control.PaintWithErrorHandling(PaintEventArgs e, Int16 layer)
   at System.Windows.Forms.Control.WmPaint(Message& m)
   at System.Windows.Forms.Control.WndProc(Message& m)
   at System.Windows.Forms.NativeWindow.Callback(IntPtr hWnd, Int32 msg, IntPtr wparam, IntPtr lparam)
'numpy.float64' value cannot be converted to System.Single
```

Hope this is the last one...

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
