### PR TITLE
Update type annotations for audited widgets.

### DIFF
--- a/changes/1952.misc.rst
+++ b/changes/1952.misc.rst
@@ -1,0 +1,1 @@
+Type annotations were updated for all widgets that have been audited.

--- a/core/src/toga/widgets/activityindicator.py
+++ b/core/src/toga/widgets/activityindicator.py
@@ -4,7 +4,12 @@ from .base import Widget
 
 
 class ActivityIndicator(Widget):
-    def __init__(self, id=None, style=None, running=False):
+    def __init__(
+        self,
+        id=None,
+        style=None,
+        running: bool = False,
+    ):
         """Create a new ActivityIndicator widget.
 
         Inherits from :class:`~toga.widgets.base.Widget`.
@@ -23,7 +28,7 @@ class ActivityIndicator(Widget):
             self.start()
 
     @property
-    def enabled(self):
+    def enabled(self) -> bool:
         """Is the widget currently enabled? i.e., can the user interact with the widget?
 
         ActivityIndicator widgets cannot be disabled; this property will always return
@@ -40,7 +45,7 @@ class ActivityIndicator(Widget):
         pass
 
     @property
-    def is_running(self):
+    def is_running(self) -> bool:
         """Determine if the activity indicator is currently running.
 
         Use ``start()`` and ``stop()`` to change the running state.

--- a/core/src/toga/widgets/activityindicator.py
+++ b/core/src/toga/widgets/activityindicator.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .base import Widget
 
 

--- a/core/src/toga/widgets/base.py
+++ b/core/src/toga/widgets/base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from builtins import id as identifier
 
 from travertino.node import Node

--- a/core/src/toga/widgets/base.py
+++ b/core/src/toga/widgets/base.py
@@ -21,18 +21,18 @@ class WidgetRegistry(dict):
         # method instead.
         raise RuntimeError("Widgets cannot be directly added to a registry")
 
-    def update(self, widgets):
+    def update(self, widgets: list[Widget]):
         for widget in widgets:
             self.add(widget)
 
-    def add(self, widget):
+    def add(self, widget: Widget):
         if widget.id in self:
             # Prevent from adding the same widget twice
             # or adding 2 widgets with the same id
             raise KeyError(f"There is already a widget with the id {widget.id!r}")
         super().__setitem__(widget.id, widget)
 
-    def remove(self, id):
+    def remove(self, id: str):
         del self[id]
 
     def __iter__(self):
@@ -72,7 +72,7 @@ class Widget(Node):
         return f"<{self.__class__.__name__}:0x{identifier(self):x}>"
 
     @property
-    def id(self):
+    def id(self) -> str:
         """The unique identifier for the widget."""
         return self._id
 
@@ -91,7 +91,7 @@ class Widget(Node):
     def tab_index(self, tab_index):
         self._impl.set_tab_index(tab_index)
 
-    def add(self, *children):
+    def add(self, *children: list[Widget]):
         """Add the provided widgets as children of this widget.
 
         If a child widget already has a parent, it will be re-parented as a
@@ -120,7 +120,7 @@ class Widget(Node):
         if self.window:
             self.window.content.refresh()
 
-    def insert(self, index, child):
+    def insert(self, index: int, child: Widget):
         """Insert a widget as a child of this widget.
 
         If a child widget already has a parent, it will be re-parented as a
@@ -150,7 +150,7 @@ class Widget(Node):
         if self.window:
             self.window.content.refresh()
 
-    def remove(self, *children):
+    def remove(self, *children: list[Widget]):
         """Remove the provided widgets as children of this node.
 
         Any nominated child widget that is not a child of this widget will
@@ -244,7 +244,7 @@ class Widget(Node):
             window.widgets.add(self)
 
     @property
-    def enabled(self):
+    def enabled(self) -> bool:
         """Is the widget currently enabled? i.e., can the user interact with the widget?"""
         return self._impl.get_enabled()
 

--- a/core/src/toga/widgets/box.py
+++ b/core/src/toga/widgets/box.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .base import Widget
 
 

--- a/core/src/toga/widgets/box.py
+++ b/core/src/toga/widgets/box.py
@@ -8,7 +8,7 @@ class Box(Widget):
         self,
         id=None,
         style=None,
-        children=None,
+        children: list[Widget] | None = None,
     ):
         """Create a new Box container widget.
 
@@ -30,7 +30,7 @@ class Box(Widget):
             self.add(*children)
 
     @property
-    def enabled(self):
+    def enabled(self) -> bool:
         """Is the widget currently enabled? i.e., can the user interact with the widget?
 
         Box widgets cannot be disabled; this property will always return True; any

--- a/core/src/toga/widgets/button.py
+++ b/core/src/toga/widgets/button.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from toga.handlers import wrapped_handler
 
 from .base import Widget

--- a/core/src/toga/widgets/button.py
+++ b/core/src/toga/widgets/button.py
@@ -11,8 +11,8 @@ class Button(Widget):
         text,
         id=None,
         style=None,
-        on_press=None,
-        enabled=True,
+        on_press: callable | None = None,
+        enabled: bool = True,
     ):
         """Create a new button widget.
 
@@ -41,7 +41,7 @@ class Button(Widget):
         self.enabled = enabled
 
     @property
-    def text(self):
+    def text(self) -> str:
         """The text displayed on the button.
 
         ``None``, and the Unicode codepoint U+200B (ZERO WIDTH SPACE), will be
@@ -66,7 +66,7 @@ class Button(Widget):
         self.refresh()
 
     @property
-    def on_press(self):
+    def on_press(self) -> callable:
         """The handler to invoke when the button is pressed."""
         return self._on_press
 

--- a/core/src/toga/widgets/divider.py
+++ b/core/src/toga/widgets/divider.py
@@ -30,7 +30,7 @@ class Divider(Widget):
         self.direction = direction
 
     @property
-    def enabled(self):
+    def enabled(self) -> bool:
         """Is the widget currently enabled? i.e., can the user interact with the widget?
 
         Divider widgets cannot be disabled; this property will always return True; any

--- a/core/src/toga/widgets/divider.py
+++ b/core/src/toga/widgets/divider.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .base import Widget
 
 

--- a/core/src/toga/widgets/label.py
+++ b/core/src/toga/widgets/label.py
@@ -6,7 +6,7 @@ from .base import Widget
 class Label(Widget):
     def __init__(
         self,
-        text,
+        text: str,
         id=None,
         style=None,
     ):
@@ -31,7 +31,7 @@ class Label(Widget):
         pass
 
     @property
-    def text(self):
+    def text(self) -> str:
         """The text displayed by the label.
 
         ``None``, and the Unicode codepoint U+200B (ZERO WIDTH SPACE), will be

--- a/core/src/toga/widgets/label.py
+++ b/core/src/toga/widgets/label.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .base import Widget
 
 

--- a/core/src/toga/widgets/multilinetextinput.py
+++ b/core/src/toga/widgets/multilinetextinput.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from toga.handlers import wrapped_handler
 
 from .base import Widget

--- a/core/src/toga/widgets/multilinetextinput.py
+++ b/core/src/toga/widgets/multilinetextinput.py
@@ -10,10 +10,10 @@ class MultilineTextInput(Widget):
         self,
         id=None,
         style=None,
-        value: str = None,
+        value: str | None = None,
         readonly: bool = False,
-        placeholder: str = None,
-        on_change=None,
+        placeholder: str | None = None,
+        on_change: callable | None = None,
     ):
         """Create a new multi-line text input widget.
 
@@ -96,7 +96,7 @@ class MultilineTextInput(Widget):
         self._impl.scroll_to_top()
 
     @property
-    def on_change(self):
+    def on_change(self) -> callable:
         """The handler to invoke when the value of the widget changes."""
         return self._on_change
 

--- a/core/src/toga/widgets/progressbar.py
+++ b/core/src/toga/widgets/progressbar.py
@@ -8,9 +8,9 @@ class ProgressBar(Widget):
         self,
         id=None,
         style=None,
-        max=1.0,
-        value=0.0,
-        running=False,
+        max: float = 1.0,
+        value: float = 0.0,
+        running: bool = False,
     ):
         """Create a new Progress Bar widget.
 

--- a/core/src/toga/widgets/progressbar.py
+++ b/core/src/toga/widgets/progressbar.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .base import Widget
 
 
@@ -39,7 +41,7 @@ class ProgressBar(Widget):
             self.start()
 
     @property
-    def enabled(self):
+    def enabled(self) -> bool:
         """Is the widget currently enabled? i.e., can the user interact with the widget?
 
         ProgressBar widgets cannot be disabled; this property will always return True;
@@ -52,7 +54,7 @@ class ProgressBar(Widget):
         pass
 
     @property
-    def is_running(self):
+    def is_running(self) -> bool:
         """Describe if the activity indicator is currently running.
 
         Use ``start()`` and ``stop()`` to change the running state.
@@ -62,7 +64,7 @@ class ProgressBar(Widget):
         return self._impl.is_running()
 
     @property
-    def is_determinate(self):
+    def is_determinate(self) -> bool:
         """Describe whether the progress bar has a known or indeterminate maximum.
 
         True if the progress bar has determinate length; False otherwise.
@@ -86,7 +88,7 @@ class ProgressBar(Widget):
             self._impl.stop()
 
     @property
-    def value(self):
+    def value(self) -> float:
         """The current value of the progress indicator.
 
         If the progress bar is determinate, the value must be between 0 and
@@ -104,7 +106,7 @@ class ProgressBar(Widget):
             self._impl.set_value(value)
 
     @property
-    def max(self):
+    def max(self) -> float | None:
         """The value indicating completion of the task being monitored.
 
         Must be a number > 0, or ``None`` for a task of indeterminate length.

--- a/core/src/toga/widgets/slider.py
+++ b/core/src/toga/widgets/slider.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
-from typing import Callable
 
 from toga.handlers import wrapped_handler
 
@@ -14,13 +13,13 @@ class Slider(Widget):
         self,
         id=None,
         style=None,
-        value=None,
-        range=(0, 1),
-        tick_count=None,
-        on_change=None,
-        on_press=None,
-        on_release=None,
-        enabled=True,
+        value: float | None = None,
+        range: tuple[float, float] = (0.0, 1.0),
+        tick_count: int | None = None,
+        on_change: callable | None = None,
+        on_press: callable | None = None,
+        on_release: callable | None = None,
+        enabled: bool = True,
     ):
         """Create a new slider widget.
 
@@ -99,7 +98,7 @@ class Slider(Widget):
         return value
 
     @property
-    def range(self) -> tuple[float]:
+    def range(self) -> tuple[float, float]:
         """Range of allowed values, in the form (min, max).
 
         If a range is set which doesn't include the current value, the value will be
@@ -214,7 +213,7 @@ class Slider(Widget):
             self.value = self.min + (tick_value - 1) * self.tick_step
 
     @property
-    def on_change(self) -> Callable:
+    def on_change(self) -> callable:
         """Handler to invoke when the value of the slider is changed, either by the user
         or programmatically.
 
@@ -227,7 +226,7 @@ class Slider(Widget):
         self._on_change = wrapped_handler(self, handler)
 
     @property
-    def on_press(self) -> Callable:
+    def on_press(self) -> callable:
         """Handler to invoke when the user presses the slider before changing it."""
         return self._on_press
 
@@ -236,7 +235,7 @@ class Slider(Widget):
         self._on_press = wrapped_handler(self, handler)
 
     @property
-    def on_release(self) -> Callable:
+    def on_release(self) -> callable:
         """Handler to invoke when the user releases the slider after changing it."""
         return self._on_release
 

--- a/core/src/toga/widgets/slider.py
+++ b/core/src/toga/widgets/slider.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
-from typing import Callable, Optional, Tuple
+from typing import Callable
 
 from toga.handlers import wrapped_handler
 
@@ -97,7 +99,7 @@ class Slider(Widget):
         return value
 
     @property
-    def range(self) -> Tuple[float]:
+    def range(self) -> tuple[float]:
         """Range of allowed values, in the form (min, max).
 
         If a range is set which doesn't include the current value, the value will be
@@ -137,7 +139,7 @@ class Slider(Widget):
         return self.range[1]
 
     @property
-    def tick_count(self) -> Optional[int]:
+    def tick_count(self) -> int | None:
         """Number of tick marks to display on the slider.
 
         * If this is ``None``, the slider will be continuous.
@@ -170,7 +172,7 @@ class Slider(Widget):
             self.value = old_value
 
     @property
-    def tick_step(self) -> Optional[float]:
+    def tick_step(self) -> float | None:
         """Step between adjacent ticks.
 
         * If the slider is continuous, this property returns ``None``
@@ -185,7 +187,7 @@ class Slider(Widget):
         return (self.max - self.min) / (self.tick_count - 1)
 
     @property
-    def tick_value(self) -> Optional[int]:
+    def tick_value(self) -> int | None:
         """Value of the slider, measured in ticks.
 
         * If the slider is continuous, this property returns ``None``.

--- a/core/src/toga/widgets/switch.py
+++ b/core/src/toga/widgets/switch.py
@@ -11,7 +11,7 @@ class Switch(Widget):
         text,
         id=None,
         style=None,
-        on_change=None,
+        on_change: callable | None = None,
         value: bool = False,
         enabled: bool = True,
     ):
@@ -70,7 +70,7 @@ class Switch(Widget):
         self.refresh()
 
     @property
-    def on_change(self):
+    def on_change(self) -> callable:
         """The handler to invoke when the value of the switch changes."""
         return self._on_change
 

--- a/core/src/toga/widgets/switch.py
+++ b/core/src/toga/widgets/switch.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from toga.handlers import wrapped_handler
 
 from .base import Widget
@@ -10,8 +12,8 @@ class Switch(Widget):
         id=None,
         style=None,
         on_change=None,
-        value=False,
-        enabled=True,
+        value: bool = False,
+        enabled: bool = True,
     ):
         """Create a new Switch widget.
 
@@ -21,6 +23,7 @@ class Switch(Widget):
         :param id: The ID for the widget.
         :param style: A style object. If no style is provided, a default style
             will be applied to the widget.
+        :param value: The initial value for the switch.
         :param on_change: A handler that will be invoked when the switch changes
             value.
         :param enabled: Is the switch enabled (i.e., can it be pressed?).
@@ -42,7 +45,7 @@ class Switch(Widget):
         self.enabled = enabled
 
     @property
-    def text(self):
+    def text(self) -> str:
         """The text label for the Switch.
 
         ``None``, and the Unicode codepoint U+200B (ZERO WIDTH SPACE), will be
@@ -76,7 +79,7 @@ class Switch(Widget):
         self._on_change = wrapped_handler(self, handler)
 
     @property
-    def value(self):
+    def value(self) -> bool:
         """The current state of the switch, as a Boolean.
 
         Any non-Boolean value will be converted to a Boolean.


### PR DESCRIPTION
At some point during the audit, we decided to introduce type annotations as part of documentation. 

This PR retrospectively applies type annotations (including adding `from __future__ import annotations` so we can benefit from the most recent set of typing conventions).

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
