### PR TITLE
Cleanups of testbed probe usage to get some missing coverage.

### DIFF
--- a/changes/1830.misc.rst
+++ b/changes/1830.misc.rst
@@ -1,0 +1,1 @@
+Probe usage in the testbed was slightly modified to improve coverage.

--- a/cocoa/tests_backend/widgets/activityindicator.py
+++ b/cocoa/tests_backend/widgets/activityindicator.py
@@ -5,9 +5,3 @@ from .base import SimpleProbe
 
 class ActivityIndicatorProbe(SimpleProbe):
     native_class = NSProgressIndicator
-
-    @property
-    def is_running(self):
-        # Cocoa doesn't have a native concept of running;
-        # use the impl's proxy representation.
-        return self.widget._impl._is_running

--- a/cocoa/tests_backend/widgets/divider.py
+++ b/cocoa/tests_backend/widgets/divider.py
@@ -5,9 +5,3 @@ from .base import SimpleProbe
 
 class DividerProbe(SimpleProbe):
     native_class = NSBox
-
-    @property
-    def direction(self):
-        # Cocoa doesn't have a native concept of divider direction;
-        # use the impl's proxy representation.
-        return self.widget._impl._direction

--- a/gtk/src/toga_gtk/widgets/activityindicator.py
+++ b/gtk/src/toga_gtk/widgets/activityindicator.py
@@ -5,9 +5,6 @@ from .base import Widget
 class ActivityIndicator(Widget):
     def create(self):
         self.native = Gtk.Spinner()
-        self.native.set_name(f"toga-{self.interface.id}")
-        self.native.get_style_context().add_class("toga")
-        self.native.interface = self.interface
 
     def is_running(self):
         return self.native.get_property("active")

--- a/gtk/src/toga_gtk/widgets/base.py
+++ b/gtk/src/toga_gtk/widgets/base.py
@@ -11,6 +11,17 @@ class Widget:
         self.native = None
         self.style_providers = {}
         self.create()
+
+        # Ensure the native widget has links to the interface and impl
+        self.native.interface = self.interface
+        self.native._impl = self
+
+        # Ensure the native widget has GTK CSS style attributes; create() should
+        # ensure any other widgets are also styled appropriately.
+        self.native.set_name(f"toga-{self.interface.id}")
+        self.native.get_style_context().add_class("toga")
+
+        # Ensure initial styles are applied.
         self.interface.style.reapply()
 
     @property

--- a/gtk/src/toga_gtk/widgets/box.py
+++ b/gtk/src/toga_gtk/widgets/box.py
@@ -7,7 +7,3 @@ class Box(Widget):
         self.min_width = None
         self.min_height = None
         self.native = Gtk.Box()
-        self.native.set_name(f"toga-{self.interface.id}")
-        self.native.get_style_context().add_class("toga")
-        self.native._impl = self
-        self.native.interface = self.interface

--- a/gtk/src/toga_gtk/widgets/box.py
+++ b/gtk/src/toga_gtk/widgets/box.py
@@ -7,5 +7,7 @@ class Box(Widget):
         self.min_width = None
         self.min_height = None
         self.native = Gtk.Box()
+        self.native.set_name(f"toga-{self.interface.id}")
+        self.native.get_style_context().add_class("toga")
         self.native._impl = self
         self.native.interface = self.interface

--- a/gtk/src/toga_gtk/widgets/button.py
+++ b/gtk/src/toga_gtk/widgets/button.py
@@ -9,10 +9,6 @@ from .base import Widget
 class Button(Widget):
     def create(self):
         self.native = Gtk.Button()
-        self.native.set_name(f"toga-{self.interface.id}")
-        self.native.get_style_context().add_class("toga")
-        self.native.interface = self.interface
-
         self.native.connect("clicked", self.gtk_on_press)
 
     def get_text(self):

--- a/gtk/src/toga_gtk/widgets/canvas.py
+++ b/gtk/src/toga_gtk/widgets/canvas.py
@@ -11,7 +11,7 @@ class Canvas(Widget):
             )
 
         self.native = Gtk.DrawingArea()
-        self.native.interface = self.interface
+
         self.native.connect("draw", self.gtk_draw_callback)
         self.native.connect("size-allocate", self.gtk_on_size_allocate)
         self.native.connect("button-press-event", self.mouse_down)

--- a/gtk/src/toga_gtk/widgets/detailedlist.py
+++ b/gtk/src/toga_gtk/widgets/detailedlist.py
@@ -48,8 +48,6 @@ class DetailedList(Widget):
         self.refresh_button.overlay_over(self.native)
         self.scroll_button.overlay_over(self.native)
 
-        self.native.interface = self.interface
-
         self.gtk_on_select_signal_handler = self.list_box.connect(
             "row-selected", self.gtk_on_row_selected
         )

--- a/gtk/src/toga_gtk/widgets/divider.py
+++ b/gtk/src/toga_gtk/widgets/divider.py
@@ -7,7 +7,6 @@ from .base import Widget
 class Divider(Widget):
     def create(self):
         self.native = Gtk.Separator()
-        self.native.interface = self.interface
 
     def rehint(self):
         width = self.native.get_preferred_width()

--- a/gtk/src/toga_gtk/widgets/imageview.py
+++ b/gtk/src/toga_gtk/widgets/imageview.py
@@ -8,7 +8,6 @@ class ImageView(Widget):
         self._image = Gtk.Image()
         self._pixbuf = None
         self.native.add(self._image)
-        self.native.interface = self.interface
 
     def set_image(self, image):
         self._pixbuf = image._impl.native

--- a/gtk/src/toga_gtk/widgets/label.py
+++ b/gtk/src/toga_gtk/widgets/label.py
@@ -7,10 +7,6 @@ from .base import Widget
 class Label(Widget):
     def create(self):
         self.native = Gtk.Label()
-        self.native.set_name(f"toga-{self.interface.id}")
-        self.native.get_style_context().add_class("toga")
-        self.native.interface = self.interface
-
         self.native.set_line_wrap(False)
 
     def set_alignment(self, value):

--- a/gtk/src/toga_gtk/widgets/multilinetextinput.py
+++ b/gtk/src/toga_gtk/widgets/multilinetextinput.py
@@ -9,7 +9,6 @@ class MultilineTextInput(Widget):
         # Wrap the TextView in a ScrolledWindow in order to show a
         # vertical scroll bar when necessary.
         self.native = Gtk.ScrolledWindow()
-        self.native.interface = self.interface
         self.native.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
 
         self.textview = Gtk.TextView()

--- a/gtk/src/toga_gtk/widgets/numberinput.py
+++ b/gtk/src/toga_gtk/widgets/numberinput.py
@@ -12,7 +12,6 @@ class NumberInput(Widget):
         self.adjustment = Gtk.Adjustment()
 
         self.native = Gtk.SpinButton()
-        self.native.interface = self.interface
         self.native.set_adjustment(self.adjustment)
         self.native.set_numeric(True)
 

--- a/gtk/src/toga_gtk/widgets/optioncontainer.py
+++ b/gtk/src/toga_gtk/widgets/optioncontainer.py
@@ -7,7 +7,6 @@ class OptionContainer(Widget):
     def create(self):
         # We want a single unified widget; the vbox is the representation of that widget.
         self.native = Gtk.Notebook()
-        self.native.interface = self.interface
         self.native.connect("switch-page", self.gtk_on_switch_page)
 
     def gtk_on_switch_page(self, widget, page, page_num):

--- a/gtk/src/toga_gtk/widgets/progressbar.py
+++ b/gtk/src/toga_gtk/widgets/progressbar.py
@@ -7,7 +7,6 @@ PROGRESSBAR_TICK_INTERVAL = 100  # ms per tick
 class ProgressBar(Widget):
     def create(self):
         self.native = Gtk.ProgressBar()
-        self.native.interface = self.interface
 
     def _render_disabled(self):
         self.native.set_fraction(0)

--- a/gtk/src/toga_gtk/widgets/scrollcontainer.py
+++ b/gtk/src/toga_gtk/widgets/scrollcontainer.py
@@ -13,7 +13,6 @@ class ScrollContainer(Widget):
         self.native.set_min_content_height(self.interface.MIN_HEIGHT)
 
         self.native.set_overlay_scrolling(True)
-        self.native.interface = self.interface
 
         self.inner_container = TogaContainer()
         self.native.add(self.inner_container)

--- a/gtk/src/toga_gtk/widgets/selection.py
+++ b/gtk/src/toga_gtk/widgets/selection.py
@@ -7,7 +7,6 @@ from .base import Widget
 class Selection(Widget):
     def create(self):
         self.native = Gtk.ComboBoxText.new()
-        self.native.interface = self.interface
         self.native.connect("changed", self.gtk_on_select)
 
     def gtk_on_select(self, widget):

--- a/gtk/src/toga_gtk/widgets/slider.py
+++ b/gtk/src/toga_gtk/widgets/slider.py
@@ -9,7 +9,6 @@ class Slider(Widget):
         self.adj = Gtk.Adjustment()
 
         self.native = Gtk.Scale.new(Gtk.Orientation.HORIZONTAL, self.adj)
-        self.native.interface = self.interface
         self.native.connect("value-changed", self.gtk_on_change)
 
     def gtk_on_change(self, widget):

--- a/gtk/src/toga_gtk/widgets/splitcontainer.py
+++ b/gtk/src/toga_gtk/widgets/splitcontainer.py
@@ -40,8 +40,6 @@ class SplitContainer(Widget):
         else:
             raise ValueError("Allowed orientation is VERTICAL or HORIZONTAL")
 
-        self.native.interface = self.interface
-
     def add_content(self, position, widget, flex):
         # Add all children to the content widget.
         sub_container = TogaContainer()

--- a/gtk/src/toga_gtk/widgets/switch.py
+++ b/gtk/src/toga_gtk/widgets/switch.py
@@ -7,7 +7,6 @@ from .base import Widget
 class Switch(Widget):
     def create(self):
         self.native = Gtk.Box()
-        self.native.interface = self.interface
 
         self.label = Gtk.Label(xalign=0)
         self.label.set_line_wrap(True)

--- a/gtk/src/toga_gtk/widgets/textinput.py
+++ b/gtk/src/toga_gtk/widgets/textinput.py
@@ -7,7 +7,6 @@ from .base import Widget
 class TextInput(Widget):
     def create(self):
         self.native = Gtk.Entry()
-        self.native.interface = self.interface
         self.native.connect("show", lambda event: self.refresh())
         self.native.connect("changed", self.gtk_on_change)
         self.native.connect("focus-in-event", self.gtk_focus_in_event)

--- a/gtk/src/toga_gtk/widgets/tree.py
+++ b/gtk/src/toga_gtk/widgets/tree.py
@@ -33,7 +33,6 @@ class Tree(Widget):
             self.treeview.append_column(column)
 
         self.native = Gtk.ScrolledWindow()
-        self.native.interface = self.interface
         self.native.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
         self.native.add(self.treeview)
         self.native.set_min_content_width(200)

--- a/gtk/src/toga_gtk/widgets/webview.py
+++ b/gtk/src/toga_gtk/widgets/webview.py
@@ -17,7 +17,6 @@ class WebView(Widget):
             )
 
         self.native = WebKit2.WebView()
-        self.native.interface = self.interface
 
         settings = self.native.get_settings()
         settings.set_property("enable-developer-extras", True)

--- a/gtk/tests_backend/widgets/activityindicator.py
+++ b/gtk/tests_backend/widgets/activityindicator.py
@@ -5,7 +5,3 @@ from .base import SimpleProbe
 
 class ActivityIndicatorProbe(SimpleProbe):
     native_class = Gtk.Spinner
-
-    @property
-    def is_running(self):
-        return self.native.get_property("active")

--- a/gtk/tests_backend/widgets/box.py
+++ b/gtk/tests_backend/widgets/box.py
@@ -1,0 +1,7 @@
+from toga_gtk.libs import Gtk
+
+from .base import SimpleProbe
+
+
+class BoxProbe(SimpleProbe):
+    native_class = Gtk.Box

--- a/gtk/tests_backend/widgets/divider.py
+++ b/gtk/tests_backend/widgets/divider.py
@@ -1,4 +1,3 @@
-import toga
 from toga_gtk.libs import Gtk
 
 from .base import SimpleProbe
@@ -6,11 +5,3 @@ from .base import SimpleProbe
 
 class DividerProbe(SimpleProbe):
     native_class = Gtk.Separator
-
-    @property
-    def direction(self):
-        return (
-            toga.Divider.VERTICAL
-            if self.native.get_orientation() == Gtk.Orientation.VERTICAL
-            else toga.Divider.HORIZONTAL
-        )

--- a/testbed/tests/conftest.py
+++ b/testbed/tests/conftest.py
@@ -2,7 +2,7 @@ import asyncio
 import inspect
 from dataclasses import dataclass
 
-from pytest import fixture, register_assert_rewrite
+from pytest import fixture, register_assert_rewrite, skip
 
 import toga
 
@@ -11,6 +11,12 @@ import toga
 register_assert_rewrite("tests.assertions")
 register_assert_rewrite("tests.widgets")
 register_assert_rewrite("tests_backend")
+
+
+def skip_on_platforms(*platforms):
+    current_platform = toga.platform.current_platform
+    if current_platform in platforms:
+        skip(f"not applicable on {current_platform}")
 
 
 @fixture(scope="session")

--- a/testbed/tests/widgets/probe.py
+++ b/testbed/tests/widgets/probe.py
@@ -1,15 +1,7 @@
 from importlib import import_module
 
-import pytest
-
 
 def get_probe(widget):
     name = type(widget).__name__
-
-    try:
-        module = import_module(f"tests_backend.widgets.{name.lower()}")
-        return getattr(module, f"{name}Probe")(widget)
-    except ModuleNotFoundError:
-        pytest.skip(f"No platform probe module found for widget {name!r}")
-    except AttributeError:
-        pytest.skip(f"No platform probe found for widget {name!r}")
+    module = import_module(f"tests_backend.widgets.{name.lower()}")
+    return getattr(module, f"{name}Probe")(widget)

--- a/testbed/tests/widgets/test_activityindicator.py
+++ b/testbed/tests/widgets/test_activityindicator.py
@@ -2,13 +2,13 @@ import pytest
 
 import toga
 
+from ..conftest import skip_on_platforms
+
 
 @pytest.fixture
 async def widget():
-    try:
-        return toga.ActivityIndicator()
-    except AttributeError:
-        pytest.skip("Platform doesn't implement the ActivityIndicator widget")
+    skip_on_platforms("android", "iOS", "windows")
+    return toga.ActivityIndicator()
 
 
 async def test_start_stop(widget, probe):

--- a/testbed/tests/widgets/test_activityindicator.py
+++ b/testbed/tests/widgets/test_activityindicator.py
@@ -14,19 +14,19 @@ async def widget():
 async def test_start_stop(widget, probe):
     "The activity indicator can be started and stopped"
     # Widget should be initially stopped
-    assert not probe.is_running
+    assert not widget.is_running
 
     widget.start()
     await probe.redraw()
 
     # Widget should now be started
-    assert probe.is_running
+    assert widget.is_running
 
     widget.stop()
     await probe.redraw()
 
     # Widget should now be stopped
-    assert not probe.is_running
+    assert not widget.is_running
 
 
 async def test_fixed_square_widget_size(widget, probe):

--- a/testbed/tests/widgets/test_divider.py
+++ b/testbed/tests/widgets/test_divider.py
@@ -3,13 +3,13 @@ import pytest
 import toga
 from toga.style.pack import COLUMN, ROW
 
+from ..conftest import skip_on_platforms
+
 
 @pytest.fixture
 async def widget():
-    try:
-        return toga.Divider()
-    except AttributeError:
-        pytest.skip("Platform doesn't implement the Divider widget")
+    skip_on_platforms("android", "iOS")
+    return toga.Divider()
 
 
 async def test_directions(widget, probe):

--- a/testbed/tests/widgets/test_divider.py
+++ b/testbed/tests/widgets/test_divider.py
@@ -17,7 +17,7 @@ async def test_directions(widget, probe):
     # Widget should be initially horizontal.
     # Container is initially a row box, so the divider will be
     # both narrow and short
-    assert probe.direction == toga.Divider.HORIZONTAL
+    assert widget.direction == toga.Divider.HORIZONTAL
     assert probe.height < 10
     assert probe.width < 10
 
@@ -26,7 +26,7 @@ async def test_directions(widget, probe):
     await probe.redraw()
 
     # The divider will now be wide, but short.
-    assert probe.direction == toga.Divider.HORIZONTAL
+    assert widget.direction == toga.Divider.HORIZONTAL
     assert probe.height < 10
     assert probe.width > 100
 
@@ -35,7 +35,7 @@ async def test_directions(widget, probe):
     await probe.redraw()
 
     # In a column box, a vertical divider will be narrow and short.
-    assert probe.direction == toga.Divider.VERTICAL
+    assert widget.direction == toga.Divider.VERTICAL
     assert probe.height < 10
     assert probe.width < 10
 
@@ -44,6 +44,6 @@ async def test_directions(widget, probe):
     await probe.redraw()
 
     # In a row box, a vertical divider will be narrow and tall.
-    assert probe.direction == toga.Divider.VERTICAL
+    assert widget.direction == toga.Divider.VERTICAL
     assert probe.height > 100
     assert probe.width < 10

--- a/winforms/src/toga_winforms/widgets/box.py
+++ b/winforms/src/toga_winforms/widgets/box.py
@@ -13,27 +13,26 @@ class Box(Widget):
         self.native.interface = self.interface
 
     def set_bounds(self, x, y, width, height):
-        if self.native:
-            vertical_shift = 0
-            try:
-                # If the box is the outer widget, we need to shift it to the frame vertical_shift
-                vertical_shift = (
-                    self.frame.vertical_shift - self.interface.style.padding_top
-                )
-                # The outermost widget assumes the size of the viewport
-                width = self.viewport.width
-                height = self.viewport.height
-            except AttributeError:
-                vertical_shift = self.interface.style.padding_top
-            horizontal_shift = self.interface.style.padding_left
-            horizontal_size_adjustment = (
-                self.interface.style.padding_right + horizontal_shift
+        vertical_shift = 0
+        try:
+            # If the box is the outer widget, we need to shift it to the frame vertical_shift
+            vertical_shift = (
+                self.frame.vertical_shift - self.interface.style.padding_top
             )
-            vertical_size_adjustment = self.interface.style.padding_bottom
-            self.native.Size = Size(
-                width + horizontal_size_adjustment, height + vertical_size_adjustment
-            )
-            self.native.Location = Point(x - horizontal_shift, y + vertical_shift)
+            # The outermost widget assumes the size of the viewport
+            width = self.viewport.width
+            height = self.viewport.height
+        except AttributeError:
+            vertical_shift = self.interface.style.padding_top
+        horizontal_shift = self.interface.style.padding_left
+        horizontal_size_adjustment = (
+            self.interface.style.padding_right + horizontal_shift
+        )
+        vertical_size_adjustment = self.interface.style.padding_bottom
+        self.native.Size = Size(
+            width + horizontal_size_adjustment, height + vertical_size_adjustment
+        )
+        self.native.Location = Point(x - horizontal_shift, y + vertical_shift)
 
     def set_background_color(self, value):
         if value:

--- a/winforms/tests_backend/widgets/box.py
+++ b/winforms/tests_backend/widgets/box.py
@@ -1,0 +1,7 @@
+import System.Windows.Forms
+
+from .base import SimpleProbe
+
+
+class BoxProbe(SimpleProbe):
+    native_class = System.Windows.Forms.Panel

--- a/winforms/tests_backend/widgets/divider.py
+++ b/winforms/tests_backend/widgets/divider.py
@@ -5,9 +5,3 @@ from .base import SimpleProbe
 
 class DividerProbe(SimpleProbe):
     native_class = System.Windows.Forms.Label
-
-    @property
-    def direction(self):
-        # Winforms doesn't have a native concept of divider direction;
-        # use the impl's proxy representation.
-        return self.widget._impl._direction


### PR DESCRIPTION
The recent audit of Divider missed some coverage because a probe was being used instead of a native getter on the implementation. The audit of Box somehow completely missed committing the entire GTK and Winforms implementations.

This PR:
* updates the tests to use the native widget getter rather than a probe property when a widget getter exists.
* Adds the Winforms and GTK implementation of the Box probe that was somehow missed in the commit of #1820.
* Reworks the way GTK applies style to ensure that the native widget will always have the required CSS style attributes.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
