### PR TITLE
BugFix for MultilineTextInput on Android

### DIFF
--- a/src/android/toga_android/widgets/multilinetextinput.py
+++ b/src/android/toga_android/widgets/multilinetextinput.py
@@ -29,17 +29,13 @@ class TogaTextWatcher(TextWatcher):
 
 class MultilineTextInput(Widget):
     def create(self):
+        self._textChangedListener = None
         self.native = EditText(self._native_activity)
         self.native.setInputType(
             InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_MULTI_LINE
         )
         # Set default alignment
         self.set_alignment(LEFT)
-
-        # Add the listener last; some actions (such as setting the input type)
-        # emit a change message, and we don't want to pass those on until
-        # the widget is fully configured.
-        self.native.addTextChangedListener(TogaTextWatcher(self))
 
     def get_value(self):
         return self.native.getText().toString()
@@ -73,8 +69,10 @@ class MultilineTextInput(Widget):
         self.native.setText(value)
 
     def set_on_change(self, handler):
-        # No special handling required.
-        pass
+        if self._textChangedListener:
+            self.native.removeTextChangedListener(self._textChangedListener)
+        self._textChangedListener = TogaTextWatcher(self)
+        self.native.addTextChangedListener(self._textChangedListener)
 
     def rehint(self):
         self.interface.intrinsic.width = at_least(self.interface.MIN_WIDTH)


### PR DESCRIPTION
This PR fixes the problem that on_change was called before the widget was fully configured

When running the MultilineTextInput example (without this bugfix) on Android, you get following error message:
D Python  : Native invocation 129448237098512 :: afterTextChanged
E Python  : Traceback (most recent call last):
E Python  :   File
"/data/user/0/org.beeware.multilinetextinput/files/python/user_code/app_packages/rubicon/java/api.py", line 54, in dispatch
E Python  :     val = getattr(pyinstance, method)(*args)
E Python  :   File "/data/user/0/org.beeware.multilinetextinput/files/python/user_code/app_packages/toga_android/widgets/multilinetextinput.py", line 23, in afterTextChanged
E Python  :     if self.interface.on_change:
E Python  :   File
"/data/user/0/org.beeware.multilinetextinput/files/python/user_code/app_packages/toga/widgets/multilinetextinput.py",line 123, in on_change
E Python  :     return self._on_change
E Python  : AttributeError: 'MultilineTextInput' object has no attribute '_on_change'
D Python  : Native invocation done.
D MainActivity: Python.run() end

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
