### PR TITLE
Move GTK font measuring to Canvas widget

### DIFF
--- a/gtk/src/toga_gtk/fonts.py
+++ b/gtk/src/toga_gtk/fonts.py
@@ -55,17 +55,3 @@ class Font:
             _FONT_CACHE[self.interface] = font
 
         self.native = font
-
-    def measure(self, text, widget, tight=False):
-        layout = widget.create_pango_layout(text)
-
-        layout.set_font_description(self.native)
-        ink, logical = layout.get_extents()
-        if tight:
-            width = (ink.width / Pango.SCALE) - (ink.width * 0.2) / Pango.SCALE
-            height = ink.height / Pango.SCALE
-        else:
-            width = (logical.width / Pango.SCALE) - (logical.width * 0.2) / Pango.SCALE
-            height = logical.height / Pango.SCALE
-
-        return width, height

--- a/gtk/src/toga_gtk/widgets/canvas.py
+++ b/gtk/src/toga_gtk/widgets/canvas.py
@@ -227,7 +227,18 @@ class Canvas(Widget):
             y += height
 
     def measure_text(self, text, font, tight=False):
-        return font._impl.measure(text, widget=self.native, tight=tight)
+        layout = self.native.create_pango_layout(text)
+
+        layout.set_font_description(self.native)
+        ink, logical = layout.get_extents()
+        if tight:
+            width = (ink.width / Pango.SCALE) - (ink.width * 0.2) / Pango.SCALE
+            height = ink.height / Pango.SCALE
+        else:
+            width = (logical.width / Pango.SCALE) - (logical.width * 0.2) / Pango.SCALE
+            height = logical.height / Pango.SCALE
+
+        return width, height
 
     def get_image_data(self):
         self.interface.factory.not_implemented("Canvas.get_image_data()")


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Moves the logic for measuring font size on GTK from the `Font` class to the `Canvas` widget to align with Winforms.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
