### PR TITLE
[cocoa] Fix impl access in NumberInput widget

### DIFF
--- a/changes/1757.bugfix.rst
+++ b/changes/1757.bugfix.rst
@@ -1,0 +1,1 @@
+Fix updating the value and calling on_change for NumberInput widgets in Cococa.

--- a/cocoa/src/toga_cocoa/widgets/numberinput.py
+++ b/cocoa/src/toga_cocoa/widgets/numberinput.py
@@ -39,7 +39,7 @@ class TogaStepper(NSStepper):
     @objc_method
     def controlTextDidChange_(self, notification) -> None:
         try:
-            value = str(self._impl.input.stringValue)
+            value = str(self.impl.input.stringValue)
             # Try to convert to a decimal. If the value isn't a number,
             # this will raise InvalidOperation
             Decimal(value)


### PR DESCRIPTION
Fix accessing the implementation layer (`_impl` -> `impl`) in TogaStepper which is part of the NumberInput widget.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
