### PR TITLE
Update coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,11 @@
 [run]
+branch = True
 source = src/core/toga
 omit =
     src/core/toga/**/__init__.py
 
 [report]
 show_missing = True
+exclude_lines =
+    pragma: no cover
+    @(abc\.)?abstractmethod

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./src/core/coverage.xml
+        file: ./coverage.xml
         flags: unittests
         fail_ci_if_error: true
 

--- a/src/core/tests/test_paths.py
+++ b/src/core/tests/test_paths.py
@@ -16,6 +16,30 @@ class TestPaths(unittest.TestCase):
         if '__main__' in sys.modules:
             del sys.modules['__main__']
 
+    def assert_paths(self, output, app_path, app_name):
+        "Assert the paths for the standalone app are consistent"
+        results = output.splitlines()
+        self.assertIn(
+            f"app.paths.app={app_path.resolve()}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.data={(Path.home() / 'user_data' / f'org.testbed.{app_name}').resolve()}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.cache={(Path.home() / 'cache' / f'org.testbed.{app_name}').resolve()}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.logs={(Path.home() / 'logs' / f'org.testbed.{app_name}').resolve()}",
+            results,
+        )
+        self.assertIn(
+            f"app.paths.toga={Path(toga.__file__).parent.resolve()}",
+            results,
+        )
+
     def test_as_test(self):
         "During test conditions, the app path is the current working directory"
         app = toga.App(
@@ -45,149 +69,93 @@ class TestPaths(unittest.TestCase):
             Path(toga.__file__).parent,
         )
 
-    def assert_standalone_paths(self, output):
-        "Assert the paths for the standalone app are consistent"
-        results = output.splitlines()
-        self.assertIn(
-            f"app.paths.app={(Path.cwd() / 'tests' / 'testbed').resolve()}",
-            results,
-        )
-        self.assertIn(
-            f"app.paths.data={(Path.home() / 'user_data' / 'org.testbed.standalone-app').resolve()}",
-            results,
-        )
-        self.assertIn(
-            f"app.paths.cache={(Path.home() / 'cache' / 'org.testbed.standalone-app').resolve()}",
-            results,
-        )
-        self.assertIn(
-            f"app.paths.logs={(Path.home() / 'logs' / 'org.testbed.standalone-app').resolve()}",
-            results,
-        )
-        self.assertIn(
-            f"app.paths.toga={Path(toga.__file__).parent.resolve()}",
-            results,
-        )
-
     def test_as_interactive(self):
         "At an interactive prompt, the app path is the current working directory"
         # Spawn the standalone app using the interactive-mode mocking entry point
+        cwd = Path(__file__).parent / "testbed"
         output = subprocess.check_output(
             [sys.executable, "standalone.py", "--backend:dummy", "--interactive"],
-            cwd=Path(__file__).parent / "testbed",
+            cwd=cwd,
             text=True,
         )
-        self.assert_standalone_paths(output)
+        self.assert_paths(output, app_path=cwd, app_name="standalone-app")
 
     def test_as_file(self):
         "When started as `python app.py`, the app path is the folder holding app.py"
         # Spawn the standalone app using `standalone.py`
+        cwd = Path(__file__).parent / "testbed"
         output = subprocess.check_output(
             [sys.executable, "standalone.py", "--backend:dummy"],
-            cwd=Path(__file__).parent / "testbed",
+            cwd=cwd,
             text=True,
         )
-        self.assert_standalone_paths(output)
+        self.assert_paths(output, app_path=cwd, app_name="standalone-app")
 
     def test_as_module(self):
         "When started as `python -m app`, the app path is the folder holding app.py"
         # Spawn the standalone app app using `-m standalone`
+        cwd = Path(__file__).parent / "testbed"
         output = subprocess.check_output(
             [sys.executable, "-m", "standalone", "--backend:dummy"],
-            cwd=Path(__file__).parent / "testbed",
+            cwd=cwd,
             text=True,
         )
-        self.assert_standalone_paths(output)
-
-    def assert_simple_paths(self, output):
-        "Assert the paths for the simple app are consistent"
-        results = output.splitlines()
-        self.assertIn(
-            f"app.paths.app={(Path.cwd() / 'tests' / 'testbed' / 'simple').resolve()}",
-            results,
-        )
-        self.assertIn(
-            f"app.paths.data={(Path.home() / 'user_data' / 'org.testbed.simple-app').resolve()}",
-            results,
-        )
-        self.assertIn(
-            f"app.paths.cache={(Path.home() / 'cache' / 'org.testbed.simple-app').resolve()}",
-            results,
-        )
-        self.assertIn(
-            f"app.paths.logs={(Path.home() / 'logs' / 'org.testbed.simple-app').resolve()}", results
-        )
-        self.assertIn(
-            f"app.paths.toga={Path(toga.__file__).parent.resolve()}",
-            results,
-        )
+        self.assert_paths(output, app_path=cwd, app_name="standalone-app")
 
     def test_simple_as_file_in_module(self):
         """When a simple app is started as `python app.py` inside a runnable module,
         the app path is the folder holding app.py"""
         # Spawn the simple testbed app using `app.py`
+        cwd = Path(__file__).parent / "testbed" / "simple"
         output = subprocess.check_output(
             [sys.executable, "app.py", "--backend:dummy"],
-            cwd=Path(__file__).parent / "testbed" / "simple",
+            cwd=cwd,
             text=True,
         )
-        self.assert_simple_paths(output)
+        self.assert_paths(output, app_path=cwd, app_name="simple-app")
 
     def test_simple_as_module(self):
         """When a simple apps is started as `python -m app` inside a runnable module,
         the app path is the folder holding app.py"""
         # Spawn the simple testbed app using `-m app`
+        cwd = Path(__file__).parent / "testbed" / "simple"
         output = subprocess.check_output(
             [sys.executable, "-m", "app", "--backend:dummy"],
-            cwd=Path(__file__).parent / "testbed" / "simple",
+            cwd=cwd,
             text=True,
         )
-        self.assert_simple_paths(output)
+        self.assert_paths(output, app_path=cwd, app_name="simple-app")
 
     def test_simple_as_deep_file(self):
         "When a simple app is started as `python simple/app.py`, the app path is the folder holding app.py"
         # Spawn the simple testbed app using `-m simple`
+        cwd = Path(__file__).parent / "testbed"
         output = subprocess.check_output(
             [sys.executable, "simple/app.py", "--backend:dummy"],
-            cwd=Path(__file__).parent / "testbed",
+            cwd=cwd,
             text=True,
         )
-        self.assert_simple_paths(output)
+        self.assert_paths(output, app_path=cwd / "simple", app_name="simple-app")
 
     def test_simple_as_deep_module(self):
         "When a simple app is started as `python -m simple`, the app path is the folder holding app.py"
         # Spawn the simple testbed app using `-m simple`
+        cwd = Path(__file__).parent / "testbed"
         output = subprocess.check_output(
             [sys.executable, "-m", "simple", "--backend:dummy"],
-            cwd=Path(__file__).parent / "testbed",
+            cwd=cwd,
             text=True,
         )
-        self.assert_simple_paths(output)
+        self.assert_paths(output, app_path=cwd / "simple", app_name="simple-app")
 
     def test_installed_as_module(self):
         "When the installed app is started, the app path is the folder holding app.py"
         # Spawn the installed testbed app using `-m app`
+        cwd = Path(__file__).parent / "testbed"
         output = subprocess.check_output(
             [sys.executable, "-m", "installed", "--backend:dummy"],
-            cwd=Path(__file__).parent / "testbed",
+            cwd=cwd,
             text=True,
         )
 
-        results = output.splitlines()
-        self.assertIn(
-            f"app.paths.app={(Path.cwd() / 'tests' / 'testbed' / 'installed').resolve()}",
-            results,
-        )
-        self.assertIn(
-            f"app.paths.data={(Path.home() / 'user_data' / 'org.testbed.installed').resolve()}",
-            results,
-        )
-        self.assertIn(
-            f"app.paths.cache={(Path.home() / 'cache' / 'org.testbed.installed').resolve()}",
-            results,
-        )
-        self.assertIn(
-            f"app.paths.logs={(Path.home() / 'logs' / 'org.testbed.installed').resolve()}",
-            results,
-        )
-        self.assertIn(f"app.paths.toga={Path(toga.__file__).parent.resolve()}", results)
+        self.assert_paths(output, app_path=cwd / "installed", app_name="installed")

--- a/tox.ini
+++ b/tox.ini
@@ -13,11 +13,11 @@ deps =
     setuptools
     pytest-tldr
     pytest-cov
-changedir = {toxinidir}/src/core
+changedir = {toxinidir}
 commands:
-    python -m pip install -e .
-    python -m pip install -e ../dummy
-    pytest --cov --cov-report term-missing {posargs}
+    python -m pip install -e src/core
+    python -m pip install -e src/dummy
+    pytest src/core/tests --cov --cov-report term-missing {posargs}
     coverage xml
 
 [testenv:flake8]


### PR DESCRIPTION
This PR fixes 2 issues about running unit tests:

First, It makes sure that the coverage report change **branches coverage** in addition to **lines coverage**. it does so by adding the `branch = True` line to .coveragerc file. Moreover, I specificied of abstract methods as lines that does not require coverage.

Second, this PR fixes a bug that when running unit tests via Tox, the coverage parameters are not read from the .coveragerc file correctly. This is now taken care of as the CWD directory is the root directory of the project.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
