### PR TITLE
Flake8 tweaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,11 @@ defaults:
   run:
     shell: bash
 
+# Cancel active CI runs for a PR before starting another run
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pre-commit:
     name: Pre-commit checks

--- a/changes/1835.misc.rst
+++ b/changes/1835.misc.rst
@@ -1,0 +1,1 @@
+Removed unnecessary ``noqa`` markers for flake8 and simplified the configuration.

--- a/cocoa/src/toga_cocoa/window.py
+++ b/cocoa/src/toga_cocoa/window.py
@@ -213,7 +213,7 @@ class Window:
         # bigger. If the window is resizable, using >= allows the window to
         # be dragged larged; if not resizable, it enforces the smallest
         # size that can be programmattically set on the window.
-        self._min_width_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # NOQA: E501
+        self._min_width_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # noqa: E501
             widget.native,
             NSLayoutAttributeRight,
             NSLayoutRelationGreaterThanOrEqual,
@@ -224,7 +224,7 @@ class Window:
         )
         widget.native.addConstraint(self._min_width_constraint)
 
-        self._min_height_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # NOQA: E501
+        self._min_height_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # noqa: E501
             widget.native,
             NSLayoutAttributeBottom,
             NSLayoutRelationGreaterThanOrEqual,

--- a/core/src/toga/colors.py
+++ b/core/src/toga/colors.py
@@ -1,2 +1,2 @@
 # Use the Travertino color definitions as-is
-from travertino.colors import *  # noqa: F401,F403
+from travertino.colors import *  # noqa: F401, F403

--- a/core/src/toga/constants/__init__.py
+++ b/core/src/toga/constants/__init__.py
@@ -1,1 +1,1 @@
-from travertino.constants import *  # noqa: F401,F403
+from travertino.constants import *  # noqa: F401, F403

--- a/core/src/toga/fonts.py
+++ b/core/src/toga/fonts.py
@@ -1,7 +1,7 @@
 import warnings
 
 # Use the Travertino font definitions as-is
-from travertino import constants  # noqa: F401
+from travertino import constants
 from travertino.constants import ITALIC  # noqa: F401
 from travertino.constants import (  # noqa: F401
     BOLD,
@@ -17,7 +17,7 @@ from travertino.constants import (  # noqa: F401
     SYSTEM,
 )
 from travertino.fonts import font  # noqa: F401
-from travertino.fonts import Font as BaseFont  # noqa: F401
+from travertino.fonts import Font as BaseFont
 
 from toga.platform import get_platform_factory
 

--- a/gtk/src/toga_gtk/container.py
+++ b/gtk/src/toga_gtk/container.py
@@ -155,7 +155,7 @@ class TogaContainer(Gtk.Fixed):
         and that new geometry will be applied to all child widgets of the
         container.
         """
-        # print(self._content, f"Container layout {allocation.width}x{allocation.height} @ {allocation.x}x{allocation.y}")
+        # print(self._content, f"Container layout {allocation.width}x{allocation.height} @ {allocation.x}x{allocation.y}")  # noqa: E501
 
         # The container will occupy the full space it has been allocated.
         resized = (allocation.width, allocation.height) != (self.width, self.height)

--- a/gtk/src/toga_gtk/libs/gtk.py
+++ b/gtk/src/toga_gtk/libs/gtk.py
@@ -3,7 +3,7 @@ import gi
 gi.require_version("Gdk", "3.0")
 gi.require_version("Gtk", "3.0")
 
-from gi.repository import Gdk, GdkPixbuf, Gio, GLib, GObject, Gtk  # noqa: F401, E402
+from gi.repository import Gdk, GdkPixbuf, Gio, GLib, GObject, Gtk  # noqa: E402, F401
 
 # The following import will fail if WebKit or its API wrappers aren't
 # installed; handle failure gracefully
@@ -13,7 +13,7 @@ WebKit2 = None
 for version in ["4.0", "3.0"]:
     try:
         gi.require_version("WebKit2", version)
-        from gi.repository import WebKit2  # noqa: F401, E402
+        from gi.repository import WebKit2  # noqa: F401
 
         break
     except (ImportError, ValueError):
@@ -21,11 +21,11 @@ for version in ["4.0", "3.0"]:
 
 try:
     gi.require_version("Pango", "1.0")
-    from gi.repository import Pango  # noqa: F401, E402
+    from gi.repository import Pango
 except ImportError:
     Pango = None
 
 try:
-    import cairo  # noqa: F401, E402
+    import cairo
 except ImportError:
     cairo = None

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,6 @@
 [flake8]
-max-complexity = 30
 max-line-length = 119
-ignore = E203,E266,E501,W503
+extend-ignore =
+    # whitespace before :
+    # See https://github.com/PyCQA/pycodestyle/issues/373
+    E203,


### PR DESCRIPTION
## Changes
- Remove unnecessary `noqa` markers and clarify unqualified markers
- Simplify `flake8` configuration
  - Remove `max-complexity`.....30 is pretty high and I'm guessing someone was just trying to disable the check
  - Use [default](https://flake8.pycqa.org/en/latest/user/options.html#cmdoption-flake8-ignore) list of checks to `exclude`
    - E266 - Too many leading '#' for block comment
      - This doesn't seem to be relevant anymore
    - E501 - Line too long
      -  All (well, nearly all) of the problem cases were already marked
    - W503 - Line break occurred before a binary operator
      - In the default list of excluded checks
- Update CI to cancel the current run if a PR receives new commits

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
