### PR TITLE
Builds docs in parallel

### DIFF
--- a/changes/1882.misc.rst
+++ b/changes/1882.misc.rst
@@ -1,0 +1,1 @@
+The ``tox`` commands for building docs now use multi-processing for faster builds.

--- a/core/setup.cfg
+++ b/core/setup.cfg
@@ -79,7 +79,7 @@ docs =
     sphinx_tabs == 3.4.1
     sphinx-autobuild == 2021.3.14
     sphinx-autodoc-typehints == 1.22
-    sphinx-csv-filter == 0.4.0
+    sphinx-csv-filter == 0.4.1
     sphinxcontrib-spelling == 7.7.0
 
 [options.package_data]

--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,8 @@ commands =
 build_dir = _build
 # -W: make warnings into errors
 # --keep-going: continue on errors
-sphinx_args = -W --keep-going
+# -j: run with multiple processes
+sphinx_args = -W --keep-going -j auto
 # -v: verbose logging
 # -E: force rebuild of environment
 # -T: print traceback on error


### PR DESCRIPTION
## Changes
- With the release of sphinx-csv-filter v0.4.1, Toga docs can be built in parallel.

## Notes
- Using the `-r\--recreate` flag for `tox` may be necessary to update sphinx-csv-filter.
- This should drastically speed up builds on many core machines.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
