### PR TITLE
Android: make NumberInput handle exception when Decimal conversion fails

### DIFF
--- a/src/android/toga_android/widgets/numberinput.py
+++ b/src/android/toga_android/widgets/numberinput.py
@@ -1,4 +1,4 @@
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 
 from travertino.size import at_least
 
@@ -10,11 +10,11 @@ from .base import Widget, align
 
 
 def decimal_from_string(s):
-    """If s is the empty string, return `None`. Otherwise, convert to a `Decimal`,
-    allowing any exceptions to bubble up."""
-    if not s:
+    """Convert s to a `Decimal`, returning `None` if it's not a valid number."""
+    try:
+        return Decimal(s)
+    except InvalidOperation:
         return None
-    return Decimal(s)
 
 
 def string_from_decimal(d):


### PR DESCRIPTION
Fixes #1615. Like #1616, this is another case of Rubicon logging and ignoring a Python exception, but Chaquopy passing it through to the Android main loop, causing the app to crash.

Fixed by catching the `Decimal` conversion exception and setting the widget's `value` to `None`. Because the native widget is set to only accept numbers, the only invalid inputs I could find were the empty string, or a single `.`, `+` or `-`.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
