### PR TITLE
Window hide method and visible

### DIFF
--- a/examples/window/window/app.py
+++ b/examples/window/window/app.py
@@ -75,6 +75,14 @@ class WindowDemoApp(toga.App):
     def do_prev_content(self, widget):
         self.main_window.content = self.main_box
 
+    def do_hide(self, widget):
+        self.main_window.visible = False
+        for i in range(5, 0, -1):
+            print(f"Back in {i}...")
+            yield 1
+        self.main_window.visible = True
+        self.main_window.info_dialog("Here we go again", "I'm back!")
+
     def exit_handler(self, app, **kwargs):
         self.close_count += 1
         if self.close_count % 2 == 1:
@@ -113,6 +121,9 @@ class WindowDemoApp(toga.App):
         btn_change_content = toga.Button(
             "Change content", on_press=self.do_next_content, style=btn_style
         )
+        btn_hide = toga.Button(
+            "Hide", on_press=self.do_hide, style=btn_style
+        )
         self.main_box = toga.Box(
             children=[
                 self.label,
@@ -125,6 +136,7 @@ class WindowDemoApp(toga.App):
                 btn_do_new_windows,
                 btn_do_report,
                 btn_change_content,
+                btn_hide,
             ],
             style=Pack(direction=COLUMN)
         )

--- a/src/android/toga_android/window.py
+++ b/src/android/toga_android/window.py
@@ -91,6 +91,12 @@ class Window(ViewTreeObserver__OnGlobalLayoutListener):
     def show(self):
         pass
 
+    def hide(self):
+        self.interface.not_implemented("Window.hide()")
+
+    def get_visible(self):
+        self.interface.not_implemented("Window.get_visible()")
+
     def close(self):
         pass
 

--- a/src/android/toga_android/window.py
+++ b/src/android/toga_android/window.py
@@ -92,10 +92,12 @@ class Window(ViewTreeObserver__OnGlobalLayoutListener):
         pass
 
     def hide(self):
-        self.interface.not_implemented("Window.hide()")
+        # A no-op, as the window cannot be hidden.
+        pass
 
     def get_visible(self):
-        self.interface.not_implemented("Window.get_visible()")
+        # The window is alays visible
+        return True
 
     def close(self):
         pass

--- a/src/cocoa/toga_cocoa/window.py
+++ b/src/cocoa/toga_cocoa/window.py
@@ -286,6 +286,12 @@ class Window:
         # Refresh with the actual viewport to do the proper rendering.
         self.interface.content.refresh()
 
+    def hide(self):
+        self.interface.not_implemented("Window.hide()")
+
+    def get_visible(self):
+        self.interface.not_implemented("Window.get_visible()")
+
     def set_full_screen(self, is_full_screen):
         self.interface.factory.not_implemented('Window.set_full_screen()')
 

--- a/src/cocoa/toga_cocoa/window.py
+++ b/src/cocoa/toga_cocoa/window.py
@@ -287,10 +287,10 @@ class Window:
         self.interface.content.refresh()
 
     def hide(self):
-        self.interface.not_implemented("Window.hide()")
+        self.native.orderOut(self.native)
 
     def get_visible(self):
-        self.interface.not_implemented("Window.get_visible()")
+        return bool(self.native.isVisible)
 
     def set_full_screen(self, is_full_screen):
         self.interface.factory.not_implemented('Window.set_full_screen()')

--- a/src/core/tests/test_window.py
+++ b/src/core/tests/test_window.py
@@ -13,16 +13,58 @@ class TestWindow(TestCase):
         self.window = toga.Window(factory=toga_dummy.factory)
         self.app = toga.App("test_name", "id.app", factory=toga_dummy.factory)
 
-    def test_raises_error_when_app_not_set(self):
+    def test_show_is_not_called_in_constructor(self):
+        self.assertActionNotPerformed(self.window, "show")
+
+    def test_show_raises_error_when_app_not_set(self):
         self.app = None
-        with self.assertRaises(AttributeError):
+        with self.assertRaisesRegex(
+            AttributeError, "^Can't show a window that doesn't have an associated app$"
+        ):
             self.window.show()
+
+    def test_window_show_with_app_set(self):
+        self.window.app = self.app
+        self.window.show()
+        self.assertActionPerformed(self.window, "show")
+        self.assertTrue(self.window.visible)
+        self.assertValueSet(self.window, "visible", True)
+
+    def test_hide_raises_error_when_app_not_set(self):
+        self.app = None
+        with self.assertRaisesRegex(
+            AttributeError, "^Can't hide a window that doesn't have an associated app$"
+        ):
+            self.window.hide()
+
+    def test_window_hide_with_app_set(self):
+        self.window.app = self.app
+        self.window.hide()
+        self.assertActionPerformed(self.window, "hide")
+        self.assertFalse(self.window.visible)
+        self.assertValueSet(self.window, "visible", False)
+
+    def test_window_show_by_setting_visible_to_true(self):
+        self.window.app = self.app
+        self.window.visible = True
+        self.assertActionPerformed(self.window, "show")
+        self.assertTrue(self.window.visible)
+        self.assertValueSet(self.window, "visible", True)
+
+    def test_window_show_by_setting_visible_to_false(self):
+        self.window.app = self.app
+        self.window.visible = False
+        self.assertActionPerformed(self.window, "hide")
+        self.assertFalse(self.window.visible)
+        self.assertValueSet(self.window, "visible", False)
 
     def test_widget_created(self):
         self.assertIsNotNone(self.window.id)
         new_app = toga.App("error_name", "id.error", factory=toga_dummy.factory)
         self.window.app = self.app
-        with self.assertRaises(Exception):
+        with self.assertRaisesRegex(
+            Exception, "^Window is already associated with an App$"
+        ):
             self.window.app = new_app
 
     def test_window_title(self):
@@ -190,7 +232,7 @@ class TestWindow(TestCase):
             retry=retry,
         )
 
-    def test_save_file_dialog(self):
+    def test_save_file_dialog_with_initial_directory(self):
         title = "save_file_dialog_test"
         suggested_filename = "/path/to/initial_filename.doc"
         file_types = ["test"]
@@ -203,6 +245,22 @@ class TestWindow(TestCase):
             title=title,
             filename="initial_filename.doc",
             initial_directory=Path("/path/to"),
+            file_types=file_types,
+        )
+
+    def test_save_file_dialog_with_self_as_initial_directory(self):
+        title = "save_file_dialog_test"
+        suggested_filename = "./initial_filename.doc"
+        file_types = ["test"]
+
+        self.window.save_file_dialog(title, suggested_filename, file_types)
+
+        self.assertActionPerformedWith(
+            self.window,
+            "save_file_dialog",
+            title=title,
+            filename="initial_filename.doc",
+            initial_directory=None,
             file_types=file_types,
         )
 

--- a/src/core/toga/window.py
+++ b/src/core/toga/window.py
@@ -27,7 +27,9 @@ class Window:
     def __init__(self, id=None, title=None,
                  position=(100, 100), size=(640, 480),
                  toolbar=None, resizeable=True,
-                 closeable=True, minimizable=True, factory=None, on_close=None):
+                 closeable=True, minimizable=True,
+                 factory=None, on_close=None,
+                 ):
 
         self._id = id if id else identifier(self)
         self._impl = None
@@ -182,6 +184,12 @@ class Window:
             raise AttributeError("Can't show a window that doesn't have an associated app")
         self._impl.show()
 
+    def hide(self):
+        """ Show window, if hidden """
+        if self.app is None:
+            raise AttributeError("Can't hide a window that doesn't have an associated app")
+        self._impl.hide()
+
     @property
     def full_screen(self):
         return self._is_full_screen
@@ -190,6 +198,17 @@ class Window:
     def full_screen(self, is_full_screen):
         self._is_full_screen = is_full_screen
         self._impl.set_full_screen(is_full_screen)
+
+    @property
+    def visible(self):
+        return self._impl.get_visible()
+
+    @visible.setter
+    def visible(self, visible):
+        if visible:
+            self.show()
+        else:
+            self.hide()
 
     @property
     def on_close(self):

--- a/src/dummy/toga_dummy/window.py
+++ b/src/dummy/toga_dummy/window.py
@@ -42,6 +42,14 @@ class Window(LoggedObject):
 
     def show(self):
         self._action('show')
+        self._set_value('visible', True)
+
+    def hide(self):
+        self._action('hide')
+        self._set_value('visible', False)
+
+    def get_visible(self):
+        return self._get_value('visible')
 
     def close(self):
         self._action('close')

--- a/src/gtk/toga_gtk/window.py
+++ b/src/gtk/toga_gtk/window.py
@@ -81,8 +81,9 @@ class Window:
                 item_impl.set_draw(False)
             else:
                 item_impl = Gtk.ToolButton()
-                icon_impl = cmd.icon.bind(self.interface.factory)
-                item_impl.set_icon_widget(icon_impl.native_32)
+                if cmd.icon:
+                    icon_impl = cmd.icon.bind(self.interface.factory)
+                    item_impl.set_icon_widget(icon_impl.native_32)
                 item_impl.set_label(cmd.text)
                 item_impl.set_tooltip_text(cmd.tooltip)
                 item_impl.connect("clicked", wrapped_handler(cmd, cmd.action))
@@ -134,10 +135,10 @@ class Window:
         self.interface.content._impl.min_height = self.interface.content.layout.height
 
     def hide(self):
-        self.interface.not_implemented("Window.hide()")
+        self.native.hide()
 
     def get_visible(self):
-        self.interface.not_implemented("Window.get_visible()")
+        return self.native.get_property("visible")
 
     def gtk_delete_event(self, widget, data):
         if self._is_closing:

--- a/src/gtk/toga_gtk/window.py
+++ b/src/gtk/toga_gtk/window.py
@@ -133,6 +133,12 @@ class Window:
         self.interface.content._impl.min_width = self.interface.content.layout.width
         self.interface.content._impl.min_height = self.interface.content.layout.height
 
+    def hide(self):
+        self.interface.not_implemented("Window.hide()")
+
+    def get_visible(self):
+        self.interface.not_implemented("Window.get_visible()")
+
     def gtk_delete_event(self, widget, data):
         if self._is_closing:
             should_close = True

--- a/src/iOS/toga_iOS/window.py
+++ b/src/iOS/toga_iOS/window.py
@@ -90,5 +90,11 @@ class Window:
         # Refresh with the actual viewport to do the proper rendering.
         self.interface.content.refresh()
 
+    def hide(self):
+        self.interface.not_implemented("Window.hide()")
+
+    def get_visible(self):
+        self.interface.not_implemented("Window.get_visible()")
+
     def close(self):
         pass

--- a/src/iOS/toga_iOS/window.py
+++ b/src/iOS/toga_iOS/window.py
@@ -91,10 +91,12 @@ class Window:
         self.interface.content.refresh()
 
     def hide(self):
-        self.interface.not_implemented("Window.hide()")
+        # A no-op, as the window cannot be hidden.
+        pass
 
     def get_visible(self):
-        self.interface.not_implemented("Window.get_visible()")
+        # The window is alays visible
+        return True
 
     def close(self):
         pass

--- a/src/web/toga_web/window.py
+++ b/src/web/toga_web/window.py
@@ -71,6 +71,12 @@ class Window:
         # self.interface.content._impl.min_width = self.interface.content.layout.width
         # self.interface.content._impl.min_height = self.interface.content.layout.height
 
+    def hide(self):
+        self.interface.not_implemented("Window.hide()")
+
+    def get_visible(self):
+        self.interface.not_implemented("Window.get_visible()")
+
     def on_close(self, *args):
         pass
 

--- a/src/winforms/toga_winforms/window.py
+++ b/src/winforms/toga_winforms/window.py
@@ -172,7 +172,13 @@ class Window:
 
         if self.interface is not self.interface.app._main_window:
             self.native.Icon = self.interface.app.icon.bind(self.interface.factory).native
-            self.native.Show()
+        self.native.Show()
+
+    def hide(self):
+        self.native.Hide()
+
+    def get_visible(self):
+        return self.native.Visible
 
     def winforms_FormClosing(self, sender, event):
         # If the app is exiting, or a manual close has been requested,


### PR DESCRIPTION
Fixes #1553 

This is an implementation of the API described in the linked issue.

Now, one can programmatically hide and show a window. Moreover, a `Window.visible` attribute was add to indicate if a window is visible or not.

Added an implementation for Windows and empty implementation for all other platforms.

Added relevant unit tests and made coverage of `toga.Window` 100%.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
