### PR TITLE
add missing comma in example code

### DIFF
--- a/changes/1733.doc.rst
+++ b/changes/1733.doc.rst
@@ -1,0 +1,1 @@
+Updated documentation for to adds missing comma to example for commands.

--- a/changes/1733.doc.rst
+++ b/changes/1733.doc.rst
@@ -1,1 +1,0 @@
-Updated documentation for to adds missing comma to example for commands.

--- a/changes/1733.misc.rst
+++ b/changes/1733.misc.rst
@@ -1,0 +1,1 @@
+An error in a documentation error for commands was corrected.

--- a/docs/background/commands.rst
+++ b/docs/background/commands.rst
@@ -84,7 +84,7 @@ The following is an example of using menus and commands::
             label='Example command',
             tooltip='Tells you when it has been activated',
             shortcut='k',
-            icon='icons/pretty.png'
+            icon='icons/pretty.png',
             group=stuff_group,
             section=0
         )


### PR DESCRIPTION
Was getting a syntax error and it seems it is due to a missing comma:
https://toga.readthedocs.io/en/latest/background/commands.html#:~:text=icon%3D%27icons/pretty.png%27

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
