### PR TITLE
Correct issues with animated widgets on GTK

### DIFF
--- a/changes/1826.bugfix.rst
+++ b/changes/1826.bugfix.rst
@@ -1,0 +1,1 @@
+GTK widgets that involve animation (such as Switch or ProgressBar) are now redrawn correctly.

--- a/gtk/src/toga_gtk/container.py
+++ b/gtk/src/toga_gtk/container.py
@@ -161,12 +161,13 @@ class TogaContainer(Gtk.Fixed):
         resized = (allocation.width, allocation.height) != (self.width, self.height)
         self.set_allocation(allocation)
 
-        # This function may be called in response to irrelevant events like button clicks,
-        # so only refresh if we really need to.
-        if self._content and (resized or self.needs_redraw):
-            # Re-evaluate the layout using the allocation size as the basis for geometry
-            # print("REFRESH LAYOUT", allocation.width, allocation.height)
-            self._content.interface.refresh()
+        if self._content:
+            # This function may be called in response to irrelevant events like button clicks,
+            # so only refresh if we really need to.
+            if resized or self.needs_redraw:
+                # Re-evaluate the layout using the allocation size as the basis for geometry
+                # print("REFRESH LAYOUT", allocation.width, allocation.height)
+                self._content.interface.refresh()
 
             # WARNING! This is the list of children of the *container*, not
             # the Toga widget. Toga maintains a tree of children; all nodes


### PR DESCRIPTION
The rendering optimisation introduced by #1794 was a little bit *too* optimised; while a recalculation of geometry isn't required on every redraw, we *do* need to involve `set_allocation()` on all child widgets. If this doesn't happen, animations on widgets like Switch and ProgressBar don't get rendered correctly.

Fixes #1826.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
