### PR TITLE
Refactor dialog implementation

### DIFF
--- a/android/src/toga_android/dialogs.py
+++ b/android/src/toga_android/dialogs.py
@@ -1,4 +1,4 @@
-import asyncio
+from abc import ABC
 
 from .libs.android import R__drawable
 from .libs.android.app import AlertDialog__Builder
@@ -12,33 +12,19 @@ class OnClickListener(DialogInterface__OnClickListener):
         self._value = value
 
     def onClick(self, _dialog, _which):
-        if self._fn:
-            self._fn(self._value)
+        self._fn(self._value)
 
 
-class BaseDialog:
-    def __init__(self):
-        loop = asyncio.get_event_loop()
-        self.future = loop.create_future()
-
-    def __eq__(self, other):
-        raise RuntimeError(
-            "Can't check dialog result directly; use await or an on_result handler"
-        )
-
-    def __bool__(self):
-        raise RuntimeError(
-            "Can't check dialog result directly; use await or an on_result handler"
-        )
-
-    def __await__(self):
-        return self.future.__await__()
+class BaseDialog(ABC):
+    def __init__(self, interface):
+        self.interface = interface
+        self.interface.impl = self
 
 
 class TextDialog(BaseDialog):
     def __init__(
         self,
-        window,
+        interface,
         title,
         message,
         positive_text,
@@ -48,44 +34,42 @@ class TextDialog(BaseDialog):
     ):
         """Create Android textual dialog.
 
-        - window: Toga Window
+        - interface: Toga Window
         - title: Title of dialog
         - message: Message of dialog
         - positive_text: Button text where clicking it returns True (or None to skip)
         - negative_text: Button text where clicking it returns False (or None to skip)
         - icon: Integer used as an Android resource ID number for dialog icon (or None to skip)
         """
-        super().__init__()
+        super().__init__(interface=interface)
         self.on_result = on_result
 
-        builder = AlertDialog__Builder(window._impl.app.native)
-        builder.setCancelable(False)
-        builder.setTitle(title)
-        builder.setMessage(message)
+        self.native = AlertDialog__Builder(interface.window._impl.app.native)
+        self.native.setCancelable(False)
+        self.native.setTitle(title)
+        self.native.setMessage(message)
         if icon is not None:
-            builder.setIcon(icon)
+            self.native.setIcon(icon)
 
         if positive_text is not None:
-            builder.setPositiveButton(
+            self.native.setPositiveButton(
                 positive_text, OnClickListener(self.completion_handler, True)
             )
         if negative_text is not None:
-            builder.setNegativeButton(
+            self.native.setNegativeButton(
                 negative_text, OnClickListener(self.completion_handler, False)
             )
-        builder.show()
+        self.native.show()
 
     def completion_handler(self, return_value: bool) -> None:
-        if self.on_result:
-            self.on_result(self, return_value)
-
-        self.future.set_result(return_value)
+        self.on_result(self, return_value)
+        self.interface.future.set_result(return_value)
 
 
 class InfoDialog(TextDialog):
-    def __init__(self, window, title, message, on_result=None):
+    def __init__(self, interface, title, message, on_result=None):
         super().__init__(
-            window=window,
+            interface=interface,
             title=title,
             message=message,
             positive_text="OK",
@@ -94,9 +78,9 @@ class InfoDialog(TextDialog):
 
 
 class QuestionDialog(TextDialog):
-    def __init__(self, window, title, message, on_result=None):
+    def __init__(self, interface, title, message, on_result=None):
         super().__init__(
-            window=window,
+            interface=interface,
             title=title,
             message=message,
             positive_text="Yes",
@@ -106,9 +90,9 @@ class QuestionDialog(TextDialog):
 
 
 class ConfirmDialog(TextDialog):
-    def __init__(self, window, title, message, on_result=None):
+    def __init__(self, interface, title, message, on_result=None):
         super().__init__(
-            window=window,
+            interface=interface,
             title=title,
             message=message,
             positive_text="OK",
@@ -118,9 +102,9 @@ class ConfirmDialog(TextDialog):
 
 
 class ErrorDialog(TextDialog):
-    def __init__(self, window, title, message, on_result=None):
+    def __init__(self, interface, title, message, on_result=None):
         super().__init__(
-            window=window,
+            interface=interface,
             title=title,
             message=message,
             positive_text="OK",
@@ -130,34 +114,54 @@ class ErrorDialog(TextDialog):
 
 
 class StackTraceDialog(BaseDialog):
-    def __init__(self, window, title, message, on_result=None, **kwargs):
-        super().__init__()
-        window.factory.not_implemented("Window.stack_trace_dialog()")
+    def __init__(
+        self,
+        interface,
+        title,
+        message,
+        on_result=None,
+        **kwargs,
+    ):
+        super().__init__(interface=interface)
+        interface.window.factory.not_implemented("Window.stack_trace_dialog()")
 
 
 class SaveFileDialog(BaseDialog):
     def __init__(
         self,
-        window,
+        interface,
         title,
         filename,
         initial_directory,
         file_types=None,
         on_result=None,
     ):
-        super().__init__()
-        window.factory.not_implemented("Window.save_file_dialog()")
+        super().__init__(interface=interface)
+        interface.window.factory.not_implemented("Window.save_file_dialog()")
 
 
 class OpenFileDialog(BaseDialog):
     def __init__(
-        self, window, title, initial_directory, file_types, multiselect, on_result=None
+        self,
+        interface,
+        title,
+        initial_directory,
+        file_types,
+        multiselect,
+        on_result=None,
     ):
-        super().__init__()
-        window.factory.not_implemented("Window.open_file_dialog()")
+        super().__init__(interface=interface)
+        interface.window.factory.not_implemented("Window.open_file_dialog()")
 
 
 class SelectFolderDialog(BaseDialog):
-    def __init__(self, window, title, initial_directory, multiselect, on_result=None):
-        super().__init__()
-        window.factory.not_implemented("Window.select_folder_dialog()")
+    def __init__(
+        self,
+        interface,
+        title,
+        initial_directory,
+        multiselect,
+        on_result=None,
+    ):
+        super().__init__(interface=interface)
+        interface.window.factory.not_implemented("Window.select_folder_dialog()")

--- a/changes/1948.misc.rst
+++ b/changes/1948.misc.rst
@@ -1,0 +1,1 @@
+Dialogs were refactored to provide reuse for asynchronous results, and provide full interface/impl separation.

--- a/core/src/toga/handlers.py
+++ b/core/src/toga/handlers.py
@@ -2,6 +2,7 @@ import asyncio
 import inspect
 import sys
 import traceback
+from abc import ABC
 
 
 class NativeHandler:
@@ -83,3 +84,28 @@ def wrapped_handler(interface, handler, cleanup=None):
         _handler._raw = None
 
     return _handler
+
+
+class AsyncResult(ABC):
+    def __init__(self):
+        loop = asyncio.get_event_loop()
+        self.future = loop.create_future()
+
+    def __repr__(self):
+        return f"<Async {self.RESULT_TYPE} result; future={self.future}>"
+
+    def __await__(self):
+        return self.future.__await__()
+
+    # All the comparison dunder methods are disabled
+    def __bool__(self, other):
+        raise RuntimeError(
+            f"Can't check {self.RESULT_TYPE} result directly; use await or an on_result handler"
+        )
+
+    __lt__ = __bool__
+    __le__ = __bool__
+    __eq__ = __bool__
+    __ne__ = __bool__
+    __gt__ = __bool__
+    __ge__ = __bool__

--- a/core/src/toga/window.py
+++ b/core/src/toga/window.py
@@ -3,9 +3,18 @@ from builtins import id as identifier
 from pathlib import Path
 
 from toga.command import CommandSet
-from toga.handlers import wrapped_handler
+from toga.handlers import AsyncResult, wrapped_handler
 from toga.platform import get_platform_factory
 from toga.widgets.base import WidgetRegistry
+
+
+class Dialog(AsyncResult):
+    RESULT_TYPE = "dialog"
+
+    def __init__(self, window):
+        super().__init__()
+        self.window = window
+        self.app = window.app
 
 
 class Window:
@@ -274,9 +283,11 @@ class Window:
         :returns: An awaitable Dialog object. The Dialog object returns
             ``None`` after the user pressed the 'OK' button.
         """
-        return self.factory.dialogs.InfoDialog(
-            self, title, message, on_result=wrapped_handler(self, on_result)
+        dialog = Dialog(self)
+        self.factory.dialogs.InfoDialog(
+            dialog, title, message, on_result=wrapped_handler(self, on_result)
         )
+        return dialog
 
     def question_dialog(self, title, message, on_result=None):
         """Ask the user a yes/no question.
@@ -291,9 +302,11 @@ class Window:
             ``True`` when the 'YES' button was pressed, ``False`` when
             the 'NO' button was pressed.
         """
-        return self.factory.dialogs.QuestionDialog(
-            self, title, message, on_result=wrapped_handler(self, on_result)
+        dialog = Dialog(self)
+        self.factory.dialogs.QuestionDialog(
+            dialog, title, message, on_result=wrapped_handler(self, on_result)
         )
+        return dialog
 
     def confirm_dialog(self, title, message, on_result=None):
         """Ask the user to confirm if they wish to proceed with an action.
@@ -309,9 +322,11 @@ class Window:
             ``True`` when the 'OK' button was pressed, ``False`` when
             the 'CANCEL' button was pressed.
         """
-        return self.factory.dialogs.ConfirmDialog(
-            self, title, message, on_result=wrapped_handler(self, on_result)
+        dialog = Dialog(self)
+        self.factory.dialogs.ConfirmDialog(
+            dialog, title, message, on_result=wrapped_handler(self, on_result)
         )
+        return dialog
 
     def error_dialog(self, title, message, on_result=None):
         """Ask the user to acknowledge an error state.
@@ -325,9 +340,11 @@ class Window:
         :returns: An awaitable Dialog object. The Dialog object returns
             ``None`` after the user pressed the 'OK' button.
         """
-        return self.factory.dialogs.ErrorDialog(
-            self, title, message, on_result=wrapped_handler(self, on_result)
+        dialog = Dialog(self)
+        self.factory.dialogs.ErrorDialog(
+            dialog, title, message, on_result=wrapped_handler(self, on_result)
         )
+        return dialog
 
     def stack_trace_dialog(self, title, message, content, retry=False, on_result=None):
         """Open a dialog that allows to display a large text body, such as a stack
@@ -345,17 +362,23 @@ class Window:
             returns ``True`` if the user selected retry, and ``False`` otherwise;
             if retry is not enabled, the dialog object returns ``None``.
         """
-        return self.factory.dialogs.StackTraceDialog(
-            self,
+        dialog = Dialog(self)
+        self.factory.dialogs.StackTraceDialog(
+            dialog,
             title,
             message,
             content=content,
             retry=retry,
             on_result=wrapped_handler(self, on_result),
         )
+        return dialog
 
     def save_file_dialog(
-        self, title, suggested_filename, file_types=None, on_result=None
+        self,
+        title,
+        suggested_filename,
+        file_types=None,
+        on_result=None,
     ):
         """Prompt the user for a location to save a file.
 
@@ -374,6 +397,7 @@ class Window:
             a path object for the selected file location, or ``None`` if
             the user cancelled the save operation.
         """
+        dialog = Dialog(self)
         # Convert suggested filename to a path (if it isn't already),
         # and break it into a filename and a directory
         suggested_path = Path(suggested_filename)
@@ -382,14 +406,15 @@ class Window:
             initial_directory = None
         filename = suggested_path.name
 
-        return self.factory.dialogs.SaveFileDialog(
-            self,
+        self.factory.dialogs.SaveFileDialog(
+            dialog,
             title,
             filename=filename,
             initial_directory=initial_directory,
             file_types=file_types,
             on_result=wrapped_handler(self, on_result),
         )
+        return dialog
 
     def open_file_dialog(
         self,
@@ -417,17 +442,23 @@ class Window:
             ``Path`` otherwise. Returns ``None`` if the open operation is
             cancelled by the user.
         """
-        return self.factory.dialogs.OpenFileDialog(
-            self,
+        dialog = Dialog(self)
+        self.factory.dialogs.OpenFileDialog(
+            dialog,
             title,
             initial_directory=Path(initial_directory) if initial_directory else None,
             file_types=file_types,
             multiselect=multiselect,
             on_result=wrapped_handler(self, on_result),
         )
+        return dialog
 
     def select_folder_dialog(
-        self, title, initial_directory=None, multiselect=False, on_result=None
+        self,
+        title,
+        initial_directory=None,
+        multiselect=False,
+        on_result=None,
     ):
         """Ask the user to select a directory/folder (or folders) to open.
 
@@ -446,10 +477,12 @@ class Window:
             ``Path`` otherwise. Returns ``None`` if the open operation is
             cancelled by the user.
         """
-        return self.factory.dialogs.SelectFolderDialog(
-            self,
+        dialog = Dialog(self)
+        self.factory.dialogs.SelectFolderDialog(
+            dialog,
             title,
             initial_directory=Path(initial_directory) if initial_directory else None,
             multiselect=multiselect,
             on_result=wrapped_handler(self, on_result),
         )
+        return dialog

--- a/dummy/src/toga_dummy/dialogs.py
+++ b/dummy/src/toga_dummy/dialogs.py
@@ -1,34 +1,45 @@
-class InfoDialog:
-    def __init__(self, window, title, message, on_result=None):
-        window._impl._action(
+class BaseDialog:
+    def __init__(self, interface):
+        self.interface = interface
+        self.interface._impl = self
+
+
+class InfoDialog(BaseDialog):
+    def __init__(self, interface, title, message, on_result=None):
+        super().__init__(interface)
+        interface.window._impl._action(
             "info_dialog", title=title, message=message, on_result=on_result
         )
 
 
-class QuestionDialog:
-    def __init__(self, window, title, message, on_result=None):
-        window._impl._action(
+class QuestionDialog(BaseDialog):
+    def __init__(self, interface, title, message, on_result=None):
+        super().__init__(interface)
+        interface.window._impl._action(
             "question_dialog", title=title, message=message, on_result=on_result
         )
 
 
-class ConfirmDialog:
-    def __init__(self, window, title, message, on_result=None):
-        window._impl._action(
+class ConfirmDialog(BaseDialog):
+    def __init__(self, interface, title, message, on_result=None):
+        super().__init__(interface)
+        interface.window._impl._action(
             "confirm_dialog", title=title, message=message, on_result=on_result
         )
 
 
-class ErrorDialog:
-    def __init__(self, window, title, message, on_result=None):
-        window._impl._action(
+class ErrorDialog(BaseDialog):
+    def __init__(self, interface, title, message, on_result=None):
+        super().__init__(interface)
+        interface.window._impl._action(
             "error_dialog", title=title, message=message, on_result=on_result
         )
 
 
-class StackTraceDialog:
-    def __init__(self, window, title, message, on_result=None, **kwargs):
-        window._impl._action(
+class StackTraceDialog(BaseDialog):
+    def __init__(self, interface, title, message, on_result=None, **kwargs):
+        super().__init__(interface)
+        interface.window._impl._action(
             "stack_trace_dialog",
             title=title,
             message=message,
@@ -37,17 +48,18 @@ class StackTraceDialog:
         )
 
 
-class SaveFileDialog:
+class SaveFileDialog(BaseDialog):
     def __init__(
         self,
-        window,
+        interface,
         title,
         filename,
         initial_directory,
         file_types=None,
         on_result=None,
     ):
-        window._impl._action(
+        super().__init__(interface)
+        interface.window._impl._action(
             "save_file_dialog",
             title=title,
             filename=filename,
@@ -57,11 +69,18 @@ class SaveFileDialog:
         )
 
 
-class OpenFileDialog:
+class OpenFileDialog(BaseDialog):
     def __init__(
-        self, window, title, initial_directory, file_types, multiselect, on_result=None
+        self,
+        interface,
+        title,
+        initial_directory,
+        file_types,
+        multiselect,
+        on_result=None,
     ):
-        window._impl._action(
+        super().__init__(interface)
+        interface.window._impl._action(
             "open_file_dialog",
             title=title,
             initial_directory=initial_directory,
@@ -71,9 +90,17 @@ class OpenFileDialog:
         )
 
 
-class SelectFolderDialog:
-    def __init__(self, window, title, initial_directory, multiselect, on_result=None):
-        window._impl._action(
+class SelectFolderDialog(BaseDialog):
+    def __init__(
+        self,
+        interface,
+        title,
+        initial_directory,
+        multiselect,
+        on_result=None,
+    ):
+        super().__init__(interface)
+        interface.window._impl._action(
             "select_folder_dialog",
             title=title,
             initial_directory=initial_directory,

--- a/examples/dialogs/dialogs/app.py
+++ b/examples/dialogs/dialogs/app.py
@@ -26,7 +26,7 @@ class ExampledialogsApp(toga.App):
             )
 
     async def action_confirm_dialog(self, widget):
-        if await self.main_window.question_dialog("Toga", "Are you sure you want to?"):
+        if await self.main_window.confirm_dialog("Toga", "Are you sure you want to?"):
             self.label.text = "Lets do it!"
         else:
             self.label.text = "Left it as it was."

--- a/iOS/src/toga_iOS/dialogs.py
+++ b/iOS/src/toga_iOS/dialogs.py
@@ -1,4 +1,4 @@
-import asyncio
+from abc import ABC
 
 from rubicon.objc import Block
 from rubicon.objc.runtime import objc_id
@@ -11,53 +11,35 @@ from toga_iOS.libs import (
 )
 
 
-class BaseDialog:
-    def __init__(self):
-        loop = asyncio.get_event_loop()
-        self.future = loop.create_future()
-
-    def __eq__(self, other):
-        raise RuntimeError(
-            "Can't check dialog result directly; use await or an on_result handler"
-        )
-
-    def __bool__(self):
-        raise RuntimeError(
-            "Can't check dialog result directly; use await or an on_result handler"
-        )
-
-    def __await__(self):
-        return self.future.__await__()
+class BaseDialog(ABC):
+    def __init__(self, interface):
+        self.interface = interface
+        self.interface.impl = self
 
 
 class AlertDialog(BaseDialog):
-    def __init__(self, window, title, message, on_result=None):
-        super().__init__()
+    def __init__(self, interface, title, message, on_result=None):
+        super().__init__(interface=interface)
         self.on_result = on_result
 
-        self.dialog = UIAlertController.alertControllerWithTitle(
+        self.native = UIAlertController.alertControllerWithTitle(
             title, message=message, preferredStyle=UIAlertControllerStyle.Alert
         )
 
         self.populate_dialog()
 
-        window._impl.controller.presentViewController(
-            self.dialog,
+        interface.window._impl.controller.presentViewController(
+            self.native,
             animated=False,
             completion=None,
         )
 
-    def populate_dialog(
-        self,
-        dialog,
-    ):
+    def populate_dialog(self, native):
         pass
 
     def response(self, value):
-        if self.on_result:
-            self.on_result(self, value)
-
-        self.future.set_result(value)
+        self.on_result(self, value)
+        self.interface.future.set_result(value)
 
     def null_response(self, action: objc_id) -> None:
         self.response(None)
@@ -69,7 +51,7 @@ class AlertDialog(BaseDialog):
         self.response(False)
 
     def add_null_response_button(self, label):
-        self.dialog.addAction(
+        self.native.addAction(
             UIAlertAction.actionWithTitle(
                 label,
                 style=UIAlertActionStyle.Default,
@@ -78,7 +60,7 @@ class AlertDialog(BaseDialog):
         )
 
     def add_true_response_button(self, label):
-        self.dialog.addAction(
+        self.native.addAction(
             UIAlertAction.actionWithTitle(
                 label,
                 style=UIAlertActionStyle.Default,
@@ -87,7 +69,7 @@ class AlertDialog(BaseDialog):
         )
 
     def add_false_response_button(self, label):
-        self.dialog.addAction(
+        self.native.addAction(
             UIAlertAction.actionWithTitle(
                 label,
                 style=UIAlertActionStyle.Cancel,
@@ -97,16 +79,16 @@ class AlertDialog(BaseDialog):
 
 
 class InfoDialog(AlertDialog):
-    def __init__(self, window, title, message, on_result=None):
-        super().__init__(window, title, message, on_result=on_result)
+    def __init__(self, interface, title, message, on_result=None):
+        super().__init__(interface, title, message, on_result=on_result)
 
     def populate_dialog(self):
         self.add_null_response_button("OK")
 
 
 class QuestionDialog(AlertDialog):
-    def __init__(self, window, title, message, on_result=None):
-        super().__init__(window, title, message, on_result=on_result)
+    def __init__(self, interface, title, message, on_result=None):
+        super().__init__(interface, title, message, on_result=on_result)
 
     def populate_dialog(self):
         self.add_true_response_button("Yes")
@@ -114,8 +96,8 @@ class QuestionDialog(AlertDialog):
 
 
 class ConfirmDialog(AlertDialog):
-    def __init__(self, window, title, message, on_result=None):
-        super().__init__(window, title, message, on_result=on_result)
+    def __init__(self, interface, title, message, on_result=None):
+        super().__init__(interface, title, message, on_result=on_result)
 
     def populate_dialog(self):
         self.add_true_response_button("OK")
@@ -123,42 +105,55 @@ class ConfirmDialog(AlertDialog):
 
 
 class ErrorDialog(AlertDialog):
-    def __init__(self, window, title, message, on_result=None):
-        super().__init__(window, title, message, on_result=on_result)
+    def __init__(self, interface, title, message, on_result=None):
+        super().__init__(interface, title, message, on_result=on_result)
 
     def populate_dialog(self):
         self.add_null_response_button("OK")
 
 
 class StackTraceDialog(BaseDialog):
-    def __init__(self, window, title, message, on_result=None, **kwargs):
-        super().__init__()
-        window.factory.not_implemented("Window.stack_trace_dialog()")
+    def __init__(self, interface, title, message, on_result=None, **kwargs):
+        super().__init__(interface=interface)
+        interface.window.factory.not_implemented("Window.stack_trace_dialog()")
 
 
 class SaveFileDialog(BaseDialog):
     def __init__(
         self,
-        window,
+        interface,
         title,
         filename,
         initial_directory,
         file_types=None,
         on_result=None,
     ):
-        super().__init__()
-        window.factory.not_implemented("Window.save_file_dialog()")
+        super().__init__(interface=interface)
+        interface.window.factory.not_implemented("Window.save_file_dialog()")
 
 
 class OpenFileDialog(BaseDialog):
     def __init__(
-        self, window, title, initial_directory, file_types, multiselect, on_result=None
+        self,
+        interface,
+        title,
+        initial_directory,
+        file_types,
+        multiselect,
+        on_result=None,
     ):
-        super().__init__()
-        window.factory.not_implemented("Window.open_file_dialog()")
+        super().__init__(interface=interface)
+        interface.window.factory.not_implemented("Window.open_file_dialog()")
 
 
 class SelectFolderDialog(BaseDialog):
-    def __init__(self, window, title, initial_directory, multiselect, on_result=None):
-        super().__init__()
-        window.factory.not_implemented("Window.select_folder_dialog()")
+    def __init__(
+        self,
+        interface,
+        title,
+        initial_directory,
+        multiselect,
+        on_result=None,
+    ):
+        super().__init__(interface=interface)
+        interface.window.factory.not_implemented("Window.select_folder_dialog()")

--- a/web/src/toga_web/dialogs.py
+++ b/web/src/toga_web/dialogs.py
@@ -1,6 +1,6 @@
 from abc import ABC
 
-from toga_web.libs import create_element, js
+from toga_web.libs import create_element
 
 
 class BaseDialog(ABC):
@@ -46,61 +46,100 @@ class InfoDialog(BaseDialog):
 
 
 class QuestionDialog(BaseDialog):
-    def __init__(self, window, title, message, on_result=None):
-        super().__init__()
+    def __init__(self, interface, title, message, on_result=None):
+        super().__init__(interface=interface)
+        self.on_result = on_result
 
-        # TODO: Replace with something more customized using Bootstrap modals.
-        self.interface.future.set_result(js.confirm(message))
+        interface.window.factory.not_implemented("Window.question_dialog()")
+
+        self.on_result(self, None)
+        self.interface.future.set_result(None)
 
 
 class ConfirmDialog(BaseDialog):
-    def __init__(self, window, title, message, on_result=None):
-        super().__init__()
+    def __init__(self, interface, title, message, on_result=None):
+        super().__init__(interface=interface)
+        self.on_result = on_result
 
-        # TODO: Replace with something more customized using Bootstrap modals.
-        self.interface.future.set_result(js.confirm(message))
+        interface.window.factory.not_implemented("Window.confirm_dialog()")
+
+        self.on_result(self, None)
+        self.interface.future.set_result(None)
 
 
 class ErrorDialog(BaseDialog):
-    def __init__(self, window, title, message, on_result=None):
-        super().__init__()
+    def __init__(self, interface, title, message, on_result=None):
+        super().__init__(interface=interface)
+        self.on_result = on_result
 
-        # TODO: Replace with something more customized using Bootstrap modals.
-        self.interface.future.set_result(js.alert(message))
+        interface.window.factory.not_implemented("Window.error_dialog()")
 
-
-class StackTraceDialog:
-    def __init__(self, window, title, message, on_result=None, **kwargs):
-        super().__init__()
-        # TODO: Replace with something more customized using Bootstrap modals.
-        if kwargs.get("retry"):
-            self.interface.future.set_result(
-                js.confirm("Stack trace: \n\n:" + message + "\n\nRetry?")
-            )
-        else:
-            self.interface.future.set_result(js.alert("Stack trace: \n\n:" + message))
+        self.on_result(self, None)
+        self.interface.future.set_result(None)
 
 
-class SaveFileDialog:
+class StackTraceDialog(BaseDialog):
+    def __init__(self, interface, title, message, on_result=None, **kwargs):
+        super().__init__(interface=interface)
+        self.on_result = on_result
+
+        interface.window.factory.not_implemented("Window.stack_trace_dialog()")
+
+        self.on_result(self, None)
+        self.interface.future.set_result(None)
+
+
+class SaveFileDialog(BaseDialog):
     def __init__(
         self,
-        window,
+        interface,
         title,
         filename,
         initial_directory,
         file_types=None,
         on_result=None,
     ):
-        window.factory.not_implemented("Window.save_file_dialog()")
+        super().__init__(interface=interface)
+        self.on_result = on_result
+
+        interface.window.factory.not_implemented("Window.save_file_dialog()")
+
+        self.on_result(self, None)
+        self.interface.future.set_result(None)
 
 
-class OpenFileDialog:
+class OpenFileDialog(BaseDialog):
     def __init__(
-        self, window, title, initial_directory, file_types, multiselect, on_result=None
+        self,
+        interface,
+        title,
+        initial_directory,
+        file_types,
+        multiselect,
+        on_result=None,
     ):
-        window.factory.not_implemented("Window.open_file_dialog()")
+        super().__init__(interface=interface)
+        self.on_result = on_result
+
+        interface.window.factory.not_implemented("Window.open_file_dialog()")
+
+        self.on_result(self, None)
+        self.interface.future.set_result(None)
 
 
-class SelectFolderDialog:
-    def __init__(self, window, title, initial_directory, multiselect, on_result=None):
-        window.factory.not_implemented("Window.select_folder_dialog()")
+class SelectFolderDialog(BaseDialog):
+    def __init__(
+        self,
+        interface,
+        title,
+        initial_directory,
+        multiselect,
+        on_result=None,
+    ):
+        super().__init__(interface=interface)
+        self.on_result = on_result
+
+        interface.window.factory.not_implemented("Window.select_folder_dialog()")
+
+        self.on_result(self, None)
+        self.interface.future.set_result(None)

--- a/winforms/src/toga_winforms/dialogs.py
+++ b/winforms/src/toga_winforms/dialogs.py
@@ -1,34 +1,29 @@
 import asyncio
+from abc import ABC
 from pathlib import Path
 
 from .libs import WinFont, WinForms
 from .libs.winforms import ContentAlignment, FontFamily, FontStyle, SystemFonts
 
 
-class BaseDialog:
-    def __init__(self):
-        loop = asyncio.get_event_loop()
-        self.future = loop.create_future()
-
-    def __eq__(self, other):
-        raise RuntimeError(
-            "Can't check dialog result directly; use await or an on_result handler"
-        )
-
-    def __bool__(self):
-        raise RuntimeError(
-            "Can't check dialog result directly; use await or an on_result handler"
-        )
-
-    def __await__(self):
-        return self.future.__await__()
+class BaseDialog(ABC):
+    def __init__(self, interface):
+        self.interface = interface
+        self.interface.impl = self
 
 
 class MessageDialog(BaseDialog):
     def __init__(
-        self, window, title, message, buttons, icon, success_result=None, on_result=None
+        self,
+        interface,
+        title,
+        message,
+        buttons,
+        icon,
+        success_result=None,
+        on_result=None,
     ):
-        super().__init__()
+        super().__init__(interface=interface)
         self.on_result = on_result
 
         return_value = WinForms.MessageBox.Show(message, title, buttons, icon)
@@ -42,13 +37,13 @@ class MessageDialog(BaseDialog):
         if self.on_result:
             self.on_result(self, result)
 
-        self.future.set_result(result)
+        self.interface.future.set_result(result)
 
 
 class InfoDialog(MessageDialog):
-    def __init__(self, window, title, message, on_result=None):
+    def __init__(self, interface, title, message, on_result=None):
         super().__init__(
-            window=window,
+            interface=interface,
             title=title,
             message=message,
             buttons=WinForms.MessageBoxButtons.OK,
@@ -58,9 +53,9 @@ class InfoDialog(MessageDialog):
 
 
 class QuestionDialog(MessageDialog):
-    def __init__(self, window, title, message, on_result=None):
+    def __init__(self, interface, title, message, on_result=None):
         super().__init__(
-            window=window,
+            interface=interface,
             title=title,
             message=message,
             buttons=WinForms.MessageBoxButtons.YesNo,
@@ -71,9 +66,9 @@ class QuestionDialog(MessageDialog):
 
 
 class ConfirmDialog(MessageDialog):
-    def __init__(self, window, title, message, on_result=None):
+    def __init__(self, interface, title, message, on_result=None):
         super().__init__(
-            window=window,
+            interface=interface,
             title=title,
             message=message,
             buttons=WinForms.MessageBoxButtons.OKCancel,
@@ -84,9 +79,9 @@ class ConfirmDialog(MessageDialog):
 
 
 class ErrorDialog(MessageDialog):
-    def __init__(self, window, title, message, on_result=None):
+    def __init__(self, interface, title, message, on_result=None):
         super().__init__(
-            window=window,
+            interface=interface,
             title=title,
             message=message,
             buttons=WinForms.MessageBoxButtons.OK,
@@ -97,19 +92,26 @@ class ErrorDialog(MessageDialog):
 
 class StackTraceDialog(BaseDialog):
     def __init__(
-        self, window, title, message, content, retry, on_result=None, **kwargs
+        self,
+        interface,
+        title,
+        message,
+        content,
+        retry,
+        on_result=None,
+        **kwargs,
     ):
-        super().__init__()
+        super().__init__(interface=interface)
         self.on_result = on_result
 
-        self.dialog = WinForms.Form()
-        self.dialog.MinimizeBox = False
-        self.dialog.FormBorderStyle = self.dialog.FormBorderStyle.FixedSingle
-        self.dialog.MaximizeBox = False
-        self.dialog.FormClosing += self.winforms_FormClosing
-        self.dialog.Width = 540
-        self.dialog.Height = 320
-        self.dialog.Text = title
+        self.native = WinForms.Form()
+        self.native.MinimizeBox = False
+        self.native.FormBorderStyle = self.native.FormBorderStyle.FixedSingle
+        self.native.MaximizeBox = False
+        self.native.FormClosing += self.winforms_FormClosing
+        self.native.Width = 540
+        self.native.Height = 320
+        self.native.Text = title
 
         # The top-of-page introductory message
         textLabel = WinForms.Label()
@@ -119,7 +121,7 @@ class StackTraceDialog(BaseDialog):
         textLabel.Alignment = ContentAlignment.MiddleCenter
         textLabel.Text = message
 
-        self.dialog.Controls.Add(textLabel)
+        self.native.Controls.Add(textLabel)
 
         # A scrolling text box for the stack trace.
         trace = WinForms.RichTextBox()
@@ -136,7 +138,7 @@ class StackTraceDialog(BaseDialog):
         )
         trace.Text = content
 
-        self.dialog.Controls.Add(trace)
+        self.native.Controls.Add(trace)
 
         # Add acceptance/close buttons
         if retry:
@@ -147,7 +149,7 @@ class StackTraceDialog(BaseDialog):
             retry.Text = "Retry"
             retry.Click += self.winforms_Click_retry
 
-            self.dialog.Controls.Add(retry)
+            self.native.Controls.Add(retry)
 
             quit = WinForms.Button()
             quit.Left = 400
@@ -156,7 +158,7 @@ class StackTraceDialog(BaseDialog):
             quit.Text = "Quit"
             quit.Click += self.winforms_Click_quit
 
-            self.dialog.Controls.Add(quit)
+            self.native.Controls.Add(quit)
         else:
             accept = WinForms.Button()
             accept.Left = 400
@@ -165,9 +167,9 @@ class StackTraceDialog(BaseDialog):
             accept.Text = "Ok"
             accept.Click += self.winforms_Click_accept
 
-            self.dialog.Controls.Add(accept)
+            self.native.Controls.Add(accept)
 
-        self.dialog.ShowDialog()
+        self.native.ShowDialog()
 
     def winforms_FormClosing(self, sender, event):
         # If the close button is pressed, there won't be a future yet.
@@ -175,17 +177,16 @@ class StackTraceDialog(BaseDialog):
         # If a button is pressed, the future will be set, and a close
         # event will be triggered.
         try:
-            self.future.result()
+            self.interface.future.result()
         except asyncio.InvalidStateError:
             event.Cancel = True
 
     def handle_result(self, result):
-        if self.on_result:
-            self.on_result(self, result)
+        self.on_result(self, result)
 
-        self.future.set_result(result)
+        self.interface.future.set_result(result)
 
-        self.dialog.Close()
+        self.native.Close()
 
     def winforms_Click_quit(self, sender, event):
         self.handle_result(False)
@@ -200,8 +201,8 @@ class StackTraceDialog(BaseDialog):
 class FileDialog(BaseDialog):
     def __init__(
         self,
-        dialog,
-        window,
+        native,
+        interface,
         title,
         filename,
         initial_directory,
@@ -209,16 +210,16 @@ class FileDialog(BaseDialog):
         multiselect,
         on_result=None,
     ):
-        super().__init__()
+        super().__init__(inteface=interface)
         self.on_result = on_result
 
-        dialog.Title = title
+        native.Title = title
 
         if filename is not None:
-            dialog.FileName = filename
+            native.FileName = filename
 
         if initial_directory is not None:
-            self._set_initial_directory(dialog, str(initial_directory))
+            self._set_initial_directory(native, str(initial_directory))
 
         if file_types is not None:
             filters = [f"{ext} files (*.{ext})|*.{ext}" for ext in file_types] + [
@@ -229,32 +230,31 @@ class FileDialog(BaseDialog):
                 pattern = ";".join([f"*.{ext}" for ext in file_types])
                 filters.insert(0, f"All matching files ({pattern})|{pattern}")
 
-            dialog.Filter = "|".join(filters)
+            native.Filter = "|".join(filters)
 
         if multiselect:
-            dialog.Multiselect = True
+            native.Multiselect = True
 
-        response = dialog.ShowDialog()
+        response = native.ShowDialog()
 
         if response == WinForms.DialogResult.OK:
-            result = self._get_filenames(dialog, multiselect)
+            result = self._get_filenames(native, multiselect)
         else:
             result = None
 
-        if self.on_result:
-            self.on_result(self, result)
+        self.on_result(self, result)
 
-        self.future.set_result(result)
+        self.interface.future.set_result(result)
 
     @classmethod
-    def _get_filenames(cls, dialog, multiselect):
+    def _get_filenames(cls, native, multiselect):
         if multiselect:
-            return [Path(filename) for filename in dialog.FileNames]
+            return [Path(filename) for filename in native.FileNames]
         else:
-            return Path(dialog.FileName)
+            return Path(native.FileName)
 
     @classmethod
-    def _set_initial_directory(cls, dialog, initial_directory):
+    def _set_initial_directory(cls, native, initial_directory):
         """Set the initial directory of the given dialog.
 
         On Windows, not all file/folder dialogs work the same way,
@@ -262,17 +262,17 @@ class FileDialog(BaseDialog):
         set the initial directory in some other fashion.
 
         Args:
-            dialog (WinForms.CommonDialog): the dialog to set the
+            native (WinForms.CommonDialog): the dialog to set the
                 initial directory on.
             initial_directory (str): the path of the initial directory.
         """
-        dialog.InitialDirectory = initial_directory
+        native.InitialDirectory = initial_directory
 
 
 class SaveFileDialog(FileDialog):
     def __init__(
         self,
-        window,
+        interface,
         title,
         filename,
         initial_directory,
@@ -280,8 +280,8 @@ class SaveFileDialog(FileDialog):
         on_result=None,
     ):
         super().__init__(
-            dialog=WinForms.SaveFileDialog(),
-            window=window,
+            native=WinForms.SaveFileDialog(),
+            interface=interface,
             title=title,
             filename=filename,
             initial_directory=initial_directory,
@@ -293,11 +293,17 @@ class SaveFileDialog(FileDialog):
 
 class OpenFileDialog(FileDialog):
     def __init__(
-        self, window, title, initial_directory, file_types, multiselect, on_result=None
+        self,
+        interface,
+        title,
+        initial_directory,
+        file_types,
+        multiselect,
+        on_result=None,
     ):
         super().__init__(
             dialog=WinForms.OpenFileDialog(),
-            window=window,
+            interface=interface,
             title=title,
             filename=None,
             initial_directory=initial_directory,
@@ -308,10 +314,17 @@ class OpenFileDialog(FileDialog):
 
 
 class SelectFolderDialog(FileDialog):
-    def __init__(self, window, title, initial_directory, multiselect, on_result=None):
+    def __init__(
+        self,
+        interface,
+        title,
+        initial_directory,
+        multiselect,
+        on_result=None,
+    ):
         super().__init__(
-            dialog=WinForms.FolderBrowserDialog(),
-            window=window,
+            native=WinForms.FolderBrowserDialog(),
+            interface=interface,
             title=title,
             filename=None,
             initial_directory=initial_directory,
@@ -321,10 +334,10 @@ class SelectFolderDialog(FileDialog):
         )
 
     @classmethod
-    def _get_filenames(cls, dialog, multiselect):
-        filename = Path(dialog.SelectedPath)
+    def _get_filenames(cls, native, multiselect):
+        filename = Path(native.SelectedPath)
         return [filename] if multiselect else filename
 
     @classmethod
-    def _set_initial_directory(cls, dialog, initial_directory):
-        dialog.SelectedPath = initial_directory
+    def _set_initial_directory(cls, native, initial_directory):
+        native.SelectedPath = initial_directory

--- a/winforms/src/toga_winforms/dialogs.py
+++ b/winforms/src/toga_winforms/dialogs.py
@@ -210,7 +210,7 @@ class FileDialog(BaseDialog):
         multiselect,
         on_result=None,
     ):
-        super().__init__(inteface=interface)
+        super().__init__(interface=interface)
         self.on_result = on_result
 
         native.Title = title
@@ -302,7 +302,7 @@ class OpenFileDialog(FileDialog):
         on_result=None,
     ):
         super().__init__(
-            dialog=WinForms.OpenFileDialog(),
+            native=WinForms.OpenFileDialog(),
             interface=interface,
             title=title,
             filename=None,


### PR DESCRIPTION
In the process of auditing WebView, I noticed an opportunity for code reuse in Dialog.

This refactors the Dialogs implementation so that:
1. There's a clear interface/impl separation for dialog objects
2. There's a full `interface`/`_impl`/`native` chain. This should make dialog testing simpler (hopefully?)
3. The asynchronous result capability is factored out as a base class that can be re-used

Testing regimen for this is the `dialogs` example.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
