### PR TITLE
Fix 1235 partly

### DIFF
--- a/android/src/toga_android/app.py
+++ b/android/src/toga_android/app.py
@@ -233,3 +233,9 @@ class App:
             return result_future.result()
         except AttributeError:
             raise RuntimeError("No appropriate Activity found to handle this intent.")
+
+    def hide_cursor(self):
+        pass
+
+    def show_cursor(self):
+        pass

--- a/changes/1235.bugfix.rst
+++ b/changes/1235.bugfix.rst
@@ -1,0 +1,1 @@
+Android and iOS apps won't crash anymore if you call App.hide_cursor() or App.show_cursor().

--- a/changes/1235.bugfix.rst
+++ b/changes/1235.bugfix.rst
@@ -1,1 +1,1 @@
-Android and iOS apps won't crash anymore if you call App.hide_cursor() or App.show_cursor().
+Android and iOS apps no longer crash if you invoke ``App.hide_cursor()`` or ``App.show_cursor()``.

--- a/iOS/src/toga_iOS/app.py
+++ b/iOS/src/toga_iOS/app.py
@@ -89,3 +89,9 @@ class App:
 
     def exit(self):
         pass
+
+    def hide_cursor(self):
+        pass
+
+    def show_cursor(self):
+        pass


### PR DESCRIPTION
Add hide_cursor() and show_cursor() to App in toga_android and toga_iOS. Android and iOS apps don't crash anymore if you call these functions.
Fixes #1235 partly.
