### PR TITLE
Unpin versions in attic projects to avoid dependabot alerts.

### DIFF
--- a/attic/django/setup.py
+++ b/attic/django/setup.py
@@ -6,11 +6,9 @@ from setuptools import setup
 # Version handline needs to be programatic because
 # we can't import toga_django to compute the version;
 # and to support versioned subpackage dependencies
-with open('toga_django/__init__.py', encoding='utf8') as version_file:
+with open("toga_django/__init__.py", encoding="utf8") as version_file:
     version_match = re.search(
-        r"^__version__ = ['\"]([^'\"]*)['\"]",
-        version_file.read(),
-        re.M
+        r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M
     )
     if version_match:
         version = version_match.group(1)
@@ -19,10 +17,10 @@ with open('toga_django/__init__.py', encoding='utf8') as version_file:
 
 setup(
     version=version,
-    description='A Django backend for the Toga widget toolkit.',
+    description="A Django backend for the Toga widget toolkit.",
     install_requires=[
-        'django~=3.0',
-        'django-environ==0.4.1',
-        'toga-web==%s' % version,
+        "django",  # ~=3.0',
+        "django-environ",  # ==0.4.1',
+        "toga-web==%s" % version,
     ],
 )

--- a/attic/falcon/setup.py
+++ b/attic/falcon/setup.py
@@ -6,11 +6,9 @@ from setuptools import setup
 # Version handline needs to be programatic because
 # we can't import toga_falcon to compute the version;
 # and to support versioned subpackage dependencies
-with open('toga_falcon/__init__.py', encoding='utf8') as version_file:
+with open("toga_falcon/__init__.py", encoding="utf8") as version_file:
     version_match = re.search(
-        r"^__version__ = ['\"]([^'\"]*)['\"]",
-        version_file.read(),
-        re.M
+        r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M
     )
     if version_match:
         version = version_match.group(1)
@@ -20,6 +18,6 @@ with open('toga_falcon/__init__.py', encoding='utf8') as version_file:
 setup(
     version=version,
     install_requires=[
-        'toga-core==%s' % version,
+        "toga-core==%s" % version,
     ],
 )

--- a/attic/flask/setup.py
+++ b/attic/flask/setup.py
@@ -6,11 +6,9 @@ from setuptools import setup
 # Version handline needs to be programatic because
 # we can't import toga_flask to compute the version;
 # and to support versioned subpackage dependencies
-with open('toga_flask/__init__.py', encoding='utf8') as version_file:
+with open("toga_flask/__init__.py", encoding="utf8") as version_file:
     version_match = re.search(
-        r"^__version__ = ['\"]([^'\"]*)['\"]",
-        version_file.read(),
-        re.M
+        r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M
     )
     if version_match:
         version = version_match.group(1)
@@ -20,7 +18,7 @@ with open('toga_flask/__init__.py', encoding='utf8') as version_file:
 setup(
     version=version,
     install_requires=[
-        'flask~=2.1.1',
-        'toga-web==%s' % version,
+        "flask",
+        "toga-web==%s" % version,
     ],
 )

--- a/attic/pyramid/setup.py
+++ b/attic/pyramid/setup.py
@@ -6,11 +6,9 @@ from setuptools import setup
 # Version handline needs to be programatic because
 # we can't import toga_pyramid to compute the version;
 # and to support versioned subpackage dependencies
-with open('toga_pyramid/__init__.py', encoding='utf8') as version_file:
+with open("toga_pyramid/__init__.py", encoding="utf8") as version_file:
     version_match = re.search(
-        r"^__version__ = ['\"]([^'\"]*)['\"]",
-        version_file.read(),
-        re.M
+        r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M
     )
     if version_match:
         version = version_match.group(1)
@@ -20,6 +18,6 @@ with open('toga_pyramid/__init__.py', encoding='utf8') as version_file:
 setup(
     version=version,
     install_requires=[
-        'toga-core==%s' % version,
+        "toga-core==%s" % version,
     ],
 )

--- a/attic/starlette/setup.py
+++ b/attic/starlette/setup.py
@@ -6,11 +6,9 @@ from setuptools import setup
 # Version handline needs to be programatic because
 # we can't import toga_starlette to compute the version;
 # and to support versioned subpackage dependencies
-with open('toga_starlette/__init__.py', encoding='utf8') as version_file:
+with open("toga_starlette/__init__.py", encoding="utf8") as version_file:
     version_match = re.search(
-        r"^__version__ = ['\"]([^'\"]*)['\"]",
-        version_file.read(),
-        re.M
+        r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M
     )
     if version_match:
         version = version_match.group(1)
@@ -20,6 +18,6 @@ with open('toga_starlette/__init__.py', encoding='utf8') as version_file:
 setup(
     version=version,
     install_requires=[
-        'toga-core==%s' % version,
+        "toga-core==%s" % version,
     ],
 )

--- a/attic/tornado/setup.py
+++ b/attic/tornado/setup.py
@@ -6,11 +6,9 @@ from setuptools import setup
 # Version handline needs to be programatic because
 # we can't import toga_tornado to compute the version;
 # and to support versioned subpackage dependencies
-with open('toga_tornado/__init__.py', encoding='utf8') as version_file:
+with open("toga_tornado/__init__.py", encoding="utf8") as version_file:
     version_match = re.search(
-        r"^__version__ = ['\"]([^'\"]*)['\"]",
-        version_file.read(),
-        re.M
+        r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M
     )
     if version_match:
         version = version_match.group(1)
@@ -20,6 +18,6 @@ with open('toga_tornado/__init__.py', encoding='utf8') as version_file:
 setup(
     version=version,
     install_requires=[
-        'toga-core==%s' % version,
+        "toga-core==%s" % version,
     ],
 )

--- a/attic/win32/setup.py
+++ b/attic/win32/setup.py
@@ -1,52 +1,52 @@
-#/usr/bin/env python
+# /usr/bin/env python
 import io
 import re
 
 from setuptools import setup, find_packages
 
-with io.open('toga_win32/__init__.py', encoding='utf8') as version_file:
-    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
+with io.open("toga_win32/__init__.py", encoding="utf8") as version_file:
+    version_match = re.search(
+        r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M
+    )
     if version_match:
         version = version_match.group(1)
     else:
         raise RuntimeError("Unable to find version string.")
 
 
-with io.open('README.rst', encoding='utf8') as readme:
+with io.open("README.rst", encoding="utf8") as readme:
     long_description = readme.read()
 
 
 setup(
-    name='toga-win32',
+    name="toga-win32",
     version=version,
-    description='A Win32 (Microsoft Windows) backend for the Toga widget toolkit.',
+    description="A Win32 (Microsoft Windows) backend for the Toga widget toolkit.",
     long_description=long_description,
-    author='Russell Keith-Magee',
-    author_email='russell@keith-magee.com',
-    url='http://beeware.org/toga',
-    packages=find_packages(exclude='tests'),
-    python_requires='>=3.5',
+    author="Russell Keith-Magee",
+    author_email="russell@keith-magee.com",
+    url="http://beeware.org/toga",
+    packages=find_packages(exclude="tests"),
+    python_requires=">=3.5",
     install_requires=[
-        'toga-core==%s' % version,
+        "toga-core==%s" % version,
     ],
-    tests_require=[
-        'toga-dummy==%s' % version
-    ],
-    license='New BSD',
+    tests_require=["toga-dummy==%s" % version],
+    license="New BSD",
     classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
-        'Environment :: Win32 (MS Windows)',
-        'Operating System :: Microsoft :: Windows',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3 :: Only',
-        'Topic :: Software Development',
-        'Topic :: Software Development :: User Interfaces',
-        'Topic :: Software Development :: Widget Sets',
+        "Development Status :: 2 - Pre-Alpha",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: BSD License",
+        "Environment :: Win32 (MS Windows)",
+        "Operating System :: Microsoft :: Windows",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3 :: Only",
+        "Topic :: Software Development",
+        "Topic :: Software Development :: User Interfaces",
+        "Topic :: Software Development :: Widget Sets",
     ],
-    test_suite='tests',
+    test_suite="tests",
 )

--- a/changes/1926.misc.rst
+++ b/changes/1926.misc.rst
@@ -1,0 +1,1 @@
+Dependencies in attic projects were unpinned to avoid spurious dependabot security alerts.


### PR DESCRIPTION
Dependabot has been raising alerts for Django and Flask versions. These projects are in the attic, so there's no actual security risk. Removing the version pins allows us to keeps the code around without triggering security alerts.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
