### PR TITLE
[cocoa] Fix enabled state for NumberInput

### DIFF
--- a/changes/1756.bugfix.rst
+++ b/changes/1756.bugfix.rst
@@ -1,0 +1,1 @@
+Fix setting enabled state on NumberInput widget in Cocoa backend.

--- a/cocoa/src/toga_cocoa/widgets/numberinput.py
+++ b/cocoa/src/toga_cocoa/widgets/numberinput.py
@@ -206,6 +206,10 @@ class NumberInput(Widget):
             # converted to a Decimal.
             self.input.stringValue = value
 
+    def set_enabled(self, value):
+        self.input.enabled = value
+        self.stepper.enabled = value
+
     def rehint(self):
         # Height of a text input is known and fixed.
         stepper_size = self.input.intrinsicContentSize()


### PR DESCRIPTION
Setting the `enabled` state on `toga_cocoa.widgets.NumberInput` would inherit the parent method and set the enabled state on the `native` layer, in this case a TogaView.

It makes more sense for this widget to set the `enabled` state on the text input and stepper which are the UI elements that a user interacts with.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
