### PR TITLE
Fix bug of disappearing main menu strip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ examples/*/windows/
 
 # Memory Profiler
 mprofile_*.dat
+
+# Briefcase log files.
+briefcase.*.log

--- a/examples/window/window/app.py
+++ b/examples/window/window/app.py
@@ -137,6 +137,15 @@ class WindowDemoApp(toga.App):
             style=Pack(direction=COLUMN)
         )
 
+        restore_command = toga.Command(
+            self.do_prev_content,
+            text='Restore content',
+            tooltip='Restore main window content',
+        )
+
+        self.commands.add(restore_command)
+        self.main_window.toolbar.add(restore_command)
+
         # Add the content on the main window
         self.main_window.content = self.main_box
 

--- a/src/winforms/setup.cfg
+++ b/src/winforms/setup.cfg
@@ -39,20 +39,9 @@ keywords =
     winforms
 
 [options]
-packages = find:
 python_requires = >= 3.6
 zip_safe = False
 include_package_data = True
-
-
-[options.package_data]
-toga_winforms =
-    toga_winforms/libs/WebView2/LICENSE.md
-    toga_winforms/libs/WebView2/Microsoft.Web.WebView2.Core.dll
-    toga_winforms/libs/WebView2/Microsoft.Web.WebView2.WinForms.dll
-    toga_winforms/libs/WebView2/arm64/WebView2Loader.dll
-    toga_winforms/libs/WebView2/x64/WebView2Loader.dll
-    toga_winforms/libs/WebView2/x86/WebView2Loader.dll
 
 [options.packages.find]
 include =

--- a/src/winforms/toga_winforms/window.py
+++ b/src/winforms/toga_winforms/window.py
@@ -121,6 +121,8 @@ class Window:
     def set_content(self, widget):
         self.native.Controls.Clear()
 
+        self.native.Controls.Add(self.native.MainMenuStrip)
+
         if self.toolbar_native:
             self.native.Controls.Add(self.toolbar_native)
             # Create the lookup table of menu items,

--- a/src/winforms/toga_winforms/window.py
+++ b/src/winforms/toga_winforms/window.py
@@ -119,15 +119,23 @@ class Window:
                 child._impl.container = None
 
     def set_content(self, widget):
-        self.native.Controls.Clear()
+        has_content = False
+        for control in self.native.Controls:
+            # The main menu and toolbar are normal in-window controls;
+            # however, they shouldn't be removed if window content is
+            # removed.
+            if control != self.native.MainMenuStrip and control != self.toolbar_native:
+                has_content = True
+                self.native.Controls.Remove(control)
 
-        self.native.Controls.Add(self.native.MainMenuStrip)
-
-        if self.toolbar_native:
+        # The first time content is set for the window, we also need
+        # to add the toolbar as part of the main window content.
+        # We use "did we haev to remove any content" as a marker for
+        # whether this is the first time we're setting content.
+        if not has_content:
             self.native.Controls.Add(self.toolbar_native)
-            # Create the lookup table of menu items,
-            # then force the creation of the menus.
 
+        # Add the actual window content.
         self.native.Controls.Add(widget.native)
 
         # Set the widget's viewport to be based on the window's content.


### PR DESCRIPTION
**Description**
After the fix in #1572 , when setting the `content` property of a window in Windows, its menu strip is disappeared.

**Reproduction steps**
On a Windows computer:
1. Run the "window" example"
2. Click the "change content" button
3. See that the main menu strip above (File, Help, etc.) is gone.

**Solution**
The fix is simple: when we setting the content we clear all the Controls of the window, including the main menu strip. We simply need to add it back.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
