### PR TITLE
Android: replace `toString` with `str` in Selection

### DIFF
--- a/src/android/toga_android/widgets/selection.py
+++ b/src/android/toga_android/widgets/selection.py
@@ -22,9 +22,6 @@ class Selection(Widget):
         self.native.setOnItemSelectedListener(TogaOnItemSelectedListener(
             impl=self
         ))
-        # On Android, the list of options is provided to the `Spinner` wrapped in
-        # an `ArrayAdapter`. We store `self.adapter` to avoid having to typecast it
-        # in `add_item()`.
         self.adapter = ArrayAdapter(
             self._native_activity,
             R__layout.simple_spinner_item
@@ -45,7 +42,7 @@ class Selection(Widget):
     def get_selected_item(self):
         selected = self.native.getSelectedItem()
         if selected:
-            return selected.toString()
+            return str(selected)
         else:
             return None
 


### PR DESCRIPTION
Fixes #1603. This is caused by Chaquopy representing Java objects as their runtime type, versus Rubicon which used the declared type. `getSelectedItem` is declared to return `Object`, but in this case it'll always return a `String`, so Chaquopy automatically converts it to a Python `str` and it won't have a `toString` method anymore.

Using `str` rather than `toString` fixes this while maintaining backward compatibility with Rubicon.

I checked all the other uses of `toString` in toga_android, but none of them are on objects which could already be Strings, so they're all fine.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
