### PR TITLE
Added app.beep() to play the default system notification sound.

### DIFF
--- a/android/src/toga_android/app.py
+++ b/android/src/toga_android/app.py
@@ -206,6 +206,9 @@ class App:
     def show_about_dialog(self):
         self.interface.factory.not_implemented("App.show_about_dialog()")
 
+    def beep(self):
+        self.interface.factory.not_implemented("App.beep()")
+
     def exit(self):
         pass
 

--- a/changes/2018.feature.rst
+++ b/changes/2018.feature.rst
@@ -1,0 +1,1 @@
+The default system notification sound can be played via app.beep()

--- a/cocoa/src/toga_cocoa/app.py
+++ b/cocoa/src/toga_cocoa/app.py
@@ -18,6 +18,7 @@ from .libs import (
     NSAboutPanelOptionApplicationVersion,
     NSApplication,
     NSApplicationActivationPolicyRegular,
+    NSBeep,
     NSBundle,
     NSCursor,
     NSDocumentController,
@@ -362,6 +363,9 @@ class App:
             )
 
         self.native.orderFrontStandardAboutPanelWithOptions(options)
+
+    def beep(self):
+        NSBeep()
 
     def exit(self):
         self.loop.stop()

--- a/cocoa/src/toga_cocoa/libs/appkit.py
+++ b/cocoa/src/toga_cocoa/libs/appkit.py
@@ -15,6 +15,8 @@ from toga.constants import CENTER, JUSTIFY, LEFT, RIGHT
 appkit = load_library("AppKit")
 ######################################################################
 
+NSBeep = appkit.NSBeep
+
 ######################################################################
 # NSAffineTransform.h
 NSAffineTransform = ObjCClass("NSAffineTransform")

--- a/core/src/toga/app.py
+++ b/core/src/toga/app.py
@@ -569,6 +569,10 @@ class App:
         if self.home_page is not None:
             webbrowser.open(self.home_page)
 
+    def beep(self):
+        """Play the default system notification sound."""
+        self._impl.beep()
+
     def main_loop(self):
         """Invoke the application to handle user input.
 

--- a/core/tests/test_app.py
+++ b/core/tests/test_app.py
@@ -156,6 +156,10 @@ class AppTests(TestCase):
         for window in self.app.windows:
             self.assertIn(window, test_windows)
 
+    def test_beep(self):
+        self.app.beep()
+        self.assertActionPerformed(self.app, "beep")
+
     def test_add_background_task(self):
         async def test_handler(sender):
             pass

--- a/dummy/src/toga_dummy/app.py
+++ b/dummy/src/toga_dummy/app.py
@@ -39,6 +39,9 @@ class App(LoggedObject):
     def show_about_dialog(self):
         self._action("show_about_dialog")
 
+    def beep(self):
+        self._action("beep")
+
     def exit(self):
         self._action("exit")
 

--- a/gtk/src/toga_gtk/app.py
+++ b/gtk/src/toga_gtk/app.py
@@ -218,6 +218,9 @@ class App:
         about.run()
         about.destroy()
 
+    def beep(self):
+        Gdk.gdk_beep()
+
     def exit(self):
         self.native.quit()
 

--- a/iOS/src/toga_iOS/app.py
+++ b/iOS/src/toga_iOS/app.py
@@ -127,5 +127,8 @@ class App:
     def show_about_dialog(self):
         self.interface.factory.not_implemented("App.show_about_dialog()")
 
+    def beep(self):
+        self.interface.factory.not_implemented("App.beep()")
+
     def exit(self):
         pass

--- a/web/src/toga_web/app.py
+++ b/web/src/toga_web/app.py
@@ -176,6 +176,9 @@ class App:
 
         js.customElements.whenDefined("sl-dialog").then(show_dialog)
 
+    def beep(self):
+        self.interface.factory.not_implemented("App.beep()")
+
     def exit(self):
         pass
 

--- a/winforms/src/toga_winforms/app.py
+++ b/winforms/src/toga_winforms/app.py
@@ -10,6 +10,7 @@ from .keys import toga_to_winforms_key
 from .libs import (
     SecurityProtocolType,
     ServicePointManager,
+    SystemSounds,
     Threading,
     WinForms,
     shcore,
@@ -286,6 +287,9 @@ class App:
         self.interface.main_window.info_dialog(
             f"About {self.interface.name}", "\n".join(message_parts)
         )
+
+    def beep(self):
+        SystemSounds.Beep.Play()
 
     def exit(self):
         self._is_exiting = True

--- a/winforms/src/toga_winforms/libs/__init__.py
+++ b/winforms/src/toga_winforms/libs/__init__.py
@@ -36,6 +36,7 @@ from .winforms import (  # noqa: F401
     StringFormat,
     SystemColors,
     SystemFonts,
+    SystemSounds,
     Task,
     TaskScheduler,
     Threading,

--- a/winforms/src/toga_winforms/libs/winforms.py
+++ b/winforms/src/toga_winforms/libs/winforms.py
@@ -49,6 +49,7 @@ from System.Drawing.Imaging import ImageFormat  # noqa: F401, E402
 from System.Drawing.Text import PrivateFontCollection  # noqa: F401, E402
 from System.Globalization import CultureInfo  # noqa: F401, E402
 from System.IO import FileNotFoundException, MemoryStream  # noqa: F401, E402
+from System.Media import SystemSounds  # noqa: F401, E402
 from System.Net import SecurityProtocolType, ServicePointManager  # noqa: F401, E402
 from System.Runtime.InteropServices import ExternalException  # noqa: F401, E402
 from System.Threading.Tasks import Task, TaskScheduler  # noqa: F401, E402


### PR DESCRIPTION
`app.beep()` is a new method that will play the default system notification sound.

Only tested for macOS

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct

## API References:
- https://developer.apple.com/documentation/appkit/1473622-nsbeep
- https://docs.gtk.org/gdk3/func.beep.html
- https://learn.microsoft.com/en-us/dotnet/desktop/winforms/controls/how-to-play-a-beep-from-a-windows-form