### PR TITLE
Update stale branch references in README badges.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,10 +25,6 @@ Toga
    :target: https://github.com/beeware/toga/actions
    :alt: Build Status
 
-.. image:: https://codecov.io/gh/beeware/toga/branch/main/graph/badge.svg
-   :target: https://codecov.io/gh/beeware/toga
-   :alt: Codecov
-
 .. image:: https://img.shields.io/discord/836455665257021440?label=Discord%20Chat&logo=discord&style=plastic
    :target: https://beeware.org/bee/chat/
    :alt: Discord server

--- a/README.rst
+++ b/README.rst
@@ -18,14 +18,14 @@ Toga
     :alt: Project status
 
 .. image:: https://img.shields.io/pypi/l/toga.svg
-    :target: https://github.com/beeware/toga/blob/master/LICENSE
+    :target: https://github.com/beeware/toga/blob/main/LICENSE
     :alt: License
 
-.. image:: https://github.com/beeware/toga/workflows/CI/badge.svg?branch=master
+.. image:: https://github.com/beeware/toga/workflows/CI/badge.svg?branch=main
    :target: https://github.com/beeware/toga/actions
    :alt: Build Status
 
-.. image:: https://codecov.io/gh/beeware/toga/branch/master/graph/badge.svg
+.. image:: https://codecov.io/gh/beeware/toga/branch/main/graph/badge.svg
    :target: https://codecov.io/gh/beeware/toga
    :alt: Codecov
 

--- a/changes/1740.misc.rst
+++ b/changes/1740.misc.rst
@@ -1,0 +1,1 @@
+Stale references to the master branch in README badges was corrected.


### PR DESCRIPTION
An oversight of the master->main conversion - the CI badges in the README still referred to the master branch.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
