### PR TITLE
Add "missing" lines to coverage report, and allow for extra parameters

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ changedir = {toxinidir}/src/core
 commands:
     python -m pip install -e .
     python -m pip install -e ../dummy
-    pytest --cov
+    pytest --cov --cov-report term-missing {posargs}
     coverage xml
 
 [testenv:flake8]


### PR DESCRIPTION
This change provides a more useful output when using `tox` to run the test suite on the command line, e.g.:

```
tox -e py310
```

Will run the test suite in a python 3.10 environment, and the coverage report will include the line numbers not being covered by the tests.

It is possible to pass other parameters to `pytest`, e.g.:

```
tox -e py310 -- tests/test_platform.py 
```

Will only run the tests in the specified file.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
