### PR TITLE
Defer on-load event when clearing the URL on GTK.

### DIFF
--- a/changes/1989.misc.rst
+++ b/changes/1989.misc.rst
@@ -1,0 +1,1 @@
+The on_webview_load signal when setting the URL to None was deferred to the event loop, rather than being invoked immediately.

--- a/testbed/tests/widgets/test_webview.py
+++ b/testbed/tests/widgets/test_webview.py
@@ -71,8 +71,17 @@ async def assert_content_change(widget, probe, message, url, content, on_load):
 
 
 @pytest.fixture
-async def widget():
-    widget = toga.WebView(style=Pack(flex=1))
+async def on_load():
+    on_load = Mock()
+    return on_load
+
+
+@pytest.fixture
+async def widget(on_load):
+    widget = toga.WebView(style=Pack(flex=1), on_webview_load=on_load)
+    # We shouldn't be able to get a callback until at least one tick of the event loop
+    # has completed.
+    on_load.assert_not_called()
 
     # On Windows, the WebView has an asynchronous initialization process. Before we
     # start the test, make sure initialization is complete by checking the user agent.
@@ -95,13 +104,6 @@ async def widget():
                 raise
 
     return widget
-
-
-@pytest.fixture
-async def on_load(widget):
-    on_load = Mock()
-    widget.on_webview_load = on_load
-    return on_load
 
 
 async def test_set_url(widget, probe, on_load):
@@ -130,6 +132,24 @@ async def test_clear_url(widget, probe, on_load):
         message="Page has been cleared",
         url=None,
         content="",
+        on_load=on_load,
+    )
+
+
+async def test_load_empty_url(widget, probe, on_load):
+    "An empty URL can be loaded asynchronously into the view"
+    await wait_for(
+        widget.load_url(None),
+        LOAD_TIMEOUT,
+    )
+
+    # DOM loads aren't instantaneous; wait for the URL to appear
+    await assert_content_change(
+        widget,
+        probe,
+        message="Page has been loaded",
+        url=None,
+        content=ANY,
         on_load=on_load,
     )
 

--- a/testbed/tests/widgets/test_webview.py
+++ b/testbed/tests/widgets/test_webview.py
@@ -147,9 +147,9 @@ async def test_load_empty_url(widget, probe, on_load):
     await assert_content_change(
         widget,
         probe,
-        message="Page has been loaded",
+        message="Page has been cleared",
         url=None,
-        content=ANY,
+        content="",
         on_load=on_load,
     )
 


### PR DESCRIPTION
Via a report from @rmartin16 

Tutorial3 was crashing on GTK because the WebView widget was being created with no URL. This caused a URL of None to be set, which immediately triggered the on_webview_load handler. However, the widget hadn't completed construction, so the app hadn't assigned `self.webview` yet, and the handler crashed.

This problem didn't manifest in the testbed because the on_webview_load wasn't being set in the constructor. Even if it was, it wouldn't have caused a crash because the testbed event handler is a mock.

This PR puts the load notification event on the event queue. This means it will still trigger almost immediately, but it's guaranteed to occur *after* the widget has completed construction (because control must have been given back to the event loop).

This also ensures that the future is correctly cleared; this could have been triggered with `await load_url(None)`.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
