### PR TITLE
Bugfix for TextInput on_change on Android

### DIFF
--- a/src/android/toga_android/widgets/textinput.py
+++ b/src/android/toga_android/widgets/textinput.py
@@ -28,13 +28,9 @@ class TogaTextWatcher(TextWatcher):
 
 class TextInput(Widget):
     def create(self):
+        self._textChangedListener = None
         self.native = EditText(self._native_activity)
         self.native.setInputType(InputType.TYPE_CLASS_TEXT)
-
-        # Add the listener last; some actions (such as setting the input type)
-        # emit a change message, and we don't want to pass those on until
-        # the widget is fully configured.
-        self.native.addTextChangedListener(TogaTextWatcher(self))
 
     def get_value(self):
         return self.native.getText().toString()
@@ -68,8 +64,10 @@ class TextInput(Widget):
         self.native.setText(value)
 
     def set_on_change(self, handler):
-        # No special handling required.
-        pass
+        if self._textChangedListener:
+            self.native.removeTextChangedListener(self._textChangedListener)
+        self._textChangedListener = TogaTextWatcher(self)
+        self.native.addTextChangedListener(self._textChangedListener)
 
     def set_error(self, error_message):
         self.interface.factory.not_implemented("TextInput.set_error()")

--- a/src/core/toga/widgets/textinput.py
+++ b/src/core/toga/widgets/textinput.py
@@ -66,12 +66,12 @@ class TextInput(Widget):
         # End backwards compatibility.
         ##################################################################
 
-        self.on_change = on_change
         self.placeholder = placeholder
         self.readonly = readonly
 
-        # Set the actual value after on_change, as it may trigger change events, etc.
+        # Set the actual value before on_change, because we do not want on_change triggered by it
         self.value = value
+        self.on_change = on_change
         self.validators = validators
         self.on_lose_focus = on_lose_focus
         self.on_gain_focus = on_gain_focus


### PR DESCRIPTION
This PR fixed problem that on_change was called before the widget was fully configured
It also makes sure (on all platforms) that setting the initial value does not trigger the on_change event

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
