### PR TITLE
Correct version handling in docs.

### DIFF
--- a/changes/1750.misc.rst
+++ b/changes/1750.misc.rst
@@ -1,0 +1,1 @@
+The handling of version numbers in the documentation was changed.

--- a/core/setup.cfg
+++ b/core/setup.cfg
@@ -74,7 +74,6 @@ dev =
 docs =
     furo == 2022.12.7
     pyenchant == 3.2.2
-    setuptools-scm[toml] == 7.0.5
     sphinx == 6.1.3
     sphinx_tabs == 3.4.1
     sphinx-autobuild == 2021.3.14

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,8 +12,7 @@
 
 import os
 import sys
-
-import setuptools_scm
+from importlib.metadata import version as metadata_version
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -54,10 +53,9 @@ copyright = "2013, Russell Keith-Magee"
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-# The full version, including alpha/beta/rc tags.
-release = setuptools_scm.get_version(root="..", relative_to=__file__)
-
-# The short X.Y version.
+# The full version, including alpha/beta/rc tags
+release = metadata_version("toga-core")
+# The short X.Y version
 version = ".".join(release.split(".")[:2])
 
 # Fix the autodoc import issues
@@ -113,7 +111,7 @@ pygments_style = "sphinx"
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-# html_title = None
+html_title = f"Toga {release}"
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 # html_short_title = None


### PR DESCRIPTION
The documentation for Toga 0.3.0 has a title in the sidebar that describes the version as 0.3.1dev0+gcddb9e4a.d20230130. This is a setuptools_scm version indicating that the branch being used to build the release is dirty, but has 0 commits.

This PR:
1. Switches to using install metadata rather than setuptools_scm to determine the release version. This is the approach [recommended by setuptools_scm](https://github.com/pypa/setuptools_scm#usage-from-sphinx), because RTD can change the working directory, causing the dirty version tag. It also removes the need to have setuptools-scm in the documentation environment.
2. Modifies the title template to drop the redundant "Documentation".

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
