### PR TITLE
MultilineTextInput: scrolling to top and bottom

### DIFF
--- a/android/src/toga_android/widgets/multilinetextinput.py
+++ b/android/src/toga_android/widgets/multilinetextinput.py
@@ -76,3 +76,9 @@ class MultilineTextInput(Widget):
     def rehint(self):
         self.interface.intrinsic.width = at_least(self.interface.MIN_WIDTH)
         self.interface.intrinsic.height = at_least(self.interface.MIN_HEIGHT)
+
+    def scroll_to_bottom(self):
+        self.interface.factory.not_implemented("MultilineTextInput.scroll_to_bottom()")
+
+    def scroll_to_top(self):
+        self.interface.factory.not_implemented("MultilineTextInput.scroll_to_top()")

--- a/android/src/toga_android/widgets/multilinetextinput.py
+++ b/android/src/toga_android/widgets/multilinetextinput.py
@@ -78,7 +78,8 @@ class MultilineTextInput(Widget):
         self.interface.intrinsic.height = at_least(self.interface.MIN_HEIGHT)
 
     def scroll_to_bottom(self):
-        self.interface.factory.not_implemented("MultilineTextInput.scroll_to_bottom()")
+        last_line = (self.native.getLineCount() - 1) * self.native.getLineHeight()
+        self.native.scrollTo(0, last_line)
 
     def scroll_to_top(self):
-        self.interface.factory.not_implemented("MultilineTextInput.scroll_to_top()")
+        self.native.scrollTo(0, 0)

--- a/changes/1728.feature.rst
+++ b/changes/1728.feature.rst
@@ -1,1 +1,1 @@
-MultilineTextView in Windows, MacOS, Linux and Android can now be set to scroll to top or bottom of the text field.
+MultilineTextView can now be programmatically scrolled to the top or bottom of the text field.

--- a/changes/1728.feature.rst
+++ b/changes/1728.feature.rst
@@ -1,1 +1,1 @@
-MultilineTextView in Windows, Linux and MacOS can now be set to scroll to top or bottom of the text field.
+MultilineTextView in Windows, MacOS, Linux and Android can now be set to scroll to top or bottom of the text field.

--- a/changes/1728.feature.rst
+++ b/changes/1728.feature.rst
@@ -1,0 +1,1 @@
+MultilineTextView in Windows, Linux and MacOS can now be set to scroll to top or bottom of the text field.

--- a/cocoa/src/toga_cocoa/widgets/multilinetextinput.py
+++ b/cocoa/src/toga_cocoa/widgets/multilinetextinput.py
@@ -75,7 +75,7 @@ class MultilineTextInput(Widget):
         self.interface.factory.not_implemented("MultilineTextInput.set_on_change()")
 
     def scroll_to_bottom(self):
-        self.interface.factory.not_implemented("MultilineTextInput.scroll_to_bottom()")
+        self.text.scrollToEndOfDocument(None)
 
     def scroll_to_top(self):
-        self.interface.factory.not_implemented("MultilineTextInput.scroll_to_top()")
+        self.text.scrollToBeginningOfDocument(None)

--- a/cocoa/src/toga_cocoa/widgets/multilinetextinput.py
+++ b/cocoa/src/toga_cocoa/widgets/multilinetextinput.py
@@ -73,3 +73,9 @@ class MultilineTextInput(Widget):
 
     def set_on_change(self, handler):
         self.interface.factory.not_implemented("MultilineTextInput.set_on_change()")
+
+    def scroll_to_bottom(self):
+        self.interface.factory.not_implemented("MultilineTextInput.scroll_to_bottom()")
+
+    def scroll_to_top(self):
+        self.interface.factory.not_implemented("MultilineTextInput.scroll_to_top()")

--- a/core/src/toga/widgets/multilinetextinput.py
+++ b/core/src/toga/widgets/multilinetextinput.py
@@ -138,3 +138,11 @@ class MultilineTextInput(Widget):
         """
         self._on_change = wrapped_handler(self, handler)
         self._impl.set_on_change(self._on_change)
+
+    def scroll_to_bottom(self):
+        """Scroll the view to make the bottom of the text field visible."""
+        self._impl.scroll_to_bottom()
+
+    def scroll_to_top(self):
+        """Scroll the view to make the top of the text field visible."""
+        self._impl.scroll_to_top()

--- a/dummy/src/toga_dummy/widgets/multilinetextinput.py
+++ b/dummy/src/toga_dummy/widgets/multilinetextinput.py
@@ -19,3 +19,9 @@ class MultilineTextInput(Widget):
 
     def set_on_change(self, handler):
         self._set_value("on_change", handler)
+
+    def scroll_to_bottom(self):
+        self._action("scroll to bottom")
+
+    def scroll_to_top(self):
+        self._action("scroll to top")

--- a/examples/multilinetextinput/multilinetextinput/app.py
+++ b/examples/multilinetextinput/multilinetextinput/app.py
@@ -19,6 +19,12 @@ class ExampleMultilineTextInputApp(toga.App):
     def clear_pressed(self, widget, **kwargs):
         self.multiline_input.clear()
 
+    def scroll_to_top(self, widget):
+        self.multiline_input.scroll_to_top()
+
+    def scroll_to_bottom(self, widget):
+        self.multiline_input.scroll_to_bottom()
+
     def set_label(self, widget):
         if self.multiline_input.value == "":
             self.label.text = "Nothing has been written yet"
@@ -48,7 +54,13 @@ class ExampleMultilineTextInputApp(toga.App):
         button_clear = toga.Button(
             "Clear", on_press=self.clear_pressed, style=Pack(flex=1)
         )
-        btn_box = toga.Box(
+        button_scroll_top = toga.Button(
+            "Go to top", on_press=self.scroll_to_top, style=Pack(flex=1)
+        )
+        button_scroll_bottom = toga.Button(
+            "Go to bottom", on_press=self.scroll_to_bottom, style=Pack(flex=1)
+        )
+        btn_box1 = toga.Box(
             children=[
                 button_toggle_enabled,
                 button_toggle_readonly,
@@ -57,10 +69,17 @@ class ExampleMultilineTextInputApp(toga.App):
             ],
             style=Pack(direction=ROW, padding=10),
         )
+        btn_box2 = toga.Box(
+            children=[
+                button_scroll_top,
+                button_scroll_bottom,
+            ],
+            style=Pack(direction=ROW, padding=10),
+        )
         self.label = toga.Label("Nothing has been written yet")
 
         outer_box = toga.Box(
-            children=[btn_box, self.multiline_input, self.label],
+            children=[btn_box1, btn_box2, self.multiline_input, self.label],
             style=Pack(direction=COLUMN, padding=10),
         )
 

--- a/gtk/src/toga_gtk/widgets/multilinetextinput.py
+++ b/gtk/src/toga_gtk/widgets/multilinetextinput.py
@@ -74,3 +74,11 @@ class MultilineTextInput(Widget):
 
     def set_on_change(self, handler):
         self.interface.factory.not_implemented("MultilineTextInput.set_on_change()")
+
+    def scroll_to_bottom(self):
+        self.buffer.place_cursor(self.buffer.get_end_iter())
+        self.textview.scroll_to_mark(self.buffer.get_insert(), 0.0, True, 0.0, 0.0)
+
+    def scroll_to_top(self):
+        self.buffer.place_cursor(self.buffer.get_start_iter())
+        self.textview.scroll_to_mark(self.buffer.get_insert(), 0.0, True, 0.0, 0.0)

--- a/iOS/src/toga_iOS/widgets/multilinetextinput.py
+++ b/iOS/src/toga_iOS/widgets/multilinetextinput.py
@@ -132,3 +132,9 @@ class MultilineTextInput(Widget):
 
     def set_on_change(self, handler):
         self.interface.factory.not_implemented("MultilineTextInput.set_on_change()")
+
+    def scroll_to_bottom(self):
+        self.interface.factory.not_implemented("MultilineTextInput.scroll_to_bottom()")
+
+    def scroll_to_top(self):
+        self.interface.factory.not_implemented("MultilineTextInput.scroll_to_top()")

--- a/winforms/src/toga_winforms/widgets/multilinetextinput.py
+++ b/winforms/src/toga_winforms/widgets/multilinetextinput.py
@@ -78,3 +78,11 @@ class MultilineTextInput(Widget):
     def set_background_color(self, value):
         if value:
             self.native.BackColor = native_color(value)
+
+    def scroll_to_bottom(self):
+        self.native.SelectionStart = len(self.native.Text)
+        self.native.ScrollToCaret()
+
+    def scroll_to_top(self):
+        self.native.SelectionStart = 0
+        self.native.ScrollToCaret()


### PR DESCRIPTION
This PR adds the features `scroll_to_bottom()` and `scroll_to_top()` to the `MultilineTextInput` widget.
It's implemented for Windows, Linux , MacOS and Android. ~~The implementation for Android seems straight-forward, but I haven't set up a testing environment for this OS.~~

Use this example app for testing:
```python
"""
Demo for scroll to top/bottom
"""
import toga
from toga.style import Pack
from toga.style.pack import COLUMN, ROW


class Multiline_scroll(toga.App):
    def startup(self):
        """Demo app to demonstrate scroll_to_bottom/_top for MultilineTextInput."""
        main_box = toga.Box(style=Pack(direction=COLUMN))
        text_box = toga.Box(style=Pack(direction=COLUMN))
        button_box = toga.Box(style=Pack(direction=ROW))

        self.mlti = toga.MultilineTextInput(style=Pack(padding=(10, 70), height=60))
        text_box.add(self.mlti)

        for n in range(10):
            self.mlti.value += f"{n + 1}. Line\n"
        self.mlti.value = self.mlti.value[:-1]

        button_up = toga.Button(
            "Scroll to top",
            on_press=self.to_top,
            style=Pack(padding=5),
        )
        button_down = toga.Button(
            "Scroll to bottom",
            on_press=self.to_bottom,
            style=Pack(padding=5),
        )
        button_box.add(button_up)
        button_box.add(button_down)

        main_box.add(button_box)
        main_box.add(text_box)

        self.main_window = toga.MainWindow(
            title=self.formal_name,
            size=(100, 150),
        )
        self.main_window.content = main_box
        self.main_window.show()

    def to_top(self, widget):
        self.mlti.scroll_to_top()

    def to_bottom(self, widget):
        self.mlti.scroll_to_bottom()


def main():
    return Multiline_scroll("Multiline scroll example", "com.example.multilinescroll")


if __name__ == "__main__":
    main().main_loop()
```


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
