### PR TITLE
test, fix invalid user-provided startup() method

### DIFF
--- a/android/src/toga_android/app.py
+++ b/android/src/toga_android/app.py
@@ -187,7 +187,7 @@ class App:
         # the app's `.native` is the listener's native Java class.
         self._listener = TogaApp(self)
         # Call user code to populate the main window
-        self.interface.startup()
+        self.interface._startup()
 
     def open_document(self, fileURL):
         print("Can't open document %s (yet)" % fileURL)

--- a/changes/2047.feature.rst
+++ b/changes/2047.feature.rst
@@ -1,1 +1,1 @@
-Verify that ``app.startup`` creates a ``MainWindow``
+Applications now verify that a main window has been created as part of the ``startup()`` method.

--- a/changes/2047.feature.rst
+++ b/changes/2047.feature.rst
@@ -1,0 +1,1 @@
+Verify that ``app.startup`` creates a ``MainWindow``

--- a/cocoa/src/toga_cocoa/app.py
+++ b/cocoa/src/toga_cocoa/app.py
@@ -255,7 +255,7 @@ class App:
         self._create_app_commands()
 
         # Call user code to populate the main window
-        self.interface.startup()
+        self.interface._startup()
 
         # Create the lookup table of menu items,
         # then force the creation of the menus.

--- a/core/src/toga/app.py
+++ b/core/src/toga/app.py
@@ -554,9 +554,7 @@ class App:
         self.main_window.show()
 
     def _startup(self):
-        """Since startup can and is overridden by users, verify
-        they did the right thing in their code
-        """
+# This is a wrapper around the user's startup method that performs any post-setup validation.
         self.startup()
         self._verify_startup()
 
@@ -697,7 +695,7 @@ class DocumentApp(App):
         return self.factory.DocumentApp(interface=self)
 
     def _verify_startup(self):
-        """The class 'startup()' method has no restrictions"""
+# No post-startup validation required for DocumentApps
         pass
 
     @property

--- a/core/src/toga/app.py
+++ b/core/src/toga/app.py
@@ -553,6 +553,19 @@ class App:
 
         self.main_window.show()
 
+    def _startup(self):
+        """Since startup can and is overridden by users, verify
+        they did the right thing in their code
+        """
+        self.startup()
+        self._verify_startup()
+
+    def _verify_startup(self):
+        if not isinstance(self.main_window, MainWindow):
+            raise ValueError(
+                "user-defined startup() did not instaniate self.main_window"
+            )
+
     def about(self):
         """Display the About dialog for the app.
 
@@ -682,6 +695,10 @@ class DocumentApp(App):
 
     def _create_impl(self):
         return self.factory.DocumentApp(interface=self)
+
+    def _verify_startup(self):
+        """The class 'startup()' method has no restrictions"""
+        pass
 
     @property
     def documents(self):

--- a/core/src/toga/app.py
+++ b/core/src/toga/app.py
@@ -562,7 +562,8 @@ class App:
     def _verify_startup(self):
         if not isinstance(self.main_window, MainWindow):
             raise ValueError(
-                "user-defined startup() did not instaniate self.main_window"
+                "Application does not have a main window. "
+                "Does your startup() method assign a value to self.main_window?"
             )
 
     def about(self):

--- a/core/src/toga/app.py
+++ b/core/src/toga/app.py
@@ -554,7 +554,8 @@ class App:
         self.main_window.show()
 
     def _startup(self):
-# This is a wrapper around the user's startup method that performs any post-setup validation.
+        # This is a wrapper around the user's startup method that performs any
+        # post-setup validation.
         self.startup()
         self._verify_startup()
 
@@ -695,7 +696,7 @@ class DocumentApp(App):
         return self.factory.DocumentApp(interface=self)
 
     def _verify_startup(self):
-# No post-startup validation required for DocumentApps
+        # No post-startup validation required for DocumentApps
         pass
 
     @property

--- a/core/tests/test_app.py
+++ b/core/tests/test_app.py
@@ -173,7 +173,7 @@ class AppTests(TestCase):
         )
 
 
-class BadAppTests(TestCase):
+class StartupTests(TestCase):
     def test_override_startup(self):
         class BadApp(toga.App):
             # issue 760. A bogus startup function should raise
@@ -185,6 +185,17 @@ class BadAppTests(TestCase):
         app = BadApp(app_name="pytest", formal_name="pytest", app_id="org.beeware")
         with self.assertRaisesRegex(ValueError, msg):
             app.main_loop()
+
+    def test_startup_called(self):
+        called = []
+
+        class DocApp(toga.DocumentApp):
+            def startup(self):
+                called.append("called")
+
+        app = DocApp(app_name="pytest", formal_name="pytest", app_id="org.beeware")
+        app.main_loop()
+        self.assertEqual(called, ["called"])
 
 
 class DocumentAppTests(TestCase):

--- a/core/tests/test_app.py
+++ b/core/tests/test_app.py
@@ -173,6 +173,20 @@ class AppTests(TestCase):
         )
 
 
+class BadAppTests(TestCase):
+    def test_override_startup(self):
+        class BadApp(toga.App):
+            # issue 760. A bogus startup function should raise
+            def startup(self):
+                # This is bogus, it does not create the main window
+                pass
+
+        msg = "did not instaniate"
+        app = BadApp(app_name="pytest", formal_name="pytest", app_id="org.beeware")
+        with self.assertRaisesRegex(ValueError, msg):
+            app.main_loop()
+
+
 class DocumentAppTests(TestCase):
     def setUp(self):
         super().setUp()

--- a/core/tests/test_app.py
+++ b/core/tests/test_app.py
@@ -172,30 +172,20 @@ class AppTests(TestCase):
             args=(None,),
         )
 
-
-class StartupTests(TestCase):
     def test_override_startup(self):
         class BadApp(toga.App):
-            # issue 760. A bogus startup function should raise
+            "A startup method that doesn't assign main window raises an error (#760)"
+
             def startup(self):
-                # This is bogus, it does not create the main window
+                # Override startup but don't create a main window
                 pass
 
-        msg = "did not instaniate"
-        app = BadApp(app_name="pytest", formal_name="pytest", app_id="org.beeware")
-        with self.assertRaisesRegex(ValueError, msg):
+        app = BadApp(app_name="bad_app", formal_name="Bad Aoo", app_id="org.beeware")
+        with self.assertRaisesRegex(
+            ValueError,
+            r"Application does not have a main window.",
+        ):
             app.main_loop()
-
-    def test_startup_called(self):
-        called = []
-
-        class DocApp(toga.DocumentApp):
-            def startup(self):
-                called.append("called")
-
-        app = DocApp(app_name="pytest", formal_name="pytest", app_id="org.beeware")
-        app.main_loop()
-        self.assertEqual(called, ["called"])
 
 
 class DocumentAppTests(TestCase):
@@ -216,3 +206,15 @@ class DocumentAppTests(TestCase):
         doc = MagicMock()
         self.app._documents.append(doc)
         self.assertEqual(self.app.documents, [doc])
+
+    def test_override_startup(self):
+        mock = MagicMock()
+
+        class DocApp(toga.DocumentApp):
+            def startup(self):
+                # A document app doesn't have to provide a Main Window.
+                mock()
+
+        app = DocApp(app_name="docapp", formal_name="Doc App", app_id="org.beeware")
+        app.main_loop()
+        mock.assert_called_once()

--- a/dummy/src/toga_dummy/app.py
+++ b/dummy/src/toga_dummy/app.py
@@ -25,6 +25,7 @@ class App(LoggedObject):
 
     def create(self):
         self._action("create")
+        self.interface._startup()
 
     @not_required_on("mobile")
     def create_menus(self):
@@ -32,6 +33,7 @@ class App(LoggedObject):
 
     def main_loop(self):
         self._action("main loop")
+        self.create()
 
     def set_main_window(self, window):
         self._set_value("main_window", window)

--- a/gtk/src/toga_gtk/app.py
+++ b/gtk/src/toga_gtk/app.py
@@ -95,7 +95,7 @@ class App:
         )
         self._create_app_commands()
 
-        self.interface.startup()
+        self.interface._startup()
 
         # Create the lookup table of menu items,
         # then force the creation of the menus.

--- a/iOS/src/toga_iOS/app.py
+++ b/iOS/src/toga_iOS/app.py
@@ -65,7 +65,7 @@ class App:
 
     def create(self):
         """Calls the startup method on the interface."""
-        self.interface.startup()
+        self.interface._startup()
 
     def open_document(self, fileURL):
         """Add a new document to this app."""

--- a/web/src/toga_web/app.py
+++ b/web/src/toga_web/app.py
@@ -37,7 +37,7 @@ class App:
         self.create_menus()
 
         # Call user code to populate the main window
-        self.interface.startup()
+        self.interface._startup()
 
     def _create_submenu(self, group, items):
         submenu = create_element(

--- a/winforms/src/toga_winforms/app.py
+++ b/winforms/src/toga_winforms/app.py
@@ -129,7 +129,7 @@ class App:
         self._create_app_commands()
 
         # Call user code to populate the main window
-        self.interface.startup()
+        self.interface._startup()
         self.create_menus()
         self.interface.main_window._impl.set_app(self)
 


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

(EuroPython sprints)
Fixes #760 

Typically users will override the `App.startup()` method with one of their own. For most backends, this method must create a `MainWindow`. This PR refactors the call to `startup` so that after the call, a new `_verify_startup()` private method will be called which, for all the GUI backends, will enforce the condition. For `DocumentApp` app the verification is empty. 

Additionally, the "dummy" test backend was not properly chaining calls so `main_loop` calls `create` which calls `startup`. This was changed too to make the new feature testable.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
