### PR TITLE
Bug fix for toga.Selection on android for value

### DIFF
--- a/android/src/toga_android/widgets/selection.py
+++ b/android/src/toga_android/widgets/selection.py
@@ -41,7 +41,10 @@ class Selection(Widget):
         if selected:
             return str(selected)
         else:
-            return None
+            if self.adapter.getCount() > 0:
+                return ""
+            else:
+                return None
 
     def remove_all_items(self):
         self.adapter.clear()

--- a/android/src/toga_android/widgets/selection.py
+++ b/android/src/toga_android/widgets/selection.py
@@ -41,10 +41,7 @@ class Selection(Widget):
         if selected:
             return str(selected)
         else:
-            if self.adapter.getCount() > 0:
-                return ""
-            else:
-                return None
+            return None
 
     def remove_all_items(self):
         self.adapter.clear()

--- a/changes/1723.bugfix.rst
+++ b/changes/1723.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed bug for toga.Selection value returning None instead of an empty string.

--- a/changes/1723.bugfix.rst
+++ b/changes/1723.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed bug for toga.Selection value returning None instead of an empty string.
+A Selection widget with no items now consistently returns a current value of ``None`` on all platforms.

--- a/cocoa/src/toga_cocoa/widgets/selection.py
+++ b/cocoa/src/toga_cocoa/widgets/selection.py
@@ -43,7 +43,9 @@ class Selection(Widget):
         self.native.selectItemWithTitle(item)
 
     def get_selected_item(self):
-        return str(self.native.titleOfSelectedItem)
+        selected = self.native.titleOfSelectedItem
+        if selected:
+            return str(selected)
 
     def set_on_select(self, handler):
         pass

--- a/examples/selection/selection/app.py
+++ b/examples/selection/selection/app.py
@@ -19,6 +19,9 @@ class SelectionApp(toga.App):
 
         # Add the content on the main window
         self.selection = toga.Selection(items=self.OPTIONS)
+        self.empty_selection = toga.Selection()
+
+        self.report_label = toga.Label("", style=label_style)
 
         self.main_window.content = toga.Box(
             children=[
@@ -27,6 +30,22 @@ class SelectionApp(toga.App):
                     children=[
                         toga.Label("Select an element", style=label_style),
                         self.selection,
+                    ],
+                ),
+                toga.Box(
+                    style=box_style,
+                    children=[
+                        toga.Label("Empty selection", style=label_style),
+                        self.empty_selection,
+                    ],
+                ),
+                toga.Box(
+                    style=box_style,
+                    children=[
+                        toga.Button(
+                            "Report on selection", on_press=self.report_selection
+                        ),
+                        self.report_label,
                     ],
                 ),
                 toga.Box(
@@ -66,7 +85,7 @@ class SelectionApp(toga.App):
                 toga.Box(
                     style=box_style,
                     children=[
-                        toga.Label("use some style!", style=label_style),
+                        toga.Label("Use some style!", style=label_style),
                         toga.Selection(
                             style=Pack(width=200, padding=24),
                             items=["Curium", "Titanium", "Copernicium"],
@@ -112,6 +131,11 @@ class SelectionApp(toga.App):
         # get the current value of the slider with `selection.value`
 
         print(f"The selection widget changed to {selection.value}")
+
+    def report_selection(self, widget):
+        self.report_label.text = (
+            f"Element: {self.selection.value!r}; Empty: {self.empty_selection.value!r}"
+        )
 
 
 def main():

--- a/iOS/src/toga_iOS/widgets/selection.py
+++ b/iOS/src/toga_iOS/widgets/selection.py
@@ -69,7 +69,10 @@ class Selection(Widget):
         self.interface.factory.not_implemented("Selection.select_item()")
 
     def get_selected_item(self):
-        return self.interface.items[self.picker.selectedRowInComponent(0)]
+        try:
+            return self.interface.items[self.picker.selectedRowInComponent(0)]
+        except IndexError:
+            return None
 
     def set_on_select(self, handler):
         # No special handling required


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Added an if statement for get_selected_item that checks if the Selection has values or not. If it does not it will return None which is consistent with linux and windows. If it has values, it will return "" with type str if an empty value is selected. 
<!--- What problem does this change solve? -->
Makes the return value consistent across platforms
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Fixes #1723 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
