### PR TITLE
Two improvements to cocoa MultilineTextInput: disable richtext, and enable undo

### DIFF
--- a/android/tests_backend/widgets/base.py
+++ b/android/tests_backend/widgets/base.py
@@ -173,3 +173,9 @@ class SimpleProbe(BaseProbe):
     @property
     def has_focus(self):
         return self.widget.app._impl.native.getCurrentFocus() == self.native
+
+    async def undo(self):
+        raise NotImplementedError()
+
+    async def redo(self):
+        raise NotImplementedError()

--- a/changes/2037.feature.rst
+++ b/changes/2037.feature.rst
@@ -1,0 +1,1 @@
+The cocoa MultilineTextInput widget has been updated to disable richtext and enable undo

--- a/cocoa/src/toga_cocoa/widgets/multilinetextinput.py
+++ b/cocoa/src/toga_cocoa/widgets/multilinetextinput.py
@@ -41,6 +41,8 @@ class MultilineTextInput(Widget):
 
         self.native_text.editable = True
         self.native_text.selectable = True
+        self.native_text.richText = False
+        self.native_text.allowsUndo = True
         self.native_text.verticallyResizable = True
         self.native_text.horizontallyResizable = False
         self.native_text.usesAdaptiveColorMappingForDarkAppearance = True

--- a/cocoa/tests_backend/widgets/multilinetextinput.py
+++ b/cocoa/tests_backend/widgets/multilinetextinput.py
@@ -1,5 +1,5 @@
 from toga.colors import TRANSPARENT
-from toga_cocoa.libs import NSScrollView, NSTextView
+from toga_cocoa.libs import NSRange, NSScrollView, NSTextView
 
 from .base import SimpleProbe
 from .properties import toga_alignment, toga_color, toga_font
@@ -96,3 +96,6 @@ class MultilineTextInputProbe(SimpleProbe):
     async def wait_for_scroll_completion(self):
         # No animation associated with scroll, so this is a no-op
         pass
+
+    def set_cursor_at_end(self):
+        self.native.selectedRange = NSRange(len(self.value), 0)

--- a/cocoa/tests_backend/widgets/numberinput.py
+++ b/cocoa/tests_backend/widgets/numberinput.py
@@ -3,6 +3,7 @@ from rubicon.objc import NSPoint
 from toga.colors import TRANSPARENT
 from toga_cocoa.libs import (
     NSEventType,
+    NSRange,
     NSStepper,
     NSTextField,
     NSTextView,
@@ -107,3 +108,6 @@ class NumberInputProbe(SimpleProbe):
         return isinstance(self.native.window.firstResponder, NSTextView) and (
             self.native_input.window.firstResponder.delegate == self.native_input
         )
+
+    def set_cursor_at_end(self):
+        self.native_input.currentEditor().selectedRange = NSRange(len(self.value), 0)

--- a/cocoa/tests_backend/widgets/textinput.py
+++ b/cocoa/tests_backend/widgets/textinput.py
@@ -2,6 +2,7 @@ from toga.colors import TRANSPARENT
 from toga.constants import RIGHT
 from toga_cocoa.libs import (
     NSLeftTextAlignment,
+    NSRange,
     NSRightTextAlignment,
     NSTextField,
     NSTextView,
@@ -82,3 +83,6 @@ class TextInputProbe(SimpleProbe):
         return isinstance(self.native.window.firstResponder, NSTextView) and (
             self.native.window.firstResponder.delegate == self.native
         )
+
+    def set_cursor_at_end(self):
+        self.native.currentEditor().selectedRange = NSRange(len(self.value), 0)

--- a/gtk/tests_backend/widgets/base.py
+++ b/gtk/tests_backend/widgets/base.py
@@ -160,3 +160,9 @@ class SimpleProbe(BaseProbe):
 
         # Remove the temporary handler
         self._keypress_target.disconnect(handler_id)
+
+    async def undo(self):
+        raise NotImplementedError()
+
+    async def redo(self):
+        raise NotImplementedError()

--- a/iOS/tests_backend/widgets/base.py
+++ b/iOS/tests_backend/widgets/base.py
@@ -150,3 +150,9 @@ class SimpleProbe(BaseProbe):
                 self.native.insertText(char)
             else:
                 self.native.insertText("")
+
+    async def undo(self):
+        raise NotImplementedError()
+
+    async def redo(self):
+        raise NotImplementedError()

--- a/testbed/tests/widgets/test_multilinetextinput.py
+++ b/testbed/tests/widgets/test_multilinetextinput.py
@@ -26,6 +26,7 @@ from .test_textinput import (  # noqa: F401
     test_on_change_focus,
     test_on_change_programmatic,
     test_on_change_user,
+    test_undo_redo,
     test_value_not_hidden,
 )
 

--- a/testbed/tests/widgets/test_numberinput.py
+++ b/testbed/tests/widgets/test_numberinput.py
@@ -5,6 +5,7 @@ import pytest
 
 import toga
 
+from ..conftest import skip_on_platforms
 from .properties import (  # noqa: F401
     test_alignment,
     test_background_color,
@@ -226,3 +227,39 @@ async def test_increment_decrement(widget, probe):
         assert widget.value == expected
         handler.assert_called_once_with(widget)
         handler.reset_mock()
+
+
+async def test_undo_redo(widget, probe):
+    "The widget supports undo and redo."
+    skip_on_platforms("android", "iOS", "linux", "windows")
+
+    widget.step = "0.00001"
+    text_0 = "3.14000"
+    text_1 = "3.14159"
+    text_extra = "159"
+    widget.value = text_0
+
+    widget.focus()
+    probe.set_cursor_at_end()
+
+    # type more text
+    for _ in text_extra:
+        await probe.type_character("<backspace>")
+    for char in text_extra:
+        await probe.type_character(char)
+    await probe.redraw(f"Widget value should be {text_1!r}")
+
+    assert widget.value == Decimal(text_1)
+    assert Decimal(probe.value) == Decimal(text_1)
+
+    # undo
+    await probe.undo()
+    await probe.redraw(f"Widget value should be {text_0!r}")
+    assert widget.value == Decimal(text_0)
+    assert Decimal(probe.value) == Decimal(text_0)
+
+    # redo
+    await probe.redo()
+    await probe.redraw(f"Widget value should be {text_1!r}")
+    assert widget.value == Decimal(text_1)
+    assert Decimal(probe.value) == Decimal(text_1)

--- a/testbed/tests/widgets/test_passwordinput.py
+++ b/testbed/tests/widgets/test_passwordinput.py
@@ -26,6 +26,7 @@ from .test_textinput import (  # noqa: F401
     test_on_change_user,
     test_on_confirm,
     test_text_value,
+    test_undo_redo,
     test_validation,
     verify_focus_handlers,
     verify_vertical_alignment,

--- a/testbed/tests/widgets/test_textinput.py
+++ b/testbed/tests/widgets/test_textinput.py
@@ -5,6 +5,7 @@ import pytest
 import toga
 from toga.constants import CENTER
 
+from ..conftest import skip_on_platforms
 from ..data import TEXTS
 from .properties import (  # noqa: F401
     test_alignment,
@@ -216,3 +217,34 @@ async def test_text_value(widget, probe):
 
         assert widget.value == str(text).replace("\n", " ")
         assert probe.value == str(text).replace("\n", " ")
+
+
+async def test_undo_redo(widget, probe):
+    "The widget supports undo and redo."
+    skip_on_platforms("android", "iOS", "linux", "windows")
+
+    text_0 = str(widget.value)
+    text_extra = " World!"
+    text_1 = text_0 + text_extra
+
+    widget.focus()
+    probe.set_cursor_at_end()
+
+    # type more text
+    for char in text_extra:
+        await probe.type_character(char)
+    await probe.redraw(f"Widget value should be {text_1!r}")
+    assert widget.value == text_1
+    assert probe.value == text_1
+
+    # undo
+    await probe.undo()
+    await probe.redraw(f"Widget value should be {text_0!r}")
+    assert widget.value == text_0
+    assert probe.value == text_0
+
+    # redo
+    await probe.redo()
+    await probe.redraw(f"Widget value should be {text_1!r}")
+    assert widget.value == text_1
+    assert probe.value == text_1

--- a/winforms/tests_backend/widgets/base.py
+++ b/winforms/tests_backend/widgets/base.py
@@ -134,3 +134,9 @@ class SimpleProbe(BaseProbe):
     @property
     def has_focus(self):
         return self.native.ContainsFocus
+
+    async def undo(self):
+        raise NotImplementedError()
+
+    async def redo(self):
+        raise NotImplementedError()


### PR DESCRIPTION
I found the current cocoa implementation MultilineTextInput lacking:

- When pasting formatted text (e.g. a webpage), the formatting would stay. Since this widget doesn't allow to manipulate the formatting in any way, I think it best to disable it completely.
- The cocoa widget has undo/redo turned of by default

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
