### PR TITLE
API consistency: OptionContainer

### DIFF
--- a/examples/optioncontainer/optioncontainer/app.py
+++ b/examples/optioncontainer/optioncontainer/app.py
@@ -43,7 +43,7 @@ class ExampleOptionContainerApp(toga.App):
 
     def on_change_option_title(self, button):
         index = int(self.select_option.value)
-        self.optioncontainer.content[index].label = self.input_change_title.value
+        self.optioncontainer.content[index].text = self.input_change_title.value
 
     def on_activate_option(self, button):
         try:
@@ -70,7 +70,7 @@ class ExampleOptionContainerApp(toga.App):
 
     def on_select_tab(self, widget, option):
         self.selected_label.text = "Tab {} has been chosen: {}".format(
-            option.index, option.label,
+            option.index, option.text,
         )
 
     def startup(self):
@@ -99,7 +99,7 @@ class ExampleOptionContainerApp(toga.App):
             on_press=self.on_enable_option,
             style=style_flex
         )
-        # change label
+        # change title
         self.input_change_title = toga.TextInput(style=style_flex)
         btn_change_title = toga.Button(
             'Change title',

--- a/src/cocoa/toga_cocoa/widgets/optioncontainer.py
+++ b/src/cocoa/toga_cocoa/widgets/optioncontainer.py
@@ -44,13 +44,13 @@ class OptionContainer(Widget):
         # Add the layout constraints
         self.add_constraints()
 
-    def add_content(self, index, label, widget):
+    def add_content(self, index, text, widget):
         """ Adds a new option to the option container.
 
         Args:
             index: The index in the tab list where the tab should be added.
-            label (str): The label for the option container
-            widget: The widget or widget tree that belongs to the label.
+            text (str): The text for the option container
+            widget: The widget or widget tree that belongs to the text.
         """
         widget.viewport = CocoaViewport(widget.native)
 
@@ -58,7 +58,7 @@ class OptionContainer(Widget):
             child._impl.container = widget
 
         item = NSTabViewItem.alloc().init()
-        item.label = label
+        item.label = text
 
         # Turn the autoresizing mask on the widget widget
         # into constraints. This makes the widget fill the
@@ -101,11 +101,11 @@ class OptionContainer(Widget):
     def is_option_enabled(self, index):
         return index not in self._disabled_tabs
 
-    def set_option_label(self, index, value):
+    def set_option_text(self, index, value):
         tabview = self.native.tabViewItemAtIndex(index)
         tabview.label = value
 
-    def get_option_label(self, index):
+    def get_option_text(self, index):
         tabview = self.native.tabViewItemAtIndex(index)
         return tabview.label
 

--- a/src/core/tests/widgets/test_optioncontainer.py
+++ b/src/core/tests/widgets/test_optioncontainer.py
@@ -232,26 +232,67 @@ class OptionContainerTests(TestCase):
     def test_append_tab_deprecated(self):
         # label is a deprecated argument
         with self.assertWarns(DeprecationWarning):
-            self.op_container._content.append(label=self.text2, widget=self.widget2)
+            self.op_container.content.append(label=self.text2, widget=self.widget2)
         self.assertEqual(self.op_container.content[1].text, self.text2)
 
         # can't specify both label *and* text
         with self.assertRaises(ValueError):
-            self.op_container._content.append(text=self.text3, widget=self.widget3, label=self.text3)
+            self.op_container.content.append(text=self.text3, widget=self.widget3, label=self.text3)
 
     def test_insert_tab_deprecated(self):
         # label is a deprecated argument
         with self.assertWarns(DeprecationWarning):
-            self.op_container._content.insert(1, label=self.text2, widget=self.widget2)
+            self.op_container.content.insert(1, label=self.text2, widget=self.widget2)
         self.assertEqual(self.op_container.content[1].text, self.text2)
 
         # can't specify both label *and* text
         with self.assertRaises(ValueError):
-            self.op_container._content.insert(1, text=self.text3, widget=self.widget3, label=self.text3)
+            self.op_container.content.insert(1, text=self.text3, widget=self.widget3, label=self.text3)
 
-    # OptionList.append
-    # OptionList.insert
-    # OptionContainer.add (-> OptionList.append)
+    def test_add_mandatory_parameters(self):
+        my_op_container = toga.OptionContainer(
+            style=TestStyle(),
+            factory=toga_dummy.factory,
+            on_select=self.on_select
+        )
+
+        # text and widget parameters are mandatory
+        with self.assertRaises(TypeError):
+            my_op_container.add()
+        with self.assertRaises(TypeError):
+            my_op_container.add(self.text)
+        with self.assertRaises(TypeError):
+            my_op_container.add(widget=self.widget)
+
+    def test_append_mandatory_parameters(self):
+        my_op_container = toga.OptionContainer(
+            style=TestStyle(),
+            factory=toga_dummy.factory,
+            on_select=self.on_select
+        )
+
+        # text and widget parameters are mandatory
+        with self.assertRaises(TypeError):
+            my_op_container.content.append()
+        with self.assertRaises(TypeError):
+            my_op_container.content.append(self.text)
+        with self.assertRaises(TypeError):
+            my_op_container.content.append(widget=self.widget)
+
+    def test_insert_mandatory_parameters(self):
+        my_op_container = toga.OptionContainer(
+            style=TestStyle(),
+            factory=toga_dummy.factory,
+            on_select=self.on_select
+        )
+
+        # text and widget parameters are mandatory
+        with self.assertRaises(TypeError):
+            my_op_container.content.insert(0)
+        with self.assertRaises(TypeError):
+            my_op_container.content.insert(0, self.text)
+        with self.assertRaises(TypeError):
+            my_op_container.content.insert(0, widget=self.widget)
 
     ######################################################################
     # End backwards compatibility.

--- a/src/core/tests/widgets/test_optioncontainer.py
+++ b/src/core/tests/widgets/test_optioncontainer.py
@@ -16,25 +16,25 @@ class OptionContainerTests(TestCase):
             on_select=self.on_select
         )
         self.widget = toga.Box(style=TestStyle(), factory=toga_dummy.factory)
-        self.label2, self.widget2 = "Widget 2", toga.Box(
+        self.text2, self.widget2 = "Widget 2", toga.Box(
             style=TestStyle(), factory=toga_dummy.factory
         )
-        self.label3, self.widget3 = "Widget 3", toga.Box(
+        self.text3, self.widget3 = "Widget 3", toga.Box(
             style=TestStyle(), factory=toga_dummy.factory
         )
-        self.label = 'New Container'
-        self.op_container.add(self.label, self.widget)
+        self.text = 'New Container'
+        self.op_container.add(self.text, self.widget)
 
-    def assert_tab(self, tab, index, label, widget, enabled):
+    def assert_tab(self, tab, index, text, widget, enabled):
         self.assertEqual(tab.index, index)
-        self.assertEqual(tab.label, label)
+        self.assertEqual(tab.text, text)
         self.assertEqual(tab._interface, self.op_container)
         self.assertEqual(tab.enabled, enabled)
         self.assertEqual(tab.content, widget)
 
     def add_widgets(self):
-        self.op_container.add(self.label2, self.widget2)
-        self.op_container.add(self.label3, self.widget3)
+        self.op_container.add(self.text2, self.widget2)
+        self.op_container.add(self.text3, self.widget3)
 
     def test_on_select(self):
         self.assertEqual(self.op_container.on_select._raw, self.on_select)
@@ -45,7 +45,7 @@ class OptionContainerTests(TestCase):
 
     def test_adding_container_invokes_add_content(self):
         self.assertActionPerformedWith(
-            self.op_container, 'add content', label=self.label, widget=self.widget._impl
+            self.op_container, 'add content', text=self.text, widget=self.widget._impl
         )
 
         self.assertActionPerformedWith(
@@ -67,18 +67,18 @@ class OptionContainerTests(TestCase):
         self.assert_tab(
             self.op_container.current_tab,
             index=1,
-            label=self.label2,
+            text=self.text2,
             widget=self.widget2,
             enabled=True,
         )
 
     def test_set_current_tab_as_label(self):
         self.add_widgets()
-        self.op_container.current_tab = self.label3
+        self.op_container.current_tab = self.text3
         self.assert_tab(
             self.op_container.current_tab,
             index=2,
-            label=self.label3,
+            text=self.text3,
             widget=self.widget3,
             enabled=True,
         )
@@ -89,7 +89,7 @@ class OptionContainerTests(TestCase):
         self.assert_tab(
             self.op_container.current_tab,
             index=1,
-            label=self.label2,
+            text=self.text2,
             widget=self.widget2,
             enabled=True,
         )
@@ -101,34 +101,34 @@ class OptionContainerTests(TestCase):
         self.assert_tab(
             self.op_container.current_tab,
             index=2,
-            label=self.label3,
+            text=self.text3,
             widget=self.widget3,
             enabled=True,
         )
 
-    def test_set_current_tab_as_label_raises_an_error(self):
+    def test_set_current_tab_as_text_raises_an_error(self):
         self.add_widgets()
 
-        def set_label():
+        def set_text():
             self.op_container.current_tab = "I do not exist!"
 
-        self.assertRaises(ValueError, set_label)
+        self.assertRaises(ValueError, set_text)
 
     def test_current_tab_string_increment_raises_an_error(self):
         self.add_widgets()
 
-        def set_label():
+        def set_text():
             self.op_container.current_tab += "I do not exist!"
 
-        self.assertRaises(ValueError, set_label)
+        self.assertRaises(ValueError, set_text)
 
     def test_current_tab_string_decrement_raises_an_error(self):
         self.add_widgets()
 
-        def set_label():
+        def set_text():
             self.op_container.current_tab -= "I do not exist!"
 
-        self.assertRaises(ValueError, set_label)
+        self.assertRaises(ValueError, set_text)
 
     def test_current_tab_decrement(self):
         self.add_widgets()
@@ -137,7 +137,7 @@ class OptionContainerTests(TestCase):
         self.assert_tab(
             self.op_container.current_tab,
             index=0,
-            label=self.label,
+            text=self.text,
             widget=self.widget,
             enabled=True,
         )
@@ -176,9 +176,9 @@ class OptionContainerTests(TestCase):
             style=TestStyle(),
             factory=toga_dummy.factory,
             content=[
-                (self.label, self.widget),
-                (self.label2, self.widget2),
-                (self.label3, self.widget3),
+                (self.text, self.widget),
+                (self.text2, self.widget2),
+                (self.text3, self.widget3),
             ]
         )
         self.assertEqual(len(new_container.content), 3)
@@ -193,16 +193,66 @@ class OptionContainerTests(TestCase):
             self.assertEqual(item._content.window, window)
 
     def test_set_tab_title(self):
-        new_label = 'New Title'
-        self.op_container.content[0].label = new_label
-        self.assertEqual(self.op_container.content[0].label, new_label)
+        new_text = 'New Title'
+        self.op_container.content[0].text = new_text
+        self.assertEqual(self.op_container.content[0].text, new_text)
 
     def test_insert_tab(self):
-        self.op_container.insert(0, label=self.label2, widget=self.widget2)
-        self.assertEqual(self.op_container.content[0].label, self.label2)
+        self.op_container.insert(0, text=self.text2, widget=self.widget2)
+        self.assertEqual(self.op_container.content[0].text, self.text2)
 
     def test_set_app(self):
         app = mock.Mock()
         self.op_container.app = app
         for item in self.op_container.content:
             self.assertEqual(item._content.app, app)
+
+    ######################################################################
+    # 2022-07: Backwards compatibility
+    ######################################################################
+
+    def test_tab_label_deprecated(self):
+        new_text = 'New Text'
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(self.op_container.current_tab.label, self.text)
+        with self.assertWarns(DeprecationWarning):
+            self.op_container.current_tab.label = new_text
+        self.assertEqual(self.op_container.current_tab.text, new_text)
+
+    def test_add_tab_deprecated(self):
+        # label is a deprecated argument
+        with self.assertWarns(DeprecationWarning):
+            self.op_container.add(label=self.text2, widget=self.widget2)
+        self.assertEqual(self.op_container.content[1].text, self.text2)
+
+        # can't specify both label *and* text
+        with self.assertRaises(ValueError):
+            self.op_container.add(text=self.text3, widget=self.widget3, label=self.text3)
+
+    def test_append_tab_deprecated(self):
+        # label is a deprecated argument
+        with self.assertWarns(DeprecationWarning):
+            self.op_container._content.append(label=self.text2, widget=self.widget2)
+        self.assertEqual(self.op_container.content[1].text, self.text2)
+
+        # can't specify both label *and* text
+        with self.assertRaises(ValueError):
+            self.op_container._content.append(text=self.text3, widget=self.widget3, label=self.text3)
+
+    def test_insert_tab_deprecated(self):
+        # label is a deprecated argument
+        with self.assertWarns(DeprecationWarning):
+            self.op_container._content.insert(1, label=self.text2, widget=self.widget2)
+        self.assertEqual(self.op_container.content[1].text, self.text2)
+
+        # can't specify both label *and* text
+        with self.assertRaises(ValueError):
+            self.op_container._content.insert(1, text=self.text3, widget=self.widget3, label=self.text3)
+
+    # OptionList.append
+    # OptionList.insert
+    # OptionContainer.add (-> OptionList.append)
+
+    ######################################################################
+    # End backwards compatibility.
+    ######################################################################

--- a/src/core/toga/widgets/optioncontainer.py
+++ b/src/core/toga/widgets/optioncontainer.py
@@ -1,6 +1,13 @@
+import warnings
+
 from toga.handlers import wrapped_handler
 
 from .base import Widget
+
+# BACKWARDS COMPATIBILITY: a token object that can be used to differentiate
+# between an explicitly provided ``None``, and a unspecified value falling
+# back to a default.
+NOT_PROVIDED = object()
 
 
 class BaseOptionItem:
@@ -16,12 +23,41 @@ class BaseOptionItem:
         self._interface._impl.set_option_enabled(self.index, enabled)
 
     @property
+    def text(self):
+        return self._interface._impl.get_option_text(self.index)
+
+    @text.setter
+    def text(self, value):
+        self._interface._impl.set_option_text(self.index, value)
+
+    ######################################################################
+    # 2022-07: Backwards compatibility
+    ######################################################################
+    # label replaced with text
+    @property
     def label(self):
-        return self._interface._impl.get_option_label(self.index)
+        """ OptionItem text
+
+        **DEPRECATED: renamed as text**
+
+        Returns:
+            The OptionItem text as a ``str``
+        """
+        warnings.warn(
+            "OptionItem.label has been renamed OptionItem.text", DeprecationWarning
+        )
+        return self.text
 
     @label.setter
-    def label(self, value):
-        self._interface._impl.set_option_label(self.index, value)
+    def label(self, label):
+        warnings.warn(
+            "OptionItem.label has been renamed OptionItem.text", DeprecationWarning
+        )
+        self.text = label
+
+    ######################################################################
+    # End backwards compatibility.
+    ######################################################################
 
 
 class OptionItem(BaseOptionItem):
@@ -78,7 +114,7 @@ class OptionList:
         repr_items = ', '.join([
             '{}(title={})'.format(
                 option.__class__.__name__,
-                option.label)
+                option.text)
             for option in self
         ])
         return repr_optionlist.format(self.__class__.__name__, repr_items)
@@ -105,13 +141,98 @@ class OptionList:
     def __len__(self):
         return len(self._options)
 
-    def append(self, label, widget, enabled=True):
-        self._insert(len(self), label, widget, enabled)
+    def append(
+        self,
+        text=NOT_PROVIDED,  # BACKWARDS COMPATIBILITY: The default value
+                            # can be removed when the handling for
+                            # `label`` is removed
+        widget=NOT_PROVIDED,  # BACKWARDS COMPATIBILITY: The default value
+                              # can be removed when the handling for
+                              # `label`` is removed
+        label=None,  # DEPRECATED!
+        enabled=True,
+    ):
+        ##################################################################
+        # 2022-07: Backwards compatibility
+        ##################################################################
+        # When deleting this block, also delete the NOT_PROVIDED
+        # placeholder, and replace it's usage in default values.
 
-    def insert(self, index, label, widget, enabled=True):
-        self._insert(index, label, widget, enabled)
+        # label replaced with text
+        if label is not None:
+            if text is not NOT_PROVIDED:
+                raise ValueError(
+                    "Cannot specify both `label` and `text`; "
+                    "`label` has been deprecated, use `text`"
+                )
+            else:
+                warnings.warn(
+                    "label has been renamed text", DeprecationWarning
+                )
+                text = label
+        elif text is NOT_PROVIDED:
+            # This would be raised by Python itself; however, we need to use a placeholder
+            # value as part of the migration from text->value.
+            raise TypeError("OptionContainer.__init__ missing 1 required positional argument: 'text'")
 
-    def _insert(self, index, label, widget, enabled=True):
+        if widget is NOT_PROVIDED:
+            raise ValueError(
+                "Please specify a value for `widget`"
+            )
+
+        ##################################################################
+        # End backwards compatibility.
+        ##################################################################
+
+        self._insert(len(self), text, widget, enabled)
+
+    def insert(
+        self,
+        index,
+        text=NOT_PROVIDED,  # BACKWARDS COMPATIBILITY: The default value
+                            # can be removed when the handling for
+                            # `label`` is removed
+        widget=NOT_PROVIDED,  # BACKWARDS COMPATIBILITY: The default value
+                              # can be removed when the handling for
+                              # `label`` is removed
+        label=None,  # DEPRECATED!
+        enabled=True,
+    ):
+        ##################################################################
+        # 2022-07: Backwards compatibility
+        ##################################################################
+        # When deleting this block, also delete the NOT_PROVIDED
+        # placeholder, and replace it's usage in default values.
+
+        # label replaced with text
+        if label is not None:
+            if text is not NOT_PROVIDED:
+                raise ValueError(
+                    "Cannot specify both `label` and `text`; "
+                    "`label` has been deprecated, use `text`"
+                )
+            else:
+                warnings.warn(
+                    "label has been renamed text", DeprecationWarning
+                )
+                text = label
+        elif text is NOT_PROVIDED:
+            # This would be raised by Python itself; however, we need to use a placeholder
+            # value as part of the migration from text->value.
+            raise TypeError("OptionContainer.__init__ missing 1 required positional argument: 'text'")
+
+        if widget is NOT_PROVIDED:
+            raise ValueError(
+                "Please specify a value for `widget`"
+            )
+
+        ##################################################################
+        # End backwards compatibility.
+        ##################################################################
+
+        self._insert(index, text, widget, enabled)
+
+    def _insert(self, index, text, widget, enabled=True):
         # Create an interface wrapper for the option.
         item = OptionItem(self.interface, widget, index)
 
@@ -123,7 +244,7 @@ class OptionList:
 
         # Add the content to the implementation.
         # This will cause the native implementation to be created.
-        self.interface._impl.add_content(index, label, widget._impl)
+        self.interface._impl.add_content(index, text, widget._impl)
 
         # The option now exists on the implementation;
         # finalize the display properties that can't be resolved until the
@@ -154,8 +275,8 @@ class OptionContainer(Widget):
         self.on_select = on_select
         self._content = OptionList(self)
         if content:
-            for label, widget in content:
-                self.add(label, widget)
+            for text, widget in content:
+                self.add(text, widget)
 
         self.on_select = on_select
         # Create a proxy object to represent the currently selected item.
@@ -183,7 +304,7 @@ class OptionContainer(Widget):
         if isinstance(current_tab, str):
             try:
                 current_tab = next(
-                    filter(lambda item: item.label == current_tab, self.content)
+                    filter(lambda item: item.text == current_tab, self.content)
                 )
             except StopIteration:
                 raise ValueError("No tab named {}".format(current_tab))
@@ -201,30 +322,71 @@ class OptionContainer(Widget):
         for item in self._content:
             item._content.window = window
 
-    def add(self, label, widget):
+    def add(
+        self,
+        text=NOT_PROVIDED,  # BACKWARDS COMPATIBILITY: The default value
+                            # can be removed when the handling for
+                            # `label`` is removed
+        widget=NOT_PROVIDED,  # BACKWARDS COMPATIBILITY: The default value
+                              # can be removed when the handling for
+                              # `label`` is removed
+        label=None,  # DEPRECATED!
+    ):
         """ Add a new option to the option container.
 
         Args:
-            label (str): The label for the option.
+            text (str): The text for the option.
             widget (:class:`toga.Widget`): The widget to add to the option.
         """
         widget.app = self.app
         widget.window = self.window
 
-        self._content.append(label, widget)
+        ##################################################################
+        # 2022-07: Backwards compatibility
+        ##################################################################
+        # When deleting this block, also delete the NOT_PROVIDED
+        # placeholder, and replace it's usage in default values.
 
-    def insert(self, index, label, widget):
+        # label replaced with text
+        if label is not None:
+            if text is not NOT_PROVIDED:
+                raise ValueError(
+                    "Cannot specify both `label` and `text`; "
+                    "`label` has been deprecated, use `text`"
+                )
+            else:
+                warnings.warn(
+                    "label has been renamed text", DeprecationWarning
+                )
+                text = label
+        elif text is NOT_PROVIDED:
+            # This would be raised by Python itself; however, we need to use a placeholder
+            # value as part of the migration from text->value.
+            raise TypeError("OptionContainer.__init__ missing 1 required positional argument: 'text'")
+
+        if widget is NOT_PROVIDED:
+            raise ValueError(
+                "Please specify a value for `widget`"
+            )
+
+        ##################################################################
+        # End backwards compatibility.
+        ##################################################################
+
+        self._content.append(text, widget)
+
+    def insert(self, index, text, widget):
         """ Insert a new option at the specified index.
 
         Args:
             index (int): Index for the option.
-            label (str): The label for the option.
+            text (str): The text for the option.
             widget (:class:`toga.Widget`): The widget to add to the option.
         """
         widget.app = self.app
         widget.window = self.window
 
-        self._content.insert(index, label, widget)
+        self._content.insert(index, text, widget)
 
     def remove(self, index):
         del self._content[index]

--- a/src/core/toga/widgets/optioncontainer.py
+++ b/src/core/toga/widgets/optioncontainer.py
@@ -157,6 +157,7 @@ class OptionList:
         ##################################################################
         # When deleting this block, also delete the NOT_PROVIDED
         # placeholder, and replace it's usage in default values.
+        missing_arguments = []
 
         # label replaced with text
         if label is not None:
@@ -171,13 +172,23 @@ class OptionList:
                 )
                 text = label
         elif text is NOT_PROVIDED:
-            # This would be raised by Python itself; however, we need to use a placeholder
-            # value as part of the migration from text->value.
-            raise TypeError("OptionContainer.__init__ missing 1 required positional argument: 'text'")
+            missing_arguments.append('text')
 
         if widget is NOT_PROVIDED:
-            raise ValueError(
-                "Please specify a value for `widget`"
+            missing_arguments.append('widget')
+
+        # This would be raised by Python itself; however, we need to use a placeholder
+        # value as part of the migration from text->value.
+        if len(missing_arguments) == 1:
+            raise TypeError(
+                "OptionList.append missing 1 required positional argument: '{}'".format(missing_arguments[0])
+            )
+        elif len(missing_arguments) > 1:
+            raise TypeError(
+                "OptionList.append missing {} required positional arguments: {}".format(
+                    len(missing_arguments),
+                    ' and '.join(["'{}'".format(name) for name in missing_arguments])
+                )
             )
 
         ##################################################################
@@ -203,6 +214,7 @@ class OptionList:
         ##################################################################
         # When deleting this block, also delete the NOT_PROVIDED
         # placeholder, and replace it's usage in default values.
+        missing_arguments = []
 
         # label replaced with text
         if label is not None:
@@ -217,13 +229,23 @@ class OptionList:
                 )
                 text = label
         elif text is NOT_PROVIDED:
-            # This would be raised by Python itself; however, we need to use a placeholder
-            # value as part of the migration from text->value.
-            raise TypeError("OptionContainer.__init__ missing 1 required positional argument: 'text'")
+            missing_arguments.append('text')
 
         if widget is NOT_PROVIDED:
-            raise ValueError(
-                "Please specify a value for `widget`"
+            missing_arguments.append('widget')
+
+        # This would be raised by Python itself; however, we need to use a placeholder
+        # value as part of the migration from text->value.
+        if len(missing_arguments) == 1:
+            raise TypeError(
+                "OptionList.insert missing 1 required positional argument: '{}'".format(missing_arguments[0])
+            )
+        elif len(missing_arguments) > 1:
+            raise TypeError(
+                "OptionList.insert missing {} required positional arguments: {}".format(
+                    len(missing_arguments),
+                    ' and '.join(["'{}'".format(name) for name in missing_arguments])
+                )
             )
 
         ##################################################################
@@ -338,14 +360,12 @@ class OptionContainer(Widget):
             text (str): The text for the option.
             widget (:class:`toga.Widget`): The widget to add to the option.
         """
-        widget.app = self.app
-        widget.window = self.window
-
         ##################################################################
         # 2022-07: Backwards compatibility
         ##################################################################
         # When deleting this block, also delete the NOT_PROVIDED
         # placeholder, and replace it's usage in default values.
+        missing_arguments = []
 
         # label replaced with text
         if label is not None:
@@ -360,18 +380,31 @@ class OptionContainer(Widget):
                 )
                 text = label
         elif text is NOT_PROVIDED:
-            # This would be raised by Python itself; however, we need to use a placeholder
-            # value as part of the migration from text->value.
-            raise TypeError("OptionContainer.__init__ missing 1 required positional argument: 'text'")
+            missing_arguments.append('text')
 
         if widget is NOT_PROVIDED:
-            raise ValueError(
-                "Please specify a value for `widget`"
+            missing_arguments.append('widget')
+
+        # This would be raised by Python itself; however, we need to use a placeholder
+        # value as part of the migration from text->value.
+        if len(missing_arguments) == 1:
+            raise TypeError(
+                "OptionContainer.add missing 1 required positional argument: '{}'".format(missing_arguments[0])
+            )
+        elif len(missing_arguments) > 1:
+            raise TypeError(
+                "OptionContainer.add missing {} required positional arguments: {}".format(
+                    len(missing_arguments),
+                    ' and '.join(["'{}'".format(name) for name in missing_arguments])
+                )
             )
 
         ##################################################################
         # End backwards compatibility.
         ##################################################################
+
+        widget.app = self.app
+        widget.window = self.window
 
         self._content.append(text, widget)
 

--- a/src/dummy/toga_dummy/widgets/optioncontainer.py
+++ b/src/dummy/toga_dummy/widgets/optioncontainer.py
@@ -4,8 +4,8 @@ from ..utils import not_required
 
 @not_required
 class Option:
-    def __init__(self, label, widget, enabled):
-        self.label = label
+    def __init__(self, text, widget, enabled):
+        self.text = text
         self.widget = widget
         self.enabled = enabled
 
@@ -16,9 +16,9 @@ class OptionContainer(Widget):
         self._items = []
         self._current_index = 0
 
-    def add_content(self, index, label, widget):
-        self._action('add content', index=index, label=label, widget=widget)
-        self._items.insert(index, Option(label, widget, True))
+    def add_content(self, index, text, widget):
+        self._action('add content', index=index, text=text, widget=widget)
+        self._items.insert(index, Option(text, widget, True))
 
     def remove_content(self, index):
         if index == self._current_index:
@@ -40,13 +40,13 @@ class OptionContainer(Widget):
         self._get_value('option_{}_enabled'.format(index))
         return self._items[index].enabled
 
-    def set_option_label(self, index, value):
-        self._set_value('option_{}_label'.format(index), value=value)
-        self._items[index].label = value
+    def set_option_text(self, index, value):
+        self._set_value('option_{}_text'.format(index), value=value)
+        self._items[index].text = value
 
-    def get_option_label(self, index):
-        self._get_value('option_{}_label'.format(index))
-        return self._items[index].label
+    def get_option_text(self, index):
+        self._get_value('option_{}_text'.format(index))
+        return self._items[index].text
 
     def set_current_tab_index(self, current_tab_index):
         self._set_value('current_tab_index', current_tab_index)

--- a/src/gtk/toga_gtk/widgets/optioncontainer.py
+++ b/src/gtk/toga_gtk/widgets/optioncontainer.py
@@ -17,14 +17,14 @@ class OptionContainer(Widget):
                 option=self.interface.content[page_num]
             )
 
-    def add_content(self, index, label, widget):
+    def add_content(self, index, text, widget):
         widget.viewport = GtkViewport(widget.native)
 
         # Add all children to the content widget.
         for child in widget.interface.children:
             child._impl.container = widget
 
-        self.native.insert_page(widget.native, Gtk.Label(label=label), index)
+        self.native.insert_page(widget.native, Gtk.Label(label=text), index)
 
         # Tabs aren't visible by default;
         # tell the notebook to show all content.
@@ -48,11 +48,11 @@ class OptionContainer(Widget):
     def is_option_enabled(self, index):
         self.interface.factory.not_implemented('OptionContainer.is_option_enabled()')
 
-    def set_option_label(self, index, value):
+    def set_option_text(self, index, value):
         tab = self.native.get_nth_page(index)
         self.native.set_tab_label(tab, Gtk.Label(label=value))
 
-    def get_option_label(self, index):
+    def get_option_text(self, index):
         tab = self.native.get_nth_page(index)
         return self.native.get_tab_label(tab).get_label()
 

--- a/src/winforms/toga_winforms/widgets/optioncontainer.py
+++ b/src/winforms/toga_winforms/widgets/optioncontainer.py
@@ -9,7 +9,7 @@ class OptionContainer(Widget):
         self.native = WinForms.TabControl()
         self.native.Selected += self.winforms_selected
 
-    def add_content(self, index, label, widget):
+    def add_content(self, index, text, widget):
         widget.viewport = WinFormsViewport(self.native, self)
         widget.frame = self
         # Add all children to the content widget.
@@ -17,7 +17,7 @@ class OptionContainer(Widget):
             child._impl.container = widget
 
         item = WinForms.TabPage()
-        item.Text = label
+        item.Text = text
 
         # Enable AutoSize on the container to fill
         # the available space in the OptionContainer.
@@ -47,10 +47,10 @@ class OptionContainer(Widget):
     def is_option_enabled(self, index):
         return self.native.TabPages[index].Enabled
 
-    def set_option_label(self, index, value):
+    def set_option_text(self, index, value):
         self.native.TabPages[index].Text = value
 
-    def get_option_label(self, index):
+    def get_option_text(self, index):
         return self.native.TabPages[index].Text
 
     def get_current_tab_index(self):


### PR DESCRIPTION
As discussed on https://github.com/beeware/toga/discussions/1521

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
