### PR TITLE
Revert usage of automatic discovery by setuptools.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,15 +1,28 @@
 include .coveragerc
 include .pre-commit-config.yaml
-include check-packaging.sh
 include CONTRIBUTING.md
 include LICENSE
 include README.rst
 include release.sh
 include tox.ini
-recursive-exclude attic *
-recursive-exclude contrib *
-recursive-exclude demo *
-recursive-exclude nursery *
+include pyproject.toml
+
+prune attic
+
+include demo/AUTHORS
+include demo/CONTRIBUTING.md
+include demo/LICENSE
+include demo/MANIFEST.in
+include demo/README.rst
+include demo/pyproject.toml
+include demo/setup.cfg
+include demo/setup.py
+recursive-include demo *.icns
+recursive-include demo *.ico
+recursive-include demo *.png
+recursive-include demo *.py
+prune demo/build
+prune demo/dist
 
 include docs/make.bat
 include docs/Makefile
@@ -40,11 +53,13 @@ recursive-include examples *.html
 recursive-include examples README
 prune examples/*/.vscode
 prune examples/*/android
-prune examples/*/cocoa
-prune examples/*/gtk
+prune examples/*/linux
 prune examples/*/iOS
+prune examples/*/macOS
 prune examples/*/web
-prune examples/*/winforms
+prune examples/*/windows
+
+prune nursery
 
 include src/winforms/src/toga_winforms/libs/WebView2/LICENSE.md
 include src/winforms/src/toga_winforms/libs/WebView2/README.md
@@ -56,11 +71,13 @@ recursive-include src *.js
 recursive-include src *.png
 recursive-include src *.py
 recursive-include src *.rst
+recursive-include src pyproject.toml
 recursive-include src CONTRIBUTING.md
 recursive-include src LICENSE
 recursive-include src MANIFEST.in
 recursive-include src/winforms/src/toga_winforms/libs/WebView2 *.dll
 prune src/*/build
+prune src/*/dist
 prune src/*/.eggs
 
 include src/core/tests/testbed/installed.dist-info/INSTALLER

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=60"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,7 @@ keywords =
 [options]
 zip_safe = False
 python_requires = >= 3.7
+packages =
 
 [flake8]
 max-complexity = 25

--- a/src/android/pyproject.toml
+++ b/src/android/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=60"]
+build-backend = "setuptools.build_meta"

--- a/src/android/setup.cfg
+++ b/src/android/setup.cfg
@@ -38,10 +38,14 @@ keywords =
     android
 
 [options]
+packages = find:
 package_dir =
     = src
 python_requires = >= 3.6
 zip_safe = False
+
+[options.packages.find]
+where = src
 
 [flake8]
 exclude=\

--- a/src/cocoa/pyproject.toml
+++ b/src/cocoa/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=60"]
+build-backend = "setuptools.build_meta"

--- a/src/cocoa/setup.cfg
+++ b/src/cocoa/setup.cfg
@@ -39,10 +39,14 @@ keywords =
     cocoa
 
 [options]
+packages = find:
 package_dir =
     = src
 python_requires = >= 3.6
 zip_safe = False
+
+[options.packages.find]
+where = src
 
 [flake8]
 exclude=\

--- a/src/core/pyproject.toml
+++ b/src/core/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=60"]
+build-backend = "setuptools.build_meta"

--- a/src/core/setup.cfg
+++ b/src/core/setup.cfg
@@ -50,6 +50,7 @@ keywords =
 install_requires =
     travertino>=0.1.3
     importlib_metadata; python_version<"3.8"
+packages = find:
 package_dir =
     = src
 python_requires = >= 3.6
@@ -60,6 +61,9 @@ toga.resources =
     *.icns
     *.ico
     *.png
+
+[options.packages.find]
+where = src
 
 [flake8]
 exclude=\

--- a/src/dummy/pyproject.toml
+++ b/src/dummy/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=60"]
+build-backend = "setuptools.build_meta"

--- a/src/dummy/setup.cfg
+++ b/src/dummy/setup.cfg
@@ -37,10 +37,14 @@ keywords =
     testing
 
 [options]
+packages = find:
 package_dir =
     = src
 python_requires = >= 3.6
 zip_safe = False
+
+[options.packages.find]
+where = src
 
 [flake8]
 exclude=\

--- a/src/gtk/pyproject.toml
+++ b/src/gtk/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=60"]
+build-backend = "setuptools.build_meta"

--- a/src/gtk/setup.cfg
+++ b/src/gtk/setup.cfg
@@ -39,10 +39,14 @@ keywords =
     gtk
 
 [options]
+packages = find:
 package_dir =
     = src
 python_requires = >= 3.6
 zip_safe = False
+
+[options.packages.find]
+where = src
 
 [flake8]
 exclude=\

--- a/src/iOS/pyproject.toml
+++ b/src/iOS/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=60"]
+build-backend = "setuptools.build_meta"

--- a/src/iOS/setup.cfg
+++ b/src/iOS/setup.cfg
@@ -38,10 +38,14 @@ keywords =
     iOS
 
 [options]
+packages = find:
 package_dir =
     = src
 python_requires = >= 3.6
 zip_safe = False
+
+[options.packages.find]
+where = src
 
 [flake8]
 exclude=\

--- a/src/web/pyproject.toml
+++ b/src/web/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=60"]
+build-backend = "setuptools.build_meta"

--- a/src/web/setup.cfg
+++ b/src/web/setup.cfg
@@ -37,6 +37,7 @@ keywords =
     web
 
 [options]
+packages = find:
 package_dir =
     = src
 python_requires = >= 3.6
@@ -45,6 +46,9 @@ zip_safe = False
 [options.package_data]
 toga_web =
     static/**
+
+[options.packages.find]
+where = src
 
 [flake8]
 exclude=\

--- a/src/web/setup.py
+++ b/src/web/setup.py
@@ -20,10 +20,6 @@ with open('src/toga_web/__init__.py', encoding='utf8') as version_file:
 setup(
     version=version,
     install_requires=[
-        # TODO: Due to https://github.com/pyodide/pyodide/issues/2408, the name
-        # toga-core is ambigous when on the package hasn't been published to
-        # PyPI. As a workaround, don't specify the dependency, and manually
-        # ensure that toga-core is installed.
-        # 'toga-core==%s' % version,
+        'toga-core==%s' % version,
     ],
 )

--- a/src/winforms/pyproject.toml
+++ b/src/winforms/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=60"]
+build-backend = "setuptools.build_meta"

--- a/src/winforms/setup.cfg
+++ b/src/winforms/setup.cfg
@@ -39,6 +39,7 @@ keywords =
     winforms
 
 [options]
+packages = find:
 package_dir =
     = src
 python_requires = >= 3.6
@@ -47,6 +48,9 @@ zip_safe = False
 [options.package_data]
 toga_winforms =
     libs/WebView2/**
+
+[options.packages.find]
+where = src
 
 [flake8]
 exclude=\


### PR DESCRIPTION
#1614 modified the packaging of wheels, using the [automatic discovery](https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#automatic-discovery)  feature of Setuptools.

While this appears to generate working wheels, it doesn't produce working source installs, which is required for any of the examples in the Toga repository to work.

Automatic discovery is marked as a beta feature; so reverting may be a good idea.

This PR also:
* Corrects the lack of a toga-core dependency in toga-web
* The lack of pyproject.toml files; pip 22.3 starts complaining about these aggressively.
* The packaging of the top level wheel, ensuring that it is a pure stub with no code content.
* The manifest exclusions in the top level package.

Fixes #1632.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
