### PR TITLE
Remove duplicate entry points caused by editable installs.

### DIFF
--- a/src/core/src/toga/platform.py
+++ b/src/core/src/toga/platform.py
@@ -65,9 +65,13 @@ def get_platform_factory(factory=None):
     # End backwards compatibility.
     ######################################################################
 
-    toga_backends = entry_points(group='toga.backends')
+    # As of Setuptools 65.5, entry points are returned duplicated if the
+    # package is installed editable. Use a set to ensure that each entry point
+    # is only returned once.
+    # See https://github.com/pypa/setuptools/issues/3649
+    toga_backends = sorted(set(entry_points(group='toga.backends')))
     if not toga_backends:
-        raise RuntimeError("No toga backend could be loaded.")
+        raise RuntimeError("No Toga backend could be loaded.")
 
     backend_value = os.environ.get('TOGA_BACKEND')
     if backend_value:
@@ -81,7 +85,7 @@ def get_platform_factory(factory=None):
             )
     else:
         if len(toga_backends) == 1:
-            backend = list(toga_backends)[0]
+            backend = toga_backends[0]
         else:
             # multiple backends are installed: choose the one that matches the host platform
             matching_backends = [

--- a/src/core/src/toga/platform.py
+++ b/src/core/src/toga/platform.py
@@ -65,11 +65,7 @@ def get_platform_factory(factory=None):
     # End backwards compatibility.
     ######################################################################
 
-    # As of Setuptools 65.5, entry points are returned duplicated if the
-    # package is installed editable. Use a set to ensure that each entry point
-    # is only returned once.
-    # See https://github.com/pypa/setuptools/issues/3649
-    toga_backends = sorted(set(entry_points(group='toga.backends')))
+    toga_backends = entry_points(group='toga.backends')
     if not toga_backends:
         raise RuntimeError("No Toga backend could be loaded.")
 
@@ -84,6 +80,12 @@ def get_platform_factory(factory=None):
                 f"could not be loaded. It should be one of: {toga_backends_values}."
             )
     else:
+        # As of Setuptools 65.5, entry points are returned duplicated if the
+        # package is installed editable. Use a set to ensure that each entry point
+        # is only returned once.
+        # See https://github.com/pypa/setuptools/issues/3649
+        toga_backends = sorted(set(toga_backends))
+
         if len(toga_backends) == 1:
             backend = toga_backends[0]
         else:


### PR DESCRIPTION

pypa/setuptools#3649 causes duplicated entry points to be registered when a package is installed editable. Use `set()` to remove duplicates prior to selecting the appropriate backend.

Fixes #1636.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
