### PR TITLE
Add a web widget for divider

### DIFF
--- a/changes/2051.feature.rst
+++ b/changes/2051.feature.rst
@@ -1,0 +1,1 @@
+Divider web widget implementation introduced.

--- a/changes/2051.feature.rst
+++ b/changes/2051.feature.rst
@@ -1,1 +1,1 @@
-Divider web widget implementation introduced.
+An implementation of Divider was added to the Web backend.

--- a/docs/reference/data/widgets_by_platform.csv
+++ b/docs/reference/data/widgets_by_platform.csv
@@ -7,7 +7,7 @@ Button,General Widget,:class:`~toga.Button`,Basic clickable Button,|y|,|y|,|y|,|
 Canvas,General Widget,:class:`~toga.Canvas`,Area you can draw on,|b|,|b|,|b|,|b|,,
 DateInput,General Widget,:class:`~toga.DateInput`,A widget to select a calendar date,,,|y|,,|y|,
 DetailedList,General Widget,:class:`~toga.DetailedList`,A list of complex content,|b|,|b|,,|b|,|b|,
-Divider,General Widget,:class:`~toga.Divider`,A horizontal or vertical line,|y|,|y|,|y|,,,
+Divider,General Widget,:class:`~toga.Divider`,A horizontal or vertical line,|y|,|y|,|y|,,,|b|
 ImageView,General Widget,:class:`~toga.ImageView`,A widget that displays an image,|y|,|y|,|y|,|y|,|y|,
 Label,General Widget,:class:`~toga.Label`,Text label,|y|,|y|,|y|,|y|,|y|,|b|
 MultilineTextInput,General Widget,:class:`~toga.MultilineTextInput`,Multi-line Text Input field,|y|,|y|,|y|,|y|,|y|,

--- a/web/src/toga_web/factory.py
+++ b/web/src/toga_web/factory.py
@@ -44,7 +44,8 @@ def not_implemented(feature):
 __all__ = [
     "not_implemented",
     "App",
-    "MainWindow",  # 'DocumentApp',
+    "MainWindow",
+    # 'DocumentApp',
     "Command",
     # 'Document',
     # # Resources

--- a/web/src/toga_web/factory.py
+++ b/web/src/toga_web/factory.py
@@ -10,6 +10,7 @@ from .icons import Icon
 from .paths import Paths
 from .widgets.box import Box
 from .widgets.button import Button
+from .widgets.divider import Divider
 
 # from .widgets.canvas import Canvas
 # from .widgets.detailedlist import DetailedList
@@ -56,6 +57,7 @@ __all__ = [
     "Box",
     "Button",
     # 'Canvas',
+    "Divider",
     # 'DetailedList',
     # 'ImageView',
     "Label",

--- a/web/src/toga_web/widgets/divider.py
+++ b/web/src/toga_web/widgets/divider.py
@@ -1,18 +1,10 @@
-"""
-A web widget to display a divider.
-
-This is a web implementation of the `toga.Divider` widget.
-Details can be found in https://shoelace.style/components/divider
-"""
 from toga.constants import Direction
 
 from .base import Widget
 
 
 class Divider(Widget):
-    def create(
-        self,
-    ):
+    def create(self):
         self.native = self._create_native_widget("sl-divider")
 
     def get_direction(self):

--- a/web/src/toga_web/widgets/divider.py
+++ b/web/src/toga_web/widgets/divider.py
@@ -1,0 +1,25 @@
+"""
+A web widget to display a divider.
+
+This is a web implementation of the `toga.Divider` widget.
+Details can be found in https://shoelace.style/components/divider
+"""
+from toga.constants import Direction
+
+from .base import Widget
+
+
+class Divider(Widget):
+    def create(
+        self,
+    ):
+        self.native = self._create_native_widget("sl-divider")
+
+    def get_direction(self):
+        return self.interface.direction
+
+    def set_direction(self, value):
+        if value is Direction.VERTICAL:
+            self.native.setAttribute("vertical", "")
+        else:
+            self.native.removeAttribute("vertical")


### PR DESCRIPTION
Prior to this change, the web implementation of divider widget was only implemented as a dummy widget.

This change adds basic implementation of the divider widget and adds it into web factories.

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x ] All new features have been tested
- [ x] All new features have been documented
- [ x] I have read the **CONTRIBUTING.md** file
- [ x] I will abide by the code of conduct
