### PR TITLE
Improve error handling when Android raises an ActivityNotFoundException

### DIFF
--- a/android/src/toga_android/app.py
+++ b/android/src/toga_android/app.py
@@ -218,14 +218,15 @@ class App:
         :returns: A Dictionary containing "resultCode" (int) and "resultData" (Intent or None)
         :rtype: dict
         """
-        if not intent.resolveActivity(self.native.getPackageManager()):
+        try:
+            self._listener.last_intent_requestcode += 1
+            code = self._listener.last_intent_requestcode
+
+            result_future = asyncio.Future()
+            self._listener.running_intents[code] = result_future
+
+            self.native.startActivityForResult(intent, code)
+            await result_future
+            return result_future.result()
+        except AttributeError:
             raise RuntimeError("No appropriate Activity found to handle this intent.")
-        self._listener.last_intent_requestcode += 1
-        code = self._listener.last_intent_requestcode
-
-        result_future = asyncio.Future()
-        self._listener.running_intents[code] = result_future
-
-        self.native.startActivityForResult(intent, code)
-        await result_future
-        return result_future.result()

--- a/changes/1909.bugfix.rst
+++ b/changes/1909.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed a bug causing valid intents to not be found and failing to run.
+Error handling associated with the creation of creation of Android Intents has been improved.

--- a/changes/1909.bugfix.rst
+++ b/changes/1909.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug causing valid intents to not be found and failing to run.


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Removed if statement that called resolveActivity and replaced with a try block that excepts an Attribute Error. Ideally this would be an ActivityNotFoundException however rubicon does not have JavaExceptions to my knowledge so I couldn't set that as the except.
<!--- What problem does this change solve? -->
Fixes an issue that caused valid intents like ACTION_OPEN_DOCUMENT to return as not found when it does exist. After android 11, package visibility changed and shown in [this link](https://medium.com/androiddevelopers/package-visibility-in-android-11-cc857f221cd9). It suggests doing the try catch instead of the resolveActivity.
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Fixes #1909 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
