### PR TITLE
Add support for `briefcase run` to examples

### DIFF
--- a/changes/1995.feature.rst
+++ b/changes/1995.feature.rst
@@ -1,0 +1,1 @@
+The example apps were updated to support being run with ``briefcase run`` on all platforms.

--- a/examples/activityindicator/CHANGELOG
+++ b/examples/activityindicator/CHANGELOG
@@ -1,0 +1,1 @@
+See Toga releases for change notes.

--- a/examples/activityindicator/LICENSE
+++ b/examples/activityindicator/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.

--- a/examples/activityindicator/pyproject.toml
+++ b/examples/activityindicator/pyproject.toml
@@ -7,49 +7,49 @@ bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
-author = 'Tiberius Yak'
+author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 
 [tool.briefcase.app.activityindicator]
 formal_name = "Activity Indicator"
 description = "A testing app"
-sources = ['activityindicator']
+sources = ["activityindicator"]
 requires = [
-    '../../core',
+    "../../core",
 ]
 
 
 [tool.briefcase.app.activityindicator.macOS]
 requires = [
-    '../../cocoa',
-    'std-nslog>=1.0.0',
+    "../../cocoa",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.activityindicator.linux]
 requires = [
-    '../../gtk',
+    "../../gtk",
 ]
 
 [tool.briefcase.app.activityindicator.windows]
 requires = [
-    '../../winforms',
+    "../../winforms",
 ]
 
 # Mobile deployments
 [tool.briefcase.app.activityindicator.iOS]
 requires = [
-    '../../iOS',
-    'std-nslog>=1.0.0',
+    "../../iOS",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.activityindicator.android]
 requires = [
-    '../../android',
+    "../../android",
 ]
 
 # Web deployment
 [tool.briefcase.app.activityindicator.web]
 requires = [
-    '../../web',
+    "../../web",
 ]
 style_framework = "Shoelace v2.3"

--- a/examples/beeliza/CHANGELOG
+++ b/examples/beeliza/CHANGELOG
@@ -1,0 +1,1 @@
+See Toga releases for change notes.

--- a/examples/beeliza/LICENSE
+++ b/examples/beeliza/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.

--- a/examples/beeliza/pyproject.toml
+++ b/examples/beeliza/pyproject.toml
@@ -7,49 +7,49 @@ bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
-author = 'Tiberius Yak'
+author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 
 [tool.briefcase.app.beeliza]
 formal_name = "Beeliza"
 description = "A testing app"
-sources = ['beeliza']
+sources = ["beeliza"]
 requires = [
-    '../../core',
+    "../../core",
 ]
 
 
 [tool.briefcase.app.beeliza.macOS]
 requires = [
-    '../../cocoa',
-    'std-nslog>=1.0.0',
+    "../../cocoa",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.beeliza.linux]
 requires = [
-    '../../gtk',
+    "../../gtk",
 ]
 
 [tool.briefcase.app.beeliza.windows]
 requires = [
-    '../../winforms',
+    "../../winforms",
 ]
 
 # Mobile deployments
 [tool.briefcase.app.beeliza.iOS]
 requires = [
-    '../../iOS',
-    'std-nslog>=1.0.0',
+    "../../iOS",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.beeliza.android]
 requires = [
-    '../../android',
+    "../../android",
 ]
 
 # Web deployment
 [tool.briefcase.app.beeliza.web]
 requires = [
-    '../../web',
+    "../../web",
 ]
 style_framework = "Shoelace v2.3"

--- a/examples/box/CHANGELOG
+++ b/examples/box/CHANGELOG
@@ -1,0 +1,1 @@
+See Toga releases for change notes.

--- a/examples/box/LICENSE
+++ b/examples/box/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.

--- a/examples/box/box/app.py
+++ b/examples/box/box/app.py
@@ -73,7 +73,7 @@ class ExampleBoxApp(toga.App):
         self.outer_box.style.background_color = GREEN
 
     def reset_color(self, widget):
-        self.outer_box.style.background_color = None
+        del self.outer_box.style.background_color
 
     def toggle_yellow_button(self, widget):
         if widget.value:

--- a/examples/box/pyproject.toml
+++ b/examples/box/pyproject.toml
@@ -7,49 +7,49 @@ bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
-author = 'Tiberius Yak'
+author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 
 [tool.briefcase.app.box]
 formal_name = "Box Demo"
 description = "A testing app"
-sources = ['box']
+sources = ["box"]
 requires = [
-    '../../core',
+    "../../core",
 ]
 
 
 [tool.briefcase.app.box.macOS]
 requires = [
-    '../../cocoa',
-    'std-nslog>=1.0.0',
+    "../../cocoa",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.box.linux]
 requires = [
-    '../../gtk',
+    "../../gtk",
 ]
 
 [tool.briefcase.app.box.windows]
 requires = [
-    '../../winforms',
+    "../../winforms",
 ]
 
 # Mobile deployments
 [tool.briefcase.app.box.iOS]
 requires = [
-    '../../iOS',
-    'std-nslog>=1.0.0',
+    "../../iOS",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.box.android]
 requires = [
-    '../../android',
+    "../../android",
 ]
 
 # Web deployment
 [tool.briefcase.app.box.web]
 requires = [
-    '../../web',
+    "../../web",
 ]
 style_framework = "Shoelace v2.3"

--- a/examples/button/CHANGELOG
+++ b/examples/button/CHANGELOG
@@ -1,0 +1,1 @@
+See Toga releases for change notes.

--- a/examples/button/LICENSE
+++ b/examples/button/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.

--- a/examples/button/pyproject.toml
+++ b/examples/button/pyproject.toml
@@ -7,49 +7,49 @@ bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
-author = 'Tiberius Yak'
+author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 
 [tool.briefcase.app.button]
 formal_name = "Button Demo"
 description = "A testing app"
-sources = ['button']
+sources = ["button"]
 requires = [
-    '../../core',
+    "../../core",
 ]
 
 
 [tool.briefcase.app.button.macOS]
 requires = [
-    '../../cocoa',
-    'std-nslog>=1.0.0',
+    "../../cocoa",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.button.linux]
 requires = [
-    '../../gtk',
+    "../../gtk",
 ]
 
 [tool.briefcase.app.button.windows]
 requires = [
-    '../../winforms',
+    "../../winforms",
 ]
 
 # Mobile deployments
 [tool.briefcase.app.button.iOS]
 requires = [
-    '../../iOS',
-    'std-nslog>=1.0.0',
+    "../../iOS",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.button.android]
 requires = [
-    '../../android',
+    "../../android",
 ]
 
 # Web deployment
 [tool.briefcase.app.button.web]
 requires = [
-    '../../web',
+    "../../web",
 ]
 style_framework = "Shoelace v2.3"

--- a/examples/canvas/CHANGELOG
+++ b/examples/canvas/CHANGELOG
@@ -1,0 +1,1 @@
+See Toga releases for change notes.

--- a/examples/canvas/LICENSE
+++ b/examples/canvas/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.

--- a/examples/canvas/pyproject.toml
+++ b/examples/canvas/pyproject.toml
@@ -7,49 +7,49 @@ bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
-author = 'Tiberius Yak'
+author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 
 [tool.briefcase.app.canvas]
 formal_name = "Canvas Demo"
 description = "A testing app"
-sources = ['canvas']
+sources = ["canvas"]
 requires = [
-    '../../core',
+    "../../core",
 ]
 
 
 [tool.briefcase.app.canvas.macOS]
 requires = [
-    '../../cocoa',
-    'std-nslog>=1.0.0',
+    "../../cocoa",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.canvas.linux]
 requires = [
-    '../../gtk',
+    "../../gtk",
 ]
 
 [tool.briefcase.app.canvas.windows]
 requires = [
-    '../../winforms',
+    "../../winforms",
 ]
 
 # Mobile deployments
 [tool.briefcase.app.canvas.iOS]
 requires = [
-    '../../iOS',
-    'std-nslog>=1.0.0',
+    "../../iOS",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.canvas.android]
 requires = [
-    '../../android',
+    "../../android",
 ]
 
 # Web deployment
 [tool.briefcase.app.canvas.web]
 requires = [
-    '../../web',
+    "../../web",
 ]
 style_framework = "Shoelace v2.3"

--- a/examples/colors/CHANGELOG
+++ b/examples/colors/CHANGELOG
@@ -1,0 +1,1 @@
+See Toga releases for change notes.

--- a/examples/colors/LICENSE
+++ b/examples/colors/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.

--- a/examples/colors/pyproject.toml
+++ b/examples/colors/pyproject.toml
@@ -7,49 +7,49 @@ bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
-author = 'Tiberius Yak'
+author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 
 [tool.briefcase.app.colors]
 formal_name = "colors"
 description = "A testing app"
-sources = ['colors']
+sources = ["colors"]
 requires = [
-    '../../core',
+    "../../core",
 ]
 
 
 [tool.briefcase.app.colors.macOS]
 requires = [
-    '../../cocoa',
-    'std-nslog>=1.0.0',
+    "../../cocoa",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.colors.linux]
 requires = [
-    '../../gtk',
+    "../../gtk",
 ]
 
 [tool.briefcase.app.colors.windows]
 requires = [
-    '../../winforms',
+    "../../winforms",
 ]
 
 # Mobile deployments
 [tool.briefcase.app.colors.iOS]
 requires = [
-    '../../iOS',
-    'std-nslog>=1.0.0',
+    "../../iOS",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.colors.android]
 requires = [
-    '../../android',
+    "../../android",
 ]
 
 # Web deployment
 [tool.briefcase.app.colors.web]
 requires = [
-    '../../web',
+    "../../web",
 ]
 style_framework = "Shoelace v2.3"

--- a/examples/command/CHANGELOG
+++ b/examples/command/CHANGELOG
@@ -1,0 +1,1 @@
+See Toga releases for change notes.

--- a/examples/command/LICENSE
+++ b/examples/command/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.

--- a/examples/command/pyproject.toml
+++ b/examples/command/pyproject.toml
@@ -32,7 +32,7 @@ requires = [
 
 [tool.briefcase.app.command.windows]
 requires = [
-	"toga-winforms",
+    "../../winforms",
 ]
 
 # Mobile deployments

--- a/examples/command/pyproject.toml
+++ b/examples/command/pyproject.toml
@@ -7,49 +7,49 @@ bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
-author = 'Tiberius Yak'
+author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 
 [tool.briefcase.app.command]
 formal_name = "Command Example"
 description = "A testing app"
-sources = ['command']
+sources = ["command"]
 requires = [
-    '../../core',
+    "../../core",
 ]
 
 
 [tool.briefcase.app.command.macOS]
 requires = [
-    '../../cocoa',
-    'std-nslog>=1.0.0',
+    "../../cocoa",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.command.linux]
 requires = [
-    '../../gtk',
+    "../../gtk",
 ]
 
 [tool.briefcase.app.command.windows]
 requires = [
-	'toga-winforms',
+	"toga-winforms",
 ]
 
 # Mobile deployments
 [tool.briefcase.app.command.iOS]
 requires = [
-    '../../iOS',
-    'std-nslog>=1.0.0',
+    "../../iOS",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.command.android]
 requires = [
-    '../../android',
+    "../../android",
 ]
 
 # Web deployment
 [tool.briefcase.app.command.web]
 requires = [
-    '../../web',
+    "../../web",
 ]
 style_framework = "Shoelace v2.3"

--- a/examples/date_and_time/CHANGELOG
+++ b/examples/date_and_time/CHANGELOG
@@ -1,0 +1,1 @@
+See Toga releases for change notes.

--- a/examples/date_and_time/LICENSE
+++ b/examples/date_and_time/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.

--- a/examples/date_and_time/pyproject.toml
+++ b/examples/date_and_time/pyproject.toml
@@ -7,49 +7,49 @@ bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
-author = 'Tiberius Yak'
+author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 
 [tool.briefcase.app.date_and_time]
 formal_name = "Date And Time"
 description = "A testing app"
-sources = ['date_and_time']
+sources = ["date_and_time"]
 requires = [
-    '../../core',
+    "../../core",
 ]
 
 
 [tool.briefcase.app.date_and_time.macOS]
 requires = [
-    '../../cocoa',
-    'std-nslog>=1.0.0',
+    "../../cocoa",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.date_and_time.linux]
 requires = [
-    '../../gtk',
+    "../../gtk",
 ]
 
 [tool.briefcase.app.date_and_time.windows]
 requires = [
-    '../../winforms',
+    "../../winforms",
 ]
 
 # Mobile deployments
 [tool.briefcase.app.date_and_time.iOS]
 requires = [
-    '../../iOS',
-    'std-nslog>=1.0.0',
+    "../../iOS",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.date_and_time.android]
 requires = [
-    '../../android',
+    "../../android",
 ]
 
 # Web deployment
 [tool.briefcase.app.date_and_time.web]
 requires = [
-    '../../web',
+    "../../web",
 ]
 style_framework = "Shoelace v2.3"

--- a/examples/detailedlist/CHANGELOG
+++ b/examples/detailedlist/CHANGELOG
@@ -1,0 +1,1 @@
+See Toga releases for change notes.

--- a/examples/detailedlist/LICENSE
+++ b/examples/detailedlist/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.

--- a/examples/detailedlist/pyproject.toml
+++ b/examples/detailedlist/pyproject.toml
@@ -7,49 +7,49 @@ bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
-author = 'Tiberius Yak'
+author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 
 [tool.briefcase.app.detailedlist]
 formal_name = "DetailedList Demo"
 description = "A testing app"
-sources = ['detailedlist']
+sources = ["detailedlist"]
 requires = [
-    '../../core',
+    "../../core",
 ]
 
 
 [tool.briefcase.app.detailedlist.macOS]
 requires = [
-    '../../cocoa',
-    'std-nslog>=1.0.0',
+    "../../cocoa",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.detailedlist.linux]
 requires = [
-    '../../gtk',
+    "../../gtk",
 ]
 
 [tool.briefcase.app.detailedlist.windows]
 requires = [
-    '../../winforms',
+    "../../winforms",
 ]
 
 # Mobile deployments
 [tool.briefcase.app.detailedlist.iOS]
 requires = [
-    '../../iOS',
-    'std-nslog>=1.0.0',
+    "../../iOS",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.detailedlist.android]
 requires = [
-    '../../android',
+    "../../android",
 ]
 
 # Web deployment
 [tool.briefcase.app.detailedlist.web]
 requires = [
-    '../../web',
+    "../../web",
 ]
 style_framework = "Shoelace v2.3"

--- a/examples/dialogs/CHANGELOG
+++ b/examples/dialogs/CHANGELOG
@@ -1,0 +1,1 @@
+See Toga releases for change notes.

--- a/examples/dialogs/LICENSE
+++ b/examples/dialogs/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.

--- a/examples/dialogs/pyproject.toml
+++ b/examples/dialogs/pyproject.toml
@@ -7,49 +7,49 @@ bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
-author = 'Tiberius Yak'
+author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 
 [tool.briefcase.app.dialogs]
 formal_name = "Dialog Demo"
 description = "A testing app"
-sources = ['dialogs']
+sources = ["dialogs"]
 requires = [
-    '../../core',
+    "../../core",
 ]
 
 
 [tool.briefcase.app.dialogs.macOS]
 requires = [
-    '../../cocoa',
-    'std-nslog>=1.0.0',
+    "../../cocoa",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.dialogs.linux]
 requires = [
-    '../../gtk',
+    "../../gtk",
 ]
 
 [tool.briefcase.app.dialogs.windows]
 requires = [
-    '../../winforms',
+    "../../winforms",
 ]
 
 # Mobile deployments
 [tool.briefcase.app.dialogs.iOS]
 requires = [
-    '../../iOS',
-    'std-nslog>=1.0.0',
+    "../../iOS",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.dialogs.android]
 requires = [
-    '../../android',
+    "../../android",
 ]
 
 # Web deployment
 [tool.briefcase.app.dialogs.web]
 requires = [
-    '../../web',
+    "../../web",
 ]
 style_framework = "Shoelace v2.3"

--- a/examples/divider/CHANGELOG
+++ b/examples/divider/CHANGELOG
@@ -1,0 +1,1 @@
+See Toga releases for change notes.

--- a/examples/divider/LICENSE
+++ b/examples/divider/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.

--- a/examples/divider/pyproject.toml
+++ b/examples/divider/pyproject.toml
@@ -7,49 +7,49 @@ bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
-author = 'Tiberius Yak'
+author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 
 [tool.briefcase.app.divider]
 formal_name = "Divider Demo"
 description = "A testing app"
-sources = ['divider']
+sources = ["divider"]
 requires = [
-    '../../core',
+    "../../core",
 ]
 
 
 [tool.briefcase.app.divider.macOS]
 requires = [
-    '../../cocoa',
-    'std-nslog>=1.0.0',
+    "../../cocoa",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.divider.linux]
 requires = [
-    '../../gtk',
+    "../../gtk",
 ]
 
 [tool.briefcase.app.divider.windows]
 requires = [
-    '../../winforms',
+    "../../winforms",
 ]
 
 # Mobile deployments
 [tool.briefcase.app.divider.iOS]
 requires = [
-    '../../iOS',
-    'std-nslog>=1.0.0',
+    "../../iOS",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.divider.android]
 requires = [
-    '../../android',
+    "../../android",
 ]
 
 # Web deployment
 [tool.briefcase.app.divider.web]
 requires = [
-    '../../web',
+    "../../web",
 ]
 style_framework = "Shoelace v2.3"

--- a/examples/examples_overview/CHANGELOG
+++ b/examples/examples_overview/CHANGELOG
@@ -1,0 +1,1 @@
+See Toga releases for change notes.

--- a/examples/examples_overview/LICENSE
+++ b/examples/examples_overview/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.

--- a/examples/examples_overview/pyproject.toml
+++ b/examples/examples_overview/pyproject.toml
@@ -7,49 +7,49 @@ bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
-author = 'Tiberius Yak'
+author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 
 [tool.briefcase.app.examples_overview]
 formal_name = "Examples Overview"
 description = "A testing app"
-sources = ['examples_overview']
+sources = ["examples_overview"]
 requires = [
-    '../../core',
+    "../../core",
 ]
 
 
 [tool.briefcase.app.examples_overview.macOS]
 requires = [
-    '../../cocoa',
-    'std-nslog>=1.0.0',
+    "../../cocoa",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.examples_overview.linux]
 requires = [
-    '../../gtk',
+    "../../gtk",
 ]
 
 [tool.briefcase.app.examples_overview.windows]
 requires = [
-    '../../winforms',
+    "../../winforms",
 ]
 
 # Mobile deployments
 [tool.briefcase.app.examples_overview.iOS]
 requires = [
-    '../../iOS',
-    'std-nslog>=1.0.0',
+    "../../iOS",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.examples_overview.android]
 requires = [
-    '../../android',
+    "../../android",
 ]
 
 # Web deployment
 [tool.briefcase.app.examples_overview.web]
 requires = [
-    '../../web',
+    "../../web",
 ]
 style_framework = "Shoelace v2.3"

--- a/examples/focus/CHANGELOG
+++ b/examples/focus/CHANGELOG
@@ -1,0 +1,1 @@
+See Toga releases for change notes.

--- a/examples/focus/LICENSE
+++ b/examples/focus/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.

--- a/examples/focus/pyproject.toml
+++ b/examples/focus/pyproject.toml
@@ -48,7 +48,7 @@ requires = [
 ]
 
 # Web deployment
-[tool.briefcase.app.examples_overview.web]
+[tool.briefcase.app.focus.web]
 requires = [
     '../../web',
 ]

--- a/examples/focus/pyproject.toml
+++ b/examples/focus/pyproject.toml
@@ -7,49 +7,49 @@ bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
-author = 'Tiberius Yak'
+author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 
 [tool.briefcase.app.focus]
 formal_name = "Focus Demo"
 description = "A testing app"
-sources = ['focus']
+sources = ["focus"]
 requires = [
-    '../../core',
+    "../../core",
 ]
 
 
 [tool.briefcase.app.focus.macOS]
 requires = [
-    '../../cocoa',
-    'std-nslog>=1.0.0',
+    "../../cocoa",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.focus.linux]
 requires = [
-    '../../gtk',
+    "../../gtk",
 ]
 
 [tool.briefcase.app.focus.windows]
 requires = [
-    '../../winforms',
+    "../../winforms",
 ]
 
 # Mobile deployments
 [tool.briefcase.app.focus.iOS]
 requires = [
-    '../../iOS',
-    'std-nslog>=1.0.0',
+    "../../iOS",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.focus.android]
 requires = [
-    '../../android',
+    "../../android",
 ]
 
 # Web deployment
 [tool.briefcase.app.focus.web]
 requires = [
-    '../../web',
+    "../../web",
 ]
 style_framework = "Shoelace v2.3"

--- a/examples/font/CHANGELOG
+++ b/examples/font/CHANGELOG
@@ -1,0 +1,1 @@
+See Toga releases for change notes.

--- a/examples/font/LICENSE
+++ b/examples/font/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.

--- a/examples/font/pyproject.toml
+++ b/examples/font/pyproject.toml
@@ -7,49 +7,49 @@ bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
-author = 'Tiberius Yak'
+author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 
 [tool.briefcase.app.font]
 formal_name = "Font Example"
 description = "A testing app"
-sources = ['font']
+sources = ["font"]
 requires = [
-    '../../core',
+    "../../core",
 ]
 
 
 [tool.briefcase.app.font.macOS]
 requires = [
-    '../../cocoa',
-    'std-nslog>=1.0.0',
+    "../../cocoa",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.font.linux]
 requires = [
-    '../../gtk',
+    "../../gtk",
 ]
 
 [tool.briefcase.app.font.windows]
 requires = [
-    '../../winforms',
+    "../../winforms",
 ]
 
 # Mobile deployments
 [tool.briefcase.app.font.iOS]
 requires = [
-    '../../iOS',
-    'std-nslog>=1.0.0',
+    "../../iOS",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.font.android]
 requires = [
-    '../../android',
+    "../../android",
 ]
 
 # Web deployment
 [tool.briefcase.app.font.web]
 requires = [
-    '../../web',
+    "../../web",
 ]
 style_framework = "Shoelace v2.3"

--- a/examples/font_size/CHANGELOG
+++ b/examples/font_size/CHANGELOG
@@ -1,0 +1,1 @@
+See Toga releases for change notes.

--- a/examples/font_size/LICENSE
+++ b/examples/font_size/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.

--- a/examples/font_size/pyproject.toml
+++ b/examples/font_size/pyproject.toml
@@ -7,48 +7,48 @@ bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
-author = 'Tiberius Yak'
+author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 
 [tool.briefcase.app.font_size]
 formal_name = "Font size Test"
 description = "A testing app"
-sources = ['font_size']
+sources = ["font_size"]
 requires = [
-    '../../core',
+    "../../core",
 ]
 
 [tool.briefcase.app.font_size.macOS]
 requires = [
-    '../../cocoa',
-    'std-nslog>=1.0.0',
+    "../../cocoa",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.font_size.linux]
 requires = [
-    '../../gtk',
+    "../../gtk",
 ]
 
 [tool.briefcase.app.font_size.windows]
 requires = [
-    '../../winforms',
+    "../../winforms",
 ]
 
 # Mobile deployments
 [tool.briefcase.app.font_size.iOS]
 requires = [
-    '../../iOS',
-    'std-nslog>=1.0.0',
+    "../../iOS",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.font_size.android]
 requires = [
-    '../../android',
+    "../../android",
 ]
 
 # Web deployment
 [tool.briefcase.app.font_size.web]
 requires = [
-    '../../web',
+    "../../web",
 ]
 style_framework = "Shoelace v2.3"

--- a/examples/handlers/CHANGELOG
+++ b/examples/handlers/CHANGELOG
@@ -1,0 +1,1 @@
+See Toga releases for change notes.

--- a/examples/handlers/LICENSE
+++ b/examples/handlers/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.

--- a/examples/handlers/pyproject.toml
+++ b/examples/handlers/pyproject.toml
@@ -7,49 +7,49 @@ bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
-author = 'Tiberius Yak'
+author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 
 [tool.briefcase.app.handlers]
 formal_name = "Handler Demo"
 description = "A testing app"
-sources = ['handlers']
+sources = ["handlers"]
 requires = [
-    '../../core',
+    "../../core",
 ]
 
 
 [tool.briefcase.app.handlers.macOS]
 requires = [
-    '../../cocoa',
-    'std-nslog>=1.0.0',
+    "../../cocoa",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.handlers.linux]
 requires = [
-    '../../gtk',
+    "../../gtk",
 ]
 
 [tool.briefcase.app.handlers.windows]
 requires = [
-    '../../winforms',
+    "../../winforms",
 ]
 
 # Mobile deployments
 [tool.briefcase.app.handlers.iOS]
 requires = [
-    '../../iOS',
-    'std-nslog>=1.0.0',
+    "../../iOS",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.handlers.android]
 requires = [
-    '../../android',
+    "../../android",
 ]
 
 # Web deployment
 [tool.briefcase.app.handlers.web]
 requires = [
-    '../../web',
+    "../../web",
 ]
 style_framework = "Shoelace v2.3"

--- a/examples/imageview/CHANGELOG
+++ b/examples/imageview/CHANGELOG
@@ -1,0 +1,1 @@
+See Toga releases for change notes.

--- a/examples/imageview/LICENSE
+++ b/examples/imageview/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.

--- a/examples/imageview/pyproject.toml
+++ b/examples/imageview/pyproject.toml
@@ -16,7 +16,6 @@ description = "A testing app"
 sources = ['imageview']
 requires = [
     '../../core',
-    "Pillow",
 ]
 
 
@@ -24,16 +23,19 @@ requires = [
 requires = [
     '../../cocoa',
     'std-nslog>=1.0.0',
+    'Pillow',
 ]
 
 [tool.briefcase.app.imageview.linux]
 requires = [
     '../../gtk',
+    'Pillow',
 ]
 
 [tool.briefcase.app.imageview.windows]
 requires = [
     '../../winforms',
+    'Pillow',
 ]
 
 # Mobile deployments
@@ -46,6 +48,8 @@ requires = [
 [tool.briefcase.app.imageview.android]
 requires = [
     '../../android',
+    'Pillow==9.2.0; python_version=="3.10" or python_version=="3.9"',
+    'Pillow==8.4.0; python_version=="3.8"',
 ]
 
 # Web deployment

--- a/examples/imageview/pyproject.toml
+++ b/examples/imageview/pyproject.toml
@@ -43,6 +43,7 @@ requires = [
 requires = [
     "../../iOS",
     "std-nslog>=1.0.0",
+    "Pillow==9.4.0",
 ]
 
 [tool.briefcase.app.imageview.android]

--- a/examples/imageview/pyproject.toml
+++ b/examples/imageview/pyproject.toml
@@ -7,54 +7,54 @@ bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
-author = 'Tiberius Yak'
+author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 
 [tool.briefcase.app.imageview]
 formal_name = "ImageView Demo"
 description = "A testing app"
-sources = ['imageview']
+sources = ["imageview"]
 requires = [
-    '../../core',
+    "../../core",
 ]
 
 
 [tool.briefcase.app.imageview.macOS]
 requires = [
-    '../../cocoa',
-    'std-nslog>=1.0.0',
-    'Pillow',
+    "../../cocoa",
+    "std-nslog>=1.0.0",
+    "Pillow",
 ]
 
 [tool.briefcase.app.imageview.linux]
 requires = [
-    '../../gtk',
-    'Pillow',
+    "../../gtk",
+    "Pillow",
 ]
 
 [tool.briefcase.app.imageview.windows]
 requires = [
-    '../../winforms',
-    'Pillow',
+    "../../winforms",
+    "Pillow",
 ]
 
 # Mobile deployments
 [tool.briefcase.app.imageview.iOS]
 requires = [
-    '../../iOS',
-    'std-nslog>=1.0.0',
+    "../../iOS",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.imageview.android]
 requires = [
-    '../../android',
-    'Pillow==9.2.0; python_version=="3.10" or python_version=="3.9"',
-    'Pillow==8.4.0; python_version=="3.8"',
+    "../../android",
+    "Pillow==9.2.0; python_version=='3.10' or python_version=='3.9'",
+    "Pillow==8.4.0; python_version=='3.8'",
 ]
 
 # Web deployment
 [tool.briefcase.app.imageview.web]
 requires = [
-    '../../web',
+    "../../web",
 ]
 style_framework = "Shoelace v2.3"

--- a/examples/layout/CHANGELOG
+++ b/examples/layout/CHANGELOG
@@ -1,0 +1,1 @@
+See Toga releases for change notes.

--- a/examples/layout/LICENSE
+++ b/examples/layout/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.

--- a/examples/layout/pyproject.toml
+++ b/examples/layout/pyproject.toml
@@ -7,49 +7,49 @@ bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
-author = 'Tiberius Yak'
+author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 
 [tool.briefcase.app.layout]
 formal_name = "Layout Test"
 description = "A testing app"
-sources = ['layout']
+sources = ["layout"]
 requires = [
-    '../../core',
+    "../../core",
 ]
 
 
 [tool.briefcase.app.layout.macOS]
 requires = [
-    '../../cocoa',
-    'std-nslog>=1.0.0',
+    "../../cocoa",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.layout.linux]
 requires = [
-    '../../gtk',
+    "../../gtk",
 ]
 
 [tool.briefcase.app.layout.windows]
 requires = [
-    '../../winforms',
+    "../../winforms",
 ]
 
 # Mobile deployments
 [tool.briefcase.app.layout.iOS]
 requires = [
-    '../../iOS',
-    'std-nslog>=1.0.0',
+    "../../iOS",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.layout.android]
 requires = [
-    '../../android',
+    "../../android",
 ]
 
 # Web deployment
 [tool.briefcase.app.layout.web]
 requires = [
-    '../../web',
+    "../../web",
 ]
 style_framework = "Shoelace v2.3"

--- a/examples/multilinetextinput/CHANGELOG
+++ b/examples/multilinetextinput/CHANGELOG
@@ -1,0 +1,1 @@
+See Toga releases for change notes.

--- a/examples/multilinetextinput/LICENSE
+++ b/examples/multilinetextinput/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.

--- a/examples/multilinetextinput/pyproject.toml
+++ b/examples/multilinetextinput/pyproject.toml
@@ -7,49 +7,49 @@ bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
-author = 'Tiberius Yak'
+author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 
 [tool.briefcase.app.multilinetextinput]
 formal_name = "MultilineTextInput Demo"
 description = "A testing app"
-sources = ['multilinetextinput']
+sources = ["multilinetextinput"]
 requires = [
-    '../../core',
+    "../../core",
 ]
 
 
 [tool.briefcase.app.multilinetextinput.macOS]
 requires = [
-    '../../cocoa',
-    'std-nslog>=1.0.0',
+    "../../cocoa",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.multilinetextinput.linux]
 requires = [
-    '../../gtk',
+    "../../gtk",
 ]
 
 [tool.briefcase.app.multilinetextinput.windows]
 requires = [
-    '../../winforms',
+    "../../winforms",
 ]
 
 # Mobile deployments
 [tool.briefcase.app.multilinetextinput.iOS]
 requires = [
-    '../../iOS',
-    'std-nslog>=1.0.0',
+    "../../iOS",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.multilinetextinput.android]
 requires = [
-    '../../android',
+    "../../android",
 ]
 
 # Web deployment
 [tool.briefcase.app.multilinetextinput.web]
 requires = [
-    '../../web',
+    "../../web",
 ]
 style_framework = "Shoelace v2.3"

--- a/examples/numberinput/CHANGELOG
+++ b/examples/numberinput/CHANGELOG
@@ -1,0 +1,1 @@
+See Toga releases for change notes.

--- a/examples/numberinput/LICENSE
+++ b/examples/numberinput/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.

--- a/examples/numberinput/pyproject.toml
+++ b/examples/numberinput/pyproject.toml
@@ -7,49 +7,49 @@ bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
-author = 'Tiberius Yak'
+author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 
 [tool.briefcase.app.numberinput]
 formal_name = "Demo NumberInput"
 description = "A testing app"
-sources = ['numberinput']
+sources = ["numberinput"]
 requires = [
-    '../../core',
+    "../../core",
 ]
 
 
 [tool.briefcase.app.numberinput.macOS]
 requires = [
-    '../../cocoa',
-    'std-nslog>=1.0.0',
+    "../../cocoa",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.numberinput.linux]
 requires = [
-    '../../gtk',
+    "../../gtk",
 ]
 
 [tool.briefcase.app.numberinput.windows]
 requires = [
-    '../../winforms',
+    "../../winforms",
 ]
 
 # Mobile deployments
 [tool.briefcase.app.numberinput.iOS]
 requires = [
-    '../../iOS',
-    'std-nslog>=1.0.0',
+    "../../iOS",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.numberinput.android]
 requires = [
-    '../../android',
+    "../../android",
 ]
 
 # Web deployment
 [tool.briefcase.app.numberinput.web]
 requires = [
-    '../../web',
+    "../../web",
 ]
 style_framework = "Shoelace v2.3"

--- a/examples/optioncontainer/CHANGELOG
+++ b/examples/optioncontainer/CHANGELOG
@@ -1,0 +1,1 @@
+See Toga releases for change notes.

--- a/examples/optioncontainer/LICENSE
+++ b/examples/optioncontainer/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.

--- a/examples/optioncontainer/pyproject.toml
+++ b/examples/optioncontainer/pyproject.toml
@@ -7,49 +7,49 @@ bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
-author = 'Tiberius Yak'
+author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 
 [tool.briefcase.app.optioncontainer]
 formal_name = "Option Container Example"
 description = "A testing app"
-sources = ['optioncontainer']
+sources = ["optioncontainer"]
 requires = [
-    '../../core',
+    "../../core",
 ]
 
 
 [tool.briefcase.app.optioncontainer.macOS]
 requires = [
-    '../../cocoa',
-    'std-nslog>=1.0.0',
+    "../../cocoa",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.optioncontainer.linux]
 requires = [
-    '../../gtk',
+    "../../gtk",
 ]
 
 [tool.briefcase.app.optioncontainer.windows]
 requires = [
-    '../../winforms',
+    "../../winforms",
 ]
 
 # Mobile deployments
 [tool.briefcase.app.optioncontainer.iOS]
 requires = [
-    '../../iOS',
-    'std-nslog>=1.0.0',
+    "../../iOS",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.optioncontainer.android]
 requires = [
-    '../../android',
+    "../../android",
 ]
 
 # Web deployment
 [tool.briefcase.app.optioncontainer.web]
 requires = [
-    '../../web',
+    "../../web",
 ]
 style_framework = "Shoelace v2.3"

--- a/examples/positron-django/CHANGELOG
+++ b/examples/positron-django/CHANGELOG
@@ -1,0 +1,1 @@
+See Toga releases for change notes.

--- a/examples/positron-django/LICENSE
+++ b/examples/positron-django/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.

--- a/examples/positron-django/pyproject.toml
+++ b/examples/positron-django/pyproject.toml
@@ -7,51 +7,51 @@ bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
-author = 'Tiberius Yak'
+author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 
 [tool.briefcase.app.positron]
 formal_name = "Positron"
 description = "Electron, but in Python"
 icon = "src/positron/resources/positron"
-sources = ['src/positron', 'src/webapp']
+sources = ["src/positron", "src/webapp"]
 requires = [
-    '../../core',
-    'django~=4.1',
+    "../../core",
+    "django~=4.1",
 ]
 
 
 [tool.briefcase.app.positron.macOS]
 requires = [
-    '../../cocoa',
-    'std-nslog>=1.0.0',
+    "../../cocoa",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.positron.linux]
 requires = [
-    '../../gtk',
+    "../../gtk",
 ]
 
 [tool.briefcase.app.positron.windows]
 requires = [
-    '../../winforms',
+    "../../winforms",
 ]
 
 # Mobile deployments
 [tool.briefcase.app.positron.iOS]
 requires = [
-    '../../iOS',
-    'std-nslog>=1.0.0',
+    "../../iOS",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.positron.android]
 requires = [
-    '../../android',
+    "../../android",
 ]
 
 # Web deployment
 [tool.briefcase.app.positron.web]
 requires = [
-    '../../web',
+    "../../web",
 ]
 style_framework = "Shoelace v2.3"

--- a/examples/positron-static/CHANGELOG
+++ b/examples/positron-static/CHANGELOG
@@ -1,0 +1,1 @@
+See Toga releases for change notes.

--- a/examples/positron-static/LICENSE
+++ b/examples/positron-static/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.

--- a/examples/positron-static/pyproject.toml
+++ b/examples/positron-static/pyproject.toml
@@ -7,50 +7,50 @@ bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
-author = 'Tiberius Yak'
+author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 
 [tool.briefcase.app.positron]
 formal_name = "Positron"
 description = "Electron, but in Python"
 icon = "src/positron/resources/positron"
-sources = ['src/positron']
+sources = ["src/positron"]
 requires = [
-    '../../core',
+    "../../core",
 ]
 
 
 [tool.briefcase.app.positron.macOS]
 requires = [
-    '../../cocoa',
-    'std-nslog>=1.0.0',
+    "../../cocoa",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.positron.linux]
 requires = [
-    '../../gtk',
+    "../../gtk",
 ]
 
 [tool.briefcase.app.positron.windows]
 requires = [
-    '../../winforms',
+    "../../winforms",
 ]
 
 # Mobile deployments
 [tool.briefcase.app.positron.iOS]
 requires = [
-    '../../iOS',
-    'std-nslog>=1.0.0',
+    "../../iOS",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.positron.android]
 requires = [
-    '../../android',
+    "../../android",
 ]
 
 # Web deployment
 [tool.briefcase.app.positron.web]
 requires = [
-    '../../web',
+    "../../web",
 ]
 style_framework = "Shoelace v2.3"

--- a/examples/positron-static/src/positron/app.py
+++ b/examples/positron-static/src/positron/app.py
@@ -1,4 +1,4 @@
-from http.server import HTTPServer, SimpleHTTPRequestHandler
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from threading import Event, Thread
 
 import toga
@@ -9,7 +9,7 @@ class HTTPHandler(SimpleHTTPRequestHandler):
         return str(self.server.base_path / path[1:])
 
 
-class LocalHTTPServer(HTTPServer):
+class LocalHTTPServer(ThreadingHTTPServer):
     def __init__(self, base_path, RequestHandlerClass=HTTPHandler):
         self.base_path = base_path
         # Use port 0 to let the server select an available port.

--- a/examples/progressbar/CHANGELOG
+++ b/examples/progressbar/CHANGELOG
@@ -1,0 +1,1 @@
+See Toga releases for change notes.

--- a/examples/progressbar/LICENSE
+++ b/examples/progressbar/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.

--- a/examples/progressbar/pyproject.toml
+++ b/examples/progressbar/pyproject.toml
@@ -7,49 +7,49 @@ bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
-author = 'Tiberius Yak'
+author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 
 [tool.briefcase.app.progressbar]
 formal_name = "ProgressBar demo"
 description = "A testing app"
-sources = ['progressbar']
+sources = ["progressbar"]
 requires = [
-    '../../core',
+    "../../core",
 ]
 
 
 [tool.briefcase.app.progressbar.macOS]
 requires = [
-    '../../cocoa',
-    'std-nslog>=1.0.0',
+    "../../cocoa",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.progressbar.linux]
 requires = [
-    '../../gtk',
+    "../../gtk",
 ]
 
 [tool.briefcase.app.progressbar.windows]
 requires = [
-    '../../winforms',
+    "../../winforms",
 ]
 
 # Mobile deployments
 [tool.briefcase.app.progressbar.iOS]
 requires = [
-    '../../iOS',
-    'std-nslog>=1.0.0',
+    "../../iOS",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.progressbar.android]
 requires = [
-    '../../android',
+    "../../android",
 ]
 
 # Web deployment
 [tool.briefcase.app.progressbar.web]
 requires = [
-    '../../web',
+    "../../web",
 ]
 style_framework = "Shoelace v2.3"

--- a/examples/resize/CHANGELOG
+++ b/examples/resize/CHANGELOG
@@ -1,0 +1,1 @@
+See Toga releases for change notes.

--- a/examples/resize/LICENSE
+++ b/examples/resize/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.

--- a/examples/resize/pyproject.toml
+++ b/examples/resize/pyproject.toml
@@ -7,49 +7,49 @@ bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
-author = 'Tiberius Yak'
+author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 
 [tool.briefcase.app.resize]
 formal_name = "Resize Test"
 description = "A testing app"
-sources = ['resize']
+sources = ["resize"]
 requires = [
-    '../../core',
+    "../../core",
 ]
 
 
 [tool.briefcase.app.resize.macOS]
 requires = [
-    '../../cocoa',
-    'std-nslog>=1.0.0',
+    "../../cocoa",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.resize.linux]
 requires = [
-    '../../gtk',
+    "../../gtk",
 ]
 
 [tool.briefcase.app.resize.windows]
 requires = [
-    '../../winforms',
+    "../../winforms",
 ]
 
 # Mobile deployments
 [tool.briefcase.app.resize.iOS]
 requires = [
-    '../../iOS',
-    'std-nslog>=1.0.0',
+    "../../iOS",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.resize.android]
 requires = [
-    '../../android',
+    "../../android",
 ]
 
 # Web deployment
 [tool.briefcase.app.resize.web]
 requires = [
-    '../../web',
+    "../../web",
 ]
 style_framework = "Shoelace v2.3"

--- a/examples/scrollcontainer/CHANGELOG
+++ b/examples/scrollcontainer/CHANGELOG
@@ -1,0 +1,1 @@
+See Toga releases for change notes.

--- a/examples/scrollcontainer/LICENSE
+++ b/examples/scrollcontainer/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.

--- a/examples/scrollcontainer/pyproject.toml
+++ b/examples/scrollcontainer/pyproject.toml
@@ -7,49 +7,49 @@ bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
-author = 'Tiberius Yak'
+author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 
 [tool.briefcase.app.scrollcontainer]
 formal_name = "ScrollContainer Demo"
 description = "A testing app"
-sources = ['scrollcontainer']
+sources = ["scrollcontainer"]
 requires = [
-    '../../core',
+    "../../core",
 ]
 
 
 [tool.briefcase.app.scrollcontainer.macOS]
 requires = [
-    '../../cocoa',
-    'std-nslog>=1.0.0',
+    "../../cocoa",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.scrollcontainer.linux]
 requires = [
-    '../../gtk',
+    "../../gtk",
 ]
 
 [tool.briefcase.app.scrollcontainer.windows]
 requires = [
-    '../../winforms',
+    "../../winforms",
 ]
 
 # Mobile deployments
 [tool.briefcase.app.scrollcontainer.iOS]
 requires = [
-    '../../iOS',
-    'std-nslog>=1.0.0',
+    "../../iOS",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.scrollcontainer.android]
 requires = [
-    '../../android',
+    "../../android",
 ]
 
 # Web deployment
 [tool.briefcase.app.scrollcontainer.web]
 requires = [
-    '../../web',
+    "../../web",
 ]
 style_framework = "Shoelace v2.3"

--- a/examples/selection/CHANGELOG
+++ b/examples/selection/CHANGELOG
@@ -1,0 +1,1 @@
+See Toga releases for change notes.

--- a/examples/selection/LICENSE
+++ b/examples/selection/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.

--- a/examples/selection/pyproject.toml
+++ b/examples/selection/pyproject.toml
@@ -7,49 +7,49 @@ bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
-author = 'Tiberius Yak'
+author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 
 [tool.briefcase.app.selection]
 formal_name = "Selection Demo"
 description = "A testing app"
-sources = ['selection']
+sources = ["selection"]
 requires = [
-    '../../core',
+    "../../core",
 ]
 
 
 [tool.briefcase.app.selection.macOS]
 requires = [
-    '../../cocoa',
-    'std-nslog>=1.0.0',
+    "../../cocoa",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.selection.linux]
 requires = [
-    '../../gtk',
+    "../../gtk",
 ]
 
 [tool.briefcase.app.selection.windows]
 requires = [
-    '../../winforms',
+    "../../winforms",
 ]
 
 # Mobile deployments
 [tool.briefcase.app.selection.iOS]
 requires = [
-    '../../iOS',
-    'std-nslog>=1.0.0',
+    "../../iOS",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.selection.android]
 requires = [
-    '../../android',
+    "../../android",
 ]
 
 # Web deployment
 [tool.briefcase.app.selection.web]
 requires = [
-    '../../web',
+    "../../web",
 ]
 style_framework = "Shoelace v2.3"

--- a/examples/slider/CHANGELOG
+++ b/examples/slider/CHANGELOG
@@ -1,0 +1,1 @@
+See Toga releases for change notes.

--- a/examples/slider/LICENSE
+++ b/examples/slider/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.

--- a/examples/slider/pyproject.toml
+++ b/examples/slider/pyproject.toml
@@ -7,49 +7,49 @@ bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
-author = 'Tiberius Yak'
+author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 
 [tool.briefcase.app.slider]
 formal_name = "Slider Demo"
 description = "A testing app"
-sources = ['slider']
+sources = ["slider"]
 requires = [
-    '../../core',
+    "../../core",
 ]
 
 
 [tool.briefcase.app.slider.macOS]
 requires = [
-    '../../cocoa',
-    'std-nslog>=1.0.0',
+    "../../cocoa",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.slider.linux]
 requires = [
-    '../../gtk',
+    "../../gtk",
 ]
 
 [tool.briefcase.app.slider.windows]
 requires = [
-    '../../winforms',
+    "../../winforms",
 ]
 
 # Mobile deployments
 [tool.briefcase.app.slider.iOS]
 requires = [
-    '../../iOS',
-    'std-nslog>=1.0.0',
+    "../../iOS",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.slider.android]
 requires = [
-    '../../android',
+    "../../android",
 ]
 
 # Web deployment
 [tool.briefcase.app.slider.web]
 requires = [
-    '../../web',
+    "../../web",
 ]
 style_framework = "Shoelace v2.3"

--- a/examples/switch_demo/CHANGELOG
+++ b/examples/switch_demo/CHANGELOG
@@ -1,0 +1,1 @@
+See Toga releases for change notes.

--- a/examples/switch_demo/LICENSE
+++ b/examples/switch_demo/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.

--- a/examples/switch_demo/pyproject.toml
+++ b/examples/switch_demo/pyproject.toml
@@ -7,49 +7,49 @@ bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
-author = 'Tiberius Yak'
+author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 
 [tool.briefcase.app.switch_demo]
 formal_name = "Switch Demo"
 description = "A testing app"
-sources = ['switch_demo']
+sources = ["switch_demo"]
 requires = [
-    '../../core',
+    "../../core",
 ]
 
 
 [tool.briefcase.app.switch_demo.macOS]
 requires = [
-    '../../cocoa',
-    'std-nslog>=1.0.0',
+    "../../cocoa",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.switch_demo.linux]
 requires = [
-    '../../gtk',
+    "../../gtk",
 ]
 
 [tool.briefcase.app.switch_demo.windows]
 requires = [
-    '../../winforms',
+    "../../winforms",
 ]
 
 # Mobile deployments
 [tool.briefcase.app.switch_demo.iOS]
 requires = [
-    '../../iOS',
-    'std-nslog>=1.0.0',
+    "../../iOS",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.switch_demo.android]
 requires = [
-    '../../android',
+    "../../android",
 ]
 
 # Web deployment
 [tool.briefcase.app.switch_demo.web]
 requires = [
-    '../../web',
+    "../../web",
 ]
 style_framework = "Shoelace v2.3"

--- a/examples/table/CHANGELOG
+++ b/examples/table/CHANGELOG
@@ -1,0 +1,1 @@
+See Toga releases for change notes.

--- a/examples/table/LICENSE
+++ b/examples/table/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.

--- a/examples/table/pyproject.toml
+++ b/examples/table/pyproject.toml
@@ -7,48 +7,48 @@ bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
-author = 'Tiberius Yak'
+author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 
 [tool.briefcase.app.table]
 formal_name = "Table Demo"
 description = "A testing app"
-sources = ['table']
+sources = ["table"]
 requires = [
-    '../../core',
+    "../../core",
 ]
 
 [tool.briefcase.app.table.macOS]
 requires = [
-    '../../cocoa',
-    'std-nslog>=1.0.0',
+    "../../cocoa",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.table.linux]
 requires = [
-    '../../gtk',
+    "../../gtk",
 ]
 
 [tool.briefcase.app.table.windows]
 requires = [
-    '../../winforms',
+    "../../winforms",
 ]
 
 # Mobile deployments
 [tool.briefcase.app.table.iOS]
 requires = [
-    '../../iOS',
-    'std-nslog>=1.0.0',
+    "../../iOS",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.table.android]
 requires = [
-    '../../android',
+    "../../android",
 ]
 
 # Web deployment
 [tool.briefcase.app.table.web]
 requires = [
-    '../../web',
+    "../../web",
 ]
 style_framework = "Shoelace v2.3"

--- a/examples/table_source/CHANGELOG
+++ b/examples/table_source/CHANGELOG
@@ -1,0 +1,1 @@
+See Toga releases for change notes.

--- a/examples/table_source/LICENSE
+++ b/examples/table_source/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.

--- a/examples/table_source/pyproject.toml
+++ b/examples/table_source/pyproject.toml
@@ -7,49 +7,49 @@ bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
-author = 'Tiberius Yak'
+author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 
 [tool.briefcase.app.table_source]
 formal_name = "TableSource Demo"
 description = "A testing app"
-sources = ['table_source']
+sources = ["table_source"]
 requires = [
-    '../../core',
+    "../../core",
 ]
 
 
 [tool.briefcase.app.table_source.macOS]
 requires = [
-    '../../cocoa',
-    'std-nslog>=1.0.0',
+    "../../cocoa",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.table_source.linux]
 requires = [
-    '../../gtk',
+    "../../gtk",
 ]
 
 [tool.briefcase.app.table_source.windows]
 requires = [
-    '../../winforms',
+    "../../winforms",
 ]
 
 # Mobile deployments
 [tool.briefcase.app.table_source.iOS]
 requires = [
-    '../../iOS',
-    'std-nslog>=1.0.0',
+    "../../iOS",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.table_source.android]
 requires = [
-    '../../android',
+    "../../android",
 ]
 
 # Web deployment
 [tool.briefcase.app.table_source.web]
 requires = [
-    '../../web',
+    "../../web",
 ]
 style_framework = "Shoelace v2.3"

--- a/examples/textinput/CHANGELOG
+++ b/examples/textinput/CHANGELOG
@@ -1,0 +1,1 @@
+See Toga releases for change notes.

--- a/examples/textinput/LICENSE
+++ b/examples/textinput/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.

--- a/examples/textinput/pyproject.toml
+++ b/examples/textinput/pyproject.toml
@@ -7,49 +7,49 @@ bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
-author = 'Tiberius Yak'
+author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 
 [tool.briefcase.app.textinput]
 formal_name = "Text Input Demo"
 description = "A testing app"
-sources = ['textinput']
+sources = ["textinput"]
 requires = [
-    '../../core',
+    "../../core",
 ]
 
 
 [tool.briefcase.app.textinput.macOS]
 requires = [
-    '../../cocoa',
-    'std-nslog>=1.0.0',
+    "../../cocoa",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.textinput.linux]
 requires = [
-    '../../gtk',
+    "../../gtk",
 ]
 
 [tool.briefcase.app.textinput.windows]
 requires = [
-    '../../winforms',
+    "../../winforms",
 ]
 
 # Mobile deployments
 [tool.briefcase.app.textinput.iOS]
 requires = [
-    '../../iOS',
-    'std-nslog>=1.0.0',
+    "../../iOS",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.textinput.android]
 requires = [
-    '../../android',
+    "../../android",
 ]
 
 # Web deployment
 [tool.briefcase.app.textinput.web]
 requires = [
-    '../../web',
+    "../../web",
 ]
 style_framework = "Shoelace v2.3"

--- a/examples/tree/CHANGELOG
+++ b/examples/tree/CHANGELOG
@@ -1,0 +1,1 @@
+See Toga releases for change notes.

--- a/examples/tree/LICENSE
+++ b/examples/tree/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.

--- a/examples/tree/pyproject.toml
+++ b/examples/tree/pyproject.toml
@@ -7,49 +7,49 @@ bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
-author = 'Tiberius Yak'
+author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 
 [tool.briefcase.app.tree]
 formal_name = "Tree Demo"
 description = "A testing app"
-sources = ['tree']
+sources = ["tree"]
 requires = [
-    '../../core',
+    "../../core",
 ]
 
 
 [tool.briefcase.app.tree.macOS]
 requires = [
-    '../../cocoa',
-    'std-nslog>=1.0.0',
+    "../../cocoa",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.tree.linux]
 requires = [
-    '../../gtk',
+    "../../gtk",
 ]
 
 [tool.briefcase.app.tree.windows]
 requires = [
-    '../../winforms',
+    "../../winforms",
 ]
 
 # Mobile deployments
 [tool.briefcase.app.tree.iOS]
 requires = [
-    '../../iOS',
-    'std-nslog>=1.0.0',
+    "../../iOS",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.tree.android]
 requires = [
-    '../../android',
+    "../../android",
 ]
 
 # Web deployment
 [tool.briefcase.app.tree.web]
 requires = [
-    '../../web',
+    "../../web",
 ]
 style_framework = "Shoelace v2.3"

--- a/examples/tree_source/CHANGELOG
+++ b/examples/tree_source/CHANGELOG
@@ -1,0 +1,1 @@
+See Toga releases for change notes.

--- a/examples/tree_source/LICENSE
+++ b/examples/tree_source/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.

--- a/examples/tree_source/pyproject.toml
+++ b/examples/tree_source/pyproject.toml
@@ -7,49 +7,49 @@ bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
-author = 'Tiberius Yak'
+author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 
 [tool.briefcase.app.tree_source]
 formal_name = "TreeSource Demo"
 description = "A testing app"
-sources = ['tree_source']
+sources = ["tree_source"]
 requires = [
-    '../../core',
+    "../../core",
 ]
 
 
 [tool.briefcase.app.tree_source.macOS]
 requires = [
-    '../../cocoa',
-    'std-nslog>=1.0.0',
+    "../../cocoa",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.tree_source.linux]
 requires = [
-    '../../gtk',
+    "../../gtk",
 ]
 
 [tool.briefcase.app.tree_source.windows]
 requires = [
-    '../../winforms',
+    "../../winforms",
 ]
 
 # Mobile deployments
 [tool.briefcase.app.tree_source.iOS]
 requires = [
-    '../../iOS',
-    'std-nslog>=1.0.0',
+    "../../iOS",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.tree_source.android]
 requires = [
-    '../../android',
+    "../../android",
 ]
 
 # Web deployment
 [tool.briefcase.app.tree_source.web]
 requires = [
-    '../../web',
+    "../../web",
 ]
 style_framework = "Shoelace v2.3"

--- a/examples/tutorial0/CHANGELOG
+++ b/examples/tutorial0/CHANGELOG
@@ -1,0 +1,1 @@
+See Toga releases for change notes.

--- a/examples/tutorial0/LICENSE
+++ b/examples/tutorial0/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.

--- a/examples/tutorial0/pyproject.toml
+++ b/examples/tutorial0/pyproject.toml
@@ -7,49 +7,49 @@ bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
-author = 'Tiberius Yak'
+author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 
 [tool.briefcase.app.tutorial]
 formal_name = "Tutorial 0"
 description = "A testing app"
-sources = ['tutorial']
+sources = ["tutorial"]
 requires = [
-    '../../core',
+    "../../core",
 ]
 
 
 [tool.briefcase.app.tutorial.macOS]
 requires = [
-    '../../cocoa',
-    'std-nslog>=1.0.0',
+    "../../cocoa",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.tutorial.linux]
 requires = [
-    '../../gtk',
+    "../../gtk",
 ]
 
 [tool.briefcase.app.tutorial.windows]
 requires = [
-    '../../winforms',
+    "../../winforms",
 ]
 
 # Mobile deployments
 [tool.briefcase.app.tutorial.iOS]
 requires = [
-    '../../iOS',
-    'std-nslog>=1.0.0',
+    "../../iOS",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.tutorial.android]
 requires = [
-    '../../android',
+    "../../android",
 ]
 
 # Web deployment
 [tool.briefcase.app.tutorial.web]
 requires = [
-    '../../web',
+    "../../web",
 ]
 style_framework = "Shoelace v2.3"

--- a/examples/tutorial1/CHANGELOG
+++ b/examples/tutorial1/CHANGELOG
@@ -1,0 +1,1 @@
+See Toga releases for change notes.

--- a/examples/tutorial1/LICENSE
+++ b/examples/tutorial1/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.

--- a/examples/tutorial1/pyproject.toml
+++ b/examples/tutorial1/pyproject.toml
@@ -7,49 +7,49 @@ bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
-author = 'Tiberius Yak'
+author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 
 [tool.briefcase.app.tutorial]
 formal_name = "Tutorial 1"
 description = "A testing app"
-sources = ['tutorial']
+sources = ["tutorial"]
 requires = [
-    '../../core',
+    "../../core",
 ]
 
 
 [tool.briefcase.app.tutorial.macOS]
 requires = [
-    '../../cocoa',
-    'std-nslog>=1.0.0',
+    "../../cocoa",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.tutorial.linux]
 requires = [
-    '../../gtk',
+    "../../gtk",
 ]
 
 [tool.briefcase.app.tutorial.windows]
 requires = [
-    '../../winforms',
+    "../../winforms",
 ]
 
 # Mobile deployments
 [tool.briefcase.app.tutorial.iOS]
 requires = [
-    '../../iOS',
-    'std-nslog>=1.0.0',
+    "../../iOS",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.tutorial.android]
 requires = [
-    '../../android',
+    "../../android",
 ]
 
 # Web deployment
 [tool.briefcase.app.tutorial.web]
 requires = [
-    '../../web',
+    "../../web",
 ]
 style_framework = "Shoelace v2.3"

--- a/examples/tutorial2/CHANGELOG
+++ b/examples/tutorial2/CHANGELOG
@@ -1,0 +1,1 @@
+See Toga releases for change notes.

--- a/examples/tutorial2/LICENSE
+++ b/examples/tutorial2/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.

--- a/examples/tutorial2/pyproject.toml
+++ b/examples/tutorial2/pyproject.toml
@@ -7,49 +7,49 @@ bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
-author = 'Tiberius Yak'
+author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 
 [tool.briefcase.app.tutorial]
 formal_name = "Tutorial 2"
 description = "A testing app"
-sources = ['tutorial']
+sources = ["tutorial"]
 requires = [
-    '../../core',
+    "../../core",
 ]
 
 
 [tool.briefcase.app.tutorial.macOS]
 requires = [
-    '../../cocoa',
-    'std-nslog>=1.0.0',
+    "../../cocoa",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.tutorial.linux]
 requires = [
-    '../../gtk',
+    "../../gtk",
 ]
 
 [tool.briefcase.app.tutorial.windows]
 requires = [
-    '../../winforms',
+    "../../winforms",
 ]
 
 # Mobile deployments
 [tool.briefcase.app.tutorial.iOS]
 requires = [
-    '../../iOS',
-    'std-nslog>=1.0.0',
+    "../../iOS",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.tutorial.android]
 requires = [
-    '../../android',
+    "../../android",
 ]
 
 # Web deployment
 [tool.briefcase.app.tutorial.web]
 requires = [
-    '../../web',
+    "../../web",
 ]
 style_framework = "Shoelace v2.3"

--- a/examples/tutorial3/CHANGELOG
+++ b/examples/tutorial3/CHANGELOG
@@ -1,0 +1,1 @@
+See Toga releases for change notes.

--- a/examples/tutorial3/LICENSE
+++ b/examples/tutorial3/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.

--- a/examples/tutorial3/pyproject.toml
+++ b/examples/tutorial3/pyproject.toml
@@ -7,49 +7,49 @@ bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
-author = 'Tiberius Yak'
+author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 
 [tool.briefcase.app.tutorial]
 formal_name = "Tutorial 3"
 description = "A testing app"
-sources = ['tutorial']
+sources = ["tutorial"]
 requires = [
-    '../../core',
+    "../../core",
 ]
 
 
 [tool.briefcase.app.tutorial.macOS]
 requires = [
-    '../../cocoa',
-    'std-nslog>=1.0.0',
+    "../../cocoa",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.tutorial.linux]
 requires = [
-    '../../gtk',
+    "../../gtk",
 ]
 
 [tool.briefcase.app.tutorial.windows]
 requires = [
-    '../../winforms',
+    "../../winforms",
 ]
 
 # Mobile deployments
 [tool.briefcase.app.tutorial.iOS]
 requires = [
-    '../../iOS',
-    'std-nslog>=1.0.0',
+    "../../iOS",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.tutorial.android]
 requires = [
-    '../../android',
+    "../../android",
 ]
 
 # Web deployment
 [tool.briefcase.app.tutorial.web]
 requires = [
-    '../../web',
+    "../../web",
 ]
 style_framework = "Shoelace v2.3"

--- a/examples/tutorial4/CHANGELOG
+++ b/examples/tutorial4/CHANGELOG
@@ -1,0 +1,1 @@
+See Toga releases for change notes.

--- a/examples/tutorial4/LICENSE
+++ b/examples/tutorial4/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.

--- a/examples/tutorial4/pyproject.toml
+++ b/examples/tutorial4/pyproject.toml
@@ -7,49 +7,49 @@ bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
-author = 'Tiberius Yak'
+author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 
 [tool.briefcase.app.tutorial]
 formal_name = "Tutorial 4"
 description = "A testing app"
-sources = ['tutorial']
+sources = ["tutorial"]
 requires = [
-    '../../core',
+    "../../core",
 ]
 
 
 [tool.briefcase.app.tutorial.macOS]
 requires = [
-    '../../cocoa',
-    'std-nslog>=1.0.0',
+    "../../cocoa",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.tutorial.linux]
 requires = [
-    '../../gtk',
+    "../../gtk",
 ]
 
 [tool.briefcase.app.tutorial.windows]
 requires = [
-    '../../winforms',
+    "../../winforms",
 ]
 
 # Mobile deployments
 [tool.briefcase.app.tutorial.iOS]
 requires = [
-    '../../iOS',
-    'std-nslog>=1.0.0',
+    "../../iOS",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.tutorial.android]
 requires = [
-    '../../android',
+    "../../android",
 ]
 
 # Web deployment
 [tool.briefcase.app.tutorial.web]
 requires = [
-    '../../web',
+    "../../web",
 ]
 style_framework = "Shoelace v2.3"

--- a/examples/webview/CHANGELOG
+++ b/examples/webview/CHANGELOG
@@ -1,0 +1,1 @@
+See Toga releases for change notes.

--- a/examples/webview/LICENSE
+++ b/examples/webview/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.

--- a/examples/webview/pyproject.toml
+++ b/examples/webview/pyproject.toml
@@ -7,48 +7,48 @@ bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
-author = 'Tiberius Yak'
+author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 
 [tool.briefcase.app.webview]
 formal_name = "WebView Demo"
 description = "A demo app using all WebView features"
-sources = ['webview']
+sources = ["webview"]
 requires = [
-    '../../core',
+    "../../core",
 ]
 
 [tool.briefcase.app.webview.macOS]
 requires = [
-    '../../cocoa',
-    'std-nslog>=1.0.0',
+    "../../cocoa",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.webview.linux]
 requires = [
-    '../../gtk',
+    "../../gtk",
 ]
 
 [tool.briefcase.app.webview.windows]
 requires = [
-    '../../winforms',
+    "../../winforms",
 ]
 
 # Mobile deployments
 [tool.briefcase.app.webview.iOS]
 requires = [
-    '../../iOS',
-    'std-nslog>=1.0.0',
+    "../../iOS",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.webview.android]
 requires = [
-    '../../android',
+    "../../android",
 ]
 
 # Web deployment
 [tool.briefcase.app.webview.web]
 requires = [
-    '../../web',
+    "../../web",
 ]
 style_framework = "Shoelace v2.3"

--- a/examples/window/CHANGELOG
+++ b/examples/window/CHANGELOG
@@ -1,0 +1,1 @@
+See Toga releases for change notes.

--- a/examples/window/LICENSE
+++ b/examples/window/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.

--- a/examples/window/pyproject.toml
+++ b/examples/window/pyproject.toml
@@ -7,49 +7,49 @@ bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
-author = 'Tiberius Yak'
+author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 
 [tool.briefcase.app.window]
 formal_name = "Window Demo"
 description = "A testing app"
-sources = ['window']
+sources = ["window"]
 requires = [
-    '../../core',
+    "../../core",
 ]
 
 
 [tool.briefcase.app.window.macOS]
 requires = [
-    '../../cocoa',
-    'std-nslog>=1.0.0',
+    "../../cocoa",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.window.linux]
 requires = [
-    '../../gtk',
+    "../../gtk",
 ]
 
 [tool.briefcase.app.window.windows]
 requires = [
-    '../../winforms',
+    "../../winforms",
 ]
 
 # Mobile deployments
 [tool.briefcase.app.window.iOS]
 requires = [
-    '../../iOS',
-    'std-nslog>=1.0.0',
+    "../../iOS",
+    "std-nslog>=1.0.0",
 ]
 
 [tool.briefcase.app.window.android]
 requires = [
-    '../../android',
+    "../../android",
 ]
 
 # Web deployment
 [tool.briefcase.app.window.web]
 requires = [
-    '../../web',
+    "../../web",
 ]
 style_framework = "Shoelace v2.3"


### PR DESCRIPTION
## Changes
- Allows `briefcase run` to work for the examples for as many platforms and output formats as reasonable
- Given that these examples are currently the de facto method for users to see a widget in a native window, they should probably be runnable via `briefcase run` since `python -m` and `briefcase dev` aren't entirely native.

NOTE: This is easiest to review each commit individually.

## Limitations
- Linux
  - System
    - Running without a `--target` implies all the necessary packages are already installed on the host system
      - Maybe there's a way to help users be informed about this proactively....
    - Alternatively, supporting `--target` would require adding the appropriate `system_requires` to all the `pyproject.toml` and that just seems like a lot to maintain
  - AppImage & Flatpak
    - Both of these would require version-specific configuration in all the `pyproject.toml`.
    - While a relatively trivial `sed` command could be used to update these, the use-case for building these formats for these examples is weak

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
