### PR TITLE
Fixing dialog clashing on iOS bug (#2039)

### DIFF
--- a/changes/2039.misc.rst
+++ b/changes/2039.misc.rst
@@ -1,0 +1,1 @@
+Fixing a bug introduced in #1969 that clashes the dialog display on iOS

--- a/iOS/src/toga_iOS/dialogs.py
+++ b/iOS/src/toga_iOS/dialogs.py
@@ -28,7 +28,7 @@ class AlertDialog(BaseDialog):
 
         self.populate_dialog()
 
-        interface.window._impl.controller.presentViewController(
+        interface.window._impl.native.rootViewController.presentViewController(
             self.native,
             animated=False,
             completion=None,


### PR DESCRIPTION
<!--- Describe your changes in detail -->

in `/iOS/src/toga_iOS/dialogs.py`

```
-        interface.window._impl.controller.presentViewController(
+        interface.window._impl.native.rootViewController.presentViewController(
```

<!--- What problem does this change solve? -->

Fixing a bug introduced in #1969 that clashes the dialog display on iOS

fix #2039 

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [ ] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
