### PR TITLE
Cleanup of old docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,6 +19,7 @@ sphinx:
 # Optionally declare the Python requirements required to build your docs
 python:
   install:
-  - requirements: docs/requirements.txt
   - method: pip
     path: core
+    extra_requirements:
+    - docs

--- a/core/setup.cfg
+++ b/core/setup.cfg
@@ -63,6 +63,14 @@ zip_safe = False
 dev =
     pre-commit
     tox
+docs =
+    sphinx
+    sphinxcontrib-spelling
+    pyenchant
+    sphinx-autobuild
+    sphinx_rtd_theme
+    sphinx-csv-filter
+    sphinx_tabs
 test =
     pytest
     pytest-tldr

--- a/docs/background/philosophy.rst
+++ b/docs/background/philosophy.rst
@@ -18,7 +18,7 @@ end user with the mess.
 
 It's easy to spot apps that have been built using themed widget sets - they're
 the ones that don't behave quite like any other app. Widgets don't look
-*quite* right, or there's a menu bar on a window in an OS X app. Themes can
+*quite* right, or there's a menu bar on a window in a macOS app. Themes can
 get quite close - but there are always tell-tale signs.
 
 On top of that, native widgets are always faster than a themed generic widget.
@@ -34,7 +34,7 @@ It's not enough to just look like a native app, though - you need to *feel*
 like a native app as well.
 
 A "Quit" option under a "File" menu makes sense if you're writing a Windows
-app - but it's completely out of place if you're on OS X - the Quit option
+app - but it's completely out of place if you're on macOS - the Quit option
 should be under the application menu.
 
 And besides - why did the developer have to code the location of a Quit option
@@ -80,7 +80,7 @@ Embrace mobile
 --------------
 
 10 years ago, being a cross-platform widget toolkit meant being available
-for Windows, OS X and Linux. These days, mobile computing is much more
+for Windows, macOS and Linux. These days, mobile computing is much more
 important. But despite this, there aren't many good options for Python
 programming on mobile platforms, and cross-platform mobile coding is still
 elusive. Toga aims to correct this.

--- a/docs/background/roadmap.rst
+++ b/docs/background/roadmap.rst
@@ -167,7 +167,7 @@ Containers are widgets that can contain other widgets.
 * NavigationContainer - A container view that holds a navigable tree of subviews
 
     Essentially a view that has a "back" button to return to the previous view
-    in a hierarchy. Example of use: Top level navigation in the OS X System
+    in a hierarchy. Example of use: Top level navigation in the macOS System
     Preferences panel.
 
     - Cocoa: No native control
@@ -232,9 +232,6 @@ features.
 Platforms
 ---------
 
-Toga currently has good support for Cocoa on OS X, GTK+, and iOS.
-Proof-of-concept support exists for Windows Winforms. Support for a more
-modern Windows API would be desirable.
-
-In the mobile space, it would be great if Toga supported Android, Windows
-Phone, or any other phone platform.
+Toga currently has good support for Cocoa on macOS, GTK+, Winforms on Windows,
+iOS and Android, Proof-of-concept support exists for single page web apps.
+Support for a more modern Windows API would be desirable.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,8 +33,8 @@ Toga is a Python native, OS native, cross platform GUI toolkit. Toga consists of
 a library of base components with a shared interface to simplify
 platform-agnostic GUI development.
 
-Toga is available on Mac OS, Windows, Linux (GTK), and mobile platforms such as
-Android and iOS.
+Toga is available on macOS, Windows, Linux (GTK), Android, iOS, and for
+single-page web apps.
 
 .. figure:: tutorial/screenshots/tutorial-2.png
     :align: center

--- a/docs/reference/data/widgets_by_platform.csv
+++ b/docs/reference/data/widgets_by_platform.csv
@@ -1,4 +1,4 @@
-Component,Type,Component,Description,macOS,GTK+,Windows,iOS,Android,Django
+Component,Type,Component,Description,macOS,GTK+,Windows,iOS,Android,Web
 Application,Core Component,:class:`~toga.app.App`,The application itself,|y|,|y|,|y|,|y|,|y|,|y|
 Window,Core Component,:class:`~toga.window.Window`,Window object,|y|,|y|,|y|,|y|,|y|,|y|
 MainWindow,Core Component,:class:`~toga.app.MainWindow`,Main window of the application,|y|,|y|,|y|,|y|,|y|,|y|
@@ -9,7 +9,7 @@ DatePicker,General Widget,:class:`~toga.widgets.datepicker.DatePicker`,An input 
 DetailedList,General Widget,:class:`~toga.widgets.detailedlist.DetailedList`,A list of complex content,|y|,|y|,,|y|,|y|,
 Divider,General Widget,:class:`~toga.widgets.divider.Divider`,A horizontal or vertical line,|y|,|y|,|y|,,,
 ImageView,General Widget,:class:`~toga.widgets.imageview.ImageView`,Image Viewer,|y|,|y|,|y|,|y|,|y|,
-Label,General Widget,:class:`~toga.widgets.label.Label`,Text label,|y|,|y|,|y|,|y|,|y|,
+Label,General Widget,:class:`~toga.widgets.label.Label`,Text label,|y|,|y|,|y|,|y|,|y|,|y|
 MultilineTextInput,General Widget,:class:`~toga.widgets.multilinetextinput.MultilineTextInput`,Multi-line Text Input field,|y|,|y|,|y|,|y|,|y|,
 NumberInput,General Widget,:class:`~toga.widgets.numberinput.NumberInput`,Number Input field,|y|,|y|,|y|,|y|,|y|,
 PasswordInput,General Widget,:class:`~toga.widgets.passwordinput.PasswordInput`,A text input that hides it’s input,|y|,|y|,|y|,|y|,|y|,
@@ -21,7 +21,7 @@ Table,General Widget,:class:`~toga.widgets.table.Table`,Table of data,|y|,|y|,|y
 TextInput,General Widget,:class:`~toga.widgets.textinput.TextInput`,Text Input field,|y|,|y|,|y|,|y|,|y|,|y|
 TimePicker,General Widget,:class:`~toga.widgets.timepicker.TimePicker`,An input for times,,,|y|,,|y|,
 Tree,General Widget,:class:`~toga.widgets.tree.Tree`,Tree of data,|y|,|y|,|y|,,,
-WebView,General Widget,:class:`~toga.widgets.webview.WebView`,A panel for displaying HTML,|y|,|y|,|y|,|y|,|y|,|y|
+WebView,General Widget,:class:`~toga.widgets.webview.WebView`,A panel for displaying HTML,|y|,|y|,|y|,|y|,|y|,
 Widget,General Widget,:class:`~toga.widgets.base.Widget`,The base widget,|y|,|y|,|y|,|y|,|y|,|y|
 Box,Layout Widget,:class:`~toga.widgets.box.Box`,Container for components,|y|,|y|,|y|,|y|,|y|,|y|
 ScrollContainer,Layout Widget,:class:`~toga.widgets.scrollcontainer.ScrollContainer`,Scrollable Container,|y|,|y|,|y|,|y|,|y|,
@@ -29,6 +29,6 @@ SplitContainer,Layout Widget,:class:`~toga.widgets.splitcontainer.SplitContainer
 OptionContainer,Layout Widget,:class:`~toga.widgets.optioncontainer.OptionContainer`,Option Container,|y|,|y|,|y|,,,
 Font,Resource,:class:`~toga.fonts.Font`,Fonts,|y|,|y|,|y|,|y|,|y|,
 Command,Resource,:class:`~toga.command.Command`,Command,|y|,|y|,|y|,,|y|,
-Group,Resource,:class:`~toga.command.Group`,Command group,|y|,|y|,|y|,|y|,|y|,|y|
+Group,Resource,:class:`~toga.command.Group`,Command group,|y|,|y|,|y|,|y|,|y|,
 Icon,Resource,:class:`~toga.icons.Icon`,"An icon for buttons, menus, etc",|y|,|y|,|y|,|y|,|y|,
 Image,Resource,:class:`~toga.images.Image`,An image,|y|,|y|,|y|,|y|,|y|,

--- a/docs/reference/platforms.rst
+++ b/docs/reference/platforms.rst
@@ -121,7 +121,6 @@ Planned platform support
 
 Eventually, the Toga project would like to provide support for the following platforms:
 
- * Other Python web frameworks (e.g., Flask, Pyramid)
  * UWP (Native Windows 8 and Windows mobile)
  * Qt (for KDE based desktops)
  * tvOS (for AppleTV devices)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,0 @@
-sphinx
-sphinxcontrib-spelling
-pyenchant
-sphinx-autobuild
-sphinx_rtd_theme
-sphinx-csv-filter
-sphinx_tabs

--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -265,7 +265,7 @@ at the top of this guide.
 
     Toga has some minimum requirements:
 
-    * If you're on OS X, you need to be on 10.10 (Yosemite) or newer.
+    * If you're on macOS, you need to be on 10.10 (Yosemite) or newer.
 
     * If you're on Linux, you need to have GTK+ 3.10 or newer. This is the
       version that ships starting with Ubuntu 14.04 and Fedora 20.

--- a/tox.ini
+++ b/tox.ini
@@ -46,8 +46,7 @@ commands =
 [testenv:docs]
 skip_install = True
 deps =
-    -r{toxinidir}/docs/requirements.txt
-    ./core
+    ./core[docs]
 commands =
     python -m sphinx -W docs build/sphinx
 


### PR DESCRIPTION
A collection of miscellaneous docs cleanups:

* Removing references to the "Django" backend
* Updated references from "OS X" to "macOS"
* Updated descriptions of currently active platforms
* Consolidated docs requirements definitions as an extra on the core module.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
