### PR TITLE
Improve error message when a platform doesn't support a widget.

### DIFF
--- a/android/src/toga_android/factory.py
+++ b/android/src/toga_android/factory.py
@@ -62,3 +62,7 @@ __all__ = [
     "Paths",
     "dialogs",
 ]
+
+
+def __getattr__(name):  # pragma: no cover
+    raise NotImplementedError(f"Toga's Android backend doesn't implement {name}")

--- a/changes/1992.feature.rst
+++ b/changes/1992.feature.rst
@@ -1,0 +1,1 @@
+A more informative error message is returned when a platform backend doesn't support a widget.

--- a/cocoa/src/toga_cocoa/factory.py
+++ b/cocoa/src/toga_cocoa/factory.py
@@ -77,3 +77,7 @@ __all__ = [
     "WebView",
     "Window",
 ]
+
+
+def __getattr__(name):  # pragma: no cover
+    raise NotImplementedError(f"Toga's Cocoa backend doesn't implement {name}")

--- a/gtk/src/toga_gtk/factory.py
+++ b/gtk/src/toga_gtk/factory.py
@@ -73,3 +73,7 @@ __all__ = [
     "WebView",
     "Window",
 ]
+
+
+def __getattr__(name):  # pragma: no cover
+    raise NotImplementedError(f"Toga's GTK backend doesn't implement {name}")

--- a/iOS/src/toga_iOS/factory.py
+++ b/iOS/src/toga_iOS/factory.py
@@ -72,3 +72,7 @@ __all__ = [
     "WebView",
     "Window",
 ]
+
+
+def __getattr__(name):  # pragma: no cover
+    raise NotImplementedError(f"Toga's iOS backend doesn't implement {name}")

--- a/web/src/toga_web/factory.py
+++ b/web/src/toga_web/factory.py
@@ -75,3 +75,7 @@ __all__ = [
     # 'WebView',
     # 'Window',
 ]
+
+
+def __getattr__(name):  # pragma: no cover
+    raise NotImplementedError(f"Toga's Web backend doesn't implement {name}")

--- a/winforms/src/toga_winforms/factory.py
+++ b/winforms/src/toga_winforms/factory.py
@@ -72,3 +72,7 @@ __all__ = [
     "WebView",
     "Window",
 ]
+
+
+def __getattr__(name):  # pragma: no cover
+    raise NotImplementedError(f"Toga's Winforms backend doesn't implement {name}")


### PR DESCRIPTION
When a platform doesn't support a widget, the user currently gets an error of the form:
```
Traceback (most recent call last):
...
  File ".../toga/widgets/datepicker.py", line 43, in __init__
    self._impl = self.factory.DatePicker(interface=self)
AttributeError: module 'toga_gtk.factory' has no attribute 'DatePicker'
```

This has been the source of regular confusion in support channels, as this isn't a clear indication that a widget isn't supported. 

This PR adds a PEP562 handler for the platform factories so that a missing widget in a factory is now reported as:

```
Traceback (most recent call last):
...
  File ".../toga_gtk/factory.py", line 83, in __getattr__
    raise NotImplementedError(f"Toga's GTK backend doesn't implement {name}")
NotImplementedError: Toga's GTK backend doesn't implement DatePicker
```

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
