### PR TITLE
Cleanup of event handlers

### DIFF
--- a/android/src/toga_android/app.py
+++ b/android/src/toga_android/app.py
@@ -209,9 +209,6 @@ class App:
     def exit(self):
         pass
 
-    def set_on_exit(self, value):
-        pass
-
     async def intent_result(self, intent):
         """Calls an Intent and waits for its result.
 

--- a/android/src/toga_android/widgets/button.py
+++ b/android/src/toga_android/widgets/button.py
@@ -15,8 +15,7 @@ class TogaOnClickListener(OnClickListener):
         self.button_impl = button_impl
 
     def onClick(self, _view):
-        if self.button_impl.interface.on_press:
-            self.button_impl.interface.on_press(widget=self.button_impl.interface)
+        self.button_impl.interface.on_press()
 
 
 class Button(TextViewWidget):

--- a/android/src/toga_android/widgets/button.py
+++ b/android/src/toga_android/widgets/button.py
@@ -15,7 +15,7 @@ class TogaOnClickListener(OnClickListener):
         self.button_impl = button_impl
 
     def onClick(self, _view):
-        self.button_impl.interface.on_press()
+        self.button_impl.interface.on_press(None)
 
 
 class Button(TextViewWidget):
@@ -32,10 +32,6 @@ class Button(TextViewWidget):
 
     def set_enabled(self, value):
         self.native.setEnabled(value)
-
-    def set_on_press(self, handler):
-        # No special handling required
-        pass
 
     def set_background_color(self, value):
         # Do not use self.native.setBackgroundColor - this messes with the button style!

--- a/android/src/toga_android/widgets/slider.py
+++ b/android/src/toga_android/widgets/slider.py
@@ -11,8 +11,7 @@ class TogaOnSeekBarChangeListener(SeekBar__OnSeekBarChangeListener):
         self.impl = impl
 
     def onProgressChanged(self, _view, _progress, _from_user):
-        if self.impl.interface.on_change:
-            self.impl.interface.on_change(widget=self.impl.interface)
+        self.impl.interface.on_change(None)
 
     # Add two unused methods so that the Java interface is completely implemented.
     def onStartTrackingTouch(self, native_seekbar):
@@ -73,13 +72,3 @@ class Slider(Widget):
         )
         self.interface.intrinsic.width = at_least(self.native.getMeasuredWidth())
         self.interface.intrinsic.height = self.native.getMeasuredHeight()
-
-    def set_on_change(self, handler):
-        # No special handling required
-        pass
-
-    def set_on_press(self, handler):
-        self.interface.factory.not_implemented("Slider.set_on_press()")
-
-    def set_on_release(self, handler):
-        self.interface.factory.not_implemented("Slider.set_on_release()")

--- a/android/src/toga_android/widgets/switch.py
+++ b/android/src/toga_android/widgets/switch.py
@@ -14,7 +14,7 @@ class OnCheckedChangeListener(CompoundButton__OnCheckedChangeListener):
         self._impl = impl
 
     def onCheckedChanged(self, _button, _checked):
-        self._impl.interface.on_change()
+        self._impl.interface.on_change(None)
 
 
 class Switch(TextViewWidget):
@@ -37,10 +37,6 @@ class Switch(TextViewWidget):
 
     def get_value(self):
         return self.native.isChecked()
-
-    def set_on_change(self, handler):
-        # No special handling required
-        pass
 
     def rehint(self):
         if not self.native.getLayoutParams():

--- a/android/src/toga_android/widgets/switch.py
+++ b/android/src/toga_android/widgets/switch.py
@@ -14,8 +14,7 @@ class OnCheckedChangeListener(CompoundButton__OnCheckedChangeListener):
         self._impl = impl
 
     def onCheckedChanged(self, _button, _checked):
-        if self._impl.interface.on_change:
-            self._impl.interface.on_change(widget=self._impl.interface)
+        self._impl.interface.on_change()
 
 
 class Switch(TextViewWidget):

--- a/changes/1833.feature.rst
+++ b/changes/1833.feature.rst
@@ -1,0 +1,1 @@
+Event handlers have been internally modified to simplify their definition and use on backends.

--- a/cocoa/src/toga_cocoa/app.py
+++ b/cocoa/src/toga_cocoa/app.py
@@ -367,9 +367,6 @@ class App:
     def exit(self):
         self.loop.stop()
 
-    def set_on_exit(self, value):
-        pass
-
     def current_window(self):
         return self.native.keyWindow
 

--- a/cocoa/src/toga_cocoa/widgets/button.py
+++ b/cocoa/src/toga_cocoa/widgets/button.py
@@ -21,8 +21,7 @@ class TogaButton(NSButton):
 
     @objc_method
     def onPress_(self, obj) -> None:
-        if self.interface.on_press:
-            self.interface.on_press(self.interface)
+        self.interface.on_press()
 
 
 class Button(Widget):

--- a/cocoa/src/toga_cocoa/widgets/button.py
+++ b/cocoa/src/toga_cocoa/widgets/button.py
@@ -21,7 +21,7 @@ class TogaButton(NSButton):
 
     @objc_method
     def onPress_(self, obj) -> None:
-        self.interface.on_press()
+        self.interface.on_press(None)
 
 
 class Button(Widget):
@@ -70,10 +70,6 @@ class Button(Widget):
 
     def set_text(self, text):
         self.native.title = text
-
-    def set_on_press(self, handler):
-        # No special handling required
-        pass
 
     def set_background_color(self, color):
         if color == TRANSPARENT or color is None:

--- a/cocoa/src/toga_cocoa/widgets/slider.py
+++ b/cocoa/src/toga_cocoa/widgets/slider.py
@@ -19,14 +19,11 @@ class TogaSlider(NSSlider):
     def onSlide_(self, sender) -> None:
         event_type = sender.window.currentEvent().type
         if event_type == NSEventType.LeftMouseDown:
-            if self.interface.on_press:
-                self.interface.on_press(self.interface)
+            self.interface.on_press(None)
         elif event_type == NSEventType.LeftMouseUp:
-            if self.interface.on_release:
-                self.interface.on_release(self.interface)
+            self.interface.on_release(None)
 
-        if self.interface.on_change:
-            self.interface.on_change(self.interface)
+        self.interface.on_change(None)
 
 
 class Slider(Widget):
@@ -63,12 +60,3 @@ class Slider(Widget):
         content_size = self.native.intrinsicContentSize()
         self.interface.intrinsic.height = content_size.height
         self.interface.intrinsic.width = at_least(self.interface.MIN_WIDTH)
-
-    def set_on_change(self, handler):
-        pass
-
-    def set_on_press(self, handler):
-        pass
-
-    def set_on_release(self, handler):
-        pass

--- a/cocoa/src/toga_cocoa/widgets/switch.py
+++ b/cocoa/src/toga_cocoa/widgets/switch.py
@@ -20,7 +20,7 @@ class TogaSwitch(NSButton):
 
     @objc_method
     def onPress_(self, obj) -> None:
-        self.interface.on_change()
+        self.interface.on_change(None)
 
 
 class Switch(Widget):
@@ -63,6 +63,3 @@ class Switch(Widget):
         content_size = self.native.intrinsicContentSize()
         self.interface.intrinsic.height = content_size.height
         self.interface.intrinsic.width = at_least(content_size.width)
-
-    def set_on_change(self, handler):
-        pass

--- a/cocoa/src/toga_cocoa/widgets/switch.py
+++ b/cocoa/src/toga_cocoa/widgets/switch.py
@@ -20,8 +20,7 @@ class TogaSwitch(NSButton):
 
     @objc_method
     def onPress_(self, obj) -> None:
-        if self.interface.on_change:
-            self.interface.on_change(self.interface)
+        self.interface.on_change()
 
 
 class Switch(Widget):

--- a/cocoa/src/toga_cocoa/window.py
+++ b/cocoa/src/toga_cocoa/window.py
@@ -310,9 +310,6 @@ class Window:
     def set_full_screen(self, is_full_screen):
         self.interface.factory.not_implemented("Window.set_full_screen()")
 
-    def set_on_close(self, handler):
-        pass
-
     def cocoa_windowShouldClose(self):
         if self.interface.on_close:
             # The on_close handler has a cleanup method that will enforce

--- a/core/src/toga/app.py
+++ b/core/src/toga/app.py
@@ -118,9 +118,10 @@ class MainWindow(Window):
         Args:
             handler (:obj:`callable`): The handler passed.
         """
-        raise AttributeError(
-            "Cannot set on_close handler for the main window. Use the app on_exit handler instead"
-        )
+        if handler:
+            raise AttributeError(
+                "Cannot set on_close handler for the main window. Use the app on_exit handler instead"
+            )
 
 
 class App:
@@ -551,7 +552,7 @@ class App:
 
     def exit(self):
         """Quit the application gracefully."""
-        self.on_exit()
+        self.on_exit(None)
 
     @property
     def on_exit(self):
@@ -579,7 +580,6 @@ class App:
                 app._impl.exit()
 
         self._on_exit = wrapped_handler(self, handler, cleanup=cleanup)
-        self._impl.set_on_exit(self._on_exit)
 
     def add_background_task(self, handler):
         """Schedule a task to run in the background.
@@ -592,7 +592,7 @@ class App:
 
         :param handler: A coroutine, generator or callable.
         """
-        self._impl.loop.call_soon_threadsafe(wrapped_handler(self, handler))
+        self._impl.loop.call_soon_threadsafe(wrapped_handler(self, handler), None)
 
 
 class DocumentApp(App):

--- a/core/src/toga/app.py
+++ b/core/src/toga/app.py
@@ -339,7 +339,6 @@ class App:
         # the + and += operators); adding a window to TogaApp.windows
         # would assign the window to the app.
         self.windows = WindowSet(self, windows)
-        self._on_exit = None
 
         self._full_screen_windows = None
 
@@ -552,10 +551,7 @@ class App:
 
     def exit(self):
         """Quit the application gracefully."""
-        if self.on_exit:
-            self.on_exit(self)
-        else:
-            self._impl.exit()
+        self.on_exit()
 
     @property
     def on_exit(self):
@@ -573,6 +569,10 @@ class App:
         Args:
             handler (:obj:`callable`): The handler to invoke before the app exits.
         """
+        if handler is None:
+
+            def handler(app, *args, **kwargs):
+                app._impl.exit()
 
         def cleanup(app, should_exit):
             if should_exit:
@@ -592,7 +592,7 @@ class App:
 
         :param handler: A coroutine, generator or callable.
         """
-        self._impl.loop.call_soon_threadsafe(wrapped_handler(self, handler), self)
+        self._impl.loop.call_soon_threadsafe(wrapped_handler(self, handler))
 
 
 class DocumentApp(App):

--- a/core/src/toga/handlers.py
+++ b/core/src/toga/handlers.py
@@ -55,7 +55,7 @@ def wrapped_handler(interface, handler, cleanup=None):
         if isinstance(handler, NativeHandler):
             return handler.native
 
-        def _handler(widget, *args, **kwargs):
+        def _handler(*args, **kwargs):
             if asyncio.iscoroutinefunction(handler):
                 asyncio.ensure_future(
                     handler_with_cleanup(handler, cleanup, interface, *args, **kwargs)
@@ -75,4 +75,11 @@ def wrapped_handler(interface, handler, cleanup=None):
 
         _handler._raw = handler
 
-        return _handler
+    else:
+        # A dummy no-op handler
+        def _handler(*args, **kwargs):
+            pass
+
+        _handler._raw = None
+
+    return _handler

--- a/core/src/toga/handlers.py
+++ b/core/src/toga/handlers.py
@@ -55,7 +55,7 @@ def wrapped_handler(interface, handler, cleanup=None):
         if isinstance(handler, NativeHandler):
             return handler.native
 
-        def _handler(*args, **kwargs):
+        def _handler(widget, *args, **kwargs):
             if asyncio.iscoroutinefunction(handler):
                 asyncio.ensure_future(
                     handler_with_cleanup(handler, cleanup, interface, *args, **kwargs)
@@ -77,7 +77,7 @@ def wrapped_handler(interface, handler, cleanup=None):
 
     else:
         # A dummy no-op handler
-        def _handler(*args, **kwargs):
+        def _handler(widget, *args, **kwargs):
             pass
 
         _handler._raw = None

--- a/core/src/toga/widgets/button.py
+++ b/core/src/toga/widgets/button.py
@@ -30,8 +30,11 @@ class Button(Widget):
         # Create a platform specific implementation of a Button
         self._impl = self.factory.Button(interface=self)
 
-        # Set all the properties
+        # Set a dummy handler before installing the actual on_press, because we do not want
+        # on_press triggered by the initial value being set
+        self.on_press = None
         self.text = text
+
         self.on_press = on_press
         self.enabled = enabled
 

--- a/core/src/toga/widgets/button.py
+++ b/core/src/toga/widgets/button.py
@@ -71,4 +71,3 @@ class Button(Widget):
     @on_press.setter
     def on_press(self, handler):
         self._on_press = wrapped_handler(self, handler)
-        self._impl.set_on_press(self._on_press)

--- a/core/src/toga/widgets/slider.py
+++ b/core/src/toga/widgets/slider.py
@@ -77,8 +77,9 @@ class Slider(Widget):
         self.range = range
         self.tick_count = tick_count
 
-        # IMPORTANT NOTE: Setting value before on_change in order to not
-        # call it in constructor. Please do not move it from here.
+        # Set a dummy handler before installing the actual on_change, because we do not want
+        # on_change triggered by the initial value being set
+        self.on_change = None
         self.value = value
 
         if on_slide:
@@ -116,8 +117,7 @@ class Slider(Widget):
                 )
             )
         self._impl.set_value(final)
-        if self.on_change:
-            self.on_change(self)
+        self.on_change(self)
 
     @property
     def range(self):
@@ -192,7 +192,6 @@ class Slider(Widget):
     @on_change.setter
     def on_change(self, handler):
         self._on_change = wrapped_handler(self, handler)
-        self._impl.set_on_change(self._on_change)
 
     @property
     def on_press(self):
@@ -206,7 +205,6 @@ class Slider(Widget):
     @on_press.setter
     def on_press(self, handler):
         self._on_press = wrapped_handler(self, handler)
-        self._impl.set_on_press(self._on_press)
 
     @property
     def on_release(self):
@@ -220,7 +218,6 @@ class Slider(Widget):
     @on_release.setter
     def on_release(self, handler):
         self._on_release = wrapped_handler(self, handler)
-        self._impl.set_on_release(self._on_release)
 
     @property
     def on_slide(self):

--- a/core/src/toga/widgets/switch.py
+++ b/core/src/toga/widgets/switch.py
@@ -155,7 +155,6 @@ class Switch(Widget):
     @on_change.setter
     def on_change(self, handler):
         self._on_change = wrapped_handler(self, handler)
-        self._impl.set_on_change(self._on_change)
 
     @property
     def value(self):

--- a/core/src/toga/widgets/switch.py
+++ b/core/src/toga/widgets/switch.py
@@ -116,10 +116,11 @@ class Switch(Widget):
 
         self.text = text
 
-        # Set the actual value before on_change, because we do not want on_change triggered by it
-        # However, we need to prime the handler property in case it is accessed.
-        self._on_change = None
+        # Set a dummy handler before installing the actual on_change, because we do not want
+        # on_change triggered by the initial value being set
+        self.on_change = None
         self.value = value
+
         self.on_change = on_change
 
         self.enabled = enabled

--- a/core/src/toga/window.py
+++ b/core/src/toga/window.py
@@ -70,9 +70,7 @@ class Window:
 
         self._toolbar = CommandSet(widget=self, on_change=self._impl.create_toolbar)
 
-        self._on_close = None
-        if on_close is not None:
-            self.on_close = on_close
+        self.on_close = on_close
 
     @property
     def id(self):
@@ -255,7 +253,6 @@ class Window:
                 window.close()
 
         self._on_close = wrapped_handler(self, handler, cleanup=cleanup)
-        self._impl.set_on_close(self._on_close)
 
     def close(self):
         self.app.windows -= self

--- a/core/tests/test_window.py
+++ b/core/tests/test_window.py
@@ -204,7 +204,7 @@ class TestWindow(TestCase):
     def test_on_close(self):
         with patch.object(self.window, "_impl"):
             self.app.windows += self.window
-            self.assertIsNone(self.window._on_close)
+            self.assertIsNone(self.window.on_close._raw)
 
             # set a new callback
             def callback(window, **extra):
@@ -213,7 +213,7 @@ class TestWindow(TestCase):
             self.window.on_close = callback
             self.assertEqual(self.window.on_close._raw, callback)
             self.assertEqual(
-                self.window.on_close(a=1),
+                self.window.on_close(None, a=1),
                 "called <class 'toga.window.Window'> with {'a': 1}",
             )
 
@@ -226,7 +226,7 @@ class TestWindow(TestCase):
 
         self.assertEqual(window.on_close._raw, callback)
         self.assertEqual(
-            window.on_close(a=1),
+            window.on_close(None, a=1),
             "called <class 'toga.window.Window'> with {'a': 1}",
         )
 

--- a/core/tests/test_window.py
+++ b/core/tests/test_window.py
@@ -213,7 +213,7 @@ class TestWindow(TestCase):
             self.window.on_close = callback
             self.assertEqual(self.window.on_close._raw, callback)
             self.assertEqual(
-                self.window.on_close("widget", a=1),
+                self.window.on_close(a=1),
                 "called <class 'toga.window.Window'> with {'a': 1}",
             )
 
@@ -226,7 +226,7 @@ class TestWindow(TestCase):
 
         self.assertEqual(window.on_close._raw, callback)
         self.assertEqual(
-            window.on_close("widget", a=1),
+            window.on_close(a=1),
             "called <class 'toga.window.Window'> with {'a': 1}",
         )
 

--- a/core/tests/widgets/test_button.py
+++ b/core/tests/widgets/test_button.py
@@ -1,12 +1,9 @@
+from unittest.mock import Mock
+
 import pytest
 
 import toga
-from toga_dummy.utils import (
-    EventLog,
-    assert_action_performed,
-    assert_action_performed_with,
-    attribute_value,
-)
+from toga_dummy.utils import EventLog, assert_action_performed, attribute_value
 
 
 @pytest.fixture
@@ -52,23 +49,20 @@ def test_button_text(button, value, expected):
 def test_button_on_press(button):
     """The on_press handler can be invoked."""
     # No handler initially
-    assert button._on_press is None
+    assert button._on_press._raw is None
 
     # Define and set a new callback
-    def callback(widget, **extra):
-        widget._impl._action("callback invoked", widget=widget, extra=extra)
+    handler = Mock()
 
-    button.on_press = callback
+    button.on_press = handler
 
-    assert button.on_press._raw == callback
+    assert button.on_press._raw == handler
 
     # Backend has the wrapped version
     assert attribute_value(button, "on_press") == button._on_press
 
     # Invoke the callback
-    button.on_press(button, a=1)
+    button.on_press(a=1)
 
     # Callback was invoked
-    assert_action_performed_with(
-        button, "callback invoked", widget=button, extra={"a": 1}
-    )
+    handler.assert_called_once_with(button, a=1)

--- a/core/tests/widgets/test_button.py
+++ b/core/tests/widgets/test_button.py
@@ -58,11 +58,8 @@ def test_button_on_press(button):
 
     assert button.on_press._raw == handler
 
-    # Backend has the wrapped version
-    assert attribute_value(button, "on_press") == button._on_press
-
     # Invoke the callback
-    button.on_press(a=1)
+    button._impl.simulate_press()
 
     # Callback was invoked
-    handler.assert_called_once_with(button, a=1)
+    handler.assert_called_once_with(button)

--- a/core/tests/widgets/test_canvas.py
+++ b/core/tests/widgets/test_canvas.py
@@ -617,7 +617,7 @@ class CanvasTests(TestCase):
         )
 
     def test_on_resize(self):
-        self.assertIsNone(self.testing_canvas._on_resize)
+        self.assertIsNone(self.testing_canvas.on_resize._raw)
 
         # set a new callback
         def callback(widget, **extra):
@@ -626,7 +626,7 @@ class CanvasTests(TestCase):
         self.testing_canvas.on_resize = callback
         self.assertEqual(self.testing_canvas.on_resize._raw, callback)
         self.assertEqual(
-            self.testing_canvas.on_resize("widget", a=1),
+            self.testing_canvas.on_resize(a=1),
             "called <class 'toga.widgets.canvas.Canvas'> with {'a': 1}",
         )
         self.assertValueSet(
@@ -635,7 +635,7 @@ class CanvasTests(TestCase):
 
     def test_on_press(self):
         """Check on_press handler being invoked."""
-        self.assertIsNone(self.testing_canvas._on_press)
+        self.assertIsNone(self.testing_canvas.on_press._raw)
 
         # set a new callback
         def callback(widget, **extra):
@@ -644,7 +644,7 @@ class CanvasTests(TestCase):
         self.testing_canvas.on_press = callback
         self.assertEqual(self.testing_canvas.on_press._raw, callback)
         self.assertEqual(
-            self.testing_canvas.on_press("widget", a=1),
+            self.testing_canvas.on_press(a=1),
             "called <class 'toga.widgets.canvas.Canvas'> with {'a': 1}",
         )
         self.assertValueSet(
@@ -653,7 +653,7 @@ class CanvasTests(TestCase):
 
     def test_on_release(self):
         """Check on_release handler being invoked."""
-        self.assertIsNone(self.testing_canvas._on_release)
+        self.assertIsNone(self.testing_canvas.on_release._raw)
 
         # set a new callback
         def callback(widget, **extra):
@@ -662,7 +662,7 @@ class CanvasTests(TestCase):
         self.testing_canvas.on_release = callback
         self.assertEqual(self.testing_canvas.on_release._raw, callback)
         self.assertEqual(
-            self.testing_canvas.on_release("widget", a=1),
+            self.testing_canvas.on_release(a=1),
             "called <class 'toga.widgets.canvas.Canvas'> with {'a': 1}",
         )
         self.assertValueSet(
@@ -671,7 +671,7 @@ class CanvasTests(TestCase):
 
     def test_on_drag(self):
         """Check on_drag handler being invoked."""
-        self.assertIsNone(self.testing_canvas._on_drag)
+        self.assertIsNone(self.testing_canvas.on_drag._raw)
 
         # set a new callback
         def callback(widget, **extra):
@@ -680,14 +680,14 @@ class CanvasTests(TestCase):
         self.testing_canvas.on_drag = callback
         self.assertEqual(self.testing_canvas.on_drag._raw, callback)
         self.assertEqual(
-            self.testing_canvas.on_drag("widget", a=1),
+            self.testing_canvas.on_drag(a=1),
             "called <class 'toga.widgets.canvas.Canvas'> with {'a': 1}",
         )
         self.assertValueSet(self.testing_canvas, "on_drag", self.testing_canvas.on_drag)
 
     def test_on_alt_press(self):
         """Check on_alt_press handler being invoked."""
-        self.assertIsNone(self.testing_canvas._on_alt_press)
+        self.assertIsNone(self.testing_canvas.on_alt_press._raw)
 
         # set a new callback
         def callback(widget, **extra):
@@ -696,7 +696,7 @@ class CanvasTests(TestCase):
         self.testing_canvas.on_alt_press = callback
         self.assertEqual(self.testing_canvas.on_alt_press._raw, callback)
         self.assertEqual(
-            self.testing_canvas.on_alt_press("widget", a=1),
+            self.testing_canvas.on_alt_press(a=1),
             "called <class 'toga.widgets.canvas.Canvas'> with {'a': 1}",
         )
         self.assertValueSet(
@@ -705,7 +705,7 @@ class CanvasTests(TestCase):
 
     def test_on_alt_release(self):
         """Check on_alt_release handler being invoked."""
-        self.assertIsNone(self.testing_canvas._on_alt_release)
+        self.assertIsNone(self.testing_canvas.on_alt_release._raw)
 
         # set a new callback
         def callback(widget, **extra):
@@ -714,7 +714,7 @@ class CanvasTests(TestCase):
         self.testing_canvas.on_alt_release = callback
         self.assertEqual(self.testing_canvas.on_alt_release._raw, callback)
         self.assertEqual(
-            self.testing_canvas.on_alt_release("widget", a=1),
+            self.testing_canvas.on_alt_release(a=1),
             "called <class 'toga.widgets.canvas.Canvas'> with {'a': 1}",
         )
         self.assertValueSet(
@@ -723,7 +723,7 @@ class CanvasTests(TestCase):
 
     def test_on_alt_drag(self):
         """Check on_alt_dragged handler being invoked."""
-        self.assertIsNone(self.testing_canvas._on_alt_drag)
+        self.assertIsNone(self.testing_canvas.on_alt_drag._raw)
 
         # set a new callback
         def callback(widget, **extra):
@@ -732,7 +732,7 @@ class CanvasTests(TestCase):
         self.testing_canvas.on_alt_drag = callback
         self.assertEqual(self.testing_canvas.on_alt_drag._raw, callback)
         self.assertEqual(
-            self.testing_canvas.on_alt_drag("widget", a=1),
+            self.testing_canvas.on_alt_drag(a=1),
             "called <class 'toga.widgets.canvas.Canvas'> with {'a': 1}",
         )
         self.assertValueSet(

--- a/core/tests/widgets/test_canvas.py
+++ b/core/tests/widgets/test_canvas.py
@@ -626,7 +626,7 @@ class CanvasTests(TestCase):
         self.testing_canvas.on_resize = callback
         self.assertEqual(self.testing_canvas.on_resize._raw, callback)
         self.assertEqual(
-            self.testing_canvas.on_resize(a=1),
+            self.testing_canvas.on_resize(None, a=1),
             "called <class 'toga.widgets.canvas.Canvas'> with {'a': 1}",
         )
         self.assertValueSet(
@@ -644,7 +644,7 @@ class CanvasTests(TestCase):
         self.testing_canvas.on_press = callback
         self.assertEqual(self.testing_canvas.on_press._raw, callback)
         self.assertEqual(
-            self.testing_canvas.on_press(a=1),
+            self.testing_canvas.on_press(None, a=1),
             "called <class 'toga.widgets.canvas.Canvas'> with {'a': 1}",
         )
         self.assertValueSet(
@@ -662,7 +662,7 @@ class CanvasTests(TestCase):
         self.testing_canvas.on_release = callback
         self.assertEqual(self.testing_canvas.on_release._raw, callback)
         self.assertEqual(
-            self.testing_canvas.on_release(a=1),
+            self.testing_canvas.on_release(None, a=1),
             "called <class 'toga.widgets.canvas.Canvas'> with {'a': 1}",
         )
         self.assertValueSet(
@@ -680,7 +680,7 @@ class CanvasTests(TestCase):
         self.testing_canvas.on_drag = callback
         self.assertEqual(self.testing_canvas.on_drag._raw, callback)
         self.assertEqual(
-            self.testing_canvas.on_drag(a=1),
+            self.testing_canvas.on_drag(None, a=1),
             "called <class 'toga.widgets.canvas.Canvas'> with {'a': 1}",
         )
         self.assertValueSet(self.testing_canvas, "on_drag", self.testing_canvas.on_drag)
@@ -696,7 +696,7 @@ class CanvasTests(TestCase):
         self.testing_canvas.on_alt_press = callback
         self.assertEqual(self.testing_canvas.on_alt_press._raw, callback)
         self.assertEqual(
-            self.testing_canvas.on_alt_press(a=1),
+            self.testing_canvas.on_alt_press(None, a=1),
             "called <class 'toga.widgets.canvas.Canvas'> with {'a': 1}",
         )
         self.assertValueSet(
@@ -714,7 +714,7 @@ class CanvasTests(TestCase):
         self.testing_canvas.on_alt_release = callback
         self.assertEqual(self.testing_canvas.on_alt_release._raw, callback)
         self.assertEqual(
-            self.testing_canvas.on_alt_release(a=1),
+            self.testing_canvas.on_alt_release(None, a=1),
             "called <class 'toga.widgets.canvas.Canvas'> with {'a': 1}",
         )
         self.assertValueSet(
@@ -732,7 +732,7 @@ class CanvasTests(TestCase):
         self.testing_canvas.on_alt_drag = callback
         self.assertEqual(self.testing_canvas.on_alt_drag._raw, callback)
         self.assertEqual(
-            self.testing_canvas.on_alt_drag(a=1),
+            self.testing_canvas.on_alt_drag(None, a=1),
             "called <class 'toga.widgets.canvas.Canvas'> with {'a': 1}",
         )
         self.assertValueSet(

--- a/core/tests/widgets/test_detailedlist.py
+++ b/core/tests/widgets/test_detailedlist.py
@@ -61,7 +61,7 @@ class TestDetailedList(TestCase):
         self.assertValueSet(self.dlist, "scroll to", len(self.dlist.data) - 1)
 
     def test_on_delete(self):
-        self.assertIsNone(self.dlist._on_delete)
+        self.assertIsNone(self.dlist.on_delete._raw)
 
         # set a new callback
         def callback(widget, **extra):
@@ -70,13 +70,13 @@ class TestDetailedList(TestCase):
         self.dlist.on_delete = callback
         self.assertEqual(self.dlist.on_delete._raw, callback)
         self.assertEqual(
-            self.dlist.on_delete("widget", a=1),
+            self.dlist.on_delete(a=1),
             "called <class 'toga.widgets.detailedlist.DetailedList'> with {'a': 1}",
         )
         self.assertValueSet(self.dlist, "on_delete", self.dlist.on_delete)
 
     def test_on_refresh(self):
-        self.assertIsNone(self.dlist._on_refresh)
+        self.assertIsNone(self.dlist.on_refresh._raw)
 
         # set a new callback
         def callback(widget, **extra):
@@ -85,13 +85,13 @@ class TestDetailedList(TestCase):
         self.dlist.on_refresh = callback
         self.assertEqual(self.dlist.on_refresh._raw, callback)
         self.assertEqual(
-            self.dlist.on_refresh("widget", a=1),
+            self.dlist.on_refresh(a=1),
             "called <class 'toga.widgets.detailedlist.DetailedList'> with {'a': 1}",
         )
         self.assertValueSet(self.dlist, "on_refresh", self.dlist.on_refresh)
 
     def test_on_select(self):
-        self.assertIsNone(self.dlist._on_select)
+        self.assertIsNone(self.dlist._on_select._raw)
 
         # set a new callback
         def callback(widget, **extra):
@@ -100,7 +100,7 @@ class TestDetailedList(TestCase):
         self.dlist.on_select = callback
         self.assertEqual(self.dlist.on_select._raw, callback)
         self.assertEqual(
-            self.dlist.on_select("widget", a=1),
+            self.dlist.on_select(a=1),
             "called <class 'toga.widgets.detailedlist.DetailedList'> with {'a': 1}",
         )
         self.assertValueSet(self.dlist, "on_select", self.dlist.on_select)

--- a/core/tests/widgets/test_detailedlist.py
+++ b/core/tests/widgets/test_detailedlist.py
@@ -70,7 +70,7 @@ class TestDetailedList(TestCase):
         self.dlist.on_delete = callback
         self.assertEqual(self.dlist.on_delete._raw, callback)
         self.assertEqual(
-            self.dlist.on_delete(a=1),
+            self.dlist.on_delete(None, a=1),
             "called <class 'toga.widgets.detailedlist.DetailedList'> with {'a': 1}",
         )
         self.assertValueSet(self.dlist, "on_delete", self.dlist.on_delete)
@@ -85,7 +85,7 @@ class TestDetailedList(TestCase):
         self.dlist.on_refresh = callback
         self.assertEqual(self.dlist.on_refresh._raw, callback)
         self.assertEqual(
-            self.dlist.on_refresh(a=1),
+            self.dlist.on_refresh(None, a=1),
             "called <class 'toga.widgets.detailedlist.DetailedList'> with {'a': 1}",
         )
         self.assertValueSet(self.dlist, "on_refresh", self.dlist.on_refresh)
@@ -100,7 +100,7 @@ class TestDetailedList(TestCase):
         self.dlist.on_select = callback
         self.assertEqual(self.dlist.on_select._raw, callback)
         self.assertEqual(
-            self.dlist.on_select(a=1),
+            self.dlist.on_select(None, a=1),
             "called <class 'toga.widgets.detailedlist.DetailedList'> with {'a': 1}",
         )
         self.assertValueSet(self.dlist, "on_select", self.dlist.on_select)

--- a/core/tests/widgets/test_selection.py
+++ b/core/tests/widgets/test_selection.py
@@ -45,7 +45,7 @@ class SelectionTests(TestCase):
             self.selection.value = "not in items"
 
     def test_on_select(self):
-        on_select = self.selection.on_select
+        on_select = self.selection.on_select._raw
         self.assertEqual(on_select, None)
 
     def test_focus(self):

--- a/dummy/src/toga_dummy/app.py
+++ b/dummy/src/toga_dummy/app.py
@@ -42,9 +42,6 @@ class App(LoggedObject):
     def exit(self):
         self._action("exit")
 
-    def set_on_exit(self, value):
-        self._set_value("on_exit", value)
-
     @not_required_on("mobile")
     def current_window(self):
         self._action("current_window")

--- a/dummy/src/toga_dummy/test_implementation.py
+++ b/dummy/src/toga_dummy/test_implementation.py
@@ -219,7 +219,9 @@ class DefinitionExtractor:
                 class_node = self._classes[class_name]
                 for node in ast.walk(class_node):
                     if isinstance(node, ast.FunctionDef):
-                        if self.is_required_for_platform(node):
+                        if self.is_required_for_platform(
+                            node
+                        ) and not node.name.startswith("simulate_"):
                             methods.append(node.name)
         return methods
 

--- a/dummy/src/toga_dummy/widgets/button.py
+++ b/dummy/src/toga_dummy/widgets/button.py
@@ -11,5 +11,5 @@ class Button(Widget):
     def set_text(self, text):
         self._set_value("text", text)
 
-    def set_on_press(self, handler):
-        self._set_value("on_press", handler)
+    def simulate_press(self):
+        self.interface.on_press(None)

--- a/dummy/src/toga_dummy/widgets/slider.py
+++ b/dummy/src/toga_dummy/widgets/slider.py
@@ -16,12 +16,3 @@ class Slider(Widget):
 
     def set_tick_count(self, tick_count):
         self._set_value("tick_count", tick_count)
-
-    def set_on_change(self, handler):
-        self._set_value("on_change", handler)
-
-    def set_on_press(self, handler):
-        self._set_value("on_press", handler)
-
-    def set_on_release(self, handler):
-        self._set_value("on_press", handler)

--- a/dummy/src/toga_dummy/widgets/switch.py
+++ b/dummy/src/toga_dummy/widgets/switch.py
@@ -14,5 +14,5 @@ class Switch(Widget):
     def get_value(self):
         return self._get_value("value")
 
-    def set_on_change(self, handler):
-        self._set_value("on_change", handler)
+    def simulate_toggle(self):
+        self.interface.on_change(None)

--- a/dummy/src/toga_dummy/window.py
+++ b/dummy/src/toga_dummy/window.py
@@ -79,7 +79,3 @@ class Window(LoggedObject):
     @not_required
     def toga_on_close(self):
         self._action("handle Window on_close")
-
-    @not_required_on("mobile")
-    def set_on_close(self, handler):
-        self._set_value("on_close", handler)

--- a/gtk/src/toga_gtk/widgets/button.py
+++ b/gtk/src/toga_gtk/widgets/button.py
@@ -20,10 +20,6 @@ class Button(Widget):
     def set_enabled(self, value):
         self.native.set_sensitive(value)
 
-    def set_on_press(self, handler):
-        # No special handling required
-        pass
-
     def set_background_color(self, color):
         # Buttons interpret TRANSPARENT backgrounds as a reset
         if color == TRANSPARENT:
@@ -39,4 +35,4 @@ class Button(Widget):
         self.interface.intrinsic.height = height[1]
 
     def gtk_on_press(self, event):
-        self.interface.on_press()
+        self.interface.on_press(None)

--- a/gtk/src/toga_gtk/widgets/button.py
+++ b/gtk/src/toga_gtk/widgets/button.py
@@ -39,5 +39,4 @@ class Button(Widget):
         self.interface.intrinsic.height = height[1]
 
     def gtk_on_press(self, event):
-        if self.interface.on_press:
-            self.interface.on_press(self.interface)
+        self.interface.on_press()

--- a/gtk/src/toga_gtk/widgets/slider.py
+++ b/gtk/src/toga_gtk/widgets/slider.py
@@ -12,18 +12,7 @@ class Slider(Widget):
         self.native.connect("value-changed", self.gtk_on_change)
 
     def gtk_on_change(self, widget):
-        if self.interface.on_change:
-            self.interface.on_change(widget)
-
-    def set_on_change(self, handler):
-        # No special handling required
-        pass
-
-    def set_on_press(self, handler):
-        self.interface.factory.not_implemented("Slider.set_on_press()")
-
-    def set_on_release(self, handler):
-        self.interface.factory.not_implemented("Slider.set_on_release()")
+        self.interface.on_change(None)
 
     def set_value(self, value):
         self.adj.set_value(value)

--- a/gtk/src/toga_gtk/widgets/switch.py
+++ b/gtk/src/toga_gtk/widgets/switch.py
@@ -19,8 +19,7 @@ class Switch(Widget):
         self.native.connect("show", lambda event: self.refresh())
 
     def gtk_on_change(self, widget, state):
-        if self.interface.on_change:
-            self.interface.on_change(self.interface)
+        self.interface.on_change()
 
     def set_on_change(self, handler):
         pass

--- a/gtk/src/toga_gtk/widgets/switch.py
+++ b/gtk/src/toga_gtk/widgets/switch.py
@@ -19,10 +19,7 @@ class Switch(Widget):
         self.native.connect("show", lambda event: self.refresh())
 
     def gtk_on_change(self, widget, state):
-        self.interface.on_change()
-
-    def set_on_change(self, handler):
-        pass
+        self.interface.on_change(None)
 
     def set_text(self, text):
         self.label.set_text(self.interface.text)

--- a/gtk/src/toga_gtk/window.py
+++ b/gtk/src/toga_gtk/window.py
@@ -118,9 +118,6 @@ class Window:
         # closing the window) should be performed.
         return not should_close
 
-    def set_on_close(self, handler):
-        pass
-
     def close(self):
         self._is_closing = True
         self.native.close()

--- a/iOS/src/toga_iOS/app.py
+++ b/iOS/src/toga_iOS/app.py
@@ -124,6 +124,3 @@ class App:
 
     def exit(self):
         pass
-
-    def set_on_exit(self, value):
-        pass

--- a/iOS/src/toga_iOS/widgets/button.py
+++ b/iOS/src/toga_iOS/widgets/button.py
@@ -19,7 +19,7 @@ class TogaButton(UIButton):
 
     @objc_method
     def onPress_(self, obj) -> None:
-        self.interface.on_press()
+        self.interface.on_press(None)
 
 
 class Button(Widget):
@@ -44,10 +44,6 @@ class Button(Widget):
 
     def set_text(self, text):
         self.native.setTitle(text, forState=UIControlStateNormal)
-
-    def set_on_press(self, handler):
-        # No special handling required.
-        pass
 
     def set_color(self, color):
         if color is None:

--- a/iOS/src/toga_iOS/widgets/button.py
+++ b/iOS/src/toga_iOS/widgets/button.py
@@ -19,8 +19,7 @@ class TogaButton(UIButton):
 
     @objc_method
     def onPress_(self, obj) -> None:
-        if self.interface.on_press:
-            self.interface.on_press(self.interface)
+        self.interface.on_press()
 
 
 class Button(Widget):

--- a/iOS/src/toga_iOS/widgets/slider.py
+++ b/iOS/src/toga_iOS/widgets/slider.py
@@ -11,8 +11,7 @@ class TogaSlider(UISlider):
 
     @objc_method
     def onSlide_(self, obj) -> None:
-        if self.interface.on_change:
-            self.interface.on_change(self.interface)
+        self.interface.on_change(None)
 
 
 class Slider(Widget):
@@ -48,13 +47,3 @@ class Slider(Widget):
         fitting_size = self.native.systemLayoutSizeFittingSize_(CGSize(0, 0))
         self.interface.intrinsic.width = at_least(fitting_size.width)
         self.interface.intrinsic.height = fitting_size.height
-
-    def set_on_change(self, handler):
-        # No special handling required
-        pass
-
-    def set_on_press(self, handler):
-        self.interface.factory.not_implemented("Slider.set_on_press()")
-
-    def set_on_release(self, handler):
-        self.interface.factory.not_implemented("Slider.set_on_release()")

--- a/iOS/src/toga_iOS/widgets/switch.py
+++ b/iOS/src/toga_iOS/widgets/switch.py
@@ -17,7 +17,7 @@ class TogaSwitch(UISwitch):
 
     @objc_method
     def onPress_(self, obj) -> None:
-        self.interface.on_change()
+        self.interface.on_change(None)
 
 
 class Switch(Widget):
@@ -49,10 +49,6 @@ class Switch(Widget):
 
     def get_value(self):
         return self.native_switch.isOn()
-
-    def set_on_change(self, handler):
-        # No special handling required
-        pass
 
     def get_enabled(self):
         value = self.native_switch.isEnabled()

--- a/iOS/src/toga_iOS/widgets/switch.py
+++ b/iOS/src/toga_iOS/widgets/switch.py
@@ -17,8 +17,7 @@ class TogaSwitch(UISwitch):
 
     @objc_method
     def onPress_(self, obj) -> None:
-        if self.interface.on_change:
-            self.interface.on_change(self.interface)
+        self.interface.on_change()
 
 
 class Switch(Widget):

--- a/web/src/toga_web/app.py
+++ b/web/src/toga_web/app.py
@@ -190,9 +190,6 @@ class App:
     def exit(self):
         pass
 
-    def set_on_exit(self, value):
-        pass
-
     def current_window(self):
         self.interface.factory.not_implemented("App.current_window()")
 

--- a/web/src/toga_web/widgets/button.py
+++ b/web/src/toga_web/widgets/button.py
@@ -10,7 +10,7 @@ class Button(Widget):
         self.native.onclick = self.dom_onclick
 
     def dom_onclick(self, event):
-        self.interface.on_press()
+        self.interface.on_press(None)
 
     def get_text(self):
         return self.native.innerHTML
@@ -22,9 +22,6 @@ class Button(Widget):
         self.native.disabled = not value
 
     def set_background_color(self, value):
-        pass
-
-    def set_on_press(self, handler):
         pass
 
     def rehint(self):

--- a/web/src/toga_web/widgets/button.py
+++ b/web/src/toga_web/widgets/button.py
@@ -10,8 +10,7 @@ class Button(Widget):
         self.native.onclick = self.dom_onclick
 
     def dom_onclick(self, event):
-        if self.interface.on_press:
-            self.interface.on_press(self.interface)
+        self.interface.on_press()
 
     def get_text(self):
         return self.native.innerHTML

--- a/web/src/toga_web/window.py
+++ b/web/src/toga_web/window.py
@@ -93,6 +93,3 @@ class Window:
 
     def set_full_screen(self, is_full_screen):
         self.interface.factory.not_implemented("Window.set_full_screen()")
-
-    def set_on_close(self, handler):
-        pass

--- a/winforms/src/toga_winforms/app.py
+++ b/winforms/src/toga_winforms/app.py
@@ -289,9 +289,6 @@ class App:
     def set_main_window(self, window):
         self.app_context.MainForm = window._impl.native
 
-    def set_on_exit(self, value):
-        pass
-
     def current_window(self):
         self.interface.factory.not_implemented("App.current_window()")
 

--- a/winforms/src/toga_winforms/widgets/button.py
+++ b/winforms/src/toga_winforms/widgets/button.py
@@ -13,7 +13,7 @@ class Button(Widget):
         self.set_enabled(self.interface._enabled)
 
     def winforms_click(self, sender, event):
-        self.interface.on_press(self.interface)
+        self.interface.on_press(None)
 
     def get_text(self):
         value = self.native.Text
@@ -34,10 +34,6 @@ class Button(Widget):
 
     def set_enabled(self, value):
         self.native.Enabled = self.interface._enabled
-
-    def set_on_press(self, handler):
-        # No special handling required
-        pass
 
     def rehint(self):
         # self.native.Size = Size(0, 0)

--- a/winforms/src/toga_winforms/widgets/button.py
+++ b/winforms/src/toga_winforms/widgets/button.py
@@ -13,8 +13,7 @@ class Button(Widget):
         self.set_enabled(self.interface._enabled)
 
     def winforms_click(self, sender, event):
-        if self.interface.on_press:
-            self.interface.on_press(self.interface)
+        self.interface.on_press(self.interface)
 
     def get_text(self):
         value = self.native.Text

--- a/winforms/src/toga_winforms/widgets/slider.py
+++ b/winforms/src/toga_winforms/widgets/slider.py
@@ -35,22 +35,19 @@ class Slider(Widget):
         self.set_tick_count(self.interface.tick_count)
 
     def winforms_scroll(self, sender, event):
-        if self.container and self.interface.on_change:
-            self.interface.on_change(self.interface)
+        self.interface.on_change(None)
 
     def winforms_mouse_down(self, sender, event):
         """Since picking and releasing the slider is also a change, calling the
         on_change method."""
-        if self.container and self.interface.on_press:
-            self.interface.on_press(self.interface)
+        self.interface.on_press(None)
         self.winforms_scroll(sender, event)
 
     def winforms_mouse_up(self, sender, event):
         """Since picking and releasing the slider is also a change, calling the
         on_change method."""
         self.winforms_scroll(sender, event)
-        if self.container and self.interface.on_release:
-            self.interface.on_release(self.interface)
+        self.interface.on_release(None)
 
     def get_value(self):
         actual_value = self.native.Value
@@ -80,12 +77,3 @@ class Slider(Widget):
         else:
             self.native.TickStyle = BOTTOM_RIGHT_TICK_STYLE
             self.native.Maximum = tick_count - 1
-
-    def set_on_change(self, handler):
-        pass
-
-    def set_on_press(self, handler):
-        pass
-
-    def set_on_release(self, handler):
-        pass

--- a/winforms/src/toga_winforms/widgets/switch.py
+++ b/winforms/src/toga_winforms/widgets/switch.py
@@ -11,7 +11,7 @@ class Switch(Widget):
         self.native.CheckedChanged += self.winforms_checked_changed
 
     def winforms_checked_changed(self, sender, event):
-        self.interface.on_change()
+        self.interface.on_change(None)
 
     def set_text(self, text):
         self.native.Text = self.interface.text
@@ -24,9 +24,6 @@ class Switch(Widget):
 
     def get_value(self):
         return self.native.Checked
-
-    def set_on_change(self, handler):
-        pass
 
     def rehint(self):
         self.interface.intrinsic.width = at_least(self.native.PreferredSize.Width)

--- a/winforms/src/toga_winforms/widgets/switch.py
+++ b/winforms/src/toga_winforms/widgets/switch.py
@@ -11,9 +11,7 @@ class Switch(Widget):
         self.native.CheckedChanged += self.winforms_checked_changed
 
     def winforms_checked_changed(self, sender, event):
-        if self.container:
-            if self.interface.on_change:
-                self.interface.on_change(self.interface)
+        self.interface.on_change()
 
     def set_text(self, text):
         self.native.Text = self.interface.text

--- a/winforms/src/toga_winforms/window.py
+++ b/winforms/src/toga_winforms/window.py
@@ -200,9 +200,6 @@ class Window:
     def set_full_screen(self, is_full_screen):
         self.interface.factory.not_implemented("Window.set_full_screen()")
 
-    def set_on_close(self, handler):
-        pass
-
     def close(self):
         self._is_closing = True
         self.native.Close()


### PR DESCRIPTION
Cleans up the definition and usage of event handlers. 

Fully ported across Button, Switch, Slider, App and Window.

* Ensures event handlers can always be invoked, removing the need for 'if handler: handler()' checks. This logic can be rolled out through other widgets as they are ported.
* The first argument to signal handlers has always been ignored in favour of the version used at time of binding. For now, this argument has been converted to None on the ported widgets; once we have 100% coverage, we can do a revision pass and remove this argument (and update `handler.py` to remove the need for the argument)
* The `set_on_*` handlers have been removed from the ported widgets. Again, this logic can be rolled out through other widgets as they are ported.
* The dummy interface check has been modified to ignore any method starting with `simulate_`; this prefix can be used to add methods on the dummy for exercising simulations of user-facing behavior (see `simulate_press` on button)
 
## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
