### PR TITLE
Fix winforms datepicker widget unexpected date format

### DIFF
--- a/changes/1699.bugfix.rst
+++ b/changes/1699.bugfix.rst
@@ -1,0 +1,1 @@
+DateTime widgets on Windows are able to generate dates that are independent of the system locale.

--- a/winforms/src/toga_winforms/libs/__init__.py
+++ b/winforms/src/toga_winforms/libs/__init__.py
@@ -9,6 +9,7 @@ from .winforms import (  # noqa: F401
     Bitmap,
     Color,
     Convert,
+    CultureInfo,
     Drawing2D,
     FillMode,
     FontFamily,

--- a/winforms/src/toga_winforms/libs/winforms.py
+++ b/winforms/src/toga_winforms/libs/winforms.py
@@ -46,6 +46,7 @@ from System.Drawing.Drawing2D import (  # noqa: F401, E402
 )
 from System.Drawing.Imaging import ImageFormat  # noqa: F401, E402
 from System.Drawing.Text import PrivateFontCollection  # noqa: F401, E402
+from System.Globalization import CultureInfo  # noqa: F401, E402
 from System.IO import FileNotFoundException, MemoryStream  # noqa: F401, E402
 from System.Net import SecurityProtocolType, ServicePointManager  # noqa: F401, E402
 from System.Runtime.InteropServices import ExternalException  # noqa: F401, E402

--- a/winforms/src/toga_winforms/widgets/datepicker.py
+++ b/winforms/src/toga_winforms/widgets/datepicker.py
@@ -2,7 +2,7 @@ import datetime
 
 from travertino.size import at_least
 
-from toga_winforms.libs import WinDateTime, WinForms
+from toga_winforms.libs import CultureInfo, WinDateTime, WinForms
 
 from .base import Widget
 
@@ -12,7 +12,12 @@ class DatePicker(Widget):
         self.native = WinForms.DateTimePicker()
 
     def get_value(self):
-        return datetime.datetime.strptime(self.native.Text, "%A, %B %d, %Y").date()
+        return datetime.datetime.strptime(
+            self.native.Value.ToString(
+                "yyyy-MM-ddTHH:mm:sszzz", CultureInfo.InvariantCulture
+            ),
+            "%Y-%m-%dT%H:%M:%S%z",
+        ).date()
 
     def set_value(self, value):
         self.native.Value = WinDateTime(value.year, value.month, value.day)


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Fixes #1699. 
The Winforms native datepicker widget "Value" attribute is a native DateTime object. This converts the DateTime object to text using the ISO 8601 format. It is then parsed to a Python datetime object using strptime(). This solves the problem of the date format being dependent on local Windows settings.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
