### PR TITLE
Add fallback when TLS1.2/1.3 support isn't present

### DIFF
--- a/src/winforms/toga_winforms/app.py
+++ b/src/winforms/toga_winforms/app.py
@@ -81,8 +81,20 @@ class App:
         # turned off by default. SSL3, TLS1.0 and TLS1.1 are *not* enabled
         # as they are deprecated protocols and their use should *not* be
         # encouraged.
-        ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12
-        ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls13
+        try:
+            ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12
+        except AttributeError:
+            print(
+                "WARNING: Your Windows .NET install does not support TLS1.2. "
+                "You may experience difficulties accessing some web server content."
+            )
+        try:
+            ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls13
+        except AttributeError:
+            print(
+                "WARNING: Your Windows .NET install does not support TLS1.3. "
+                "You may experience difficulties accessing some web server content."
+            )
 
         self.interface.commands.add(
             toga.Command(


### PR DESCRIPTION
On Windows, the default network settings do not enable TLS1.2 or TLS1.3, so we explicitly enable TLS1.2 and 1.3 support.

However, TLS1.3 support was only added in .NET 4.8, and it's possible that end-users won't have .NET 4.8 installed. This manifests as an AttributeError accessing the `Tls13` constant (Refs beeware/beeware#170)

Rather than crashing when the user has an older version of .NET, this PR raises a warning to the user. An app that doesn't use web content won't be affected by the lack of TLS1.2/1.3 support; apps that *do* use web content will fail to connect to the server, which is bad, but having a log entry describe the problem is better than an outright crash.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
