### PR TITLE
Correct iOS delegate method prototype

### DIFF
--- a/changes/1963.misc.rst
+++ b/changes/1963.misc.rst
@@ -1,0 +1,1 @@
+The iOS handler for focus changes was corrected to correctly resign focus.

--- a/iOS/src/toga_iOS/widgets/multilinetextinput.py
+++ b/iOS/src/toga_iOS/widgets/multilinetextinput.py
@@ -42,10 +42,6 @@ class TogaMultilineTextView(UITextView, protocols=[UIKeyInput]):
         return point_inside
 
     @objc_method
-    def textViewShouldEndEditing_(self, text_view):
-        return True
-
-    @objc_method
     def textViewDidBeginEditing_(self, text_view):
         self.placeholder_label.setHidden(True)
 


### PR DESCRIPTION
After the merge of #1946, we've been seeing intermittent failures on two iOS tests:

* tests/widgets/test_multilinetextinput.py::test_focus
* tests/widgets/test_multilinetextinput.py::test_placeholder_focus

The errors are both caused when the widget being tested *loses* focus as a result of another widget being explicitly given focus. In CI conditions, the widget *doesn't* lose focus as a result of call to give the other widget focus. 

I haven't been able to reproduce this problem locally; however, via #1960 I have been able to rule out it being an issue of the event loop not catching up - a longer wait after the focus call doesn't make the test pass; this indicates that the widget is refusing to give up focus.

The willingness of a UITextView widget to give up focus is controlled by its delegate; specifically, the `textViewShouldEndEditing:` selector. This method returns `True` if the view is allowed to lose focus. 

The current implementation decleares this method, but *doesn't* declare a return type on the delegate method. ObjC only uses the argument prototype for matching, so the delegate was being found; however, the return type wasn't declared, so Rubicon would have been interpreting the `True` value as a `c_void_p` before passing to the ObjC runtime. In most cases, this will result in the right answer, but clearly there is an edge case where it could fall through and be interpreted as `False`.

The problem appears to be fixed by explicitly providing a return value of `bool` on the delegate method; but we're not actually doing anything in our custom implementation of the method, and implementation is explicitly described as [optional, with a default behavior equivalent to returning YES](https://developer.apple.com/documentation/uikit/uitextviewdelegate/1618603-textviewshouldendediting?language=objc), so we can simplify our code by removing the method entirely.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
