### PR TITLE
Remove :inherited-members: from most classes, and add :undoc-members:

### DIFF
--- a/changes/1766.misc.rst
+++ b/changes/1766.misc.rst
@@ -1,0 +1,1 @@
+Remove :inherited-members: from most classes, and add :undoc-members:

--- a/docs/reference/api/app.rst
+++ b/docs/reference/api/app.rst
@@ -57,4 +57,3 @@ Reference
 .. autoclass:: toga.app.App
    :members:
    :undoc-members:
-   :inherited-members:

--- a/docs/reference/api/containers/box.rst
+++ b/docs/reference/api/containers/box.rst
@@ -69,4 +69,3 @@ Reference
 .. autoclass:: toga.widgets.box.Box
    :members:
    :undoc-members:
-   :inherited-members:

--- a/docs/reference/api/containers/optioncontainer.rst
+++ b/docs/reference/api/containers/optioncontainer.rst
@@ -37,4 +37,3 @@ Reference
 .. autoclass:: toga.widgets.optioncontainer.OptionContainer
    :members:
    :undoc-members:
-   :inherited-members:

--- a/docs/reference/api/containers/scrollcontainer.rst
+++ b/docs/reference/api/containers/scrollcontainer.rst
@@ -49,4 +49,3 @@ Reference
 .. autoclass:: toga.widgets.scrollcontainer.ScrollContainer
    :members:
    :undoc-members:
-   :inherited-members:

--- a/docs/reference/api/containers/splitcontainer.rst
+++ b/docs/reference/api/containers/splitcontainer.rst
@@ -50,4 +50,3 @@ Reference
 .. autoclass:: toga.widgets.splitcontainer.SplitContainer
    :members:
    :undoc-members:
-   :inherited-members:

--- a/docs/reference/api/mainwindow.rst
+++ b/docs/reference/api/mainwindow.rst
@@ -32,4 +32,3 @@ Reference
 .. autoclass:: toga.app.MainWindow
    :members:
    :undoc-members:
-   :inherited-members:

--- a/docs/reference/api/resources/command.rst
+++ b/docs/reference/api/resources/command.rst
@@ -21,4 +21,3 @@ Reference
 .. autoclass:: toga.command.Command
    :members:
    :undoc-members:
-   :inherited-members:

--- a/docs/reference/api/resources/fonts.rst
+++ b/docs/reference/api/resources/fonts.rst
@@ -19,4 +19,3 @@ Reference
 .. autoclass:: toga.fonts.Font
    :members:
    :undoc-members:
-   :inherited-members:

--- a/docs/reference/api/resources/group.rst
+++ b/docs/reference/api/resources/group.rst
@@ -22,4 +22,3 @@ Reference
 .. autoclass:: toga.command.Group
    :members:
    :undoc-members:
-   :inherited-members:

--- a/docs/reference/api/resources/icons.rst
+++ b/docs/reference/api/resources/icons.rst
@@ -42,4 +42,3 @@ Reference
 .. autoclass:: toga.icons.Icon
    :members:
    :undoc-members:
-   :inherited-members:

--- a/docs/reference/api/resources/images.rst
+++ b/docs/reference/api/resources/images.rst
@@ -37,4 +37,3 @@ Reference
 .. autoclass:: toga.images.Image
    :members:
    :undoc-members:
-   :inherited-members:

--- a/docs/reference/api/widgets/activityindicator.rst
+++ b/docs/reference/api/widgets/activityindicator.rst
@@ -31,4 +31,3 @@ Reference
 .. autoclass:: toga.widgets.activityindicator.ActivityIndicator
    :members:
    :undoc-members:
-   :inherited-members:

--- a/docs/reference/api/widgets/button.rst
+++ b/docs/reference/api/widgets/button.rst
@@ -51,3 +51,4 @@ Reference
 
 .. autoclass:: toga.widgets.button.Button
    :members:
+   :undoc-members:

--- a/docs/reference/api/widgets/canvas.rst
+++ b/docs/reference/api/widgets/canvas.rst
@@ -73,7 +73,6 @@ Main Interface
 .. autoclass:: toga.widgets.canvas.Canvas
    :members:
    :undoc-members:
-   :inherited-members:
    :exclude-members: canvas, add_draw_obj
 
 Lower-Level Classes
@@ -81,4 +80,5 @@ Lower-Level Classes
 
 .. automodule:: toga.widgets.canvas
    :members:
+   :undoc-members:
    :exclude-members: Canvas, add_draw_obj

--- a/docs/reference/api/widgets/detailedlist.rst
+++ b/docs/reference/api/widgets/detailedlist.rst
@@ -22,4 +22,3 @@ Reference
 .. autoclass:: toga.widgets.detailedlist.DetailedList
    :members:
    :undoc-members:
-   :inherited-members:

--- a/docs/reference/api/widgets/divider.rst
+++ b/docs/reference/api/widgets/divider.rst
@@ -41,4 +41,3 @@ Reference
 .. autoclass:: toga.widgets.divider.Divider
    :members:
    :undoc-members:
-   :inherited-members:

--- a/docs/reference/api/widgets/imageview.rst
+++ b/docs/reference/api/widgets/imageview.rst
@@ -28,4 +28,3 @@ Reference
 .. autoclass:: toga.widgets.imageview.ImageView
    :members:
    :undoc-members:
-   :inherited-members:

--- a/docs/reference/api/widgets/label.rst
+++ b/docs/reference/api/widgets/label.rst
@@ -32,3 +32,4 @@ Reference
 
 .. autoclass:: toga.widgets.label.Label
    :members:
+   :undoc-members:

--- a/docs/reference/api/widgets/multilinetextinput.rst
+++ b/docs/reference/api/widgets/multilinetextinput.rst
@@ -28,4 +28,3 @@ Reference
 .. autoclass:: toga.widgets.multilinetextinput.MultilineTextInput
    :members:
    :undoc-members:
-   :inherited-members:

--- a/docs/reference/api/widgets/numberinput.rst
+++ b/docs/reference/api/widgets/numberinput.rst
@@ -31,4 +31,3 @@ Reference
 .. autoclass:: toga.widgets.numberinput.NumberInput
    :members:
    :undoc-members:
-   :inherited-members:

--- a/docs/reference/api/widgets/passwordinput.rst
+++ b/docs/reference/api/widgets/passwordinput.rst
@@ -21,4 +21,3 @@ Reference
 .. autoclass:: toga.widgets.passwordinput.PasswordInput
    :members:
    :undoc-members:
-   :inherited-members:

--- a/docs/reference/api/widgets/progressbar.rst
+++ b/docs/reference/api/widgets/progressbar.rst
@@ -71,4 +71,3 @@ Reference
 .. autoclass:: toga.widgets.progressbar.ProgressBar
    :members:
    :undoc-members:
-   :inherited-members:

--- a/docs/reference/api/widgets/selection.rst
+++ b/docs/reference/api/widgets/selection.rst
@@ -31,4 +31,3 @@ Reference
 .. autoclass:: toga.widgets.selection.Selection
    :members:
    :undoc-members:
-   :inherited-members:

--- a/docs/reference/api/widgets/slider.rst
+++ b/docs/reference/api/widgets/slider.rst
@@ -22,4 +22,3 @@ Reference
 .. autoclass:: toga.widgets.slider.Slider
    :members:
    :undoc-members:
-   :inherited-members:

--- a/docs/reference/api/widgets/switch.rst
+++ b/docs/reference/api/widgets/switch.rst
@@ -30,4 +30,3 @@ Reference
 .. autoclass:: toga.widgets.switch.Switch
    :members:
    :undoc-members:
-   :inherited-members:

--- a/docs/reference/api/widgets/table.rst
+++ b/docs/reference/api/widgets/table.rst
@@ -38,4 +38,3 @@ Reference
 .. autoclass:: toga.widgets.table.Table
    :members:
    :undoc-members:
-   :inherited-members:

--- a/docs/reference/api/widgets/textinput.rst
+++ b/docs/reference/api/widgets/textinput.rst
@@ -31,4 +31,3 @@ Reference
 .. autoclass:: toga.widgets.textinput.TextInput
    :members:
    :undoc-members:
-   :inherited-members:

--- a/docs/reference/api/widgets/tree.rst
+++ b/docs/reference/api/widgets/tree.rst
@@ -40,4 +40,3 @@ Reference
 .. autoclass:: toga.widgets.tree.Tree
    :members:
    :undoc-members:
-   :inherited-members:

--- a/docs/reference/api/widgets/webview.rst
+++ b/docs/reference/api/widgets/webview.rst
@@ -52,4 +52,3 @@ Reference
 .. autoclass:: toga.widgets.webview.WebView
    :members:
    :undoc-members:
-   :inherited-members:

--- a/docs/reference/api/widgets/widget.rst
+++ b/docs/reference/api/widgets/widget.rst
@@ -18,4 +18,5 @@ Reference
 
 .. autoclass:: toga.widgets.base.Widget
    :members:
+   :undoc-members:
    :inherited-members:

--- a/docs/reference/api/window.rst
+++ b/docs/reference/api/window.rst
@@ -50,4 +50,3 @@ Reference
 .. autoclass:: toga.window.Window
    :members:
    :undoc-members:
-   :inherited-members:


### PR DESCRIPTION
Removed `:inherited-members:` from all classes, except `Widget`, which inherits many of its members from Travertino. We could do this one widget at a time as we proceed, but I'd prefer to clean them all up now because it makes the docs much easier to navigate.

Added `:undoc-members:` to all classes that don't currently have it. All public members should have documentation, so this setting means that if we ever forget to document a member, it will still appear in the documentation, making it more useful to users, and more obvious to us that something is missing.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
