### PR TITLE
Replace deprecated WebView API usage to evaluate javascript on Gtk

### DIFF
--- a/changes/2085.bugfix.rst
+++ b/changes/2085.bugfix.rst
@@ -1,0 +1,1 @@
+Replace usage of deprecated APIs to evaluate JavaScript in a toga.WebView on Gtk.

--- a/changes/2085.bugfix.rst
+++ b/changes/2085.bugfix.rst
@@ -1,1 +1,0 @@
-Replace usage of deprecated APIs to evaluate JavaScript in a toga.WebView on Gtk.

--- a/changes/2085.misc.rst
+++ b/changes/2085.misc.rst
@@ -1,0 +1,1 @@
+WebView no longer uses the deprecated ``run_javascript`` API on Gtk.

--- a/gtk/src/toga_gtk/widgets/webview.py
+++ b/gtk/src/toga_gtk/widgets/webview.py
@@ -80,11 +80,10 @@ class WebView(Widget):
         # Define a callback that will update the future when
         # the Javascript is complete.
         def gtk_js_finished(webview, task, *user_data):
-            """If `run_javascript_finish` from GTK returns a result, unmarshal it, and
+            """If `evaluate_javascript_finish` from GTK returns a result, unmarshal it, and
             call back with the result."""
             try:
-                js_result = webview.run_javascript_finish(task)
-                value = js_result.get_js_value()
+                value = webview.evaluate_javascript_finish(task)
                 if value.is_boolean():
                     value = value.to_boolean()
                 elif value.is_number():
@@ -103,7 +102,14 @@ class WebView(Widget):
 
         # Invoke the javascript method, with a callback that will set
         # the future when a result is available.
-        self.native.run_javascript(javascript, None, gtk_js_finished)
+        self.native.evaluate_javascript(
+            script=javascript,
+            length=len(javascript),
+            world_name=None,
+            source_uri=None,
+            cancellable=None,
+            callback=gtk_js_finished,
+        )
 
         # wait for the future, and return the result
         return result


### PR DESCRIPTION
Replace `run_javascript()` with `evaluate_javascript()` in `toga_gtk.WebView`.

Fixes #2085.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
