### PR TITLE
Corrections to widget and window handling

### DIFF
--- a/changes/1659.bugfix.rst
+++ b/changes/1659.bugfix.rst
@@ -1,0 +1,1 @@
+An error caused by retrieving `app.current_window` on macOS has been resolved.

--- a/changes/1660.bugfix.rst
+++ b/changes/1660.bugfix.rst
@@ -1,0 +1,1 @@
+If a window has existing content when it is added to an app, the widget registry no longer raises an error.

--- a/src/cocoa/src/toga_cocoa/window.py
+++ b/src/cocoa/src/toga_cocoa/window.py
@@ -139,6 +139,11 @@ class WindowDelegate(NSObject):
         item.action(obj)
 
 
+class TogaWindow(NSWindow):
+    interface = objc_property(object, weak=True)
+    impl = objc_property(object, weak=True)
+
+
 class Window:
     def __init__(self, interface, title, position, size):
         self.interface = interface
@@ -156,12 +161,14 @@ class Window:
 
         # Create the window with a default frame;
         # we'll update size and position later.
-        self.native = NSWindow.alloc().initWithContentRect(
+        self.native = TogaWindow.alloc().initWithContentRect(
             NSMakeRect(0, 0, 0, 0),
             styleMask=mask,
             backing=NSBackingStoreBuffered,
             defer=False,
         )
+        self.native.interface = self.interface
+        self.native._impl = self
 
         self.set_title(title)
         self.set_size(size)

--- a/src/cocoa/src/toga_cocoa/window.py
+++ b/src/cocoa/src/toga_cocoa/window.py
@@ -168,7 +168,7 @@ class Window:
             defer=False,
         )
         self.native.interface = self.interface
-        self.native._impl = self
+        self.native.impl = self
 
         self.set_title(title)
         self.set_size(size)

--- a/src/core/src/toga/window.py
+++ b/src/core/src/toga/window.py
@@ -104,7 +104,6 @@ class Window:
 
         self._app = app
         self._impl.set_app(app._impl)
-        app.widgets.update(self.widgets)
 
         if self.content:
             self.content.app = app

--- a/src/core/tests/test_window.py
+++ b/src/core/tests/test_window.py
@@ -124,19 +124,32 @@ class TestWindow(TestCase):
 
     def test_set_app_adds_window_widgets_to_app(self):
 
-        id1, id2, id3 = "id1", "id2", "id3"
+        id0, id1, id2, id3 = "id0", "id1", "id2", "id3"
         widget1, widget2, widget3 = (
-            toga.Widget(id=id1),
-            toga.Widget(id=id2),
-            toga.Widget(id=id3),
+            toga.Label(id=id1, text="label 1"),
+            toga.Label(id=id2, text="label 1"),
+            toga.Label(id=id3, text="label 1"),
         )
-        self.window.widgets.update({widget1, widget2, widget3})
+        content = toga.Box(id=id0, children=[widget1, widget2, widget3])
 
+        self.window.content = content
+
+        # The window has widgets in it's repository
+        self.assertEqual(len(self.window.widgets), 4)
+        self.assertEqual(self.window.widgets[id0], content)
+        self.assertEqual(self.window.widgets[id1], widget1)
+        self.assertEqual(self.window.widgets[id2], widget2)
+        self.assertEqual(self.window.widgets[id3], widget3)
+
+        # The app doesn't know about the widgets
         self.assertEqual(len(self.app.widgets), 0)
 
+        # Assign the window to the app
         self.window.app = self.app
 
-        self.assertEqual(len(self.app.widgets), 3)
+        # The window's content widgets are now known to the app.
+        self.assertEqual(len(self.app.widgets), 4)
+        self.assertEqual(self.app.widgets[id0], content)
         self.assertEqual(self.app.widgets[id1], widget1)
         self.assertEqual(self.app.widgets[id2], widget2)
         self.assertEqual(self.app.widgets[id3], widget3)

--- a/src/dummy/src/toga_dummy/window.py
+++ b/src/dummy/src/toga_dummy/window.py
@@ -1,6 +1,21 @@
 from .utils import LoggedObject, not_required, not_required_on
 
 
+class Viewport:
+    def __init__(self, window):
+        self.baseline_dpi = 96
+        self.dpi = 96
+        self.window = window
+
+    @property
+    def width(self):
+        return self.window.get_size()[0]
+
+    @property
+    def height(self):
+        return self.window.get_size()[1]
+
+
 class Window(LoggedObject):
     def __init__(self, interface, title, position, size):
         super().__init__()
@@ -18,6 +33,8 @@ class Window(LoggedObject):
 
     def set_content(self, widget):
         self._action("set content", widget=widget)
+        self._set_value("content", widget)
+        widget.viewport = Viewport(self)
 
     def get_title(self):
         return self._get_value("title")

--- a/src/dummy/src/toga_dummy/window.py
+++ b/src/dummy/src/toga_dummy/window.py
@@ -1,6 +1,7 @@
 from .utils import LoggedObject, not_required, not_required_on
 
 
+@not_required
 class Viewport:
     def __init__(self, window):
         self.baseline_dpi = 96


### PR DESCRIPTION
Two corrections to recent changes in window and widget handling.

1. Ensures that NSWindow retains a backreference to the interface and impl of the window. These previously existed, but were  removed by #1328 when references were made weak. However, the `current_window()` implementation requires that the native widget can navigate back to the interface. This PR re-introduces the references, but as weak references so that there won't be circular references.
2. Modifies the handling of the app registry, removing the explicit addition of a window's widgets to the app registry when the window is assigned to an app. This was introduced by #1599, with a test; however, the test was unrealistic - it defined a collection of widgets, and manually added them to the window's widget repository without adding them as content of the window. The realistic test case is when the window has content, and the window is added to the app. 3. 

Fixing the test case for (2) triggered a whole lot of layout code that wasn't previously being exercised; this required adding a Viewport implementation to the Dummy backend.

Discovered while updating Podium to use Toga 0.3.0dev39, rather than 0.3.0dev21.

Fixes #1659
Fixes #1660

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
