### PR TITLE
Android: make Paths cache __main__ module location during startup

### DIFF
--- a/src/android/toga_android/paths.py
+++ b/src/android/toga_android/paths.py
@@ -13,18 +13,13 @@ class Paths:
     def __context(self):
         return App.app._impl.native.getApplicationContext()
 
+    def __init__(self):
+        # On Android, __main__ only exists during app startup, so cache its location now.
+        self._app = Path(sys.modules["__main__"].__file__).parent
+
     @property
     def app(self):
-        try:
-            return Path(sys.modules["__main__"].__file__).parent
-        except KeyError:
-            # If we're running in test conditions,
-            # there is no __main__ module.
-            return Path.cwd()
-        except AttributeError:
-            # If we're running at an interactive prompt,
-            # the __main__ module isn't file-based.
-            return Path.cwd()
+        return self._app
 
     @property
     def data(self):


### PR DESCRIPTION
Fixes #1607.

Since Paths.app and Paths.toga should work the same way on all platforms, I initially tried moving them to a base class in the Toga core. But this broke TestPaths.test_as_test, which assumes that Paths.app works exactly the same way as it currently does and can therefore be influenced by deleting the `__main__` module "as a proxy for being in test conditions". Which doesn't really make sense, because in test conditions there *is* a `__main__` module, and it's the test runner. 

It would require some restructuring of how the Paths class is instantiated, but in future I wonder if, rather than depending on something as inconsistent as a `__main__` module, it might make more sense to define Paths.app as the location of the class of the associated App object.

Anyway, to keep things simple I've just made the change in the Android implementation for now.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
