### PR TITLE
Fix docs reference to `toga.paths.Paths`

### DIFF
--- a/changes/1998.misc.rst
+++ b/changes/1998.misc.rst
@@ -1,0 +1,1 @@
+The reference to ``toga.paths.Paths`` in API Reference was corrected to resolve correctly.

--- a/docs/reference/data/widgets_by_platform.csv
+++ b/docs/reference/data/widgets_by_platform.csv
@@ -27,7 +27,7 @@ Box,Layout Widget,:class:`~toga.widgets.box.Box`,Container for components,|y|,|y
 ScrollContainer,Layout Widget,:class:`~toga.widgets.scrollcontainer.ScrollContainer`,Scrollable Container,|b|,|b|,|b|,|b|,|b|,
 SplitContainer,Layout Widget,:class:`~toga.widgets.splitcontainer.SplitContainer`,Split Container,|b|,|b|,|b|,,,
 OptionContainer,Layout Widget,:class:`~toga.widgets.optioncontainer.OptionContainer`,Option Container,|b|,|b|,|b|,,,
-App Paths,Resource,:class:~`toga.paths.Paths`,A mechanism for obtaining platform-appropriate filesystem locations for an application.,|y|,|y|,|y|,|y|,|y|,
+App Paths,Resource,:class:`~toga.paths.Paths`,A mechanism for obtaining platform-appropriate filesystem locations for an application.,|y|,|y|,|y|,|y|,|y|,
 Font,Resource,:class:`~toga.fonts.Font`,Fonts,|b|,|b|,|b|,|b|,|b|,
 Command,Resource,:class:`~toga.command.Command`,Command,|b|,|b|,|b|,,|b|,
 Group,Resource,:class:`~toga.command.Group`,Command group,|b|,|b|,|b|,|b|,|b|,


### PR DESCRIPTION
I couldn't tell if an existing PR has already fixed this; please just close if so.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
