### PR TITLE
Use call_soon_threadsafe for background tasks, and consolidate implementation

### DIFF
--- a/android/src/toga_android/app.py
+++ b/android/src/toga_android/app.py
@@ -212,9 +212,6 @@ class App:
     def set_on_exit(self, value):
         pass
 
-    def add_background_task(self, handler):
-        self.loop.call_soon(handler, self)
-
     async def intent_result(self, intent):
         """Calls an Intent and waits for its result.
 

--- a/changes/1705.bugfix.rst
+++ b/changes/1705.bugfix.rst
@@ -1,0 +1,1 @@
+Background tasks are now added in threadsafe mode.

--- a/cocoa/src/toga_cocoa/app.py
+++ b/cocoa/src/toga_cocoa/app.py
@@ -415,9 +415,6 @@ class App:
 
         self._cursor_visible = False
 
-    def add_background_task(self, handler):
-        self.loop.call_soon(handler, self)
-
     def open_document(self, fileURL):
         """No-op when the app is not a ``DocumentApp``."""
 

--- a/core/src/toga/app.py
+++ b/core/src/toga/app.py
@@ -592,7 +592,7 @@ class App:
 
         :param handler: A coroutine, generator or callable.
         """
-        self._impl.add_background_task(wrapped_handler(self, handler))
+        self._impl.loop.call_soon_threadsafe(wrapped_handler(self, handler), self)
 
 
 class DocumentApp(App):

--- a/core/tests/test_app.py
+++ b/core/tests/test_app.py
@@ -157,11 +157,16 @@ class AppTests(TestCase):
             self.assertIn(window, test_windows)
 
     def test_add_background_task(self):
-        async def handler(sender):
+        async def test_handler(sender):
             pass
 
-        self.app.add_background_task(handler)
-        self.assertActionPerformed(self.app, "add_background_task")
+        self.app.add_background_task(test_handler)
+        self.assertActionPerformedWith(
+            self.app,
+            "loop:call_soon_threadsafe",
+            handler=test_handler,
+            args=(self.app,),
+        )
 
 
 class DocumentAppTests(TestCase):

--- a/dummy/src/toga_dummy/app.py
+++ b/dummy/src/toga_dummy/app.py
@@ -8,10 +8,20 @@ class MainWindow(Window):
         self.action("handle MainWindow on_close")
 
 
+@not_required
+class EventLoop:
+    def __init__(self, app):
+        self.app = app
+
+    def call_soon_threadsafe(self, handler, *args):
+        self.app._action("loop:call_soon_threadsafe", handler=handler, args=args)
+
+
 class App(LoggedObject):
     def __init__(self, interface):
         super().__init__()
         self.interface = interface
+        self.loop = EventLoop(self)
 
     def create(self):
         self._action("create")
@@ -54,9 +64,6 @@ class App(LoggedObject):
     @not_required_on("mobile")
     def hide_cursor(self):
         self._action("hide_cursor")
-
-    def add_background_task(self, handler):
-        self._action("add_background_task", handler=handler)
 
 
 @not_required_on("mobile", "web")

--- a/dummy/src/toga_dummy/utils.py
+++ b/dummy/src/toga_dummy/utils.py
@@ -1,5 +1,6 @@
 import sys
 import unittest
+from unittest.mock import Mock
 
 from travertino.declaration import BaseStyle
 from travertino.layout import BaseBox
@@ -442,8 +443,20 @@ class TestCase(unittest.TestCase):
                 # a match.
                 for key, value in test_data.items():
                     try:
-                        if data[key] != value:
-                            found = False
+                        try:
+                            # Look for a `_raw` attribute, as that will be the
+                            # directly comparable object
+                            raw = data[key]._raw
+                            # If the _raw attribute is a mock, it doesn't actually exist
+                            if isinstance(data[key]._raw, Mock):
+                                raise AttributeError()
+
+                            if raw != value:
+                                found = False
+                        except AttributeError:
+                            # No raw attribute; use the provided value as-is
+                            if data[key] != value:
+                                found = False
                     except KeyError:
                         found = False
 

--- a/gtk/src/toga_gtk/app.py
+++ b/gtk/src/toga_gtk/app.py
@@ -248,9 +248,6 @@ class App:
     def hide_cursor(self):
         self.interface.factory.not_implemented("App.hide_cursor()")
 
-    def add_background_task(self, handler):
-        self.loop.call_soon(handler, self)
-
 
 class DocumentApp(App):
     def _create_app_commands(self):

--- a/iOS/src/toga_iOS/app.py
+++ b/iOS/src/toga_iOS/app.py
@@ -125,6 +125,3 @@ class App:
 
     def set_on_exit(self, value):
         pass
-
-    def add_background_task(self, handler):
-        self.loop.call_soon(handler, self)

--- a/web/src/toga_web/app.py
+++ b/web/src/toga_web/app.py
@@ -208,6 +208,3 @@ class App:
 
     def hide_cursor(self):
         self.interface.factory.not_implemented("App.hide_cursor()")
-
-    def add_background_task(self, handler):
-        self.interface.factory.not_implemented("App.add_background_task()")

--- a/winforms/src/toga_winforms/app.py
+++ b/winforms/src/toga_winforms/app.py
@@ -304,9 +304,6 @@ class App:
     def hide_cursor(self):
         self.interface.factory.not_implemented("App.hide_cursor()")
 
-    def add_background_task(self, handler):
-        self.loop.call_soon(handler, self)
-
 
 class DocumentApp(App):
     def _create_app_commands(self):


### PR DESCRIPTION
Consolidates the common implementation of `add_background_task()` into the interface, and uses the threadsafe `call_soon` variant.

As a review note: This means that the `loop` attribute is now part of the public "_impl" API. I've opted for the simple approach here of just assuming the attribute exists; however, it may be worth considering whether we should promote `loop` to the interface layer (with construction of the loop deferred to the backend), or add a formal impl API for accessing the loop from the interface layer.

Fixes #1705.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
