### PR TITLE
Ensure the Switch on_change handler has a value before it might be used

### DIFF
--- a/src/core/toga/widgets/switch.py
+++ b/src/core/toga/widgets/switch.py
@@ -105,8 +105,13 @@ class Switch(Widget):
         ##################################################################
 
         self.text = text
+
+        # Set the actual value before on_change, because we do not want on_change triggered by it
+        # However, we need to prime the handler property in case it is accessed.
+        self._on_change = None
         self.value = value
         self.on_change = on_change
+
         self.enabled = enabled
 
     @property


### PR DESCRIPTION
Same idea as #1610.

To reproduce, run examples/box on Android:
```
com.chaquo.python.PyException: AttributeError: 'Switch' object has no attribute '_on_change'
       at <python>.toga.widgets.switch.on_change(switch.py:137)
       at <python>.toga_android.widgets.switch.onCheckedChanged(switch.py:18)
       at <python>.chaquopy_java.call(chaquopy_java.pyx:379)
       at <python>.chaquopy_java.Java_com_chaquo_python_PyObject_callAttrThrowsNative(chaquopy_java.pyx:351)
       at com.chaquo.python.PyObject.callAttrThrowsNative(Native Method)
       at com.chaquo.python.PyObject.callAttrThrows(PyObject.java:232)
       at com.chaquo.python.PyInvocationHandler.invoke(PyInvocationHandler.java:31)
       at java.lang.reflect.Proxy.invoke(Proxy.java:1006)
       at $Proxy15.onCheckedChanged(Unknown Source)
       at android.widget.CompoundButton.setChecked(CompoundButton.java:222)
       at android.widget.Switch.setChecked(Switch.java:1250)
       at <python>.java.chaquopy.CQPEnv.check_exception(env.pxi:546)
       at <python>.java.chaquopy.CQPEnv.CallNonvirtualVoidMethodA(env.pxi:242)
       at <python>.java.chaquopy.JavaMethod.call_nonvirtual_method(class.pxi:884)
       at <python>.java.chaquopy.JavaMethod.__call__(class.pxi:795)
       at <python>.java.chaquopy.JavaMethod.__get__.lambda2(class.pxi:775)
       at <python>.toga_android.widgets.switch.set_value(switch.py:38)
       at <python>.toga.widgets.switch.value(switch.py:157)
       at <python>.toga.widgets.switch.__init__(switch.py:108)
       at <python>.box.app.startup(app.py:60)
       at <python>.toga_android.app.create(app.py:175)
       at <python>.toga_android.app.main_loop(app.py:186)
       at <python>.toga.app.main_loop(app.py:517)
       at <python>.__main__.<module>(__main__.py:4)
```

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
