### PR TITLE
Text input is valid property

### DIFF
--- a/examples/textinput/textinput/app.py
+++ b/examples/textinput/textinput/app.py
@@ -21,7 +21,8 @@ class TextInputApp(toga.App):
             self.text_input.value
         )
 
-        self.password_label.text = "Your password is: {}".format(
+        self.password_label.text = "Your password is {}: {}".format(
+            "valid" if self.password_input.is_valid else "invalid",
             self.password_input.value
         )
 
@@ -32,16 +33,9 @@ class TextInputApp(toga.App):
             self.number_label.text = "You didn't enter a number"
 
         # Wait 5 seconds
-        self.label.text = 'Counting down from 5...'
-        yield 1
-        self.label.text = 'Counting down from 4...'
-        yield 1
-        self.label.text = 'Counting down from 3...'
-        yield 1
-        self.label.text = 'Counting down from 2...'
-        yield 1
-        self.label.text = 'Counting down from 1...'
-        yield 1
+        for i in range(5, 0, -1):
+            self.label.text = 'Counting down from {}...'.format(i)
+            yield 1
         self.label.text = 'Enter some values and press extract.'
 
         # Renable the inputs again.

--- a/src/android/toga_android/widgets/textinput.py
+++ b/src/android/toga_android/widgets/textinput.py
@@ -77,6 +77,9 @@ class TextInput(Widget):
     def clear_error(self):
         self.interface.factory.not_implemented("TextInput.clear_error()")
 
+    def is_valid(self):
+        self.interface.factory.not_implemented("TextInput.is_valid()")
+
     def rehint(self):
         self.interface.intrinsic.width = at_least(self.interface.MIN_WIDTH)
         # Refuse to call measure() if widget has no container, i.e., has no LayoutParams.

--- a/src/cocoa/toga_cocoa/widgets/textinput.py
+++ b/src/cocoa/toga_cocoa/widgets/textinput.py
@@ -117,3 +117,7 @@ class TextInput(Widget):
     def clear_error(self):
         # Cocoa TextInput can't ever be in an invalid state, so clear is a no-op
         pass
+
+    def is_valid(self):
+        # Cocoa TextInput can't ever be in an invalid state, so it is always valid
+        return True

--- a/src/core/tests/widgets/test_textinput.py
+++ b/src/core/tests/widgets/test_textinput.py
@@ -117,9 +117,20 @@ class ValidatedTextInputTests(TestCase):
             validators=[validator],
             factory=toga_dummy.factory
         )
+        self.assertTrue(text_input.is_valid)
         self.assertValueNotSet(text_input, "error")
+        self.assertValueSet(text_input, "valid", True)
         self.assertActionPerformed(text_input, "clear_error")
         validator.assert_called_once_with(self.value)
+
+    def test_getting_is_valid_invokes_impl_method(self):
+        text_input = toga.TextInput(
+            value=self.value,
+            factory=toga_dummy.factory
+        )
+        self.assertValueNotGet(text_input, 'valid')
+        text_input.is_valid
+        self.assertValueGet(text_input, 'valid')
 
     def test_validator_run_after_set(self):
         message = "This is an error message"
@@ -129,11 +140,15 @@ class ValidatedTextInputTests(TestCase):
             factory=toga_dummy.factory
         )
 
+        self.assertTrue(text_input.is_valid)
         self.assertValueNotSet(text_input, "error")
+        self.assertValueSet(text_input, "valid", True)
 
         text_input.validators = [validator]
 
+        self.assertFalse(text_input.is_valid)
         self.assertValueSet(text_input, "error", message)
+        self.assertValueSet(text_input, "valid", False)
         validator.assert_called_once_with(self.value)
 
     def test_text_input_with_no_validator_is_valid(self):
@@ -142,6 +157,7 @@ class ValidatedTextInputTests(TestCase):
             factory=toga_dummy.factory
         )
         self.assertTrue(text_input.validate())
+        self.assertTrue(text_input.is_valid)
 
     def test_validate_true_when_valid(self):
         validator = Mock(return_value=None)
@@ -169,9 +185,13 @@ class ValidatedTextInputTests(TestCase):
             validators=[validator],
             factory=toga_dummy.factory
         )
+        self.assertTrue(text_input.is_valid)
+        self.assertValueSet(text_input, "valid", True)
         self.assertValueNotSet(text_input, "error")
 
         text_input.validate()
+        self.assertTrue(text_input.is_valid)
+        self.assertValueSet(text_input, "valid", True)
         self.assertValueNotSet(text_input, "error")
         self.assertEqual(
             validator.call_args_list, [call(self.value), call(self.value)]
@@ -185,10 +205,14 @@ class ValidatedTextInputTests(TestCase):
             validators=[validator],
             factory=toga_dummy.factory
         )
+        self.assertTrue(text_input.is_valid)
         self.assertValueNotSet(text_input, "error")
+        self.assertValueSet(text_input, "valid", True)
 
         text_input.validate()
+        self.assertFalse(text_input.is_valid)
         self.assertValueSet(text_input, "error", message)
+        self.assertValueSet(text_input, "valid", False)
         self.assertEqual(
             validator.call_args_list, [call(self.value), call(self.value)]
         )

--- a/src/core/toga/widgets/textinput.py
+++ b/src/core/toga/widgets/textinput.py
@@ -128,6 +128,10 @@ class TextInput(Widget):
             v = str(value)
         self._impl.set_value(v)
 
+    @property
+    def is_valid(self):
+        return self._impl.is_valid()
+
     def clear(self):
         """ Clears the text of the widget """
         self.value = ''

--- a/src/dummy/toga_dummy/utils.py
+++ b/src/dummy/toga_dummy/utils.py
@@ -367,6 +367,12 @@ class TestCase(unittest.TestCase):
         except AttributeError:
             self.fail('Widget {} is not a logged object'.format(_widget))
 
+    def assertValueNotGet(self, _widget, attr):
+        self.assertTrue(
+            attr not in _widget._impl._gets,
+            msg="Expected {attr} not to be get, but it was.".format(attr=attr)
+        )
+
     def assertValueNotSet(self, _widget, attr):
         self.assertTrue(
             attr not in _widget._impl._sets,

--- a/src/dummy/toga_dummy/widgets/textinput.py
+++ b/src/dummy/toga_dummy/widgets/textinput.py
@@ -37,6 +37,11 @@ class TextInput(Widget):
 
     def set_error(self, error_message):
         self._set_value('error', error_message)
+        self._set_value('valid', False)
 
     def clear_error(self):
         self._action('clear_error')
+        self._set_value('valid', True)
+
+    def is_valid(self):
+        return self._get_value('valid')

--- a/src/gtk/toga_gtk/widgets/textinput.py
+++ b/src/gtk/toga_gtk/widgets/textinput.py
@@ -59,3 +59,6 @@ class TextInput(Widget):
 
     def clear_error(self):
         self.interface.factory.not_implemented("TextInput.clear_error()")
+
+    def is_valid(self):
+        self.interface.factory.not_implemented("TextInput.is_valid()")

--- a/src/iOS/toga_iOS/widgets/textinput.py
+++ b/src/iOS/toga_iOS/widgets/textinput.py
@@ -79,3 +79,6 @@ class TextInput(Widget):
 
     def clear_error(self):
         self.interface.factory.not_implemented("TextInput.clear_error()")
+
+    def is_valid(self):
+        self.interface.factory.not_implemented("TextInput.is_valid()")

--- a/src/winforms/toga_winforms/widgets/textinput.py
+++ b/src/winforms/toga_winforms/widgets/textinput.py
@@ -100,6 +100,9 @@ class TextInput(Widget):
         if self.container and self.interface.on_lose_focus:
             self.interface.on_lose_focus(self.interface)
 
+    def is_valid(self):
+        return self.error_provider.GetError(self.native) == ""
+
     def clear_error(self):
         self.error_provider.SetError(self.native, "")
 


### PR DESCRIPTION
Fixes #1582 

Added `TextInput.is_valid` property as suggested in the linked issue.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
