### PR TITLE
Test coverage cleanups

### DIFF
--- a/changes/2004.misc.rst
+++ b/changes/2004.misc.rst
@@ -1,0 +1,1 @@
+Test coverage was restored for DateInput, TimeInput and Button widgets.

--- a/cocoa/src/toga_cocoa/widgets/button.py
+++ b/cocoa/src/toga_cocoa/widgets/button.py
@@ -2,6 +2,7 @@ from travertino.size import at_least
 
 from toga.colors import TRANSPARENT
 from toga.fonts import SYSTEM_DEFAULT_FONT_SIZE
+from toga.style.pack import NONE
 from toga_cocoa.colors import native_color
 from toga_cocoa.libs import (
     SEL,
@@ -46,7 +47,7 @@ class Button(Widget):
         # RegularSquare button.
         if (
             self.interface.style.font_size != SYSTEM_DEFAULT_FONT_SIZE
-            or self.interface.style.height
+            or self.interface.style.height != NONE
         ):
             self.native.bezelStyle = NSBezelStyle.RegularSquare
         else:

--- a/cocoa/tests_backend/widgets/button.py
+++ b/cocoa/tests_backend/widgets/button.py
@@ -1,5 +1,6 @@
 from pytest import xfail
 
+from toga.style.pack import NONE
 from toga_cocoa.libs import NSBezelStyle, NSButton, NSFont
 
 from .base import SimpleProbe
@@ -33,7 +34,7 @@ class ButtonProbe(SimpleProbe):
         # If the button has a manual height set, or has a non-default font size
         # it should have a different bezel style.
         if (
-            self.widget.style.height
+            self.widget.style.height != NONE
             or self.native.font.pointSize != NSFont.systemFontSize
         ):
             assert self.native.bezelStyle == NSBezelStyle.RegularSquare

--- a/core/src/toga/platform.py
+++ b/core/src/toga/platform.py
@@ -1,7 +1,6 @@
 import importlib
 import os
 import sys
-import warnings
 from functools import lru_cache
 
 try:
@@ -30,44 +29,31 @@ _TOGA_PLATFORMS = {
 }
 
 
-try:
-    current_platform = os.environ["TOGA_PLATFORM"]
-except KeyError:
+def get_current_platform():
     # Rely on `sys.getandroidapilevel`, which only exists on Android; see
     # https://github.com/beeware/Python-Android-support/issues/8
     if hasattr(sys, "getandroidapilevel"):
-        current_platform = "android"
+        return "android"
     elif sys.platform.startswith("freebsd"):
-        current_platform = "freeBSD"
+        return "freeBSD"
     else:
-        current_platform = _TOGA_PLATFORMS.get(sys.platform)
+        return _TOGA_PLATFORMS.get(sys.platform)
+
+
+current_platform = get_current_platform()
 
 
 @lru_cache(maxsize=1)
-def get_platform_factory(factory=None):
-    """This function figures out what the current host platform is and imports the
-    adequate factory. The factory is the interface to all platform specific
-    implementations.
+def get_platform_factory():
+    """Determine the current host platform and import the platform factory.
 
-    If the TOGA_BACKEND environment variable is set, the factory will be loaded
+    If the ``TOGA_BACKEND`` environment variable is set, the factory will be loaded
     from that module.
 
-    Returns: The suitable factory for the current host platform.
+    Raises :any:`RuntimeError` if an appropriate host platform cannot be identified.
 
-    Raises:
-        RuntimeError: If no supported host platform can be identified.
+    :returns: The factory for the host platform.
     """
-
-    ######################################################################
-    # 2022-09: Backwards compatibility
-    ######################################################################
-    # factory no longer used
-    if factory:
-        warnings.warn("The factory argument is no longer used.", DeprecationWarning)
-    ######################################################################
-    # End backwards compatibility.
-    ######################################################################
-
     toga_backends = entry_points(group="toga.backends")
     if not toga_backends:
         raise RuntimeError("No Toga backend could be loaded.")
@@ -104,7 +90,9 @@ def get_platform_factory(factory=None):
                 )
                 raise RuntimeError(
                     f"Multiple Toga backends are installed ({toga_backends_string}), "
-                    f"but none of them match your current platform ({current_platform!r})."
+                    f"but none of them match your current platform ({current_platform!r}). "
+                    "Install a backend for your current platform, or use "
+                    "TOGA_BACKEND to specify a backend."
                 )
             if len(matching_backends) > 1:
                 toga_backends_string = ", ".join(

--- a/core/tests/test_platform.py
+++ b/core/tests/test_platform.py
@@ -1,6 +1,7 @@
-import os
-import unittest
-from unittest.mock import Mock, patch
+import sys
+from unittest.mock import Mock
+
+import pytest
 
 import toga_dummy
 
@@ -14,7 +15,98 @@ try:
 except ImportError:
     from importlib.metadata import EntryPoint
 
-from toga.platform import current_platform, get_platform_factory
+import toga.platform
+from toga.platform import current_platform, get_current_platform, get_platform_factory
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    monkeypatch.delenv("TOGA_BACKEND")
+
+
+@pytest.fixture
+def platform_factory_1():
+    return Mock()
+
+
+@pytest.fixture
+def platform_factory_2():
+    return Mock()
+
+
+def patch_platforms(monkeypatch, platforms):
+    monkeypatch.setattr(
+        sys,
+        "modules",
+        {f"{name}_module.factory": factory for name, factory, _ in platforms},
+    )
+
+    monkeypatch.setattr(
+        toga.platform,
+        "entry_points",
+        Mock(
+            return_value=[
+                EntryPoint(
+                    name=current_platform if is_current else name,
+                    value=f"{name}_module",
+                    group="self.backends",
+                )
+                for name, _, is_current in platforms
+            ]
+        ),
+    )
+
+
+def test_get_current_platform_desktop():
+    assert (
+        get_current_platform()
+        == {
+            "darwin": "macOS",
+            "linux": "linux",
+            "win32": "windows",
+        }[sys.platform]
+    )
+
+
+def test_get_current_platform_android_inferred(monkeypatch):
+    "Android platform can be inferred from existence of sys.getandroidapilevel"
+    monkeypatch.setattr(sys, "platform", "linux")
+    try:
+        # since there isn't an existing attribute of this name, it can't be patched.
+        sys.getandroidapilevel = Mock(return_value=42)
+        assert get_current_platform() == "android"
+    finally:
+        del sys.getandroidapilevel
+
+
+def test_get_current_platform_android(monkeypatch):
+    "Android platform can be obtained directly from sys.platform"
+    monkeypatch.setattr(sys, "platform", "android")
+    try:
+        # since there isn't an existing attribute of this name, it can't be patched.
+        sys.getandroidapilevel = Mock(return_value=42)
+        assert get_current_platform() == "android"
+    finally:
+        del sys.getandroidapilevel
+
+
+def test_get_current_platform_iOS(monkeypatch):
+    "iOS platform can be obtained directly from sys.platform"
+    monkeypatch.setattr(sys, "platform", "ios")
+    assert get_current_platform() == "iOS"
+
+
+def test_get_current_platform_web(monkeypatch):
+    "Web platform can be obtained directly from sys.platform"
+    monkeypatch.setattr(sys, "platform", "emscripten")
+    assert get_current_platform() == "web"
+
+
+@pytest.mark.parametrize("value", ["freebsd12", "freebsd13", "freebsd14"])
+def test_get_current_platform_freebsd(monkeypatch, value):
+    "FreeBSD platform can be obtained directly from sys.platform"
+    monkeypatch.setattr(sys, "platform", value)
+    assert get_current_platform() == "freeBSD"
 
 
 def _get_platform_factory():
@@ -24,119 +116,92 @@ def _get_platform_factory():
     return factory
 
 
-@patch.dict(os.environ, {"TOGA_BACKEND": ""})
-class PlatformTests(unittest.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.group = "toga.backends"
+def test_no_platforms(monkeypatch, clean_env):
+    patch_platforms(monkeypatch, [])
+    with pytest.raises(
+        RuntimeError,
+        match=r"No Toga backend could be loaded.",
+    ):
+        _get_platform_factory()
 
-    def test_no_platforms(self):
-        with patch("toga.platform.entry_points", return_value=None):
-            with self.assertRaises(RuntimeError):
-                _get_platform_factory()
 
-    def test_one_platform_installed(self):
-        only_platform_factory = Mock()
-        platform_factories = {
-            "only_platform_module.factory": only_platform_factory,
-        }
-        entry_points = [
-            EntryPoint(
-                name="only_platform", value="only_platform_module", group=self.group
-            ),
-        ]
-        with patch.dict("sys.modules", platform_factories):
-            with patch("toga.platform.entry_points", return_value=entry_points):
-                factory = _get_platform_factory()
-                self.assertEqual(factory, only_platform_factory)
+def test_one_platform_installed(monkeypatch, clean_env):
+    only_platform_factory = Mock()
+    patch_platforms(monkeypatch, [("only_platform", only_platform_factory, False)])
 
-    def test_multiple_platforms_installed(self):
-        current_platform_factory = Mock()
-        other_platform_factory = Mock()
-        platform_factories = {
-            "current_platform_module.factory": current_platform_factory,
-            "other_platform_module.factory": other_platform_factory,
-        }
-        entry_points = [
-            EntryPoint(
-                name=current_platform, value="current_platform_module", group=self.group
-            ),
-            EntryPoint(
-                name="other_platform", value="other_platform_module", group=self.group
-            ),
-        ]
-        with patch.dict("sys.modules", platform_factories):
-            with patch("toga.platform.entry_points", return_value=entry_points):
-                factory = _get_platform_factory()
-                self.assertEqual(factory, current_platform_factory)
+    factory = _get_platform_factory()
+    assert factory == only_platform_factory
 
-    def test_multiple_platforms_installed_fail_both_appropriate(self):
-        current_platform_factory_1 = Mock()
-        current_platform_factory_2 = Mock()
-        platform_factories = {
-            "current_platform_module_1.factory": current_platform_factory_1,
-            "current_platform_module_2.factory": current_platform_factory_2,
-        }
-        entry_points = [
-            EntryPoint(
-                name=current_platform,
-                value="current_platform_module_1",
-                group=self.group,
-            ),
-            EntryPoint(
-                name=current_platform,
-                value="current_platform_module_2",
-                group=self.group,
-            ),
-        ]
-        with patch.dict("sys.modules", platform_factories):
-            with patch("toga.platform.entry_points", return_value=entry_points):
-                with self.assertRaises(RuntimeError):
-                    _get_platform_factory()
 
-    def test_multiple_platforms_installed_fail_none_appropriate(self):
-        other_platform_factory_1 = Mock()
-        other_platform_factory_2 = Mock()
-        platform_factories = {
-            "other_platform_module_1.factory": other_platform_factory_1,
-            "other_platform_module_2.factory": other_platform_factory_2,
-        }
-        entry_points = [
-            EntryPoint(
-                name="other_platform_1",
-                value="other_platform_module_1",
-                group=self.group,
-            ),
-            EntryPoint(
-                name="other_platform_2",
-                value="other_platform_module_2",
-                group=self.group,
-            ),
-        ]
-        with patch.dict("sys.modules", platform_factories):
-            with patch("toga.platform.entry_points", return_value=entry_points):
-                with self.assertRaises(RuntimeError):
-                    _get_platform_factory()
+def test_multiple_platforms_installed(monkeypatch, clean_env):
+    current_platform_factory = Mock()
+    other_platform_factory = Mock()
+    patch_platforms(
+        monkeypatch,
+        [
+            ("other_platform", other_platform_factory, False),
+            ("current_platform", current_platform_factory, True),
+        ],
+    )
 
-    @patch.dict(os.environ, {"TOGA_BACKEND": "toga_dummy"})
-    def test_environment_variable(self):
-        self.assertEqual(toga_dummy.factory, _get_platform_factory())
+    factory = _get_platform_factory()
+    assert factory == current_platform_factory
 
-    @patch.dict(os.environ, {"TOGA_BACKEND": "fake_platform_module"})
-    def test_environment_variable_fail(self):
-        with self.assertRaises(RuntimeError):
-            _get_platform_factory()
 
-    ######################################################################
-    # 2022-09: Backwards compatibility
-    ######################################################################
+def test_multiple_platforms_installed_fail_both_appropriate(monkeypatch, clean_env):
+    current_platform_factory_1 = Mock()
+    current_platform_factory_2 = Mock()
+    patch_platforms(
+        monkeypatch,
+        [
+            ("current_platform_1", current_platform_factory_1, True),
+            ("current_platform_2", current_platform_factory_2, True),
+        ],
+    )
 
-    def test_factory_deprecated(self):
-        my_factory = object()
-        with self.assertWarns(DeprecationWarning):
-            factory = get_platform_factory(factory=my_factory)
-        self.assertNotEqual(factory, my_factory)
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            r"Multiple candidate toga backends found: \('current_platform_1_module' "
+            r"\(.*\), 'current_platform_2_module' \(.*\)\). Uninstall the backends you "
+            r"don't require, or use TOGA_BACKEND to specify a backend."
+        ),
+    ):
+        _get_platform_factory()
 
-    ######################################################################
-    # End backwards compatibility.
-    ######################################################################
+
+def test_multiple_platforms_installed_fail_none_appropriate(monkeypatch, clean_env):
+    other_platform_factory_1 = Mock()
+    other_platform_factory_2 = Mock()
+    patch_platforms(
+        monkeypatch,
+        [
+            ("other_platform_1", other_platform_factory_1, False),
+            ("other_platform_2", other_platform_factory_2, False),
+        ],
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            r"Multiple Toga backends are installed \('other_platform_1_module' "
+            r"\(.*\), 'other_platform_2_module' \(.*\)\), but none of them match "
+            r"your current platform \('.*'\). Install a backend for your current "
+            r"platform, or use TOGA_BACKEND to specify a backend."
+        ),
+    ):
+        _get_platform_factory()
+
+
+def test_environment_variable(monkeypatch):
+    monkeypatch.setenv("TOGA_BACKEND", "toga_dummy")
+    assert toga_dummy.factory == _get_platform_factory()
+
+
+def test_environment_variable_fail(monkeypatch):
+    monkeypatch.setenv("TOGA_BACKEND", "fake_platform_module")
+    with pytest.raises(
+        RuntimeError,
+        match=r"The backend specified by TOGA_BACKEND \('fake_platform_module'\) could not be loaded.",
+    ):
+        _get_platform_factory()

--- a/core/tests/widgets/test_dateinput.py
+++ b/core/tests/widgets/test_dateinput.py
@@ -262,3 +262,9 @@ def test_deprecated_names():
     widget.max_date = MAX
     assert widget.max_date == MAX
     assert widget.max_value == MAX
+
+    with warns(DeprecationWarning, match="DatePicker has been renamed DateInput"):
+        widget = toga.DatePicker()
+
+    assert widget.min_date == date(1800, 1, 1)
+    assert widget.max_date == date(8999, 12, 31)

--- a/core/tests/widgets/test_timeinput.py
+++ b/core/tests/widgets/test_timeinput.py
@@ -250,3 +250,9 @@ def test_deprecated_names():
     widget.max_time = MAX
     assert widget.max_time == MAX
     assert widget.max_value == MAX
+
+    with warns(DeprecationWarning, match="TimePicker has been renamed TimeInput"):
+        widget = toga.TimePicker()
+
+    assert widget.min_time == time(0, 0, 0)
+    assert widget.max_time == time(23, 59, 59)


### PR DESCRIPTION
* Restores 100% core test coverage for DateInput and TimeInput (caused by a missing code path in the deprecation shim)
* Restores 100% cocoa test coverage for Button (caused by the recent change to interpret default widget height as NONE, rather than 0)
* Ports the toga.platform tests to pytest. Not sure why, but the introduction of the NotImplmented factory shim in #1992 caused local pytest runs to fail for me. Tox runs were fine; but since we needed to update the tests anyway, now was as good a time as any. This also corrects a minor issue with the definition of `current_platform`, and gets the module to 100% test coverage.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
