### PR TITLE
Ensure the on_change handler has a value before it might be used.

### DIFF
--- a/examples/textinput/textinput/app.py
+++ b/examples/textinput/textinput/app.py
@@ -13,12 +13,14 @@ class TextInputApp(toga.App):
     def do_extract_values(self, widget, **kwargs):
         # Disable all the text inputs
         self.text_input.enabled = False
+        self.text_input_placeholder.enabled = False
         self.password_input.enabled = False
         self.number_input.enabled = False
 
         # Update the labels with the extracted values
-        self.text_label.text = "Text content: {}".format(
-            self.text_input.value
+        self.text_label.text = "Text content: {}; {}".format(
+            self.text_input.value,
+            self.text_input_placeholder.value,
         )
 
         self.password_label.text = "Your password is {}: {}".format(
@@ -40,6 +42,7 @@ class TextInputApp(toga.App):
 
         # Renable the inputs again.
         self.text_input.enabled = True
+        self.text_input_placeholder.enabled = True
         self.password_input.enabled = True
         self.number_input.enabled = True
 
@@ -60,6 +63,10 @@ class TextInputApp(toga.App):
 
         # Text inputs and a button
         self.text_input = toga.TextInput(
+            value='Initial value',
+            placeholder='Type something...', style=Pack(padding=10)
+        )
+        self.text_input_placeholder = toga.TextInput(
             placeholder='Type something...', style=Pack(padding=10)
         )
         self.password_input = toga.PasswordInput(
@@ -91,6 +98,7 @@ class TextInputApp(toga.App):
             children=[
                 self.label,
                 self.text_input,
+                self.text_input_placeholder,
                 self.password_input,
                 self.password_content_label,
                 self.email_input,

--- a/src/core/toga/widgets/textinput.py
+++ b/src/core/toga/widgets/textinput.py
@@ -70,7 +70,10 @@ class TextInput(Widget):
         self.readonly = readonly
 
         # Set the actual value before on_change, because we do not want on_change triggered by it
+        # However, we need to prime the handler property in case it is accessed.
+        self._on_change = None
         self.value = value
+
         self.on_change = on_change
         self.validators = validators
         self.on_lose_focus = on_lose_focus


### PR DESCRIPTION
Although we don't want the `on_change` handler to fire when the initial value is set, we need to ensure the property for the handler has a value so that if setting the initial value triggers the handler, an error isn't raised.

Fixes #1602.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
