### PR TITLE
Added basic documentation for async function to update progress bar

### DIFF
--- a/docs/reference/api/widgets/progressbar.rst
+++ b/docs/reference/api/widgets/progressbar.rst
@@ -55,6 +55,36 @@ animates as a throbbing or "ping pong" animation.
     # Stop progress animation
     progress.stop()
 
+To update the progress bar's current value without blocking the applicaiton, you
+you will need to use an async function. This function can either be assigned to
+a background task or assigned to an event handler like on_press for a button. If
+the function does not have a proper await response, you can sleep between each
+update to show the update on the progress bar.
+
+.. code-block:: python
+
+    import toga
+    import asyncio
+
+    class MyApp(toga.App):
+        def startup(self):
+            # build UI
+            self.progress_bar = toga.ProgressBar(max=100)
+
+            self.button = toga.Button(on_press=progress)
+            # or
+            self.add_background_task(progress)
+
+
+
+        async def progress(self):
+            await asyncio.sleep(0.1)
+            #or
+            await #response
+
+    def main():
+        return MyApp('First App', 'org.beeware.helloworld')
+
 Notes
 -----
 


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Made changes to the progressbar.rst file to add basic documentation explaining how to use the progress bar in a way to not block the GUI loop. A more in depth explanation and example could be useful but I feel would take up a lot of space on the reference page and a topic guide on it would be a better place for it. 
<!--- What problem does this change solve? -->
Clears up confusion on how to use the progress bar widget
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
#1232 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
