### PR TITLE
Cleanup a test warning on cocoa

### DIFF
--- a/changes/2053.misc.rst
+++ b/changes/2053.misc.rst
@@ -1,0 +1,1 @@
+An edge case in SplitContainer having empty content was corrected on Cocoa.

--- a/cocoa/src/toga_cocoa/widgets/splitcontainer.py
+++ b/cocoa/src/toga_cocoa/widgets/splitcontainer.py
@@ -16,7 +16,8 @@ class TogaSplitView(NSSplitView):
     def splitViewDidResizeSubviews_(self, notification) -> None:
         # If the split has moved, a resize of all the content panels is required.
         for container in self.impl.sub_containers:
-            container.content.interface.refresh()
+            if container.content:
+                container.content.interface.refresh()
 
         # Apply any pending split
         self.performSelector(


### PR DESCRIPTION
A late change to #1984 added checks for split containers managing non-content. This test *passed* on Cocoa, but was raising a warning because the event handler was crashing. 

This PR adds protection against that edge case. No extra test or coverage is required, as the branch was being implicitly hit previously, but was raising a warning as a result.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
