### PR TITLE
Make API support table circles a more consistent size

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,6 +15,7 @@ build:
 sphinx:
   builder: html
   configuration: docs/conf.py
+  fail_on_warning: true
 
 # Build docs as PDF (other options are epub and htmlzip)
 formats:

--- a/changes/1802.misc.rst
+++ b/changes/1802.misc.rst
@@ -1,0 +1,1 @@
+Make API support table circles a more consistent size

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -16,3 +16,10 @@ table.docutils {
     font-size: var(--font-size--normal);
     font-weight: bold;
 }
+
+span.beta, span.stable {
+    /* Use fonts where the black and white circles have consistent size and alignment. */
+    font-family: Arial, "Lucida Grande", sans-serif;
+    font-size: x-large;
+    line-height: 1;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -100,8 +100,10 @@ pygments_style = "sphinx"
 
 # API status indicators.
 rst_prolog = """
-.. |y| replace:: ●
-.. |b| replace:: ○
+.. role:: stable
+.. role:: beta
+.. |y| replace:: :stable:`●`
+.. |b| replace:: :beta:`○`
 """
 
 

--- a/docs/reference/style/pack.rst
+++ b/docs/reference/style/pack.rst
@@ -11,7 +11,7 @@ properties exist to control color, text alignment and so on.
 It is similar in some ways to the CSS Flexbox algorithm; but dramatically
 simplified, as there is no allowance for overflowing boxes.
 
-.. admonition::
+.. note::
 
    The string values defined here are the string literals that the Pack
    algorithm accepts. These values are also pre-defined as Python constants in


### PR DESCRIPTION
The fonts in the Furo style sheet are:
```
-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji;
```
On macOS, this resolves to the system font SF, where the black and white circles are the same size, and fairly large. But on Windows it uses Segoe UI, where the black circle is much smaller than the white one.

This PR makes the tables use fonts whose circles are equally-sized, and fit in well with the specified font size.

I considered using other Unicode circles instead, but none of them worked well enough:
* The "medium" circles appeared as emojis by default, which stopped them responding to dark mode. There's a variation character which is supposed to switch them back to text mode, but it only worked on Windows, not macOS. 
* The "large" circles were not supported by SF, Arial or Lucida Grande, causing the browser to fall back on other fonts with inconsistent alignment. 

Test document for future reference:
```html
<!DOCTYPE html>
<html>
<head><title>Circle test</title></head>
<body>
<p>Plain: &#x25cb; &#x25cf;</p>
<p>Medium: &#x26aa; &#x26ab;</p>
<p>Medium text: &#x26aa;&#xfe0e; &#x26ab;&#xfe0e;</p>
<p>Large: &#x25ef; &#x2b24;</p>
</body>
</html>
```

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
