### PR TITLE
Load Image from bytes

### DIFF
--- a/examples/imageview/imageview/app.py
+++ b/examples/imageview/imageview/app.py
@@ -1,3 +1,5 @@
+import io
+
 import toga
 from toga.style.pack import CENTER, COLUMN
 
@@ -27,9 +29,21 @@ class ImageViewApp(toga.App):
         box.add(imageview_from_pathlib_path)
 
         # image from bytes
-        with open(self.paths.app / 'resources/pride-brutus.png', 'rb') as f:
-            data = f.read()
-        image_from_bytes = toga.Image(data)
+        try:
+            # generate an image using pillow
+            from PIL import Image, ImageDraw
+            img = Image.new('RGBA', size=(110, 30))
+            d1 = ImageDraw.Draw(img)
+            d1.text((20, 10), "Pillow image", fill='green')
+            # get png bytes
+            buffer = io.BytesIO()
+            img.save(buffer, format='png', compress_level=0)
+            data = buffer.getvalue()
+        except ImportError:
+            # if pillow is not installed, fallback to loading a file
+            with open(self.paths.app / 'resources/pride-brutus.png', 'rb') as f:
+                data = f.read()
+        image_from_bytes = toga.Image(data=data)
         imageview_from_bytes = toga.ImageView(image_from_bytes)
         imageview_from_bytes.style.update(height=72)
         box.add(imageview_from_bytes)

--- a/examples/imageview/imageview/app.py
+++ b/examples/imageview/imageview/app.py
@@ -26,6 +26,14 @@ class ImageViewApp(toga.App):
         imageview_from_pathlib_path.style.update(height=72)
         box.add(imageview_from_pathlib_path)
 
+        # image from bytes
+        with open(self.paths.app / 'resources/pride-brutus.png', 'rb') as f:
+            data = f.read()
+        image_from_bytes = toga.Image(data)
+        imageview_from_bytes = toga.ImageView(image_from_bytes)
+        imageview_from_bytes.style.update(height=72)
+        box.add(imageview_from_bytes)
+
         # image from remote URL
         # no style parameters - we let Pack determine how to allocate
         # the space

--- a/examples/imageview/imageview/app.py
+++ b/examples/imageview/imageview/app.py
@@ -3,6 +3,8 @@ import io
 import toga
 from toga.style.pack import CENTER, COLUMN
 
+from PIL import Image, ImageDraw
+
 
 class ImageViewApp(toga.App):
     def startup(self):
@@ -29,21 +31,15 @@ class ImageViewApp(toga.App):
         box.add(imageview_from_pathlib_path)
 
         # image from bytes
-        try:
-            # generate an image using pillow
-            from PIL import Image, ImageDraw
-            img = Image.new('RGBA', size=(110, 30))
-            d1 = ImageDraw.Draw(img)
-            d1.text((20, 10), "Pillow image", fill='green')
-            # get png bytes
-            buffer = io.BytesIO()
-            img.save(buffer, format='png', compress_level=0)
-            data = buffer.getvalue()
-        except ImportError:
-            # if pillow is not installed, fallback to loading a file
-            with open(self.paths.app / 'resources/pride-brutus.png', 'rb') as f:
-                data = f.read()
-        image_from_bytes = toga.Image(data=data)
+        # generate an image using pillow
+        img = Image.new('RGBA', size=(110, 30))
+        d1 = ImageDraw.Draw(img)
+        d1.text((20, 10), "Pillow image", fill='green')
+        # get png bytes
+        buffer = io.BytesIO()
+        img.save(buffer, format='png', compress_level=0)
+
+        image_from_bytes = toga.Image(data=buffer.getvalue())
         imageview_from_bytes = toga.ImageView(image_from_bytes)
         imageview_from_bytes.style.update(height=72)
         box.add(imageview_from_bytes)

--- a/examples/imageview/pyproject.toml
+++ b/examples/imageview/pyproject.toml
@@ -16,6 +16,7 @@ description = "A testing app"
 sources = ['imageview']
 requires = [
     '../../src/core',
+    "Pillow",
 ]
 
 

--- a/src/android/toga_android/images.py
+++ b/src/android/toga_android/images.py
@@ -2,7 +2,7 @@ from .libs.android.graphics import BitmapFactory
 
 
 class Image:
-    def __init__(self, interface, path=None, url=None):
+    def __init__(self, interface, path=None, url=None, data=None):
         self.interface = interface
         self.path = path
         self.url = url
@@ -12,3 +12,5 @@ class Image:
         elif url:
             # Android BitmapFactory nor ImageView provide a convenient async way to fetch images by URL
             self.native = None
+        elif data:
+            self.native = BitmapFactory.decodeByteArray(data, 0, len(data))

--- a/src/cocoa/toga_cocoa/images.py
+++ b/src/cocoa/toga_cocoa/images.py
@@ -1,8 +1,9 @@
 from toga_cocoa.libs import NSURL, NSImage
+from toga_cocoa.libs.foundation import NSData
 
 
 class Image:
-    def __init__(self, interface, path=None, url=None):
+    def __init__(self, interface, path=None, url=None, data=None):
         self.interface = interface
         self.path = path
         self.url = url
@@ -12,4 +13,8 @@ class Image:
         elif url:
             self.native = NSImage.alloc().initByReferencingURL(
                 NSURL.URLWithString_(url)
+            )
+        elif data:
+            self.native = NSImage.alloc().initWithData(
+                NSData.dataWithBytes(data, length=len(data))
             )

--- a/src/cocoa/toga_cocoa/libs/foundation.py
+++ b/src/cocoa/toga_cocoa/libs/foundation.py
@@ -20,6 +20,10 @@ NSBundle.declare_class_property('mainBundle')
 NSBundle.declare_property('bundlePath')
 
 ######################################################################
+# NSData.h
+NSData = ObjCClass('NSData')
+
+######################################################################
 # NSFileWrapper.h
 NSFileWrapper = ObjCClass('NSFileWrapper')
 

--- a/src/core/tests/test_image.py
+++ b/src/core/tests/test_image.py
@@ -80,7 +80,7 @@ class ImageTests(TestCase):
             toga.Image(None)
 
     def test_too_many_arguments(self):
-        path='/image.png'
+        path = '/image.png'
         data = bytes([1])
         with self.assertRaises(ValueError):
             toga.Image(path=path, data=data)

--- a/src/core/tests/test_image.py
+++ b/src/core/tests/test_image.py
@@ -67,3 +67,10 @@ class ImageTests(TestCase):
 
     def test_url_image_path(self):
         self.assertEqual(self.url_image.path, self.url_path)
+
+    def test_bytes_image(self):
+        data = bytes([1])
+        bytes_image = toga.Image(data)
+        bytes_image.bind(factory=toga_dummy.factory)
+        self.assertEqual(bytes_image._impl.interface, bytes_image)
+        self.assertActionPerformedWith(bytes_image, 'load image data', data=data)

--- a/src/core/tests/test_image.py
+++ b/src/core/tests/test_image.py
@@ -70,7 +70,17 @@ class ImageTests(TestCase):
 
     def test_bytes_image(self):
         data = bytes([1])
-        bytes_image = toga.Image(data)
+        bytes_image = toga.Image(data=data)
         bytes_image.bind(factory=toga_dummy.factory)
         self.assertEqual(bytes_image._impl.interface, bytes_image)
         self.assertActionPerformedWith(bytes_image, 'load image data', data=data)
+
+    def test_not_enough_arguments(self):
+        with self.assertRaises(ValueError):
+            toga.Image(None)
+
+    def test_too_many_arguments(self):
+        path='/image.png'
+        data = bytes([1])
+        with self.assertRaises(ValueError):
+            toga.Image(path=path, data=data)

--- a/src/core/toga/images.py
+++ b/src/core/toga/images.py
@@ -8,22 +8,25 @@ class Image:
     :param path: Path to the image. Allowed values can be local file
         (relative or absolute path) or URL (HTTP or HTTPS). Relative paths
         will be interpreted relative to the application module directory.
-        TODO: or bytes object containig a valid image...
+    :param data: A bytes object with the contents of an image in a supported
+        format.
     """
-    def __init__(self, value=None, path=None):
-        if path is not None:
-            value = path  # TODO: code to deprecate path
-        self.data = None
-        self.path = None
+    def __init__(self, path=None, *, data=None):
+        if path is None and data is None:
+            raise ValueError('Either path or data must be set.')
+        if path is not None and data is not None:
+            raise ValueError('Only either path or data can be set.')
 
-        if isinstance(value, bytes):
-            self.data = value
-        elif isinstance(value, pathlib.Path):
-            self.path = value
-        elif value.startswith('http://') or value.startswith('https://'):
-            self.path = value
+        if path:
+            if isinstance(path, pathlib.Path):
+                self.path = path
+            elif path.startswith('http://') or path.startswith('https://'):
+                self.path = path
+            else:
+                self.path = pathlib.Path(path)
         else:
-            self.path = pathlib.Path(value)
+            self.path = None
+        self.data = data
 
         # Resource is late bound.
         self._impl = None

--- a/src/core/toga/images.py
+++ b/src/core/toga/images.py
@@ -7,8 +7,8 @@ class Image:
 
     :param path: Path to the image. Allowed values can be local file
         (relative or absolute path) or URL (HTTP or HTTPS). Relative paths
-        will be interpreted relative to the application module directory.
-    TODO: or bytes object containig a valid image...
+        will be interpreted relative to the application module directory. 
+        TODO: or bytes object containig a valid image...
     """
     def __init__(self, value=None, path=None):
         if path is not None:

--- a/src/core/toga/images.py
+++ b/src/core/toga/images.py
@@ -8,14 +8,22 @@ class Image:
     :param path: Path to the image. Allowed values can be local file
         (relative or absolute path) or URL (HTTP or HTTPS). Relative paths
         will be interpreted relative to the application module directory.
+    TODO: or bytes object containig a valid image...
     """
-    def __init__(self, path):
-        if isinstance(path, pathlib.Path):
-            self.path = path
-        elif path.startswith('http://') or path.startswith('https://'):
-            self.path = path
+    def __init__(self, value=None, path=None):
+        if path is not None:
+            value = path  #TODO: code to deprecate path
+        self.data = None
+        self.path = None
+
+        if isinstance(value, bytes):
+            self.data = value
+        elif isinstance(value, pathlib.Path):
+            self.path = value
+        elif value.startswith('http://') or value.startswith('https://'):
+            self.path = value
         else:
-            self.path = pathlib.Path(path)
+            self.path = pathlib.Path(value)
 
         # Resource is late bound.
         self._impl = None
@@ -24,14 +32,16 @@ class Image:
         """
         Bind the Image to a factory.
 
-        Creates the underlying platform implemenation of the Image. Raises
+        Creates the underlying platform implementation of the Image. Raises
         FileNotFoundError if the path is a non-existent local file.
 
         :param factory: The platform factory to bind to.
         :returns: The platform implementation
         """
         if self._impl is None:
-            if isinstance(self.path, pathlib.Path):
+            if self.data is not None:
+                self._impl = factory.Image(interface=self, data=self.data)
+            elif isinstance(self.path, pathlib.Path):
                 full_path = factory.paths.app / self.path
                 if not full_path.exists():
                     raise FileNotFoundError(

--- a/src/core/toga/images.py
+++ b/src/core/toga/images.py
@@ -7,7 +7,7 @@ class Image:
 
     :param path: Path to the image. Allowed values can be local file
         (relative or absolute path) or URL (HTTP or HTTPS). Relative paths
-        will be interpreted relative to the application module directory. 
+        will be interpreted relative to the application module directory.
         TODO: or bytes object containig a valid image...
     """
     def __init__(self, value=None, path=None):

--- a/src/core/toga/images.py
+++ b/src/core/toga/images.py
@@ -12,7 +12,7 @@ class Image:
     """
     def __init__(self, value=None, path=None):
         if path is not None:
-            value = path  #TODO: code to deprecate path
+            value = path  # TODO: code to deprecate path
         self.data = None
         self.path = None
 

--- a/src/dummy/toga_dummy/images.py
+++ b/src/dummy/toga_dummy/images.py
@@ -2,7 +2,7 @@ from .utils import LoggedObject
 
 
 class Image(LoggedObject):
-    def __init__(self, interface, path=None, url=None):
+    def __init__(self, interface, path=None, url=None, data=None):
         super().__init__()
         self.interface = interface
         self.path = path
@@ -12,3 +12,5 @@ class Image(LoggedObject):
             self._action('load image file', path=path)
         elif self.url:
             self._action('load image url', url=url)
+        elif data:
+            self._action('load image data', data=data)

--- a/src/gtk/toga_gtk/images.py
+++ b/src/gtk/toga_gtk/images.py
@@ -17,4 +17,5 @@ class Image:
                 input_stream = Gio.MemoryInputStream.new_from_data(result.read(), None)
                 self.native = GdkPixbuf.Pixbuf.new_from_stream(input_stream, None)
         elif data:
-            pass
+            input_stream = Gio.MemoryInputStream.new_from_data(data, None)
+            self.native = GdkPixbuf.Pixbuf.new_from_stream(input_stream, None)

--- a/src/gtk/toga_gtk/images.py
+++ b/src/gtk/toga_gtk/images.py
@@ -4,15 +4,17 @@ from toga_gtk.libs import GdkPixbuf, Gio
 
 
 class Image:
-    def __init__(self, interface, path=None, url=None):
+    def __init__(self, interface, path=None, url=None, data=None):
         self.interface = interface
         self.path = path
         self.url = url
 
         if path:
             self.native = GdkPixbuf.Pixbuf.new_from_file(str(path))
-        else:
+        elif url:
             request = Request(url, headers={'User-Agent': ''})
             with urlopen(request) as result:
                 input_stream = Gio.MemoryInputStream.new_from_data(result.read(), None)
                 self.native = GdkPixbuf.Pixbuf.new_from_stream(input_stream, None)
+        elif data:
+            pass

--- a/src/iOS/toga_iOS/images.py
+++ b/src/iOS/toga_iOS/images.py
@@ -2,7 +2,7 @@ from toga_iOS.libs import NSURL, NSData, UIImage
 
 
 class Image(object):
-    def __init__(self, interface, path=None, url=None):
+    def __init__(self, interface, path=None, url=None, data=None):
         self.interface = interface
         self.path = path
         self.url = url
@@ -15,4 +15,8 @@ class Image(object):
                 NSData.dataWithContentsOfURL_(
                     NSURL.URLWithString_(path)
                 )
+            )
+        elif data:
+            self.native = UIImage.imageWithData_(
+                NSData.dataWithBytes(data, length=len(data))
             )

--- a/src/winforms/toga_winforms/images.py
+++ b/src/winforms/toga_winforms/images.py
@@ -1,4 +1,4 @@
-from toga_winforms.libs import WinImage
+from toga_winforms.libs import WinImage, MemoryStream
 
 
 class Image(object):
@@ -14,4 +14,5 @@ class Image(object):
             # not as standalone resources
             self.native = None
         elif data:
-            pass
+            stream = MemoryStream(data)
+            self.native = WinImage.FromStream(stream)

--- a/src/winforms/toga_winforms/images.py
+++ b/src/winforms/toga_winforms/images.py
@@ -2,7 +2,7 @@ from toga_winforms.libs import WinImage
 
 
 class Image(object):
-    def __init__(self, interface, path=None, url=None):
+    def __init__(self, interface, path=None, url=None, data=None):
         self.interface = interface
         self.path = path
         self.url = url
@@ -13,3 +13,5 @@ class Image(object):
             # Windows loads URL images in the view,
             # not as standalone resources
             self.native = None
+        elif data:
+            pass

--- a/src/winforms/toga_winforms/libs/__init__.py
+++ b/src/winforms/toga_winforms/libs/__init__.py
@@ -15,6 +15,7 @@ from .winforms import (  # noqa: F401
     Graphics,
     GraphicsPath,
     Matrix,
+    MemoryStream,
     Pen,
     Point,
     PointF,

--- a/src/winforms/toga_winforms/libs/winforms.py
+++ b/src/winforms/toga_winforms/libs/winforms.py
@@ -50,7 +50,7 @@ from System.Drawing.Drawing2D import (  # noqa: F401, E402
 
 from System.Drawing.Text import PrivateFontCollection  # noqa: F401, E402
 
-from System.IO import FileNotFoundException  # noqa: F401, E402
+from System.IO import FileNotFoundException, MemoryStream  # noqa: F401, E402
 from System.Runtime.InteropServices import ExternalException  # noqa: F401, E402
 
 from System.Threading.Tasks import Task, TaskScheduler  # noqa: F401, E402


### PR DESCRIPTION
Currently Image loads files by file path or URL. This PR adds a `bytes` object as an option.
Refs #1348

I'd like feedback on whether overloading the positional argument for the Image constructor is well received. Its name, `path`, makes no sense anymore. I changed it to value.

Implemented on all backends, but only tested on macOS.

## PR Checklist:
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
