### PR TITLE
Make release history issue numbers into GitHub links

### DIFF
--- a/changes/1724.doc.rst
+++ b/changes/1724.doc.rst
@@ -1,0 +1,1 @@
+Release history now contains links to GitHub issues.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,8 @@ known_first_party = [
 [tool.towncrier]
 directory = "changes"
 package = "toga"
-package_dir = "src"
+package_dir = "core/src"
 filename = "docs/background/releases.rst"
 title_format = "{version} ({project_date})"
+issue_format = "`#{issue} <https://github.com/beeware/toga/issues/{issue}>`__"
 template = "changes/template.rst"

--- a/tox.ini
+++ b/tox.ini
@@ -40,6 +40,7 @@ commands =
 skip_install = True
 deps =
     towncrier ~= 22.8
+    ./core
 commands =
     towncrier {posargs}
 


### PR DESCRIPTION
Before:
```
* Apps can now specify the order in which widgets receive focus. (#1686)
```
After:
```
* Apps can now specify the order in which widgets receive focus. (`#1686 <https://github.com/beeware/toga/issues/1686>`__)
```
Although this always produces an `/issues` URL, GitHub will automatically redirect it to a `/pull` URL if the number happens to refer to a PR.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
