### PR TITLE
Android: make ScrollContainer use correct widget for viewport

### DIFF
--- a/src/android/toga_android/widgets/scrollcontainer.py
+++ b/src/android/toga_android/widgets/scrollcontainer.py
@@ -59,7 +59,7 @@ class ScrollContainer(Widget):
             self.set_content(self.interface.content)
 
     def set_content(self, widget):
-        widget.viewport = AndroidViewport(widget.native)
+        widget.viewport = AndroidViewport(self.native)
         content_view_params = LinearLayout__LayoutParams(
             LinearLayout__LayoutParams.MATCH_PARENT,
             LinearLayout__LayoutParams.MATCH_PARENT


### PR DESCRIPTION
Fixes #1604.

The reason this issue appeared in dev36 was because of #1507. Before that, the widget passed to AndroidViewport was only used to get at the Resources object, so all viewports were the same size: a rather unreliable estimate of the size of the whole window. #1507 changed AndroidViewport to return the dimensions of the widget that was passed to it. 

So this PR fixes ScrollContainer to create its viewport from the container, not the content.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
