### PR TITLE
Refine Linux dependencies for developing and using Toga

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
           - backend: gtk
             pre-command: |
               sudo apt update -y
-              sudo apt install -y libfuse2 pkg-config python3-dev libgirepository1.0-dev libcairo2-dev gir1.2-gtk-3.0
+              sudo apt install -y pkg-config python3-dev libgirepository1.0-dev libcairo2-dev gir1.2-gtk-3.0
 
           - backend: iOS
             runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,9 @@ jobs:
             runs-on: macos-latest
 
           - backend: gtk
-            pre-command: "sudo apt-get update -y && sudo apt-get install -y python3-gi python3-gi-cairo gir1.2-gtk-3.0 python3-dev libgirepository1.0-dev libcairo2-dev pkg-config libfuse2"
+            pre-command: |
+              sudo apt update -y
+              sudo apt install -y libfuse2 pkg-config python3-dev libgirepository1.0-dev libcairo2-dev gir1.2-gtk-3.0
 
           - backend: iOS
             runs-on: macos-latest
@@ -207,17 +209,18 @@ jobs:
             # The package list should be the same as in tutorial-0.rst, and the BeeWare
             # tutorial, plus flwm to provide a window manager
             pre-command: |
-                sudo apt-get update -y && sudo apt-get install -y python3-dev python3-cairo-dev python3-gi-cairo libgirepository1.0-dev libcairo2-dev libpango1.0-dev gir1.2-webkit2-4.0 pkg-config flwm
+              sudo apt update -y
+              sudo apt install -y flwm pkg-config python3-dev libgirepository1.0-dev libcairo2-dev gir1.2-webkit2-4.0
 
-                # Start Virtual X server
-                echo "Start X server..."
-                Xvfb :99 -screen 0 2048x1536x24 &
-                sleep 1
+              # Start Virtual X server
+              echo "Start X server..."
+              Xvfb :99 -screen 0 2048x1536x24 &
+              sleep 1
 
-                # Start Window manager
-                echo "Start window manager..."
-                DISPLAY=:99 flwm &
-                sleep 1
+              # Start Window manager
+              echo "Start window manager..."
+              DISPLAY=:99 flwm &
+              sleep 1
 
             briefcase-run-prefix: 'DISPLAY=:99'
             setup-python: false  # Use the system Python packages.

--- a/changes/2021.doc.rst
+++ b/changes/2021.doc.rst
@@ -1,0 +1,1 @@
+The Linux system dependencies were updated to reflect current requirements for developing and using Toga.

--- a/docs/how-to/contribute-code.rst
+++ b/docs/how-to/contribute-code.rst
@@ -84,27 +84,27 @@ Next, install any additional dependencies for your operating system:
 
     .. code-block:: console
 
-      (venv) $ sudo apt-get update
-      (venv) $ sudo apt-get install python3-dev libgirepository1.0-dev libcairo2-dev libpango1.0-dev libwebkit2gtk-4.0-37 gir1.2-webkit2-4.0
+      (venv) $ sudo apt update
+      (venv) $ sudo apt install pkg-config python3-dev libgirepository1.0-dev libcairo2-dev gir1.2-webkit2-4.0 libcanberra-gtk3-module
 
     Fedora
 
     .. code-block:: console
 
-      (venv) $ sudo dnf install pkg-config python3-devel gobject-introspection-devel cairo-devel cairo-gobject-devel pango-devel webkitgtk3
+      (venv) $ sudo dnf install pkg-config python3-devel gobject-introspection-devel cairo-gobject-devel webkitgtk4 libcanberra-gtk3
 
     Arch / Manjaro
 
     .. code-block:: console
 
-      (venv) $ sudo pacman -Syu git pkgconf cairo python-cairo pango gobject-introspection gobject-introspection-runtime python-gobject webkit2gtk
+      (venv) $ sudo pacman -Syu git pkgconf gobject-introspection cairo webkit2gtk libcanberra
 
     FreeBSD
 
     .. code-block:: console
 
       (venv) $ sudo pkg update
-      (venv) $ sudo pkg install gtk3 pango gobject-introspection cairo webkit2-gtk3
+      (venv) $ sudo pkg install gobject-introspection cairo webkit2-gtk3
 
   .. group-tab:: Windows
 

--- a/docs/how-to/contribute-code.rst
+++ b/docs/how-to/contribute-code.rst
@@ -91,7 +91,7 @@ Next, install any additional dependencies for your operating system:
 
     .. code-block:: console
 
-      (venv) $ sudo dnf install pkg-config python3-devel gobject-introspection-devel cairo-gobject-devel webkitgtk4 libcanberra-gtk3
+      (venv) $ sudo dnf install pkg-config python3-devel gobject-introspection-devel cairo-gobject-devel webkit2gtk3 libcanberra-gtk3
 
     Arch / Manjaro
 

--- a/docs/how-to/contribute-docs.rst
+++ b/docs/how-to/contribute-docs.rst
@@ -44,8 +44,8 @@ You'll also need to install the Enchant spell checking library.
 
     .. code-block:: console
 
-      $ sudo apt-get update
-      $ sudo apt-get install enchant-2
+      $ sudo apt update
+      $ sudo apt install enchant-2
 
     **Fedora**
 

--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -80,7 +80,7 @@ Next, install Toga into your virtual environment:
 
     .. code-block:: console
 
-      (venv) $ sudo dnf install pkg-config python3-devel gobject-introspection-devel cairo-gobject-devel webkitgtk4 libcanberra-gtk3
+      (venv) $ sudo dnf install pkg-config python3-devel gobject-introspection-devel cairo-gobject-devel webkit2gtk3 libcanberra-gtk3
 
     Arch / Manjaro
 

--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -73,30 +73,30 @@ Next, install Toga into your virtual environment:
 
     .. code-block:: console
 
-      (venv) $ sudo apt-get update
-      (venv) $ sudo apt-get install python3-dev python3-cairo-dev python3-gi-cairo libgirepository1.0-dev libcairo2-dev libpango1.0-dev gir1.2-webkit2-4.0 pkg-config
+      (venv) $ sudo apt update
+      (venv) $ sudo apt install pkg-config python3-dev libgirepository1.0-dev libcairo2-dev gir1.2-webkit2-4.0 libcanberra-gtk3-module
 
     Fedora
 
     .. code-block:: console
 
-      (venv) $ sudo dnf install pkg-config python3-devel gobject-introspection-devel cairo-devel cairo-gobject-devel pango-devel webkitgtk3
+      (venv) $ sudo dnf install pkg-config python3-devel gobject-introspection-devel cairo-gobject-devel webkitgtk4 libcanberra-gtk3
 
     Arch / Manjaro
 
     .. code-block:: console
 
-      (venv) $ sudo pacman -Syu git pkgconf cairo python-cairo pango gobject-introspection gobject-introspection-runtime python-gobject webkit2gtk
+      (venv) $ sudo pacman -Syu git pkgconf gobject-introspection cairo webkit2gtk libcanberra
 
     FreeBSD
 
     .. code-block:: console
 
       (venv) $ sudo pkg update
-      (venv) $ sudo pkg install gtk3 pango gobject-introspection cairo webkit2-gtk3
+      (venv) $ sudo pkg install gobject-introspection cairo webkit2-gtk3 libcanberra-gtk3
 
     If you're not using one of these, you'll need to work out how to install
-    the developer libraries for ``python3``, ``cairo``, ``pango``, and
+    the developer libraries for ``python3``, ``cairo``, and
     ``gobject-introspection`` (and please let us know so we can improve this
     documentation!)
 

--- a/gtk/README.rst
+++ b/gtk/README.rst
@@ -22,15 +22,11 @@ starting with Ubuntu 14.04 and Fedora 20. You also need to install the Python
 have WebKit, plus the GI bindings to WebKit installed. This means you'll need
 to install the following:
 
-* **Ubuntu 14.04** ``apt-get install python3-gi gir1.2-webkit-3.0``
+* **Ubuntu 18.04+ / Debian 10+** ``sudo apt install python3-gi python3-gi-cairo gir1.2-webkit2-4.0``
 
-* **Ubuntu 16.04 / Debian 8** ``apt-get install python3-gi gir1.2-webkit2-4.0``
-  or ``apt-get install python3-gi gir1.2-webkit-3.0``
+* **Fedora** ``sudo dnf install python3-gobject webkitgtk4``
 
-* **Fedora** ``dnf install python3-gobject pywebkitgtk``
-  or ``yum install python3-gobject pywebkitgtk``
-
-* **Arch Linux** ``pacman -S python-gobject webkit2gtk``
+* **Arch Linux** ``sudo pacman -S python-gobject webkit2gtk``
 
 Community
 ---------

--- a/gtk/README.rst
+++ b/gtk/README.rst
@@ -24,7 +24,7 @@ to install the following:
 
 * **Ubuntu 18.04+ / Debian 10+** ``sudo apt install python3-gi python3-gi-cairo gir1.2-webkit2-4.0``
 
-* **Fedora** ``sudo dnf install python3-gobject webkitgtk4``
+* **Fedora** ``sudo dnf install python3-gobject webkit2gtk3``
 
 * **Arch Linux** ``sudo pacman -S python-gobject webkit2gtk``
 

--- a/testbed/pyproject.toml
+++ b/testbed/pyproject.toml
@@ -49,7 +49,6 @@ requires = [
 
 [tool.briefcase.app.testbed.linux.appimage]
 system_requires = [
-    "gir1.2-webkit2-4.0",
     "libcairo2-dev",
     "libgirepository1.0-dev",
     "libgtk-3-dev",


### PR DESCRIPTION
## Changes
- Follow on work from beeware/beeware#231
- Stops installing Python packages for `PyGObject` and `cairo` from Debian repos
  - This includes `python3-gi`, `python3-gi-cairo`, etc
  - When `PyGObject` is installed from PyPI, it brings along all the Python stuff it needs
  - This also aligns Toga's install instructions with PYGobject's install [instructions](https://pygobject.readthedocs.io/en/latest/getting_started.html).
- Stops installing `libpango1.0-dev` since these headers are not needed for anything
  - `libpango` will be installed as a dependency of `libgtk-3-0`

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
