### PR TITLE
Make headings optional

### DIFF
--- a/changes/1767.feature.txt
+++ b/changes/1767.feature.txt
@@ -1,0 +1,2 @@
+Headings are no longer mandatory for Tree widgets.
+If headings are not provided, the widget will not display its header bar.

--- a/cocoa/src/toga_cocoa/widgets/tree.py
+++ b/cocoa/src/toga_cocoa/widgets/tree.py
@@ -218,6 +218,8 @@ class Tree(Widget):
         self.tree.columnAutoresizingStyle = NSTableViewColumnAutoresizingStyle.Uniform
         self.tree.usesAlternatingRowBackgroundColors = True
         self.tree.allowsMultipleSelection = self.interface.multiple_select
+        if self.interface.headings is None:
+            self.tree.headerView = None
 
         # Create columns for the tree
         self.columns = []
@@ -225,9 +227,7 @@ class Tree(Widget):
         # conversion from ObjC string to Python String, create the
         # ObjC string once and cache it.
         self.column_identifiers = {}
-        for i, (heading, accessor) in enumerate(
-            zip(self.interface.headings, self.interface._accessors)
-        ):
+        for accessor in self.interface._accessors:
             column_identifier = at(accessor)
             self.column_identifiers[id(column_identifier)] = accessor
             column = NSTableColumn.alloc().initWithIdentifier(column_identifier)
@@ -238,8 +238,9 @@ class Tree(Widget):
             #     column.sortDescriptorPrototype = sort_descriptor
             self.tree.addTableColumn(column)
             self.columns.append(column)
-
-            column.headerCell.stringValue = heading
+        if self.interface.headings:
+            for i, heading in enumerate(self.interface.headings):
+                self.columns[i].headerCell.stringValue = heading
 
         # Put the tree arrows in the first column.
         self.tree.outlineTableColumn = self.columns[0]

--- a/core/src/toga/sources/accessors.py
+++ b/core/src/toga/sources/accessors.py
@@ -53,7 +53,17 @@ def build_accessors(headings, accessors):
         A finalised list of accessors.
     """
     if accessors:
-        if isinstance(accessors, dict):
+        if headings is None:
+            if not isinstance(accessors, (list, tuple)):
+                raise TypeError(
+                    "When no headings are provided, accessors must be a list or tuple"
+                )
+            if not all(accessors):
+                raise ValueError(
+                    "When no headings are provided, all accessors must be defined"
+                )
+            result = accessors
+        elif isinstance(accessors, dict):
             result = [
                 accessors[h] if h in accessors else to_accessor(h) for h in headings
             ]
@@ -66,7 +76,10 @@ def build_accessors(headings, accessors):
                 for h, a in zip(headings, accessors)
             ]
     else:
-        result = [to_accessor(h) for h in headings]
+        if headings:
+            result = [to_accessor(h) for h in headings]
+        else:
+            raise ValueError("Either headings or accessors must be provided")
 
     if len(result) != len(set(result)):
         raise ValueError("Data accessors are not unique.")

--- a/core/src/toga/sources/tree_source.py
+++ b/core/src/toga/sources/tree_source.py
@@ -92,8 +92,7 @@ class TreeSource(Source):
     def _create_nodes(self, data):
         if isinstance(data, dict):
             return [
-                self._create_node(value, children)
-                for value, children in sorted(data.items())
+                self._create_node(value, children) for value, children in data.items()
             ]
         else:
             return [self._create_node(value) for value in data]

--- a/core/src/toga/widgets/tree.py
+++ b/core/src/toga/widgets/tree.py
@@ -43,7 +43,7 @@ class Tree(Widget):
 
     :param accessors: Optional; a list of attributes to access the value in the
         columns. If not given, the headings will be taken. If no headings were
-        given, accessors wil be sintesized (only for list, dict or tuple data).
+        given, accessors will be synthesized (only for list, dict or tuple data).
     :param multiple_select: Boolean; if ``True``, allows for the selection of
         multiple rows. Defaults to ``False``.
     :param on_select: A handler to be invoked when the user selects one or

--- a/core/src/toga/widgets/tree.py
+++ b/core/src/toga/widgets/tree.py
@@ -16,9 +16,22 @@ class Tree(Widget):
     :param style: An optional style object. If no style is provided then a new
         one will be created for the widget.
     :param data: The data to display in the widget. Can be an instance of
-        :class:`~toga.sources.TreeSource`, a list, dict or tuple with data to
-        display in the tree widget, or a class instance which implements the
-        interface of :class:`~toga.sources.TreeSource`. Entries can be:
+        :class:`~toga.sources.TreeSource` or a class instance which implements
+        the interface of :class:`~toga.sources.TreeSource`.
+        It can also be a list (or tuple), in this case each list item will
+        populate a row, without hierarchy.
+        It can also be a dict, in this case a key will populate a row, and its
+        value will populate children rows.
+
+        Each of these entries (list item, dict key and values) must consist of
+        a collection of cells, either:
+
+          - a list (or tuple), in which case the accessors will be matched by
+            index.
+
+          - a dict, in which case the key is used as the accessor.
+
+        The data displayed in a tree cell are:
 
           - any Python object ``value`` with a string representation. This
             string will be shown in the widget. If ``value`` has an attribute
@@ -29,7 +42,8 @@ class Tree(Widget):
             ``value`` will be used as text.
 
     :param accessors: Optional; a list of attributes to access the value in the
-        columns. If not given, the headings will be taken.
+        columns. If not given, the headings will be taken. If no headings were
+        given, accessors wil be sintesized (only for list, dict or tuple data).
     :param multiple_select: Boolean; if ``True``, allows for the selection of
         multiple rows. Defaults to ``False``.
     :param on_select: A handler to be invoked when the user selects one or

--- a/core/tests/widgets/test_tree.py
+++ b/core/tests/widgets/test_tree.py
@@ -1,85 +1,573 @@
+from unittest.mock import Mock
+
+import pytest
+
 import toga
-from toga.sources import TreeSource
-from toga_dummy.utils import TestCase
+from toga.sources import Source, TreeSource
+from toga.sources.tree_source import Node
+from toga_dummy.utils import assert_action_performed
 
 
-class TreeTests(TestCase):
-    def setUp(self):
-        super().setUp()
+@pytest.fixture
+def headings():
+    return [f"Heading {x}" for x in range(3)]
 
-        self.headings = [f"Heading {x}" for x in range(3)]
 
-        self.data = None
-        self.tree = toga.Tree(
-            headings=self.headings,
-            data=self.data,
-        )
+@pytest.fixture
+def accessors():
+    return [f"heading{i}" for i in range(3)]
 
-    def test_widget_created(self):
-        self.assertEqual(self.tree._impl.interface, self.tree)
-        self.assertActionPerformed(self.tree, "create Tree")
-        self.assertIsInstance(self.tree.data, TreeSource)
 
-        self.assertEqual(self.tree.headings, self.headings)
+@pytest.fixture
+def missing_value():
+    return "---"
 
-    def test_setter_creates_tree_with_TreeSource_data(self):
-        data = {("one", 1): [("one.one", 1.1), ("one.two", 2.1)], ("two", 2): None}
 
-        accessors = [f"heading{i}" for i in range(3)]
+@pytest.fixture
+def dict_data():
+    return {
+        ("one", 1): [
+            ("one.one", 1.1),
+            ("one.two", 2.1),
+        ],
+        ("two", 2): None,
+    }
 
-        self.tree.data = TreeSource(data=data, accessors=accessors)
 
-        self.assertIsInstance(self.tree.data, TreeSource)
-        self.assertEqual(self.tree.data[0].heading0, "one")
-        self.assertEqual(self.tree.data[0][0].heading1, 1.1)
-        self.assertEqual(self.tree.data[1].heading1, 2)
+@pytest.fixture
+def treesource_data(dict_data, accessors):
+    return TreeSource(dict_data, accessors)
 
-    def test_setter_creates_tree_with_dict_data(self):
-        self.data = {
-            ("first", 111): None,
-            ("second", 222): [],
-            ("third", 333): [
-                ("third.one", 331),
-                {"heading_0": "third.two", "heading_1": 332},
+
+@pytest.fixture
+def list_data(dict_data):
+    return list(dict_data.keys())
+
+
+@pytest.fixture
+def tuple_data(dict_data):
+    return tuple(dict_data.keys())
+
+
+@pytest.fixture
+def mysource_headings():
+    return ["Item name", "Item value"]
+
+
+@pytest.fixture
+def mysource_accessors():
+    return ["name", "value"]
+
+
+@pytest.fixture
+def mysource_data():
+    class MySource(Source):
+        def __init__(self, data):
+            super().__init__()
+            self._data = data
+
+        def __len__(self):
+            return len(self._data)
+
+        def __getitem__(self, index):
+            return self._data[index]
+
+        def can_have_children(self):
+            return True
+
+    class MyNode:
+        def __init__(self, name, value, children=None):
+            self._name = name
+            self._value = value
+            self._children = children
+
+        @property
+        def name(self):
+            return self._name
+
+        @property
+        def value(self):
+            return self._value
+
+        def __len__(self):
+            return len(self._children)
+
+        def __getitem__(self, index):
+            return self._children[index]
+
+        def can_have_children(self):
+            return self._children is not None
+
+    return MySource(
+        [
+            MyNode(
+                "one",
+                1,
+                children=[
+                    MyNode("one.one", 1.1),
+                    MyNode("one.two", 1.2),
+                ],
+            ),
+            MyNode("two", 2, children=[]),
+        ]
+    )
+
+
+@pytest.fixture
+def tree(headings, missing_value):
+    return toga.Tree(headings=headings, missing_value=missing_value)
+
+
+def test_widget_created(tree, headings, missing_value):
+    "A tree widget can be created"
+    assert tree._impl.interface is tree
+    assert_action_performed(tree, "create Tree")
+    assert isinstance(tree.data, TreeSource)
+    assert tree.headings is headings
+    assert tree.missing_value is missing_value
+    assert len(tree.data) == 0
+
+
+def test_widget_not_created():
+    "A tree widget cannot be created without arguments"
+    with pytest.raises(ValueError):
+        _ = toga.Tree()
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (False, False),
+        (True, True),
+    ],
+)
+def test_multiselect(headings, value, expected):
+    "The multiselect status of the widget can be set."
+    # Widget is initially not multiselect.
+    tree = toga.Tree(headings=headings, data=None)
+    assert tree.multiple_select is False
+
+    # Set multiselect explicitly.
+    tree = toga.Tree(headings=headings, data=None, multiple_select=value)
+    assert tree.multiple_select is expected
+
+    # Cannot change multiselect
+    with pytest.raises(AttributeError):
+        tree.multiple_select = not value
+
+
+def test_selection(tree):
+    "The selection property can be read."
+    _ = tree.selection
+    assert_action_performed(tree, "get selection")
+
+
+def test_on_select(tree):
+    "The on_select handler can be invoked."
+    # No handler initially
+    assert tree._on_select._raw is None
+
+    # Define and set a new callback
+    handler = Mock()
+
+    tree.on_select = handler
+
+    assert tree.on_select._raw == handler
+
+    # Invoke the callback
+    tree._impl.simulate_select()
+
+    # Callback was invoked
+    handler.assert_called_once_with(tree)
+
+
+def test_on_double_click(tree):
+    "The on_double_click handler can be invoked."
+    # No handler initially
+    assert tree._on_double_click._raw is None
+
+    # Define and set a new callback
+    handler = Mock()
+
+    tree.on_double_click = handler
+
+    assert tree.on_double_click._raw == handler
+
+    # Invoke the callback
+    tree._impl.simulate_double_click()
+
+    # Callback was invoked
+    handler.assert_called_once_with(tree)
+
+
+def test_accessor_synthesis_list_of_tuples():
+    "Accessors are synthesized from a list of tuples, when no headings nor accessors are provided."
+    data = [
+        ("one", 1),
+        ("two", 2),
+    ]
+    tree = toga.Tree(data=data)
+    assert isinstance(tree.data, TreeSource)
+    assert isinstance(tree.data[0], Node)
+
+    # Accessors are syntesized
+    assert len(tree._accessors) == 2
+    with pytest.raises(AttributeError):
+        _ = tree.data[0].heading0 == "one"
+    assert tree.data[0].can_have_children() is False
+
+
+def test_accessor_synthesis_dict_of_tuples():
+    "Accessors are synthesized from a dict of tuples, when no headings nor accessors are provided."
+    data = {
+        ("one", 1): None,
+        ("two", 2): None,
+    }
+    tree = toga.Tree(data=data)
+    assert isinstance(tree.data, TreeSource)
+    assert isinstance(tree.data[0], Node)
+
+    # Accessors are syntesized
+    assert len(tree._accessors) == 2
+    with pytest.raises(AttributeError):
+        _ = tree.data[0].heading0 == "one"
+    assert tree.data[0].can_have_children() is False
+
+
+def test_accessor_inference_list_of_dicts():
+    "Accessors are infered from a list of dicts, if no headings nor accessors are provided."
+    data = [
+        {"heading0": "one", "heading1": 1},
+        {"heading0": "two", "heading1": 2},
+    ]
+    tree = toga.Tree(data=data)
+    assert isinstance(tree.data, TreeSource)
+    assert isinstance(tree.data[0], Node)
+
+    # Accessors are taken from the data
+    assert len(tree._accessors) == 2
+    assert tree.data[0].heading0 == "one"
+    assert tree.data[0].can_have_children() is False
+
+
+def test_invalid_data():
+    "Accessors cannot be infered from data of wrong type."
+    data = {
+        ("one", 1),
+        ("two", 2),
+    }
+    with pytest.raises(TypeError):
+        _ = toga.Tree(data=data)
+
+
+def test_invalid_values():
+    "Accessors cannot be infered from data values of wrong type."
+    data = [
+        "one",
+        "two",
+    ]
+    with pytest.raises(TypeError):
+        _ = toga.Tree(data=data)
+
+
+def test_mixed_native_data(headings, accessors):
+    "Heterogeneous data can be be provided."
+    data = {
+        ("one", 1): [
+            ("one.one", 1.1),
+            ("one.two", (toga.Icon.DEFAULT_ICON, 1.2)),
+            ((toga.Icon.DEFAULT_ICON, "one.three"), 1.3),
+            {accessors[0]: "one.four", accessors[1]: 1.4},
+            {accessors[1]: (toga.Icon.DEFAULT_ICON, 1.5), accessors[0]: "one.five"},
+        ],
+        ("two", 2): {
+            ("two.one", 2.1): [
+                ("two.one.one", "2.1.1"),
             ],
-        }
-        self.tree.data = self.data
+            ("two.two", 2.2): None,
+        },
+        ("three", 3): None,
+        ("four", 4): {},
+        ("five", 5): [],
+    }
+    tree = toga.Tree(headings=headings, data=data, accessors=accessors)
+    assert isinstance(tree.data, TreeSource)
+    assert isinstance(tree.data[0], Node)
+    assert tree.data[0].heading0 == "one"
+    assert tree.data[0][0].heading0 == "one.one"
+    assert tree.data[0][0].heading1 == 1.1
+    assert tree.data[0][1].heading1 == (toga.Icon.DEFAULT_ICON, 1.2)
+    assert tree.data[0][2].heading0 == (toga.Icon.DEFAULT_ICON, "one.three")
+    assert tree.data[0][3].heading1 == 1.4
+    assert tree.data[0][4].heading1 == (toga.Icon.DEFAULT_ICON, 1.5)
+    assert tree.data[1].heading1 == 2
+    assert tree.data[1][0][0].heading1 == "2.1.1"
+    assert tree.data[0].can_have_children() is True
+    assert tree.data[0][0].can_have_children() is False
+    assert tree.data[1][0].can_have_children() is True
+    assert tree.data[1][1].can_have_children() is False
+    assert tree.data[2].can_have_children() is False
+    assert tree.data[3].can_have_children() is True
+    assert tree.data[4].can_have_children() is True
 
-        self.assertIsInstance(self.tree.data, TreeSource)
-        self.assertFalse(self.tree.data[0].can_have_children())
-        self.assertTrue(self.tree.data[1].can_have_children())
-        self.assertEqual(self.tree.data[1].heading_1, 222)
-        self.assertEqual(self.tree.data[2][0].heading_1, 331)
 
-    def test_data_setter_creates_tree_with_tuple_data(self):
-        pass
+##################
+# Check that the tree accessors connect to the data
+##################
 
-    def test_data_setter_creates_tree_with_list_data(self):
-        pass
 
-    def test_data_setter_creates_tree_with_data_source(self):
-        pass
+def _check_data_access(tree):
+    assert getattr(tree.data[0], tree._accessors[0]) == "one"
+    assert getattr(tree.data[0], tree._accessors[1]) == 1
 
-    def test_data_setter_creates_tree_with_data_none(self):
-        pass
 
-    def test_multiselect_getter(self):
-        super().setUp()
-        self.headings = [f"Heading {x}" for x in range(3)]
+def test_constructor_without_data_nor_headings_nor_accessors():
+    "A tree cannot be created without data, headings, accessors"
+    with pytest.raises(ValueError):
+        _ = toga.Tree()
 
-        self.data = None
-        self.tree = toga.Tree(
-            headings=self.headings,
-            data=self.data,
-            multiple_select=True,
-        )
 
-        self.assertEqual(self.tree.multiple_select, True)
+# mysource_data
+##################
 
-        self.tree = toga.Tree(
-            headings=self.headings,
-            data=self.data,
-            multiple_select=False,
-        )
 
-        self.assertEqual(self.tree.multiple_select, False)
+def test_constructor_with_source_data(
+    mysource_headings, mysource_accessors, mysource_data
+):
+    "A tree can be created with custom Source data, headings, accessors"
+    tree = toga.Tree(
+        headings=mysource_headings, data=mysource_data, accessors=mysource_accessors
+    )
+    _check_data_access(tree)
+
+
+def test_constructor_with_source_data_without_headings(
+    mysource_accessors, mysource_data
+):
+    "A tree can be created with custom Source data, accessors, without headings"
+    tree = toga.Tree(data=mysource_data, accessors=mysource_accessors)
+    _check_data_access(tree)
+
+
+def test_constructor_with_source_data_with_headings_without_accessors(
+    mysource_headings, mysource_data
+):
+    "A tree can be created with custom Source data, with headings, without accessors"
+    tree = toga.Tree(headings=mysource_headings, data=mysource_data)
+    with pytest.raises(AttributeError):
+        # unfortunately, the headings do not match the data
+        _check_data_access(tree)
+
+
+def test_constructor_with_source_data_without_headings_nor_accessors(mysource_data):
+    "A tree cannot be created with custom Source data, without headings, accessors"
+    with pytest.raises(ValueError):
+        _ = toga.Tree(data=mysource_data)
+
+
+def test_data_setter_with_source_data(
+    mysource_headings, mysource_accessors, mysource_data
+):
+    "A custom Source can be assigned to .data on a tree with accessors, headings"
+    tree = toga.Tree(headings=mysource_headings, accessors=mysource_accessors)
+    tree.data = mysource_data
+    _check_data_access(tree)
+
+
+def test_data_setter_with_source_data_without_headings(
+    mysource_accessors, mysource_data
+):
+    "A custom Source can be assigned to .data on a tree with accessors, without headings"
+    tree = toga.Tree(accessors=mysource_accessors)
+    tree.data = mysource_data
+    _check_data_access(tree)
+
+
+def test_data_setter_with_source_data_with_headings_without_accessors(
+    mysource_headings, mysource_data
+):
+    "A custom Source data cannot be assigned to .data on a tree without accessors"
+    tree = toga.Tree(headings=mysource_headings)
+    tree.data = mysource_data
+    with pytest.raises(AttributeError):
+        _check_data_access(tree)
+
+
+# treesource_data
+##################
+
+
+def test_constructor_with_treesource_data(headings, accessors, treesource_data):
+    "A tree can be created with TreeSource data, headings, accessors"
+    tree = toga.Tree(headings=headings, data=treesource_data, accessors=accessors)
+    _check_data_access(tree)
+
+
+def test_constructor_with_treesource_data_without_accessors(headings, treesource_data):
+    "A tree can be created with TreeSource data, headings, without accessors"
+    tree = toga.Tree(headings=headings, data=treesource_data)
+    with pytest.raises(AttributeError):
+        # unfortunately, the headings do not match the data
+        _check_data_access(tree)
+
+
+def test_constructor_with_treesource_data_without_headings(accessors, treesource_data):
+    "A tree can be created with TreeSource data, accessors, without headings"
+    tree = toga.Tree(data=treesource_data, accessors=accessors)
+    _check_data_access(tree)
+
+
+def test_constructor_with_treesource_data_without_headings_nor_accessors(
+    treesource_data,
+):
+    "A tree cannot be created with TreeSource data, without headings, accessors"
+    with pytest.raises(ValueError):
+        _ = toga.Tree(data=treesource_data)
+
+
+def test_data_setter_with_treesource_data(headings, accessors, treesource_data):
+    "A TreeSource can be assigned to .data on a tree with accessors, headings"
+    tree = toga.Tree(headings=headings, accessors=accessors)
+    tree.data = treesource_data
+    _check_data_access(tree)
+
+
+def test_data_setter_with_treesource_data_without_accessors(headings, treesource_data):
+    "A TreeSource can be assigned to .data on a tree with headings, without accessors"
+    tree = toga.Tree(headings=headings)
+    tree.data = treesource_data
+    with pytest.raises(AttributeError):
+        # unfortunately, the headings do not match the data
+        _check_data_access(tree)
+
+
+def test_data_setter_with_treesource_data_without_headings(accessors, treesource_data):
+    "A TreeSource can be assigned to .data on a tree with accessors, without headings"
+    tree = toga.Tree(accessors=accessors)
+    tree.data = treesource_data
+    _check_data_access(tree)
+
+
+# dict_data
+##################
+
+
+def test_constructor_with_dict_data(headings, accessors, dict_data):
+    "A tree can be created with dict data, headings, accessors"
+    tree = toga.Tree(headings=headings, data=dict_data, accessors=accessors)
+    _check_data_access(tree)
+
+
+def test_constructor_with_dict_data_without_accessors(headings, dict_data):
+    "A tree can be created with dict data, headings, without accessors"
+    tree = toga.Tree(headings=headings, data=dict_data)
+    _check_data_access(tree)
+    # accessors are derived from headings
+    assert tree._accessors[0] == "heading_0"
+
+
+def test_constructor_with_dict_data_without_headings(accessors, dict_data):
+    "A tree can be created with dict data, accessors, without headings"
+    tree = toga.Tree(data=dict_data, accessors=accessors)
+    _check_data_access(tree)
+
+
+def test_constructor_with_dict_data_without_headings_nor_accessors(dict_data):
+    "A tree can be created with dict data, without accessors, headings"
+    tree = toga.Tree(data=dict_data)
+    _check_data_access(tree)
+    # accessors are syntesized
+    with pytest.raises(AttributeError):
+        _ = tree.data[0].heading0
+    with pytest.raises(AttributeError):
+        _ = tree.data[0].heading_0
+
+
+def test_data_setter_with_dict_data(headings, accessors, dict_data):
+    "A dict can be assigned to .data on a tree with accessors, headings"
+    tree = toga.Tree(headings=headings, accessors=accessors)
+    tree.data = dict_data
+    _check_data_access(tree)
+
+
+def test_data_setter_with_dict_data_without_accessors(headings, dict_data):
+    "A dict can be assigned to .data on a tree with headings, without accessors"
+    tree = toga.Tree(headings=headings)
+    tree.data = dict_data
+    _check_data_access(tree)
+    # accessors are derived from headings
+    assert tree._accessors[0] == "heading_0"
+
+
+def test_data_setter_with_dict_data_without_headings(accessors, dict_data):
+    "A dict can be assigned to .data on a tree with accessors, without headings"
+    tree = toga.Tree(accessors=accessors)
+    tree.data = dict_data
+    _check_data_access(tree)
+
+
+# list_data / tuple_data
+##################
+
+
+@pytest.mark.parametrize("data", ["list_data", "tuple_data"])
+def test_constructor_with_list_data(headings, accessors, data, request):
+    "A tree can be created with list or tuple data, headings, accessors"
+    tree = toga.Tree(
+        headings=headings, data=request.getfixturevalue(data), accessors=accessors
+    )
+    _check_data_access(tree)
+
+
+@pytest.mark.parametrize("data", ["list_data", "tuple_data"])
+def test_constructor_with_list_data_without_accessors(headings, data, request):
+    "A tree can be created with list or tuple data, headings, without accessors"
+    tree = toga.Tree(headings=headings, data=request.getfixturevalue(data))
+    _check_data_access(tree)
+    # accessors are derived from headings
+    assert tree._accessors[0] == "heading_0"
+
+
+@pytest.mark.parametrize("data", ["list_data", "tuple_data"])
+def test_constructor_with_list_data_without_headings(accessors, data, request):
+    "A tree can be created with list or tuple data, accessors, without headings"
+    tree = toga.Tree(data=request.getfixturevalue(data), accessors=accessors)
+    _check_data_access(tree)
+
+
+@pytest.mark.parametrize("data", ["list_data", "tuple_data"])
+def test_constructor_with_list_data_without_headings_nor_accessors(data, request):
+    "A tree can be created with list or tuple data, without accessors, headings"
+    tree = toga.Tree(data=request.getfixturevalue(data))
+    _check_data_access(tree)
+    # accessors are syntesized
+    with pytest.raises(AttributeError):
+        _ = tree.data[0].heading0
+    with pytest.raises(AttributeError):
+        _ = tree.data[0].heading_0
+
+
+@pytest.mark.parametrize("data", ["list_data", "tuple_data"])
+def test_data_setter_with_list_data(headings, accessors, data, request):
+    "A list or tuple can be assigned to .data on a tree with accessors, headings"
+    tree = toga.Tree(headings=headings, accessors=accessors)
+    tree.data = request.getfixturevalue(data)
+    _check_data_access(tree)
+
+
+@pytest.mark.parametrize("data", ["list_data", "tuple_data"])
+def test_data_setter_with_list_data_without_accessors(headings, data, request):
+    "A list or tuple can be assigned to .data on a tree with headings, without accessors"
+    tree = toga.Tree(headings=headings)
+    tree.data = request.getfixturevalue(data)
+    _check_data_access(tree)
+    # accessors are derived from headings
+    assert tree._accessors[0] == "heading_0"
+
+
+@pytest.mark.parametrize("data", ["list_data", "tuple_data"])
+def test_data_setter_with_list_data_without_headings(accessors, data, request):
+    "A list or tuple can be assigned to .data on a tree with accessors, without headings"
+    tree = toga.Tree(accessors=accessors)
+    tree.data = request.getfixturevalue(data)
+    _check_data_access(tree)

--- a/dummy/src/toga_dummy/widgets/tree.py
+++ b/dummy/src/toga_dummy/widgets/tree.py
@@ -29,3 +29,9 @@ class Tree(Widget):
 
     def set_on_double_click(self, handler):
         self._set_value("on_double_click", handler)
+
+    def simulate_select(self):
+        self.interface.on_select(None)
+
+    def simulate_double_click(self):
+        self.interface.on_double_click(None)

--- a/gtk/src/toga_gtk/widgets/tree.py
+++ b/gtk/src/toga_gtk/widgets/tree.py
@@ -28,7 +28,12 @@ class Tree(Widget):
             self.selection.set_mode(Gtk.SelectionMode.SINGLE)
         self.selection.connect("changed", self.gtk_on_select)
 
-        for i, heading in enumerate(self.interface.headings):
+        if self.interface.headings:
+            _headings = self.interface.headings
+        else:
+            _headings = self.interface._accessors
+            self.treeview.set_headers_visible(False)
+        for i, heading in enumerate(_headings):
             renderer = Gtk.CellRendererText()
             column = Gtk.TreeViewColumn(heading, renderer, text=i + 1)
             self.treeview.append_column(column)


### PR DESCRIPTION
Headings is now optional for the Tree widget. 

If not provided, the widget will not show the header.

Not tested for GTK.

I took the opportunity to migrate the Tree widget tests to pytest, and improve the coverage.

Fixes #1767 

## PR Checklist:
- [ ] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
