### PR TITLE
Correct size hinting on GTK DetailedList.

### DIFF
--- a/changes/1920.bugfix.rst
+++ b/changes/1920.bugfix.rst
@@ -1,0 +1,1 @@
+The DetailedList widget on GTK now provides an accurate size hint during layout.

--- a/gtk/src/toga_gtk/widgets/detailedlist.py
+++ b/gtk/src/toga_gtk/widgets/detailedlist.py
@@ -1,3 +1,5 @@
+from travertino.size import at_least
+
 from ..libs import Gdk, Gio, GLib, Gtk
 from .base import Widget
 from .internal.buttons.refresh import RefreshButton
@@ -213,3 +215,7 @@ class DetailedList(Widget):
         self.refresh_button.list_changed()
         self.scroll_button.list_changed()
         return True
+
+    def rehint(self):
+        self.interface.intrinsic.width = at_least(self.interface._MIN_WIDTH)
+        self.interface.intrinsic.height = at_least(self.interface._MIN_HEIGHT)


### PR DESCRIPTION
GTK's DetailedList widget wasn't providing a size hint; as a result, it was collapsing to size 0 when placed inside a box.

Fixes #1920.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
