### PR TITLE
Corrections to address CI failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
             runs-on: macos-latest
 
           - backend: gtk
-            pre-command: "sudo apt-get update -y && sudo apt-get install -y python3-gi python3-gi-cairo gir1.2-gtk-3.0 python3-dev libgirepository1.0-dev libcairo2-dev pkg-config"
+            pre-command: "sudo apt-get update -y && sudo apt-get install -y python3-gi python3-gi-cairo gir1.2-gtk-3.0 python3-dev libgirepository1.0-dev libcairo2-dev pkg-config libfuse2"
 
           - backend: iOS
             runs-on: macos-latest
@@ -199,7 +199,7 @@ jobs:
 
           - backend: linux
             runs-on: ubuntu-latest
-            pre-command: "sudo apt-get update -y && sudo apt-get install -y python3-gi python3-gi-cairo gir1.2-gtk-3.0 python3-dev libgirepository1.0-dev libcairo2-dev pkg-config"
+            pre-command: "sudo apt-get update -y && sudo apt-get install -y python3-gi python3-gi-cairo gir1.2-gtk-3.0 python3-dev libgirepository1.0-dev libcairo2-dev pkg-config libfuse2"
             briefcase-run-prefix: 'xvfb-run -a -s "-screen 0 2048x1536x24"'
 
           - backend: windows

--- a/changes/1712.misc.rst
+++ b/changes/1712.misc.rst
@@ -1,0 +1,1 @@
+Some small changes were made to support recent changes in CI environments.

--- a/core/tests/utils.py
+++ b/core/tests/utils.py
@@ -5,7 +5,7 @@ def async_test(coroutine):
     """Run an async test to completion."""
 
     def _test(self):
-        asyncio.new_event_loop().run_until_complete(coroutine(self))
+        asyncio.run(coroutine(self))
 
     return _test
 

--- a/core/tests/utils.py
+++ b/core/tests/utils.py
@@ -5,7 +5,7 @@ def async_test(coroutine):
     """Run an async test to completion."""
 
     def _test(self):
-        asyncio.get_event_loop().run_until_complete(coroutine(self))
+        asyncio.new_event_loop().run_until_complete(coroutine(self))
 
     return _test
 


### PR DESCRIPTION
The CI pass for #1709 revealed 2 problems with our CI configuration:

1. GitHub Actions has moved ubuntu-latest to 22.04; this no longer has fuse2 by default, causing AppImage runtime tests to fail
2. Python 3.12.0a3 formally changed the long-deprecated behavior of `asyncio.get_event_loop()`.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
