### PR TITLE
Remove a stray instantiation in the web paths

### DIFF
--- a/changes/1988.misc.rst
+++ b/changes/1988.misc.rst
@@ -1,0 +1,1 @@
+An error in path instantiation by the web backend was corrected.

--- a/examples/tutorial0/pyproject.toml
+++ b/examples/tutorial0/pyproject.toml
@@ -53,5 +53,3 @@ requires = [
     '../../web',
 ]
 style_framework = "Shoelace v2.3"
-
-template = "../../../templates/briefcase-web-static-template"

--- a/web/src/toga_web/paths.py
+++ b/web/src/toga_web/paths.py
@@ -16,6 +16,3 @@ class Paths:
 
     def get_logs_path(self):
         return Path.home() / "log"
-
-
-paths = Paths()


### PR DESCRIPTION
In the recent updates to app paths, the web paths weren't fully tested. The web backend tries to instantiate an instance of Paths (which is no longer required); but the instantiation doesn't provide the necessary arguments, so it fails. 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
