### PR TITLE
Alter the version pin for pygobject in testbed.

### DIFF
--- a/changes/2052.misc.rst
+++ b/changes/2052.misc.rst
@@ -1,0 +1,1 @@
+The version pin for the prerelease pygobject has been updated, following the resolution of pygobject#119.

--- a/testbed/pyproject.toml
+++ b/testbed/pyproject.toml
@@ -43,8 +43,9 @@ test_sources = [
 ]
 requires = [
     "../gtk",
-    # PyGObject #119 breaks the test suite; we need to use a PR version.
-    "git+https://gitlab.gnome.org/monnerat/pygobject.git@issue119",
+    # PyGObject #119 breaks the test suite; the fix has been merged, but we need to use
+    # a mainline version of PyGObject until we can pin an official release.
+    "git+https://gitlab.gnome.org/GNOME/pygobject.git@5acfb6cc7c34c8ce9e20aef7eaaa79f27248b1a6",
 ]
 
 [tool.briefcase.app.testbed.linux.appimage]
@@ -97,4 +98,3 @@ build_gradle_extra_content = "android.defaultConfig.python.extractPackages 'toga
 requires = [
     "../web"
 ]
-style_framework = "Shoelace v2.3"


### PR DESCRIPTION
https://gitlab.gnome.org/GNOME/pygobject/-/issues/119 has finally been resolved; however, as a result, the git branch we were using to obtain a patched version has now been deleted. This updates the version pin in testbed. 

Once the next release of pygobject is made, we can pin a formal release number, rather than a git repo hash.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
