### PR TITLE
Adopt Rubicon 0.4.5rc1

### DIFF
--- a/changes/1751.misc.rst
+++ b/changes/1751.misc.rst
@@ -1,0 +1,1 @@
+The Rubicon-ObjC version specifier was updated to an RC version because 0.4.4 was yanked, but we need the new features in the main branch.

--- a/cocoa/setup.py
+++ b/cocoa/setup.py
@@ -18,7 +18,7 @@ with open("src/toga_cocoa/__init__.py", encoding="utf8") as version_file:
 setup(
     version=version,
     install_requires=[
-        "rubicon-objc>=0.4.5rc1",
-        f"toga-core=={version}",
+        "rubicon-objc >= 0.4.5rc1, < 0.5.0",
+        f"toga-core == {version}",
     ],
 )

--- a/cocoa/setup.py
+++ b/cocoa/setup.py
@@ -18,7 +18,7 @@ with open("src/toga_cocoa/__init__.py", encoding="utf8") as version_file:
 setup(
     version=version,
     install_requires=[
-        "rubicon-objc>=0.4.4",
+        "rubicon-objc>=0.4.5rc1",
         f"toga-core=={version}",
     ],
 )

--- a/iOS/setup.py
+++ b/iOS/setup.py
@@ -18,7 +18,7 @@ with open("src/toga_iOS/__init__.py", encoding="utf8") as version_file:
 setup(
     version=version,
     install_requires=[
-        "rubicon-objc>=0.4.5rc1",
-        f"toga-core=={version}",
+        "rubicon-objc >= 0.4.5rc1, < 0.5.0",
+        f"toga-core == {version}",
     ],
 )

--- a/iOS/setup.py
+++ b/iOS/setup.py
@@ -18,7 +18,7 @@ with open("src/toga_iOS/__init__.py", encoding="utf8") as version_file:
 setup(
     version=version,
     install_requires=[
-        "rubicon-objc>=0.4.4",
+        "rubicon-objc>=0.4.5rc1",
         f"toga-core=={version}",
     ],
 )


### PR DESCRIPTION
Updates cocoa and iOS to set a rubicon 0.4.5rc1 minimum version. This is required because 0.4.4 had to be yanked, as it is incompatible with the version of Toga that is available for general use (0.3.0dev39). By publishing a prerelease version of Rubicon, and then including a version specifier that will pick up that prerelease, we can have access to the new features of Rubicon without affecting current production users.

This will fail CI until rubicon-objc 0.4.5rc1 is publishes (hopefully early tomorrow).

Fixes #1750

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
