### PR TITLE
Fixed bug related to missing_value for android and linux

### DIFF
--- a/android/src/toga_android/widgets/table.py
+++ b/android/src/toga_android/widgets/table.py
@@ -173,7 +173,11 @@ class Table(Widget):
         if self.interface.data is None or self.interface._accessors is None:
             return None
         row_object = self.interface.data[row_index]
-        value = getattr(row_object, self.interface._accessors[col_index])
+        value = getattr(
+            row_object,
+            self.interface._accessors[col_index],
+            self.interface.missing_value,
+        )
         return value
 
     def get_selection(self):

--- a/changes/1879.bugfix.rst
+++ b/changes/1879.bugfix.rst
@@ -1,1 +1,1 @@
-Fixes a bug on android and linux that caused an error if values were not provided for all headings.
+Missing value handling on Tables was fixed on Android and Linux.

--- a/changes/1879.bugfix.rst
+++ b/changes/1879.bugfix.rst
@@ -1,0 +1,1 @@
+Fixes a bug on android and linux that caused an error if values were not provided for all headings.

--- a/changes/1913.feature.rst
+++ b/changes/1913.feature.rst
@@ -1,0 +1,1 @@
+Missing value handling was added to Trees.

--- a/cocoa/src/toga_cocoa/widgets/tree.py
+++ b/cocoa/src/toga_cocoa/widgets/tree.py
@@ -94,7 +94,7 @@ class TogaTree(NSOutlineView):
         except AttributeError:
             # If the node doesn't have a property with the
             # accessor name, assume an empty string value.
-            value = ""
+            value = self.interface.missing_value
             icon_iface = None
 
         # If the value has an icon, get the _impl.
@@ -139,7 +139,9 @@ class TogaTree(NSOutlineView):
         heights = [default_row_height]
 
         for column in self.tableColumns:
-            value = getattr(item.attrs["node"], str(column.identifier))
+            value = getattr(
+                item.attrs["node"], str(column.identifier), self.interface.missing_value
+            )
 
             if isinstance(value, toga.Widget):
                 # if the cell value is a widget, use its height

--- a/core/src/toga/widgets/tree.py
+++ b/core/src/toga/widgets/tree.py
@@ -33,7 +33,11 @@ class Tree(Widget):
         multiple rows. Defaults to ``False``.
     :param on_select: A handler to be invoked when the user selects one or
         multiple rows.
-    :param on_double_click: A handler to be invoked when the user double clicks a row.
+    :param on_double_click: A handler to be invoked when the user double clicks
+        a row.
+    :param missing_value: value for replacing a missing value in the data
+            source. (Default: None). When 'None', a warning message will be
+            shown.
     """
 
     MIN_WIDTH = 100
@@ -49,6 +53,7 @@ class Tree(Widget):
         multiple_select=False,
         on_select=None,
         on_double_click=None,
+        missing_value=None,
         factory=None,  # DEPRECATED!
     ):
         super().__init__(id=id, style=style)
@@ -66,11 +71,15 @@ class Tree(Widget):
         self._accessors = build_accessors(headings, accessors)
         self._multiple_select = multiple_select
         self._data = None
+        if missing_value is None:
+            print(
+                "WARNING: Using empty string for missing value in data. "
+                "Define a 'missing_value' on the table to silence this message"
+            )
+        self._missing_value = missing_value or ""
+
         self._on_select = None
         self._on_double_click = None
-
-        # TODO: Tree should have a missing_value placeholder, same as Table.
-        self.missing_value = None
 
         self._impl = self.factory.Tree(interface=self)
         self.data = data
@@ -115,6 +124,10 @@ class Tree(Widget):
         returns a list of selected data nodes. Otherwise, returns a single data node.
         """
         return self._impl.get_selection()
+
+    @property
+    def missing_value(self):
+        return self._missing_value
 
     @property
     def on_select(self):

--- a/core/src/toga/widgets/tree.py
+++ b/core/src/toga/widgets/tree.py
@@ -69,6 +69,9 @@ class Tree(Widget):
         self._on_select = None
         self._on_double_click = None
 
+        # TODO: Tree should have a missing_value placeholder, same as Table.
+        self.missing_value = None
+
         self._impl = self.factory.Tree(interface=self)
         self.data = data
 

--- a/examples/table/table/app.py
+++ b/examples/table/table/app.py
@@ -10,7 +10,7 @@ bee_movies = [
     ("The Secret Life of Bees", "2008", "7.3", "Drama"),
     ("Bee Movie", "2007", "6.1", "Animation, Adventure, Comedy"),
     ("Bees", "1998", "6.3", "Horror"),
-    ("The Girl Who Swallowed Bees", "2007", "7.5", "Short"),
+    ("The Girl Who Swallowed Bees", "2007", "7.5"),  # Missing a genre
     ("Birds Do It, Bees Do It", "1974", "7.3", "Documentary"),
     ("Bees: A Life for the Queen", "1998", "8.0", "TV Movie"),
     ("Bees in Paradise", "1944", "5.4", "Comedy, Musical"),
@@ -130,6 +130,7 @@ class ExampleTableApp(toga.App):
             multiple_select=False,
             on_select=self.on_select_handler1,
             on_double_click=self.on_double_click1,
+            missing_value="Unknown",
         )
 
         self.table2 = toga.Table(
@@ -139,6 +140,7 @@ class ExampleTableApp(toga.App):
             style=Pack(flex=1, padding_left=5),
             on_select=self.on_select_handler2,
             on_double_click=self.on_double_click2,
+            missing_value="?",
         )
 
         tablebox = toga.Box(children=[self.table1, self.table2], style=Pack(flex=1))

--- a/examples/tree/tree/app.py
+++ b/examples/tree/tree/app.py
@@ -22,7 +22,7 @@ bee_movies = [
         "year": 2007,
         "title": "The Girl Who Swallowed Bees",
         "rating": "7.5",
-        "genre": "Short",
+        # No genre defined
     },
     {
         "year": 1974,
@@ -92,6 +92,7 @@ class ExampleTreeApp(toga.App):
             headings=["Year", "Title", "Rating", "Genre"],
             on_select=self.on_select_handler,
             style=Pack(flex=1),
+            missing_value="?",
         )
 
         self.decade_1940s = self.tree.data.append(

--- a/gtk/src/toga_gtk/widgets/internal/sourcetreemodel.py
+++ b/gtk/src/toga_gtk/widgets/internal/sourcetreemodel.py
@@ -12,7 +12,7 @@ class SourceTreeModel(GObject.Object, Gtk.TreeModel):
     Maybe an method could be added (like index()) to the TreeSource to access it.
     """
 
-    def __init__(self, columns, is_tree):
+    def __init__(self, columns, is_tree, missing_value):
         """
         Args:
             columns (list(dict(str, any))): the columns excluding first column which is always the row object.
@@ -25,6 +25,7 @@ class SourceTreeModel(GObject.Object, Gtk.TreeModel):
         self.source = None
         self.columns = columns
         self.is_tree = is_tree
+        self.missing_value = missing_value
         # by storing the row and calling index later, we can opt-in for this performance
         # boost and don't have to track iterators (we would have to if we stored indices).
         self.flags = Gtk.TreeModelFlags.ITERS_PERSIST
@@ -163,7 +164,7 @@ class SourceTreeModel(GObject.Object, Gtk.TreeModel):
             return None
 
         # workaround icon+name tuple breaking gtk tree
-        ret = getattr(row, self.columns[column - 1]["attr"])
+        ret = getattr(row, self.columns[column - 1]["attr"], self.missing_value)
         if isinstance(ret, tuple):
             ret = ret[1]
         return ret

--- a/gtk/src/toga_gtk/widgets/tree.py
+++ b/gtk/src/toga_gtk/widgets/tree.py
@@ -15,7 +15,7 @@ class Tree(Widget):
         self.store = SourceTreeModel(
             [{"type": str, "attr": a} for a in self.interface._accessors],
             is_tree=is_tree,
-            missing_value=self.interface.missing_value,
+            missing_value=getattr(self.interface, "missing_value", None),
         )
 
         # Create a tree view, and put it in a scroll view.

--- a/gtk/src/toga_gtk/widgets/tree.py
+++ b/gtk/src/toga_gtk/widgets/tree.py
@@ -15,6 +15,7 @@ class Tree(Widget):
         self.store = SourceTreeModel(
             [{"type": str, "attr": a} for a in self.interface._accessors],
             is_tree=is_tree,
+            missing_value=self.interface.missing_value,
         )
 
         # Create a tree view, and put it in a scroll view.

--- a/gtk/src/toga_gtk/widgets/tree.py
+++ b/gtk/src/toga_gtk/widgets/tree.py
@@ -15,7 +15,7 @@ class Tree(Widget):
         self.store = SourceTreeModel(
             [{"type": str, "attr": a} for a in self.interface._accessors],
             is_tree=is_tree,
-            missing_value=getattr(self.interface, "missing_value", None),
+            missing_value=self.interface.missing_value,
         )
 
         # Create a tree view, and put it in a scroll view.


### PR DESCRIPTION
<!--- Describe your changes in detail -->
For linux, I passed the missing_value from self.interface.missing_value from Tree to the sourcetreemodel. I did this because self.instance is not available inside the sourcetreemodel but the value is needed to be able to solve the bug.

For android, I simply added the self.interface.missing_value as the default option for the getattr.
<!--- What problem does this change solve? -->
On android the app will crash if values are not provided for all headings, on linux it will cause an error in the logs. 
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

Fixes #1879 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
