### PR TITLE
Fix `pyodide.create_proxy` usage with `pyodide.ffi.create_proxy`

### DIFF
--- a/changes/2008.misc.rst
+++ b/changes/2008.misc.rst
@@ -1,0 +1,1 @@
+The import for Pyodide's ``create_proxy`` function was updated to import from the ``ffi`` submodule.

--- a/web/src/toga_web/libs.py
+++ b/web/src/toga_web/libs.py
@@ -16,7 +16,7 @@ except ModuleNotFoundError:
     pyodide = None
 
 
-create_proxy = pyodide.create_proxy if pyodide else lambda f: f
+create_proxy = pyodide.ffi.create_proxy if pyodide else lambda f: f
 
 
 def create_element(


### PR DESCRIPTION
- Pyodide removed most names from the root module with the 0.23.0 release. They must be accessed from their respective submodules.

Please close if already resolved with an open PR.

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
