### PR TITLE
implement gtk canvas events

### DIFF
--- a/changes/1710.feature.rst
+++ b/changes/1710.feature.rst
@@ -1,0 +1,1 @@
+Canvas events are now supported in GTK.

--- a/gtk/src/toga_gtk/widgets/canvas.py
+++ b/gtk/src/toga_gtk/widgets/canvas.py
@@ -20,13 +20,10 @@ class Canvas(Widget):
         self.native.set_events(
             Gdk.EventMask.BUTTON_PRESS_MASK
             | Gdk.EventMask.BUTTON_RELEASE_MASK
-            | Gdk.EventMask.POINTER_MOTION_MASK
+            | Gdk.EventMask.BUTTON_MOTION_MASK
         )
         # count number of active clicks
         self.clicks = 0
-        # pointer motion event has no button attribute
-        # so track which pointer button was clicked
-        self.button = 0
 
     def gtk_draw_callback(self, canvas, gtk_context):
         """Creates a draw callback.
@@ -75,7 +72,6 @@ class Canvas(Widget):
 
     def mouse_down(self, obj, event):
         self.clicks = 2 if event.type == Gdk.EventType._2BUTTON_PRESS else 1
-        self.button = event.button
         if event.button == 1 and self.interface.on_press:
             self.interface.on_press(self.interface, event.x, event.y, self.clicks)
         if event.button == 3 and self.interface.on_alt_press:
@@ -84,9 +80,9 @@ class Canvas(Widget):
     def mouse_move(self, obj, event):
         if self.clicks == 0:
             return
-        if self.button == 1 and self.interface.on_drag:
+        if event.state == Gdk.ModifierType.BUTTON1_MASK and self.interface.on_drag:
             self.interface.on_drag(self.interface, event.x, event.y, self.clicks)
-        if self.button == 3 and self.interface.on_alt_drag:
+        if event.state == Gdk.ModifierType.BUTTON3_MASK and self.interface.on_alt_drag:
             self.interface.on_alt_drag(self.interface, event.x, event.y, self.clicks)
 
     def mouse_up(self, obj, event):
@@ -95,7 +91,6 @@ class Canvas(Widget):
         if event.button == 3 and self.interface.on_alt_release:
             self.interface.on_alt_release(self.interface, event.x, event.y, self.clicks)
         self.clicks = 0
-        self.button = 0
 
     def redraw(self):
         self.native.queue_draw()

--- a/gtk/src/toga_gtk/widgets/canvas.py
+++ b/gtk/src/toga_gtk/widgets/canvas.py
@@ -14,6 +14,9 @@ class Canvas(Widget):
         self.native.interface = self.interface
         self.native.connect("draw", self.gtk_draw_callback)
         self.native.connect("size-allocate", self.gtk_on_size_allocate)
+        self.native.connect("button-press-event", self.mouse_down)
+        self.native.connect("button-release-event", self.mouse_up)
+        self.native.connect("motion-notify-event", self.mouse_move)
         self.native.set_events(
             Gdk.EventMask.BUTTON_PRESS_MASK
             | Gdk.EventMask.BUTTON_RELEASE_MASK
@@ -47,22 +50,28 @@ class Canvas(Widget):
         pass
 
     def set_on_press(self, handler):
-        self.native.connect("button-press-event", self.mouse_down)
+        """No special handling required."""
+        pass
 
     def set_on_release(self, handler):
-        self.native.connect("button-release-event", self.mouse_up)
+        """No special handling required."""
+        pass
 
     def set_on_drag(self, handler):
-        self.native.connect("motion-notify-event", self.mouse_move)
+        """No special handling required."""
+        pass
 
     def set_on_alt_press(self, handler):
-        self.native.connect("button-press-event", self.mouse_down)
+        """No special handling required."""
+        pass
 
     def set_on_alt_release(self, handler):
-        self.native.connect("button-release-event", self.mouse_up)
+        """No special handling required."""
+        pass
 
     def set_on_alt_drag(self, handler):
-        self.native.connect("motion-notify-event", self.mouse_move)
+        """No special handling required."""
+        pass
 
     def mouse_down(self, obj, event):
         self.clicks = 2 if event.type == Gdk.EventType._2BUTTON_PRESS else 1


### PR DESCRIPTION
<!--- Describe your changes in detail -->

Add GTK implementation for canvas events.

I've manually tested the following with `./examples/canvas`:
- [x] drag text with primary button
- [x] rotate text with secondary button
- [x] move text with double click of primary button

![image](https://user-images.githubusercontent.com/32495955/206912212-ffea9f0c-7f1f-411b-b8f1-3249541bbbbd.png)


<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
