### PR TITLE
Add support for `sphinx-copybutton`

### DIFF
--- a/changes/1897.doc.rst
+++ b/changes/1897.doc.rst
@@ -1,0 +1,1 @@
+All code blocks were updated to add a button to copy the relevant contents on to the user's clipboard.

--- a/core/setup.cfg
+++ b/core/setup.cfg
@@ -80,6 +80,7 @@ docs =
     sphinx-autobuild == 2021.3.14
     sphinx-autodoc-typehints == 1.22
     sphinx-csv-filter == 0.4.1
+    sphinx-copybutton == 0.5.2
     sphinxcontrib-spelling == 7.7.0
 
 [options.package_data]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,6 +33,7 @@ extensions = [
     "sphinx_autodoc_typehints",
     "sphinx_tabs.tabs",
     "crate.sphinx.csv",
+    "sphinx_copybutton",
     "sphinx.ext.intersphinx",
 ]
 # Add any paths that contain templates here, relative to this directory.
@@ -111,8 +112,42 @@ rst_prolog = """
 intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 
 # -- Options for link checking -------------------------------------------------
+
 # GitHub generates anchors in javascript
 linkcheck_ignore = [r"https://github.com/.*#"]
+
+# -- Options for copy button ---------------------------------------------------
+
+# virtual env prefix: (venv), (beeware-venv)
+venv = r"\((?:beeware-)?venv\)"
+# macOS and Linux shell prompt: $, #
+shell = r"\$|#"
+# win CMD prompt: C:\>, C:\...>
+cmd = r"C:\\>|C:\\\.\.\.>"
+# PowerShell prompt: PS C:\>, PS C:\...>
+ps = r"PS C:\\>|PS C:\\\.\.\.>"
+# zero or one whitespace char
+sp = r"\s?"
+
+# optional venv prefix
+venv_prefix = rf"(?:{venv})?"
+# one of the platforms' shell prompts
+shell_prompt = rf"(?:{shell}|{cmd}|{ps})"
+
+copybutton_prompt_text = "|".join(
+    [
+        # Python REPL
+        # r">>>\s?", r"\.\.\.\s?",
+        # IPython and Jupyter
+        # r"In \[\d*\]:\s?", r" {5,8}:\s?", r" {2,5}\.\.\.:\s?",
+        # Shell prompt
+        rf"{venv_prefix}{sp}{shell_prompt}{sp}",
+    ]
+)
+copybutton_prompt_is_regexp = True
+copybutton_remove_prompts = True
+copybutton_only_copy_prompt_lines = True
+copybutton_copy_empty_lines = False
 
 # -- Options for HTML output ---------------------------------------------------
 

--- a/docs/how-to/contribute-code.rst
+++ b/docs/how-to/contribute-code.rst
@@ -22,14 +22,14 @@ First, ensure that you have Python 3 and pip installed. To do this, run:
 
   .. group-tab:: macOS
 
-    .. code-block:: bash
+    .. code-block:: console
 
       $ python3 --version
       $ pip3 --version
 
   .. group-tab:: Linux
 
-    .. code-block:: bash
+    .. code-block:: console
 
       $ python3 --version
       $ pip3 --version
@@ -49,14 +49,14 @@ start coding. To set up a virtual environment, run:
 
   .. group-tab:: macOS
 
-    .. code-block:: bash
+    .. code-block:: console
 
       $ python3 -m venv venv
       $ source venv/bin/activate
 
   .. group-tab:: Linux
 
-    .. code-block:: bash
+    .. code-block:: console
 
       $ python3 -m venv venv
       $ source venv/bin/activate
@@ -80,7 +80,7 @@ Next, install any additional dependencies for your operating system:
 
   .. group-tab:: Linux
 
-    .. code-block:: bash
+    .. code-block:: console
 
       # Ubuntu 18.04+, Debian 10+
       (venv) $ sudo apt-get update
@@ -144,14 +144,14 @@ source packages, so we have to manually install each package:
 
   .. group-tab:: macOS
 
-    .. code-block:: bash
+    .. code-block:: console
 
       (venv) $ cd toga
       (venv) $ pip install -e "./core[dev]" -e ./dummy -e ./cocoa
 
   .. group-tab:: Linux
 
-    .. code-block:: bash
+    .. code-block:: console
 
       (venv) $ cd toga
       (venv) $ pip install -e ./core[dev] -e ./dummy -e ./gtk
@@ -172,14 +172,14 @@ git commit. To enable pre-commit, run:
 
   .. group-tab:: macOS
 
-    .. code-block:: bash
+    .. code-block:: console
 
       (venv) $ pre-commit install
       pre-commit installed at .git/hooks/pre-commit
 
   .. group-tab:: Linux
 
-    .. code-block:: bash
+    .. code-block:: console
 
       (venv) $ pre-commit install
       pre-commit installed at .git/hooks/pre-commit
@@ -199,7 +199,7 @@ pre-commit will make the changes needed to correct the problems it has found:
 
   .. group-tab:: macOS
 
-    .. code-block:: bash
+    .. code-block:: console
 
       (venv) $ git add some/interesting_file.py
       (venv) $ git commit -m "Minor change"
@@ -225,7 +225,7 @@ pre-commit will make the changes needed to correct the problems it has found:
 
   .. group-tab:: Linux
 
-    .. code-block:: bash
+    .. code-block:: console
 
       (venv) $ git add some/interesting_file.py
       (venv) $ git commit -m "Minor change"
@@ -282,7 +282,7 @@ and re-commit the change.
 
   .. group-tab:: macOS
 
-    .. code-block:: bash
+    .. code-block:: console
 
       (venv) $ git add some/interesting_file.py
       (venv) $ git commit -m "Minor change"
@@ -302,7 +302,7 @@ and re-commit the change.
 
   .. group-tab:: Linux
 
-    .. code-block:: bash
+    .. code-block:: console
 
       (venv) $ git add some/interesting_file.py
       (venv) $ git commit -m "Minor change"
@@ -538,13 +538,13 @@ To run the core test suite:
 
   .. group-tab:: macOS
 
-    .. code-block:: bash
+    .. code-block:: console
 
       (venv) $ tox -e py-core
 
   .. group-tab:: Linux
 
-    .. code-block:: bash
+    .. code-block:: console
 
       (venv) $ tox -e py-core
 
@@ -616,13 +616,13 @@ specific test, using `pytest specifiers
 
   .. group-tab:: macOS
 
-    .. code-block:: bash
+    .. code-block:: console
 
       (venv) $ tox -e py-core -- tests/path_to_test_file/test_some_test.py
 
   .. group-tab:: Linux
 
-    .. code-block:: bash
+    .. code-block:: console
 
       (venv) $ tox -e py-core -- tests/path_to_test_file/test_some_test.py
 
@@ -655,7 +655,7 @@ test mode:
 
   .. group-tab:: macOS
 
-    .. code-block:: bash
+    .. code-block:: console
 
       (venv) $ python -m pip install briefcase
       (venv) $ cd testbed
@@ -663,7 +663,7 @@ test mode:
 
   .. group-tab:: Linux
 
-    .. code-block:: bash
+    .. code-block:: console
 
       (venv) $ python -m pip install briefcase
       (venv) $ cd testbed
@@ -694,13 +694,13 @@ So - to run *only* the button tests in slow mode, you could run:
 
   .. group-tab:: macOS
 
-    .. code-block:: bash
+    .. code-block:: console
 
       (venv) $ briefcase dev --test -- tests/widgets/test_button.py --slow
 
   .. group-tab:: Linux
 
-    .. code-block:: bash
+    .. code-block:: console
 
       (venv) $ briefcase dev --test -- tests/widgets/test_button.py --slow
 
@@ -725,13 +725,13 @@ run``.
 
     To run the Android test suite:
 
-    .. code-block:: bash
+    .. code-block:: console
 
       (venv) $ briefcase run android --test
 
     To run the iOS test suite:
 
-    .. code-block:: bash
+    .. code-block:: console
 
       (venv) $ briefcase run iOS --test
 
@@ -739,7 +739,7 @@ run``.
 
     To run the Android test suite:
 
-    .. code-block:: bash
+    .. code-block:: console
 
       (venv) $ briefcase run android --test
 
@@ -858,13 +858,13 @@ To create a feature branch, run:
 
   .. group-tab:: macOS
 
-    .. code-block:: bash
+    .. code-block:: console
 
       (venv) $ git checkout -b fix-layout-bug
 
   .. group-tab:: Linux
 
-    .. code-block:: bash
+    .. code-block:: console
 
       (venv) $ git checkout -b fix-layout-bug
 

--- a/docs/how-to/contribute-code.rst
+++ b/docs/how-to/contribute-code.rst
@@ -66,7 +66,7 @@ start coding. To set up a virtual environment, run:
     .. code-block:: doscon
 
       C:\...>python3 -m venv venv
-      C:\...>venv/Scripts/activate
+      C:\...>venv\Scripts\activate
 
 Your prompt should now have a ``(venv)`` prefix in front of it.
 
@@ -80,19 +80,29 @@ Next, install any additional dependencies for your operating system:
 
   .. group-tab:: Linux
 
+    Ubuntu 18.04+, Debian 10+
+
     .. code-block:: console
 
-      # Ubuntu 18.04+, Debian 10+
       (venv) $ sudo apt-get update
       (venv) $ sudo apt-get install python3-dev libgirepository1.0-dev libcairo2-dev libpango1.0-dev libwebkit2gtk-4.0-37 gir1.2-webkit2-4.0
 
-      # Fedora
+    Fedora
+
+    .. code-block:: console
+
       (venv) $ sudo dnf install pkg-config python3-devel gobject-introspection-devel cairo-devel cairo-gobject-devel pango-devel webkitgtk3
 
-      # Arch / Manjaro
+    Arch / Manjaro
+
+    .. code-block:: console
+
       (venv) $ sudo pacman -Syu git pkgconf cairo python-cairo pango gobject-introspection gobject-introspection-runtime python-gobject webkit2gtk
 
-      # FreeBSD
+    FreeBSD
+
+    .. code-block:: console
+
       (venv) $ sudo pkg update
       (venv) $ sudo pkg install gtk3 pango gobject-introspection cairo webkit2-gtk3
 

--- a/docs/how-to/contribute-docs.rst
+++ b/docs/how-to/contribute-docs.rst
@@ -25,14 +25,14 @@ You'll also need to install the Enchant spell checking library.
 
     Enchant can be installed using `Homebrew <https://brew.sh>`__:
 
-    .. code-block:: bash
+    .. code-block:: console
 
       (venv) $ brew install enchant
 
     If you're on an M1 machine, you'll also need to manually set the location
     of the Enchant library:
 
-    .. code-block:: bash
+    .. code-block:: console
 
       (venv) $ export PYENCHANT_LIBRARY_PATH=/opt/homebrew/lib/libenchant-2.2.dylib
 
@@ -73,19 +73,19 @@ Once your development environment is set up, run:
 
   .. group-tab:: macOS
 
-    .. code-block:: bash
+    .. code-block:: console
 
       (venv) $ tox -e docs
 
   .. group-tab:: Linux
 
-    .. code-block:: bash
+    .. code-block:: console
 
       (venv) $ tox -e docs
 
   .. group-tab:: Windows
 
-    .. code-block:: powershell
+    .. code-block:: doscon
 
       (venv) C:\...>tox -e docs
 
@@ -102,13 +102,13 @@ additional "lint" checks. To run the lint checks:
 
   .. group-tab:: macOS
 
-    .. code-block:: bash
+    .. code-block:: console
 
       (venv) $ tox -e docs-lint
 
   .. group-tab:: Linux
 
-    .. code-block:: bash
+    .. code-block:: console
 
       (venv) $ tox -e docs-lint
 
@@ -143,19 +143,19 @@ To force a rebuild for all of the documentation:
 
   .. group-tab:: macOS
 
-    .. code-block:: bash
+    .. code-block:: console
 
       (venv) $ tox -e docs-all
 
   .. group-tab:: Linux
 
-    .. code-block:: bash
+    .. code-block:: console
 
       (venv) $ tox -e docs-all
 
   .. group-tab:: Windows
 
-    .. code-block:: powershell
+    .. code-block:: doscon
 
       (venv) C:\...>tox -e docs-all
 

--- a/docs/how-to/get-started.rst
+++ b/docs/how-to/get-started.rst
@@ -14,10 +14,12 @@ Quickstart
 ==========
 
 Create a new virtual environment. In your virtual environment, install Toga, and
-then run it::
+then run it:
 
-    $ python -m pip install toga-demo
-    $ toga-demo
+.. code-block:: console
+
+  $ python -m pip install toga-demo
+  $ toga-demo
 
 This will pop up a GUI window showing the full range of widgets available
 to an application using Toga.

--- a/docs/how-to/internal/release.rst
+++ b/docs/how-to/internal/release.rst
@@ -8,34 +8,44 @@ Actions to formally publish releases.
 This guide assumes that you have an ``upstream`` remote configured on your
 local clone of the Toga repository, pointing at the official repository.
 If all you have is a checkout of a personal fork of the Toga repository,
-you can configure that checkout by running::
+you can configure that checkout by running:
+
+.. code-block:: console
 
     $ git remote add upstream https://github.com/beeware/toga.git
 
 The procedure for cutting a new release is as follows:
 
-#. Check the contents of the upstream repository's main branch::
+#. Check the contents of the upstream repository's main branch:
 
-    $ git fetch upstream
-    $ git checkout --detach upstream/main
+   .. code-block:: console
+
+       $ git fetch upstream
+       $ git checkout --detach upstream/main
 
    Check that the HEAD of release now matches upstream/main.
 
-#. Ensure that the release notes are up to date. Run::
+#. Ensure that the release notes are up to date. Run:
 
-         $ tox -e towncrier -- --draft
+   .. code-block:: console
 
-   to review the release notes that will be included, and then::
+     $ tox -e towncrier -- --draft
 
-         $ tox -e towncrier
+   to review the release notes that will be included, and then:
+
+   .. code-block:: console
+
+     $ tox -e towncrier
 
    to generate the updated release notes.
 
-#. Tag the release, and push the branch and tag upstream::
+#. Tag the release, and push the branch and tag upstream:
 
-    $ git tag v1.2.3
-    $ git push upstream HEAD:main
-    $ git push upstream v1.2.3
+   .. code-block:: console
+
+     $ git tag v1.2.3
+     $ git push upstream HEAD:main
+     $ git push upstream v1.2.3
 
 #. Pushing the tag will start a workflow to create a draft release on GitHub.
    You can `follow the progress of the workflow on GitHub

--- a/docs/reference/api/app.rst
+++ b/docs/reference/api/app.rst
@@ -15,9 +15,9 @@ Usage
 
 The app class is used by instantiating with a name, namespace and callback to a startup delegate which takes 1 argument of the app instance.
 
-To start a UI loop, call `app.main_loop()`
+To start a UI loop, call ``app.main_loop()``
 
-.. code-block:: Python
+.. code-block:: python
 
     import toga
 
@@ -33,7 +33,7 @@ To start a UI loop, call `app.main_loop()`
 
 Alternatively, you can subclass App and implement the startup method
 
-.. code-block:: Python
+.. code-block:: python
 
     import toga
 

--- a/docs/reference/api/containers/box.rst
+++ b/docs/reference/api/containers/box.rst
@@ -16,7 +16,7 @@ Usage
 An empty Box can be constructed without any children, with children added to the
 box after construction:
 
-.. code-block:: Python
+.. code-block:: python
 
     import toga
 
@@ -30,7 +30,7 @@ box after construction:
 
 Alternatively, children can be specified at the time the box is constructed:
 
-.. code-block:: Python
+.. code-block:: python
 
     import toga
 

--- a/docs/reference/api/containers/optioncontainer.rst
+++ b/docs/reference/api/containers/optioncontainer.rst
@@ -16,7 +16,7 @@ The Option Container widget is a user-selection control for choosing from a pre-
 Usage
 -----
 
-.. code-block:: Python
+.. code-block:: python
 
     import toga
 

--- a/docs/reference/api/containers/scrollcontainer.rst
+++ b/docs/reference/api/containers/scrollcontainer.rst
@@ -17,7 +17,7 @@ its own scrollable selection.
 Usage
 -----
 
-.. code-block:: Python
+.. code-block:: python
 
     import toga
 
@@ -30,7 +30,7 @@ Scroll settings
 
 Horizontal or vertical scroll can be set via the initializer or using the property.
 
-.. code-block:: Python
+.. code-block:: python
 
     import toga
 

--- a/docs/reference/api/containers/splitcontainer.rst
+++ b/docs/reference/api/containers/splitcontainer.rst
@@ -16,7 +16,7 @@ The split container is a container with a movable split and the option for 2 or 
 Usage
 -----
 
-.. code-block:: Python
+.. code-block:: python
 
     import toga
 
@@ -29,9 +29,9 @@ Usage
 Setting split direction
 -----------------------
 
-Split direction is set on instantiation using the `direction` keyword argument. Direction is vertical by default.
+Split direction is set on instantiation using the ``direction`` keyword argument. Direction is vertical by default.
 
-.. code-block:: Python
+.. code-block:: python
 
     import toga
 

--- a/docs/reference/api/mainwindow.rst
+++ b/docs/reference/api/mainwindow.rst
@@ -16,7 +16,7 @@ Usage
 A MainWindow is used for desktop applications, where components need to be shown within a window-manager. Windows can be configured on
 instantiation and support displaying multiple widgets, toolbars and resizing.
 
-.. code-block:: Python
+.. code-block:: python
 
     import toga
 

--- a/docs/reference/api/widgets/activityindicator.rst
+++ b/docs/reference/api/widgets/activityindicator.rst
@@ -17,7 +17,7 @@ usually rendered as a "spinner" animation.
 Usage
 -----
 
-.. code-block:: Python
+.. code-block:: python
 
     import toga
 

--- a/docs/reference/api/widgets/button.rst
+++ b/docs/reference/api/widgets/button.rst
@@ -19,7 +19,7 @@ Usage
 
 A button has a text label. A handler can be associated with button press events.
 
-.. code-block:: Python
+.. code-block:: python
 
     import toga
 
@@ -35,7 +35,7 @@ Notes
 * A background color of ``TRANSPARENT`` will be treated as a reset of the button
   to the default system color.
 
-* On macOS, the button text color cannot be set directly; any `color` style
+* On macOS, the button text color cannot be set directly; any ``color`` style
   directive will be ignored. The text color is automatically selected by
   the platform to contrast with the background color of the button.
 

--- a/docs/reference/api/widgets/canvas.rst
+++ b/docs/reference/api/widgets/canvas.rst
@@ -15,7 +15,7 @@ Usage
 
 Simple usage to draw a black circle on the screen using the arc drawing object:
 
-.. code-block:: Python
+.. code-block:: python
 
     import toga
     canvas = toga.Canvas(style=Pack(flex=1))
@@ -28,7 +28,7 @@ want to modify the parameters of the drawing objects. Here we draw a black
 circle and black rectangle. We then change the size of the circle, move the
 rectangle, and finally delete the rectangle.
 
-.. code-block:: Python
+.. code-block:: python
 
     import toga
     canvas = toga.Canvas(style=Pack(flex=1))
@@ -47,7 +47,7 @@ character on the canvas. First, we create a hero context. Next, we create a
 black circle and a black outlined rectangle for the hero's body. Finally, we
 move the hero by 10 on the x-axis.
 
-.. code-block:: Python
+.. code-block:: python
 
     import toga
     canvas = toga.Canvas(style=Pack(flex=1))

--- a/docs/reference/api/widgets/divider.rst
+++ b/docs/reference/api/widgets/divider.rst
@@ -18,7 +18,7 @@ Usage
 
 To separate two labels stacked vertically with a horizontal line:
 
-.. code-block:: Python
+.. code-block:: python
 
     import toga
     from toga.style import Pack, COLUMN

--- a/docs/reference/api/widgets/imageview.rst
+++ b/docs/reference/api/widgets/imageview.rst
@@ -13,7 +13,7 @@ The Image View is a container for an image to be rendered on the display
 Usage
 -----
 
-.. code-block:: Python
+.. code-block:: python
 
     import toga
 

--- a/docs/reference/api/widgets/label.rst
+++ b/docs/reference/api/widgets/label.rst
@@ -16,7 +16,7 @@ A text label for annotating forms or interfaces.
 Usage
 -----
 
-.. code-block:: Python
+.. code-block:: python
 
     import toga
 

--- a/docs/reference/api/widgets/multilinetextinput.rst
+++ b/docs/reference/api/widgets/multilinetextinput.rst
@@ -13,7 +13,7 @@ The Multi-line text input is similar to the text input but designed for larger i
 Usage
 -----
 
-.. code-block:: Python
+.. code-block:: python
 
     import toga
 

--- a/docs/reference/api/widgets/numberinput.rst
+++ b/docs/reference/api/widgets/numberinput.rst
@@ -16,7 +16,7 @@ The Number input is a text input box that is limited to numeric input.
 Usage
 -----
 
-.. code-block:: Python
+.. code-block:: python
 
     import toga
 

--- a/docs/reference/api/widgets/progressbar.rst
+++ b/docs/reference/api/widgets/progressbar.rst
@@ -23,7 +23,7 @@ task. The visual indicator of the progress bar will be filled indicating the
 proportion of ``value`` relative to ``max``. ``max`` can be any positive
 numerical value.
 
-.. code-block:: Python
+.. code-block:: python
 
     import toga
 
@@ -43,7 +43,7 @@ an *indeterminate* progress bar. Any change to the value of an indeterminate
 progress bar will be ignored. When started, an indeterminate progress bar
 animates as a throbbing or "ping pong" animation.
 
-.. code-block:: Python
+.. code-block:: python
 
     import toga
 

--- a/docs/reference/api/widgets/selection.rst
+++ b/docs/reference/api/widgets/selection.rst
@@ -16,7 +16,7 @@ The Selection widget is a simple control for allowing the user to choose between
 Usage
 -----
 
-.. code-block:: Python
+.. code-block:: python
 
     import toga
 

--- a/docs/reference/api/widgets/slider.rst
+++ b/docs/reference/api/widgets/slider.rst
@@ -22,7 +22,7 @@ Usage
 A slider can either be continuous (allowing any value within the range), or discrete
 (allowing a fixed number of equally-spaced values). For example:
 
-.. code-block:: Python
+.. code-block:: python
 
     import toga
 

--- a/docs/reference/api/widgets/switch.rst
+++ b/docs/reference/api/widgets/switch.rst
@@ -18,7 +18,7 @@ unchecked). The button has a text label.
 Usage
 -----
 
-.. code-block:: Python
+.. code-block:: python
 
     import toga
 
@@ -39,7 +39,7 @@ Notes
   as a switch, the label will be left-aligned, and the switch will be
   right-aligned.
 
-* On macOS, the text color of the label cannot be set directly; any `color` style
+* On macOS, the text color of the label cannot be set directly; any ``color`` style
   directive will be ignored.
 
 Reference

--- a/docs/reference/api/widgets/table.rst
+++ b/docs/reference/api/widgets/table.rst
@@ -17,7 +17,7 @@ can be added.
 Usage
 -----
 
-.. code-block:: Python
+.. code-block:: python
 
     import toga
 

--- a/docs/reference/api/widgets/textinput.rst
+++ b/docs/reference/api/widgets/textinput.rst
@@ -16,7 +16,7 @@ The text input widget is a simple input field for user entry of text data.
 Usage
 -----
 
-.. code-block:: Python
+.. code-block:: python
 
     import toga
 

--- a/docs/reference/api/widgets/tree.rst
+++ b/docs/reference/api/widgets/tree.rst
@@ -13,7 +13,7 @@ The tree widget is still under development.
 Usage
 -----
 
-.. code-block:: Python
+.. code-block:: python
 
     import toga
 

--- a/docs/reference/api/widgets/webview.rst
+++ b/docs/reference/api/widgets/webview.rst
@@ -23,7 +23,7 @@ lightweight web server instead.
 Usage
 -----
 
-.. code-block:: Python
+.. code-block:: python
 
     import toga
 
@@ -38,11 +38,13 @@ default on some platforms. To enable WebView debugging:
 
 * macOS
 
-    Run the following at the terminal::
+    Run the following at the terminal:
+
+.. code-block:: console
 
         $ defaults write com.example.appname WebKitDeveloperExtras -bool true
 
-    substituting `com.example.appname` with the bundle ID for your app.
+    substituting ``com.example.appname`` with the bundle ID for your app.
 
 
 Reference

--- a/docs/reference/api/window.rst
+++ b/docs/reference/api/window.rst
@@ -16,7 +16,7 @@ Usage
 The window class is used for desktop applications, where components need to be shown within a window-manager. Windows can be configured on
 instantiation and support displaying multiple widgets, toolbars and resizing.
 
-.. code-block:: Python
+.. code-block:: python
 
     import toga
 

--- a/docs/reference/platforms.rst
+++ b/docs/reference/platforms.rst
@@ -15,7 +15,9 @@ macOS
 
 The backend for macOS is named `toga-cocoa`_. It supports macOS 10.10 (Yosemite)
 and later. It is installed automatically on macOS machines (machines that
-report ``sys.platform == 'darwin'``), or can be manually installed by invoking::
+report ``sys.platform == 'darwin'``), or can be manually installed by invoking:
+
+.. code-block:: console
 
     $ pip install toga-cocoa
 
@@ -33,7 +35,9 @@ Linux
 The backend for Linux platforms is named `toga-gtk`_. It supports GTK 3.4
 and later. It is installed automatically on Linux machines (machines that
 report ``sys.platform == 'linux'``), or can be manually installed by
-invoking::
+invoking:
+
+.. code-block:: console
 
     $ pip install toga-gtk
 
@@ -50,7 +54,9 @@ Windows
 The backend for Windows is named `toga-winforms`_. It supports Windows 10 with
 .NET 4 installed. It is installed automatically on Windows machines
 (machines that report ``sys.platform == 'win32'``), or can be manually
-installed by invoking::
+installed by invoking:
+
+.. code-block:: console
 
     $ pip install toga-winforms
 
@@ -69,7 +75,9 @@ iOS
 The backend for iOS is named `toga-iOS`_. It supports iOS 6 or later. It
 must be manually installed into an iOS Python project (such as one that has
 been developed using the `Python-iOS-template cookiecutter`_). It can be
-manually installed by invoking::
+manually installed by invoking:
+
+.. code-block:: console
 
     $ pip install toga-iOS
 
@@ -83,7 +91,9 @@ Android
 ~~~~~~~
 
 The backend for Android is named `toga-android`_. It can be manually installed
-by invoking::
+by invoking:
+
+.. code-block:: console
 
     $ pip install toga-android
 
@@ -98,7 +108,9 @@ Web
 ---
 
 The Web backend is named `toga-web`_. It can be manually installed
-by invoking::
+by invoking:
+
+.. code-block:: console
 
     $ pip install toga-web
 

--- a/docs/reference/platforms.rst
+++ b/docs/reference/platforms.rst
@@ -51,7 +51,7 @@ Windows
 
 .. image:: /reference/screenshots/winforms.png
 
-The backend for Windows is named `toga-winforms`_. It supports Windows 10 with
+The backend for Windows is named `toga-winforms`_. It supports Windows 11 with
 .NET 4 installed. It is installed automatically on Windows machines
 (machines that report ``sys.platform == 'win32'``), or can be manually
 installed by invoking:
@@ -60,8 +60,7 @@ installed by invoking:
 
     $ pip install toga-winforms
 
-It uses `Python.net`_. Unfortunately, python.net has not been packaged for
-Python 3.9 or higher, so you'll need to use Python 3.8 or earlier in your app.
+It uses `Python.net`_.
 
 .. _toga-winforms: https://github.com/beeware/toga/tree/main/winforms
 .. _Python.net: https://pythonnet.github.io
@@ -73,9 +72,8 @@ iOS
 ~~~
 
 The backend for iOS is named `toga-iOS`_. It supports iOS 6 or later. It
-must be manually installed into an iOS Python project (such as one that has
-been developed using the `Python-iOS-template cookiecutter`_). It can be
-manually installed by invoking:
+must be manually installed into an iOS Python project. It can be manually
+installed by invoking:
 
 .. code-block:: console
 
@@ -84,7 +82,6 @@ manually installed by invoking:
 The iOS backend is currently proof-of-concept only. Most widgets have not been
 implemented. It uses `Rubicon`_ to provide a bridge to native macOS libraries.
 
-.. _Python-iOS-template cookiecutter: https://github.com/beeware/Python-iOS-template
 .. _toga-iOS: https://github.com/beeware/toga/tree/main/iOS
 
 Android

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -32,6 +32,7 @@ iterable
 KDE
 linters
 macOS
+Manjaro
 minimizable
 Monetization
 namespace

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -18,18 +18,18 @@ Tutorials
 Tutorial 0 - your first Toga app
 ================================
 
-In :doc:`tutorial-0`, you will discover how to create a basic app and have a simple :class:`toga.widgets.button.Button` widget to click.
+In :doc:`tutorial-0`, you will discover how to create a basic app and have a simple :class:`~toga.widgets.button.Button` widget to click.
 
 Tutorial 1 - a slightly less toy example
 ========================================
 
-In :doc:`tutorial-1`, you will discover how to capture basic user input using the :class:`toga.widgets.textinput.TextInput` widget
+In :doc:`tutorial-1`, you will discover how to capture basic user input using the :class:`~toga.widgets.textinput.TextInput` widget
 and control layout.
 
 Tutorial 2 - you put the box inside another box...
 ==================================================
 
-In :doc:`tutorial-2`, you will discover how to use the :class:`toga.widgets.splitcontainer.SplitContainer` widget to display
+In :doc:`tutorial-2`, you will discover how to use the :class:`~toga.widgets.splitcontainer.SplitContainer` widget to display
 some components, a toolbar and a table.
 
 .. figure:: screenshots/tutorial-2.png
@@ -39,7 +39,7 @@ some components, a toolbar and a table.
 Tutorial 3 - let's build a browser!
 ===================================
 
-In :doc:`tutorial-3`, you will discover how to use the :class:`toga.widgets.webview.WebView` widget to display
+In :doc:`tutorial-3`, you will discover how to use the :class:`~toga.widgets.webview.WebView` widget to display
 a simple browser.
 
 .. figure:: screenshots/tutorial-3.png
@@ -49,7 +49,7 @@ a simple browser.
 Tutorial 4 - let's draw on a canvas!
 ====================================
 
-In :doc:`tutorial-4`, you will discover how to use the :class:`toga.widgets.canvas.Canvas` widget to draw
+In :doc:`tutorial-4`, you will discover how to use the :class:`~toga.widgets.canvas.Canvas` widget to draw
 lines and shapes on a canvas.
 
 .. figure:: screenshots/tutorial-4.png

--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -29,14 +29,14 @@ start coding. To set up a virtual environment, run:
 
   .. group-tab:: macOS
 
-    .. code-block:: bash
+    .. code-block:: console
 
       $ python3 -m venv venv
       $ source venv/bin/activate
 
   .. group-tab:: Linux
 
-    .. code-block:: bash
+    .. code-block:: console
 
       $ python3 -m venv venv
       $ source venv/bin/activate
@@ -46,7 +46,7 @@ start coding. To set up a virtual environment, run:
     .. code-block:: doscon
 
       C:\...>py -m venv venv
-      C:\...>venv\Scripts\activate.bat
+      C:\...>venv\Scripts\activate
 
 Your prompt should now have a ``(venv)`` prefix in front of it.
 
@@ -56,7 +56,7 @@ Next, install Toga into your virtual environment:
 
   .. group-tab:: macOS
 
-    .. code-block:: bash
+    .. code-block:: console
 
       (venv) $ python -m pip install toga
 
@@ -69,19 +69,29 @@ Next, install Toga into your virtual environment:
     ..
       The package list should be the same as in ci.yml, and the BeeWare tutorial.
 
-    .. code-block:: bash
+    Ubuntu 18.04+ / Debian 10+
 
-      # Ubuntu 18.04+ / Debian 10+
+    .. code-block:: console
+
       (venv) $ sudo apt-get update
       (venv) $ sudo apt-get install python3-dev python3-cairo-dev python3-gi-cairo libgirepository1.0-dev libcairo2-dev libpango1.0-dev gir1.2-webkit2-4.0 pkg-config
 
-      # Fedora
+    Fedora
+
+    .. code-block:: console
+
       (venv) $ sudo dnf install pkg-config python3-devel gobject-introspection-devel cairo-devel cairo-gobject-devel pango-devel webkitgtk3
 
-      # Arch / Manjaro
+    Arch / Manjaro
+
+    .. code-block:: console
+
       (venv) $ sudo pacman -Syu git pkgconf cairo python-cairo pango gobject-introspection gobject-introspection-runtime python-gobject webkit2gtk
 
-      # FreeBSD
+    FreeBSD
+
+    .. code-block:: console
+
       (venv) $ sudo pkg update
       (venv) $ sudo pkg install gtk3 pango gobject-introspection cairo webkit2-gtk3
 
@@ -92,7 +102,7 @@ Next, install Toga into your virtual environment:
 
     Then, install toga:
 
-    .. code-block:: bash
+    .. code-block:: console
 
       (venv) $ python -m pip install toga
 
@@ -132,7 +142,7 @@ of a simple button press, however, there are no extra arguments::
     def button_handler(widget):
         print("hello")
 
-When the app gets instantiated (in `main()`, discussed below), Toga will create
+When the app gets instantiated (in ``main()``, discussed below), Toga will create
 a window with a menu. We need to provide a method that tells Toga what content
 to display in the window. The method can be named anything, it just needs to
 accept an app instance::
@@ -195,13 +205,13 @@ representing the executable. The app has a name and a unique identifier. The
 identifier is used when registering any app-specific system resources. By
 convention, the identifier is a "reversed domain name". The app also accepts our
 method defining the main window contents. We wrap this creation process into a
-method called `main()`, which returns a new instance of our application::
+method called ``main()``, which returns a new instance of our application::
 
     def main():
         return toga.App('First App', 'org.beeware.helloworld', startup=build)
 
 The entry point for the project then needs to instantiate this entry point
-and start the main app loop. The call to `main_loop()` is a blocking call;
+and start the main app loop. The call to ``main_loop()`` is a blocking call;
 it won't return until you quit the main app::
 
     if __name__ == '__main__':
@@ -222,13 +232,13 @@ Here is the command to run for your platform from your working directory:
 
   .. group-tab:: macOS
 
-    .. code-block:: bash
+    .. code-block:: console
 
       (venv) $ python -m helloworld
 
   .. group-tab:: Linux
 
-    .. code-block:: bash
+    .. code-block:: console
 
       (venv) $ python -m helloworld
 
@@ -254,7 +264,9 @@ Troubleshooting issues
 Occasionally you might run into issues running Toga on your computer.
 
 Before you run the app, you'll need to install toga. Although you *can* install
-toga by just running::
+toga by just running:
+
+.. code-block:: console
 
     $ python -m pip install toga
 
@@ -279,7 +291,9 @@ at the top of this guide.
     If these requirements aren't met, Toga either won't work at all, or won't
     have full functionality.
 
-Once you've got toga installed, you can run your script::
+Once you've got toga installed, you can run your script:
+
+.. code-block:: console
 
     (venv) $ python -m helloworld
 


### PR DESCRIPTION
## Changes
- Based on beeware/beeware#210, adds support for a copy button for code blocks.
- Ensures all code blocks use the appropriate lexer for the platform's commands.
- Misc cleanup

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
