### PR TITLE
Specify source of `pre-commit` in workflow

### DIFF
--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -10,3 +10,5 @@ jobs:
     name: Update pre-commit
     uses: beeware/.github/.github/workflows/pre-commit-update.yml@main
     secrets: inherit
+    with:
+      pre-commit-source: './core[dev]'

--- a/changes/1765.misc.rst
+++ b/changes/1765.misc.rst
@@ -1,0 +1,1 @@
+Updated GitHub workflow that updates ``pre-commit`` hooks to specify how to install ``pre-commit``.


### PR DESCRIPTION
Forgot that `toga` has many packages in it; add `./core[dev]` as `pre-commit` source in workflow.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
