### PR TITLE
Update doc class references

### DIFF
--- a/changes/2001.doc.rst
+++ b/changes/2001.doc.rst
@@ -1,0 +1,1 @@
+Class references were updated to reflect their prefererred import location, rather than location where they are defined in code.

--- a/core/src/toga/app.py
+++ b/core/src/toga/app.py
@@ -169,8 +169,8 @@ class App:
         derived from packaging metadata if not provided.
     :param startup: The callback method before starting the app, typically to
         add the components. Must be a ``callable`` that expects a single
-        argument of :class:`~toga.app.App`.
-    :param windows: An iterable with objects of :class:`~toga.window.Window`
+        argument of :class:`~toga.App`.
+    :param windows: An iterable with objects of :class:`~toga.Window`
         that will be the app's secondary windows.
     """
 
@@ -458,7 +458,7 @@ class App:
     def icon(self):
         """The Icon for the app.
 
-        :returns: A ``toga.Icon`` instance for the app's icon.
+        :returns: A :class:`toga.Icon` instance for the app's icon.
         """
         return self._icon
 

--- a/core/src/toga/widgets/activityindicator.py
+++ b/core/src/toga/widgets/activityindicator.py
@@ -12,7 +12,7 @@ class ActivityIndicator(Widget):
     ):
         """Create a new ActivityIndicator widget.
 
-        Inherits from :class:`~toga.widgets.base.Widget`.
+        Inherits from :class:`toga.Widget`.
 
         :param id: The ID for the widget.
         :param style: A style object. If no style is provided, a default style

--- a/core/src/toga/widgets/box.py
+++ b/core/src/toga/widgets/box.py
@@ -12,7 +12,7 @@ class Box(Widget):
     ):
         """Create a new Box container widget.
 
-        Inherits from :class:`~toga.widgets.base.Widget`.
+        Inherits from :class:`toga.Widget`.
 
         :param id: The ID for the widget.
         :param style: A style object. If no style is provided, a default style

--- a/core/src/toga/widgets/button.py
+++ b/core/src/toga/widgets/button.py
@@ -16,7 +16,7 @@ class Button(Widget):
     ):
         """Create a new button widget.
 
-        Inherits from :class:`~toga.widgets.base.Widget`.
+        Inherits from :class:`toga.Widget`.
 
         :param text: The text to display on the button.
         :param id: The ID for the widget.

--- a/core/src/toga/widgets/canvas.py
+++ b/core/src/toga/widgets/canvas.py
@@ -337,7 +337,7 @@ class Context:
             text (str): The text to fill.
             x (float, Optional): The x coordinate of the text. Default to 0.
             y (float, Optional): The y coordinate of the text. Default to 0.
-            font (:class:`~toga.fonts.Font`, Optional): The font to write with.
+            font (:class:`toga.Font`, Optional): The font to write with.
 
         Returns:
             :class:`WriteText` object.
@@ -1124,7 +1124,7 @@ class WriteText:
         text (str): The text to fill.
         x (float, Optional): The x coordinate of the text. Default to 0.
         y (float, Optional): The y coordinate of the text. Default to 0.
-        font (:class:`toga.fonts.Font`, Optional): The font to write with.
+        font (:class:`toga.Font`, Optional): The font to write with.
     """
 
     def __init__(self, text, x, y, font):

--- a/core/src/toga/widgets/dateinput.py
+++ b/core/src/toga/widgets/dateinput.py
@@ -29,7 +29,7 @@ class DateInput(Widget):
     ):
         """Create a new DateInput widget.
 
-        Inherits from :class:`~toga.widgets.base.Widget`.
+        Inherits from :class:`toga.Widget`.
 
         :param id: The ID for the widget.
         :param style: A style object. If no style is provided, a default style

--- a/core/src/toga/widgets/divider.py
+++ b/core/src/toga/widgets/divider.py
@@ -15,7 +15,7 @@ class Divider(Widget):
     ):
         """Create a new divider line.
 
-        Inherits from :class:`~toga.widgets.base.Widget`.
+        Inherits from :class:`toga.Widget`.
 
         :param id: The ID for the widget.
         :param style: A style object. If no style is provided, a default style

--- a/core/src/toga/widgets/imageview.py
+++ b/core/src/toga/widgets/imageview.py
@@ -8,7 +8,7 @@ class ImageView(Widget):
     """
 
     Args:
-        image (:class:`~toga.images.Image`): The image to display.
+        image (:class:`~toga.Image`): The image to display.
         id (str): An identifier for this widget.
         style (:obj:`Style`):
 

--- a/core/src/toga/widgets/label.py
+++ b/core/src/toga/widgets/label.py
@@ -12,7 +12,7 @@ class Label(Widget):
     ):
         """Create a new text label.
 
-        Inherits from :class:`~toga.widgets.base.Widget`.
+        Inherits from :class:`toga.Widget`.
 
         :param text: Text of the label.
         :param id: The ID for the widget.

--- a/core/src/toga/widgets/multilinetextinput.py
+++ b/core/src/toga/widgets/multilinetextinput.py
@@ -17,7 +17,7 @@ class MultilineTextInput(Widget):
     ):
         """Create a new multi-line text input widget.
 
-        Inherits from :class:`~toga.widgets.base.Widget`.
+        Inherits from :class:`toga.Widget`.
 
         :param id: The ID for the widget.
         :param style: A style object. If no style is provided, a default style

--- a/core/src/toga/widgets/numberinput.py
+++ b/core/src/toga/widgets/numberinput.py
@@ -74,7 +74,7 @@ class NumberInput(Widget):
     ):
         """Create a new number input widget.
 
-        Inherits from :class:`~toga.widgets.base.Widget`.
+        Inherits from :class:`toga.Widget`.
 
         :param id: The ID for the widget.
         :param style: A style object. If no style is provided, a default style

--- a/core/src/toga/widgets/optioncontainer.py
+++ b/core/src/toga/widgets/optioncontainer.py
@@ -276,7 +276,7 @@ class OptionContainer(Widget):
         id (str):   An identifier for this widget.
         style (:obj:`Style`): an optional style object.
             If no style is provided then a new one will be created for the widget.
-        content (``list`` of ``tuple`` (``str``, :class:`~toga.widgets.base.Widget`)):
+        content (``list`` of ``tuple`` (``str``, :class:`~toga.Widget`)):
             Each tuple in the list is composed of a title for the option and
             the widget tree that is displayed in the option.
     """
@@ -378,7 +378,7 @@ class OptionContainer(Widget):
 
         Args:
             text (str): The text for the option.
-            widget (:class:`~toga.widgets.base.Widget`): The widget to add to the option.
+            widget (:class:`toga.Widget`): The widget to add to the option.
         """
         ##################################################################
         # 2022-07: Backwards compatibility
@@ -432,7 +432,7 @@ class OptionContainer(Widget):
         Args:
             index (int): Index for the option.
             text (str): The text for the option.
-            widget (:class:`~toga.widgets.base.Widget`): The widget to add to the option.
+            widget (:class:`toga.Widget`): The widget to add to the option.
         """
         widget.app = self.app
         widget.window = self.window

--- a/core/src/toga/widgets/passwordinput.py
+++ b/core/src/toga/widgets/passwordinput.py
@@ -6,7 +6,7 @@ from .textinput import TextInput
 class PasswordInput(TextInput):
     """Create a new password input widget.
 
-    Inherits from :class:`~toga.widgets.textinput.TextInput`.
+    Inherits from :class:`~toga.TextInput`.
     """
 
     def _create(self):

--- a/core/src/toga/widgets/progressbar.py
+++ b/core/src/toga/widgets/progressbar.py
@@ -16,7 +16,7 @@ class ProgressBar(Widget):
     ):
         """Create a new Progress Bar widget.
 
-        Inherits from :class:`~toga.widgets.base.Widget`.
+        Inherits from :class:`toga.Widget`.
 
         :param id: The ID for the widget.
         :param style: A style object. If no style is provided, a default style

--- a/core/src/toga/widgets/scrollcontainer.py
+++ b/core/src/toga/widgets/scrollcontainer.py
@@ -12,7 +12,7 @@ class ScrollContainer(Widget):
             If no style is provided then a new one will be created for the widget.
         horizontal (bool):  If True enable horizontal scroll bar.
         vertical (bool): If True enable vertical scroll bar.
-        content (:class:`~toga.widgets.base.Widget`): The content of the scroll window.
+        content (:class:`toga.Widget`): The content of the scroll window.
     """
 
     MIN_WIDTH = 100
@@ -76,7 +76,7 @@ class ScrollContainer(Widget):
         """Content of the scroll container.
 
         Returns:
-            The content of the widget (:class:`~toga.widgets.base.Widget`).
+            The content of the widget (:class:`toga.Widget`).
         """
         return self._content
 

--- a/core/src/toga/widgets/slider.py
+++ b/core/src/toga/widgets/slider.py
@@ -23,7 +23,7 @@ class Slider(Widget):
     ):
         """Create a new slider widget.
 
-        Inherits from :class:`~toga.widgets.base.Widget`.
+        Inherits from :class:`toga.Widget`.
 
         :param id: The ID for the widget.
         :param style: A style object. If no style is provided, a default style

--- a/core/src/toga/widgets/splitcontainer.py
+++ b/core/src/toga/widgets/splitcontainer.py
@@ -13,10 +13,10 @@ class SplitContainer(Widget):
             If no style is provided then a new one will be created for the widget.
         direction: The direction for the container split,
             either `SplitContainer.HORIZONTAL` or `SplitContainer.VERTICAL`
-        content(``list`` of :class:`~toga.widgets.base.Widget`): The list of components to be
+        content(``list`` of :class:`~toga.Widget`): The list of components to be
             split or tuples of components to be split and adjusting parameters
             in the following order:
-            widget (:class:`~toga.widgets.base.Widget`): The widget that will be added.
+            widget (:class:`~toga.Widget`): The widget that will be added.
             weight (float): Specifying the weighted splits.
             flex (Boolean): Should the content expand when the widget is resized. (optional)
     """
@@ -58,7 +58,7 @@ class SplitContainer(Widget):
         """The sub layouts of the `SplitContainer`.
 
         Returns:
-            A ``list`` of :class:`~toga.widgets.base.Widget`. Each element of the list
+            A ``list`` of :class:`toga.Widget`. Each element of the list
             is a sub layout of the `SplitContainer`
 
         Raises:

--- a/core/src/toga/widgets/switch.py
+++ b/core/src/toga/widgets/switch.py
@@ -17,7 +17,7 @@ class Switch(Widget):
     ):
         """Create a new Switch widget.
 
-        Inherits from :class:`~toga.widgets.base.Widget`.
+        Inherits from :class:`toga.Widget`.
 
         :param text: The text to display beside the switch.
         :param id: The ID for the widget.

--- a/core/src/toga/widgets/textinput.py
+++ b/core/src/toga/widgets/textinput.py
@@ -8,7 +8,7 @@ from .base import Widget
 class TextInput(Widget):
     """Create a new single-line text input widget.
 
-    Inherits from :class:`~toga.widgets.base.Widget`.
+    Inherits from :class:`toga.Widget`.
     """
 
     def __init__(

--- a/core/src/toga/widgets/timeinput.py
+++ b/core/src/toga/widgets/timeinput.py
@@ -20,7 +20,7 @@ class TimeInput(Widget):
     ):
         """Create a new TimeInput widget.
 
-        Inherits from :class:`~toga.widgets.base.Widget`.
+        Inherits from :class:`toga.Widget`.
 
         :param id: The ID for the widget.
         :param style: A style object. If no style is provided, a default style

--- a/core/src/toga/widgets/tree.py
+++ b/core/src/toga/widgets/tree.py
@@ -21,7 +21,7 @@ class Tree(Widget):
 
           - any Python object ``value`` with a string representation. This
             string will be shown in the widget. If ``value`` has an attribute
-            ``icon``, instance of (:class:`~toga.icons.Icon`), the icon will be
+            ``icon``, instance of (:class:`~toga.Icon`), the icon will be
             shown in front of the text.
 
           - a tuple ``(icon, value)`` where again the string representation of

--- a/core/src/toga/widgets/webview.py
+++ b/core/src/toga/widgets/webview.py
@@ -22,7 +22,7 @@ class WebView(Widget):
     ):
         """Create a new WebView widget.
 
-        Inherits from :class:`~toga.widgets.base.Widget`.
+        Inherits from :class:`toga.Widget`.
 
         :param id: The ID for the widget.
         :param style: A style object. If no style is provided, a default style

--- a/core/src/toga/window.py
+++ b/core/src/toga/window.py
@@ -25,7 +25,7 @@ class Window:
         title (str): Title for the window (optional).
         position (``tuple`` of (int, int)): Position of the window, as x,y coordinates.
         size (``tuple`` of (int, int)):  Size of the window, as (width, height) sizes, in pixels.
-        toolbar (``list`` of :class:`~toga.widgets.base.Widget`): A list of widgets to add to a toolbar
+        toolbar (``list`` of :class:`~toga.Widget`): A list of widgets to add to a toolbar
         resizeable (bool): Toggle if the window is resizable by the user, defaults to `True`.
         closeable (bool): Toggle if the window is closable by the user, defaults to `True`.
         minimizable (bool): Toggle if the window is minimizable by the user, defaults to `True`.
@@ -93,10 +93,10 @@ class Window:
 
     @property
     def app(self):
-        """Instance of the :class:`toga.app.App` that this window belongs to.
+        """Instance of the :class:`toga.App` that this window belongs to.
 
         Returns:
-            The app that it belongs to :class:`toga.app.App`.
+            The app that it belongs to :class:`toga.App`.
 
         Raises:
             Exception: If the window already is associated with another app.
@@ -135,7 +135,7 @@ class Window:
         """Toolbar for the window.
 
         Returns:
-            A ``list`` of :class:`~toga.widgets.base.Widget`
+            A ``list`` of :class:`toga.Widget`
         """
         return self._toolbar
 
@@ -145,7 +145,7 @@ class Window:
         the window and to the same app.
 
         Returns:
-            A :class:`~toga.widgets.base.Widget`
+            A :class:`toga.Widget`
         """
         return self._content
 

--- a/docs/reference/api/app.rst
+++ b/docs/reference/api/app.rst
@@ -51,6 +51,6 @@ Alternatively, you can subclass App and implement the startup method
 Reference
 ---------
 
-.. autoclass:: toga.app.App
+.. autoclass:: toga.App
    :members:
    :undoc-members:

--- a/docs/reference/api/containers/box.rst
+++ b/docs/reference/api/containers/box.rst
@@ -39,15 +39,15 @@ Alternatively, children can be specified at the time the box is constructed:
 
     box = toga.Box(children=[label1, label2])
 
-In most apps, a layout is constructed by building a tree of boxes inside boxes,
-with concrete widgets (such as :class:`~toga.widgets.label.Label` or
-:class:`~toga.widgets.button.Button`) forming the leaf nodes of the tree. Style
-directives can be applied to enforce padding around the outside of the box,
-direction of child stacking inside the box, and background color of the box.
+In most apps, a layout is constructed by building a tree of boxes inside boxes, with
+concrete widgets (such as :class:`~toga.Label` or :class:`~toga.Button`) forming the
+leaf nodes of the tree. Style directives can be applied to enforce padding around the
+outside of the box, direction of child stacking inside the box, and background color of
+the box.
 
 Reference
 ---------
 
-.. autoclass:: toga.widgets.box.Box
+.. autoclass:: toga.Box
    :members:
    :undoc-members:

--- a/docs/reference/api/containers/optioncontainer.rst
+++ b/docs/reference/api/containers/optioncontainer.rst
@@ -31,6 +31,6 @@ Usage
 Reference
 ---------
 
-.. autoclass:: toga.widgets.optioncontainer.OptionContainer
+.. autoclass:: toga.OptionContainer
    :members:
    :undoc-members:

--- a/docs/reference/api/containers/scrollcontainer.rst
+++ b/docs/reference/api/containers/scrollcontainer.rst
@@ -43,6 +43,6 @@ Horizontal or vertical scroll can be set via the initializer or using the proper
 Reference
 ---------
 
-.. autoclass:: toga.widgets.scrollcontainer.ScrollContainer
+.. autoclass:: toga.ScrollContainer
    :members:
    :undoc-members:

--- a/docs/reference/api/containers/splitcontainer.rst
+++ b/docs/reference/api/containers/splitcontainer.rst
@@ -44,6 +44,6 @@ Split direction is set on instantiation using the ``direction`` keyword argument
 Reference
 ---------
 
-.. autoclass:: toga.widgets.splitcontainer.SplitContainer
+.. autoclass:: toga.SplitContainer
    :members:
    :undoc-members:

--- a/docs/reference/api/mainwindow.rst
+++ b/docs/reference/api/mainwindow.rst
@@ -26,6 +26,6 @@ instantiation and support displaying multiple widgets, toolbars and resizing.
 Reference
 ---------
 
-.. autoclass:: toga.app.MainWindow
+.. autoclass:: toga.MainWindow
    :members:
    :undoc-members:

--- a/docs/reference/api/resources/app_paths.rst
+++ b/docs/reference/api/resources/app_paths.rst
@@ -29,7 +29,7 @@ sandbox and security policies will prevent sometimes prevent reading or
 writing files in any location other than these pre-approved locations.
 
 To assist with finding an appropriate location to store application files, every
-Toga application instance has a :attr:`~toga.app.App.paths` attribute that
+Toga application instance has a :attr:`~toga.App.paths` attribute that
 returns an instance of :class:`~toga.paths.Paths`. This object provides known
 file system locations that are appropriate for storing files of given types,
 such as configuration files, log files, cache files, or user data.

--- a/docs/reference/api/resources/command.rst
+++ b/docs/reference/api/resources/command.rst
@@ -15,6 +15,6 @@ Usage
 Reference
 ---------
 
-.. autoclass:: toga.command.Command
+.. autoclass:: toga.Command
    :members:
    :undoc-members:

--- a/docs/reference/api/resources/fonts.rst
+++ b/docs/reference/api/resources/fonts.rst
@@ -13,6 +13,6 @@ The font class is used for abstracting the platforms implementation of fonts.
 Reference
 ---------
 
-.. autoclass:: toga.fonts.Font
+.. autoclass:: toga.Font
    :members:
    :undoc-members:

--- a/docs/reference/api/resources/group.rst
+++ b/docs/reference/api/resources/group.rst
@@ -16,6 +16,6 @@ Usage
 Reference
 ---------
 
-.. autoclass:: toga.command.Group
+.. autoclass:: toga.Group
    :members:
    :undoc-members:

--- a/docs/reference/api/resources/icons.rst
+++ b/docs/reference/api/resources/icons.rst
@@ -36,6 +36,6 @@ one of the platform's allowed extensions.
 Reference
 ---------
 
-.. autoclass:: toga.icons.Icon
+.. autoclass:: toga.Icon
    :members:
    :undoc-members:

--- a/docs/reference/api/resources/images.rst
+++ b/docs/reference/api/resources/images.rst
@@ -31,6 +31,6 @@ Usage
 Reference
 ---------
 
-.. autoclass:: toga.images.Image
+.. autoclass:: toga.Image
    :members:
    :undoc-members:

--- a/docs/reference/api/resources/validators.rst
+++ b/docs/reference/api/resources/validators.rst
@@ -30,10 +30,10 @@ the user's input starts with the text "Hello":
 Toga provides built-in validators for a range of common validation types, as well
 as some base classes that can be used as a starting point for custom validators.
 
-A list of validators can then be provided to any widget that performs
-validation, such as the :class:`~toga.widgets.textinput.TextInput` widget. In
-the following example, a ``TextInput`` will validate that the user has entered
-text that starts with "hello", and has provided at least 10 characters of input:
+A list of validators can then be provided to any widget that performs validation, such
+as the :class:`~toga.TextInput` widget. In the following example, a ``TextInput`` will
+validate that the user has entered text that starts with "hello", and has provided at
+least 10 characters of input:
 
 .. code-block:: python
 

--- a/docs/reference/api/widgets/activityindicator.rst
+++ b/docs/reference/api/widgets/activityindicator.rst
@@ -39,6 +39,6 @@ Notes
 Reference
 ---------
 
-.. autoclass:: toga.widgets.activityindicator.ActivityIndicator
+.. autoclass:: toga.ActivityIndicator
    :members:
    :undoc-members:

--- a/docs/reference/api/widgets/button.rst
+++ b/docs/reference/api/widgets/button.rst
@@ -42,6 +42,6 @@ Notes
 Reference
 ---------
 
-.. autoclass:: toga.widgets.button.Button
+.. autoclass:: toga.Button
    :members:
    :undoc-members:

--- a/docs/reference/api/widgets/canvas.rst
+++ b/docs/reference/api/widgets/canvas.rst
@@ -67,7 +67,7 @@ Reference
 Main Interface
 ^^^^^^^^^^^^^^
 
-.. autoclass:: toga.widgets.canvas.Canvas
+.. autoclass:: toga.Canvas
    :members:
    :undoc-members:
    :exclude-members: canvas, add_draw_obj

--- a/docs/reference/api/widgets/dateinput.rst
+++ b/docs/reference/api/widgets/dateinput.rst
@@ -36,6 +36,6 @@ Notes
 Reference
 ---------
 
-.. autoclass:: toga.widgets.dateinput.DateInput
+.. autoclass:: toga.DateInput
    :members:
    :undoc-members:

--- a/docs/reference/api/widgets/detailedlist.rst
+++ b/docs/reference/api/widgets/detailedlist.rst
@@ -16,6 +16,6 @@ Usage
 Reference
 ---------
 
-.. autoclass:: toga.widgets.detailedlist.DetailedList
+.. autoclass:: toga.DetailedList
    :members:
    :undoc-members:

--- a/docs/reference/api/widgets/divider.rst
+++ b/docs/reference/api/widgets/divider.rst
@@ -38,6 +38,6 @@ specified, it will default to horizontal.
 Reference
 ---------
 
-.. autoclass:: toga.widgets.divider.Divider
+.. autoclass:: toga.Divider
    :members:
    :undoc-members:

--- a/docs/reference/api/widgets/imageview.rst
+++ b/docs/reference/api/widgets/imageview.rst
@@ -22,6 +22,6 @@ Usage
 Reference
 ---------
 
-.. autoclass:: toga.widgets.imageview.ImageView
+.. autoclass:: toga.ImageView
    :members:
    :undoc-members:

--- a/docs/reference/api/widgets/label.rst
+++ b/docs/reference/api/widgets/label.rst
@@ -31,6 +31,6 @@ Notes
 Reference
 ---------
 
-.. autoclass:: toga.widgets.label.Label
+.. autoclass:: toga.Label
    :members:
    :undoc-members:

--- a/docs/reference/api/widgets/multilinetextinput.rst
+++ b/docs/reference/api/widgets/multilinetextinput.rst
@@ -41,6 +41,6 @@ Notes
 Reference
 ---------
 
-.. autoclass:: toga.widgets.multilinetextinput.MultilineTextInput
+.. autoclass:: toga.MultilineTextInput
    :members:
    :undoc-members:

--- a/docs/reference/api/widgets/numberinput.rst
+++ b/docs/reference/api/widgets/numberinput.rst
@@ -30,6 +30,6 @@ precision is retained.
 Reference
 ---------
 
-.. autoclass:: toga.widgets.numberinput.NumberInput
+.. autoclass:: toga.NumberInput
    :members:
    :undoc-members:

--- a/docs/reference/api/widgets/passwordinput.rst
+++ b/docs/reference/api/widgets/passwordinput.rst
@@ -20,10 +20,9 @@ not the actual characters.
 Usage
 -----
 
-The ``PasswordInput`` is functionally identical to a
-:class:`~toga.widgets.textinput.TextInput`, except for how the text is
-displayed. All features supported by :class:`~toga.widgets.textinput.TextInput`
-are also supported by PasswordInput.
+The ``PasswordInput`` is functionally identical to a :class:`~toga.TextInput`, except
+for how the text is displayed. All features supported by :class:`~toga.TextInput` are
+also supported by PasswordInput.
 
 .. code-block:: python
 
@@ -47,6 +46,6 @@ Notes
 Reference
 ---------
 
-.. autoclass:: toga.widgets.passwordinput.PasswordInput
+.. autoclass:: toga.PasswordInput
    :members:
    :undoc-members:

--- a/docs/reference/api/widgets/progressbar.rst
+++ b/docs/reference/api/widgets/progressbar.rst
@@ -65,6 +65,6 @@ Notes
 Reference
 ---------
 
-.. autoclass:: toga.widgets.progressbar.ProgressBar
+.. autoclass:: toga.ProgressBar
    :members:
    :undoc-members:

--- a/docs/reference/api/widgets/selection.rst
+++ b/docs/reference/api/widgets/selection.rst
@@ -25,6 +25,6 @@ Usage
 Reference
 ---------
 
-.. autoclass:: toga.widgets.selection.Selection
+.. autoclass:: toga.Selection
    :members:
    :undoc-members:

--- a/docs/reference/api/widgets/slider.rst
+++ b/docs/reference/api/widgets/slider.rst
@@ -39,6 +39,6 @@ A slider can either be continuous (allowing any value within the range), or disc
 Reference
 ---------
 
-.. autoclass:: toga.widgets.slider.Slider
+.. autoclass:: toga.Slider
    :members:
    :undoc-members:

--- a/docs/reference/api/widgets/switch.rst
+++ b/docs/reference/api/widgets/switch.rst
@@ -50,6 +50,6 @@ Notes
 Reference
 ---------
 
-.. autoclass:: toga.widgets.switch.Switch
+.. autoclass:: toga.Switch
    :members:
    :undoc-members:

--- a/docs/reference/api/widgets/table.rst
+++ b/docs/reference/api/widgets/table.rst
@@ -29,9 +29,31 @@ Usage
     # Insert to row 2
     table.data.insert(2, 'Value 1', 'Value 2')
 
+        Examples:
+            >>> headings = ['Head 1', 'Head 2', 'Head 3']
+            >>> data = []
+            >>> table = Table(headings, data=data)
+
+            Data can be in several forms. A list of dictionaries, where the keys match
+            the heading names:
+
+            >>> data = [{'head_1': 'value 1', 'head_2': 'value 2', 'head_3': 'value3'}),
+            >>>         {'head_1': 'value 1', 'head_2': 'value 2', 'head_3': 'value3'}]
+
+            A list of lists. These will be mapped to the headings in order:
+
+            >>> data = [('value 1', 'value 2', 'value3'),
+            >>>         ('value 1', 'value 2', 'value3')]
+
+            A list of values. This is only accepted if there is a single heading.
+
+            >>> data = ['item 1', 'item 2', 'item 3']
+        """
+
+
 Reference
 ---------
 
-.. autoclass:: toga.widgets.table.Table
+.. autoclass:: toga.Table
    :members:
    :undoc-members:

--- a/docs/reference/api/widgets/textinput.rst
+++ b/docs/reference/api/widgets/textinput.rst
@@ -54,6 +54,6 @@ Notes
 Reference
 ---------
 
-.. autoclass:: toga.widgets.textinput.TextInput
+.. autoclass:: toga.TextInput
    :members:
    :undoc-members:

--- a/docs/reference/api/widgets/timeinput.rst
+++ b/docs/reference/api/widgets/timeinput.rst
@@ -40,6 +40,6 @@ Notes
 Reference
 ---------
 
-.. autoclass:: toga.widgets.timeinput.TimeInput
+.. autoclass:: toga.TimeInput
    :members:
    :undoc-members:

--- a/docs/reference/api/widgets/tree.rst
+++ b/docs/reference/api/widgets/tree.rst
@@ -34,6 +34,6 @@ Usage
 Reference
 ---------
 
-.. autoclass:: toga.widgets.tree.Tree
+.. autoclass:: toga.Tree
    :members:
    :undoc-members:

--- a/docs/reference/api/widgets/webview.rst
+++ b/docs/reference/api/widgets/webview.rst
@@ -60,6 +60,6 @@ Notes
 Reference
 ---------
 
-.. autoclass:: toga.widgets.webview.WebView
+.. autoclass:: toga.WebView
    :members:
    :undoc-members:

--- a/docs/reference/api/widgets/widget.rst
+++ b/docs/reference/api/widgets/widget.rst
@@ -14,7 +14,7 @@ The abstract base class of all widgets. This class should not be be instantiated
 Reference
 ---------
 
-.. autoclass:: toga.widgets.base.Widget
+.. autoclass:: toga.Widget
    :members:
    :undoc-members:
    :inherited-members:

--- a/docs/reference/api/window.rst
+++ b/docs/reference/api/window.rst
@@ -44,6 +44,6 @@ instantiation and support displaying multiple widgets, toolbars and resizing.
 Reference
 ---------
 
-.. autoclass:: toga.window.Window
+.. autoclass:: toga.Window
    :members:
    :undoc-members:

--- a/docs/reference/data/widgets_by_platform.csv
+++ b/docs/reference/data/widgets_by_platform.csv
@@ -1,36 +1,36 @@
 Component,Type,Component,Description,macOS,GTK,Windows,iOS,Android,Web
-Application,Core Component,:class:`~toga.app.App`,The application itself,|b|,|b|,|b|,|b|,|b|,|b|
-Window,Core Component,:class:`~toga.window.Window`,Window object,|b|,|b|,|b|,|b|,|b|,|b|
-MainWindow,Core Component,:class:`~toga.app.MainWindow`,Main window of the application,|b|,|b|,|b|,|b|,|b|,|b|
-ActivityIndicator,General Widget,:class:`~toga.widgets.activityindicator.ActivityIndicator`,A spinning activity animation,|y|,|y|,,,,
-Button,General Widget,:class:`~toga.widgets.button.Button`,Basic clickable Button,|y|,|y|,|y|,|y|,|y|,|b|
-Canvas,General Widget,:class:`~toga.widgets.canvas.Canvas`,Area you can draw on,|b|,|b|,|b|,|b|,,
-DateInput,General Widget,:class:`~toga.widgets.dateinput.DateInput`,A widget to select a calendar date,,,|y|,,|y|,
-DetailedList,General Widget,:class:`~toga.widgets.detailedlist.DetailedList`,A list of complex content,|b|,|b|,,|b|,|b|,
-Divider,General Widget,:class:`~toga.widgets.divider.Divider`,A horizontal or vertical line,|y|,|y|,|y|,,,
-ImageView,General Widget,:class:`~toga.widgets.imageview.ImageView`,Image Viewer,|b|,|b|,|b|,|b|,|b|,
-Label,General Widget,:class:`~toga.widgets.label.Label`,Text label,|y|,|y|,|y|,|y|,|y|,|b|
-MultilineTextInput,General Widget,:class:`~toga.widgets.multilinetextinput.MultilineTextInput`,Multi-line Text Input field,|y|,|y|,|y|,|y|,|y|,
-NumberInput,General Widget,:class:`~toga.widgets.numberinput.NumberInput`,A text input that is limited to numeric input,|y|,|y|,|y|,|y|,|y|,
-PasswordInput,General Widget,:class:`~toga.widgets.passwordinput.PasswordInput`,A text input that hides its input,|y|,|y|,|y|,|y|,|y|,
-ProgressBar,General Widget,:class:`~toga.widgets.progressbar.ProgressBar`,Progress Bar,|y|,|y|,|y|,|y|,|y|,|b|
-Selection,General Widget,:class:`~toga.widgets.selection.Selection`,Selection,|b|,|b|,|b|,|b|,|b|,
-Slider,General Widget,:class:`~toga.widgets.slider.Slider`,Slider,|y|,|y|,|y|,|y|,|y|,
-Switch,General Widget,:class:`~toga.widgets.switch.Switch`,Switch,|y|,|y|,|y|,|y|,|y|,|b|
-Table,General Widget,:class:`~toga.widgets.table.Table`,Table of data,|b|,|b|,|b|,,|b|,
-TextInput,General Widget,:class:`~toga.widgets.textinput.TextInput`,A widget for the display and editing of a single line of text.,|y|,|y|,|y|,|y|,|y|,|b|
-TimeInput,General Widget,:class:`~toga.widgets.timepicker.TimeInput`,A widget to select a clock time,,,|y|,,|y|,
-Tree,General Widget,:class:`~toga.widgets.tree.Tree`,Tree of data,|b|,|b|,|b|,,,
-WebView,General Widget,:class:`~toga.widgets.webview.WebView`,A panel for displaying HTML,|y|,|y|,|y|,|y|,|y|,
-Widget,General Widget,:class:`~toga.widgets.base.Widget`,The base widget,|y|,|y|,|y|,|y|,|y|,|b|
-Box,Layout Widget,:class:`~toga.widgets.box.Box`,Container for components,|y|,|y|,|y|,|y|,|y|,|b|
-ScrollContainer,Layout Widget,:class:`~toga.widgets.scrollcontainer.ScrollContainer`,Scrollable Container,|b|,|b|,|b|,|b|,|b|,
-SplitContainer,Layout Widget,:class:`~toga.widgets.splitcontainer.SplitContainer`,Split Container,|b|,|b|,|b|,,,
-OptionContainer,Layout Widget,:class:`~toga.widgets.optioncontainer.OptionContainer`,Option Container,|b|,|b|,|b|,,,
+Application,Core Component,:class:`~toga.App`,The application itself,|b|,|b|,|b|,|b|,|b|,|b|
+Window,Core Component,:class:`~toga.Window`,Window object,|b|,|b|,|b|,|b|,|b|,|b|
+MainWindow,Core Component,:class:`~toga.MainWindow`,Main window of the application,|b|,|b|,|b|,|b|,|b|,|b|
+ActivityIndicator,General Widget,:class:`~toga.ActivityIndicator`,A spinning activity animation,|y|,|y|,,,,
+Button,General Widget,:class:`~toga.Button`,Basic clickable Button,|y|,|y|,|y|,|y|,|y|,|b|
+Canvas,General Widget,:class:`~toga.Canvas`,Area you can draw on,|b|,|b|,|b|,|b|,,
+DateInput,General Widget,:class:`~toga.DateInput`,A widget to select a calendar date,,,|y|,,|y|,
+DetailedList,General Widget,:class:`~toga.DetailedList`,A list of complex content,|b|,|b|,,|b|,|b|,
+Divider,General Widget,:class:`~toga.Divider`,A horizontal or vertical line,|y|,|y|,|y|,,,
+ImageView,General Widget,:class:`~toga.ImageView`,Image Viewer,|b|,|b|,|b|,|b|,|b|,
+Label,General Widget,:class:`~toga.Label`,Text label,|y|,|y|,|y|,|y|,|y|,|b|
+MultilineTextInput,General Widget,:class:`~toga.MultilineTextInput`,Multi-line Text Input field,|y|,|y|,|y|,|y|,|y|,
+NumberInput,General Widget,:class:`~toga.NumberInput`,A text input that is limited to numeric input,|y|,|y|,|y|,|y|,|y|,
+PasswordInput,General Widget,:class:`~toga.PasswordInput`,A text input that hides its input,|y|,|y|,|y|,|y|,|y|,
+ProgressBar,General Widget,:class:`~toga.ProgressBar`,Progress Bar,|y|,|y|,|y|,|y|,|y|,|b|
+Selection,General Widget,:class:`~toga.Selection`,Selection,|b|,|b|,|b|,|b|,|b|,
+Slider,General Widget,:class:`~toga.Slider`,Slider,|y|,|y|,|y|,|y|,|y|,
+Switch,General Widget,:class:`~toga.Switch`,Switch,|y|,|y|,|y|,|y|,|y|,|b|
+Table,General Widget,:class:`~toga.Table`,Table of data,|b|,|b|,|b|,,|b|,
+TextInput,General Widget,:class:`~toga.TextInput`,A widget for the display and editing of a single line of text.,|y|,|y|,|y|,|y|,|y|,|b|
+TimeInput,General Widget,:class:`~toga.TimeInput`,A widget to select a clock time,,,|y|,,|y|,
+Tree,General Widget,:class:`~toga.Tree`,Tree of data,|b|,|b|,|b|,,,
+WebView,General Widget,:class:`~toga.WebView`,A panel for displaying HTML,|y|,|y|,|y|,|y|,|y|,
+Widget,General Widget,:class:`~toga.Widget`,The base widget,|y|,|y|,|y|,|y|,|y|,|b|
+Box,Layout Widget,:class:`~toga.Box`,Container for components,|y|,|y|,|y|,|y|,|y|,|b|
+ScrollContainer,Layout Widget,:class:`~toga.ScrollContainer`,Scrollable Container,|b|,|b|,|b|,|b|,|b|,
+SplitContainer,Layout Widget,:class:`~toga.SplitContainer`,Split Container,|b|,|b|,|b|,,,
+OptionContainer,Layout Widget,:class:`~toga.OptionContainer`,Option Container,|b|,|b|,|b|,,,
 App Paths,Resource,:class:`~toga.paths.Paths`,A mechanism for obtaining platform-appropriate filesystem locations for an application.,|y|,|y|,|y|,|y|,|y|,
-Font,Resource,:class:`~toga.fonts.Font`,Fonts,|b|,|b|,|b|,|b|,|b|,
-Command,Resource,:class:`~toga.command.Command`,Command,|b|,|b|,|b|,,|b|,
-Group,Resource,:class:`~toga.command.Group`,Command group,|b|,|b|,|b|,|b|,|b|,
-Icon,Resource,:class:`~toga.icons.Icon`,"An icon for buttons, menus, etc",|b|,|b|,|b|,|b|,|b|,
-Image,Resource,:class:`~toga.images.Image`,An image,|b|,|b|,|b|,|b|,|b|,
+Font,Resource,:class:`~toga.Font`,Fonts,|b|,|b|,|b|,|b|,|b|,
+Command,Resource,:class:`~toga.Command`,Command,|b|,|b|,|b|,,|b|,
+Group,Resource,:class:`~toga.Group`,Command group,|b|,|b|,|b|,|b|,|b|,
+Icon,Resource,:class:`~toga.Icon`,"An icon for buttons, menus, etc",|b|,|b|,|b|,|b|,|b|,
+Image,Resource,:class:`~toga.Image`,An image,|b|,|b|,|b|,|b|,|b|,
 Validators,Resource,:ref:`Validators <validators>`,A mechanism for validating that input meets a given set of criteria.,|y|,|y|,|y|,|y|,|y|,

--- a/docs/reference/platforms.rst
+++ b/docs/reference/platforms.rst
@@ -21,8 +21,7 @@ report ``sys.platform == 'darwin'``), or can be manually installed by invoking:
 
     $ pip install toga-cocoa
 
-The macOS backend has seen the most development to date. It uses `Rubicon`_ to
-provide a bridge to native macOS libraries.
+The macOS backend uses `Rubicon`_ to provide a bridge to native macOS libraries.
 
 .. _toga-cocoa: https://github.com/beeware/toga/tree/main/cocoa
 .. _Rubicon: https://github.com/beeware/rubicon-objc
@@ -32,8 +31,8 @@ Linux
 
 .. image:: /reference/screenshots/gtk.png
 
-The backend for Linux platforms is named `toga-gtk`_. It supports GTK 3.4
-and later. It is installed automatically on Linux machines (machines that
+The backend for Linux platforms is named `toga-gtk`_. It supports GTK 3.10
+or newer. It is installed automatically on Linux machines (machines that
 report ``sys.platform == 'linux'``), or can be manually installed by
 invoking:
 
@@ -41,8 +40,7 @@ invoking:
 
     $ pip install toga-gtk
 
-The GTK backend is reasonably well developed, but currently has some known issues
-with widget layout. It uses the native GObject Python bindings.
+The GTK backend uses the native GObject Python bindings.
 
 .. _toga-gtk: https://github.com/beeware/toga/tree/main/gtk
 
@@ -60,7 +58,7 @@ installed by invoking:
 
     $ pip install toga-winforms
 
-It uses `Python.net`_.
+The Winforms backend uses `Python.net`_.
 
 .. _toga-winforms: https://github.com/beeware/toga/tree/main/winforms
 .. _Python.net: https://pythonnet.github.io
@@ -71,32 +69,33 @@ Mobile platforms
 iOS
 ~~~
 
-The backend for iOS is named `toga-iOS`_. It supports iOS 6 or later. It
-must be manually installed into an iOS Python project. It can be manually
-installed by invoking:
+The backend for iOS is named `toga-iOS`_; it supports iOS 12 or later. It must be
+manually installed into an iOS project; you may find it helpful to use a tool like
+`Briefcase`_ with this deployment process. It can be manually installed by invoking:
 
 .. code-block:: console
 
     $ pip install toga-iOS
 
-The iOS backend is currently proof-of-concept only. Most widgets have not been
-implemented. It uses `Rubicon`_ to provide a bridge to native macOS libraries.
+The iOS backend uses `Rubicon`_ to provide a bridge to native iOS libraries.
 
 .. _toga-iOS: https://github.com/beeware/toga/tree/main/iOS
+.. _Briefcase: https://github.com/beeware/briefcase
 
 Android
 ~~~~~~~
 
-The backend for Android is named `toga-android`_. It can be manually installed
-by invoking:
+The backend for Android is named `toga-android`_; It support Android 8 or later. It must
+be manually installed into an Android project; you may find it helpful to use a tool
+like `Briefcase`_ with this deployment process. It can be manually installed by
+invoking:
 
 .. code-block:: console
 
     $ pip install toga-android
 
-The android backend is currently proof-of-concept only. Most widgets have not
-been implemented. It uses `Chaquopy`_ to provide a way to access the Android
-Java libraries and implement Java interfaces in Python.
+The Android backend uses `Chaquopy`_ to provide a way to access the Android Java
+libraries and implement Java interfaces in Python.
 
 .. _toga-android: https://github.com/beeware/toga/tree/main/android
 .. _Chaquopy: https://chaquo.com/chaquopy/
@@ -104,8 +103,9 @@ Java libraries and implement Java interfaces in Python.
 Web
 ---
 
-The Web backend is named `toga-web`_. It can be manually installed
-by invoking:
+The Web backend is named `toga-web`_. It must be manually installed into an Android
+project; you may find it helpful to use a tool like `Briefcase`_ with this deployment
+process. It can be manually installed by invoking:
 
 .. code-block:: console
 
@@ -130,11 +130,11 @@ Planned platform support
 
 Eventually, the Toga project would like to provide support for the following platforms:
 
- * UWP (Native Windows 8 and Windows mobile)
+ * WinUI (Modern Windows look and feel)
  * Qt (for KDE based desktops)
  * tvOS (for AppleTV devices)
  * watchOS (for AppleWatch devices)
- * Curses (for console)
+ * Curses/Textual (for console)
 
 If you are interested in these platforms and would like to contribute, please
 get in touch on `Mastodon <https://fosstodon.org/@beeware>`__ or

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -18,18 +18,18 @@ Tutorials
 Tutorial 0 - your first Toga app
 ================================
 
-In :doc:`tutorial-0`, you will discover how to create a basic app and have a simple :class:`~toga.widgets.button.Button` widget to click.
+In :doc:`tutorial-0`, you will discover how to create a basic app and have a simple :class:`~toga.Button` widget to click.
 
 Tutorial 1 - a slightly less toy example
 ========================================
 
-In :doc:`tutorial-1`, you will discover how to capture basic user input using the :class:`~toga.widgets.textinput.TextInput` widget
+In :doc:`tutorial-1`, you will discover how to capture basic user input using the :class:`~toga.TextInput` widget
 and control layout.
 
 Tutorial 2 - you put the box inside another box...
 ==================================================
 
-In :doc:`tutorial-2`, you will discover how to use the :class:`~toga.widgets.splitcontainer.SplitContainer` widget to display
+In :doc:`tutorial-2`, you will discover how to use the :class:`~toga.SplitContainer` widget to display
 some components, a toolbar and a table.
 
 .. figure:: screenshots/tutorial-2.png
@@ -39,7 +39,7 @@ some components, a toolbar and a table.
 Tutorial 3 - let's build a browser!
 ===================================
 
-In :doc:`tutorial-3`, you will discover how to use the :class:`~toga.widgets.webview.WebView` widget to display
+In :doc:`tutorial-3`, you will discover how to use the :class:`~toga.WebView` widget to display
 a simple browser.
 
 .. figure:: screenshots/tutorial-3.png
@@ -49,7 +49,7 @@ a simple browser.
 Tutorial 4 - let's draw on a canvas!
 ====================================
 
-In :doc:`tutorial-4`, you will discover how to use the :class:`~toga.widgets.canvas.Canvas` widget to draw
+In :doc:`tutorial-4`, you will discover how to use the :class:`~toga.Canvas` widget to draw
 lines and shapes on a canvas.
 
 .. figure:: screenshots/tutorial-4.png


### PR DESCRIPTION
Fixes #2001.

Modifies all the class references in documentation and source from the definition location to the preferred import location (generally `toga.X` rather than `toga.widgets.x.X`).

I'm not 100% happy with the fact that `:class:toga.Foo` anchors at the start of the class definition, rather than the top of the page, but I'm also not sure I see a way to fix that. Changing to `toga.Widget` format is a significant improvement, and it's no worse that it was before, so I figure this is an incremental improvement.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
