### PR TITLE
Tweak the ordering of tox installs to trick the pip resolver.

### DIFF
--- a/changes/1916.misc.rst
+++ b/changes/1916.misc.rst
@@ -1,0 +1,1 @@
+Installation ordering in tox environment was altered to ensure correct resolution of dependencies.

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ allowlist_externals =
     gtk: xvfb-run
 commands =
     # TOGA_INSTALL_COMMAND is set to a bash command by the CI workflow.
-    {env:TOGA_INSTALL_COMMAND:python -m pip install . ../core[dev] ../dummy}
+    {env:TOGA_INSTALL_COMMAND:python -m pip install ../core[dev] ../dummy .}
     {env:test_command_prefix:} coverage run -m pytest -vv {posargs}
     coverage combine
     coverage report --rcfile ../pyproject.toml


### PR DESCRIPTION
Running `tox -e py-cocoa` (or any other backend) is currently failing on local installs because the ordering of dependencies in the install leads to recent versions of pip trying to resolve the toga-core install from the toga-cocoa install, rather than using the explicit reference to toga-cocoa. 

Reordering the install order removes this problem.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
