### PR TITLE
Improves segfault error crash handling on systems without a DISPLAY variable.

### DIFF
--- a/changes/1921.bugfix.rst
+++ b/changes/1921.bugfix.rst
@@ -1,1 +1,1 @@
-Improved error caused by segfault for linux systems without a DISPLAY variable set
+Apps on Linux no longer segfault if an X Windows display cannot be identified.

--- a/changes/1921.bugfix.rst
+++ b/changes/1921.bugfix.rst
@@ -1,0 +1,1 @@
+Improved error caused by segfault for linux systems without a DISPLAY variable set

--- a/gtk/src/toga_gtk/libs/gtk.py
+++ b/gtk/src/toga_gtk/libs/gtk.py
@@ -5,6 +5,11 @@ gi.require_version("Gtk", "3.0")
 
 from gi.repository import Gdk, GdkPixbuf, Gio, GLib, GObject, Gtk  # noqa: E402, F401
 
+if Gdk.Screen.get_default() is None:
+    exit("This system does not have a DISPLAY environment variable set")
+
+print(Gdk.Screen.get_default())
+
 # The following import will fail if WebKit or its API wrappers aren't
 # installed; handle failure gracefully
 # (see https://github.com/beeware/toga/issues/26)

--- a/gtk/src/toga_gtk/libs/gtk.py
+++ b/gtk/src/toga_gtk/libs/gtk.py
@@ -6,9 +6,9 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import Gdk, GdkPixbuf, Gio, GLib, GObject, Gtk  # noqa: E402, F401
 
 if Gdk.Screen.get_default() is None:
-    exit("This system does not have a DISPLAY environment variable set")
-
-print(Gdk.Screen.get_default())
+    raise RuntimeError(
+        "Cannot identify an active display. Is the ``DISPLAY`` environment variable set correctly?"
+    )
 
 # The following import will fail if WebKit or its API wrappers aren't
 # installed; handle failure gracefully


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Added an if statement to check if Gdk has a display which will return None if $DISPLAY is not set. If it is None, it will exit and display the reason.
<!--- What problem does this change solve? -->
Makes it clear as to why the application is not running.
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
#1715 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
