### PR TITLE
Use trusted publisher for publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      # This permission is required for trusted publishing.
+      id-token: write
     strategy:
       matrix:
         package:
@@ -36,5 +39,3 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets[format('PYPI_PASSWORD_{0}', matrix.package)] }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,9 @@ jobs:
     name: Publish to TestPyPI
     runs-on: ubuntu-latest
     needs: [ci, release]
+    permissions:
+      # This permission is required for trusted publishing.
+      id-token: write
     strategy:
       matrix:
         package:
@@ -65,4 +68,3 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository_url: https://test.pypi.org/legacy/
-          password: ${{ secrets[format('TEST_PYPI_PASSWORD_{0}', matrix.package)] }}

--- a/changes/1900.misc.rst
+++ b/changes/1900.misc.rst
@@ -1,0 +1,1 @@
+Release processes were changed to use Trusted Publishing.


### PR DESCRIPTION
Adds the `id-token: write` permission to the publishing workflow to take advantage of trusted publishers.

Related to: https://github.com/beeware/beeware/issues/219

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
