### PR TITLE
Enable autodoc_default_options

### DIFF
--- a/changes/2093.misc.rst
+++ b/changes/2093.misc.rst
@@ -1,0 +1,1 @@
+Repeated autodoc options were refactored into the Sphinx configuration.

--- a/core/src/toga/widgets/activityindicator.py
+++ b/core/src/toga/widgets/activityindicator.py
@@ -14,8 +14,6 @@ class ActivityIndicator(Widget):
     ):
         """Create a new ActivityIndicator widget.
 
-        Inherits from :class:`toga.Widget`.
-
         :param id: The ID for the widget.
         :param style: A style object. If no style is provided, a default style
             will be applied to the widget.

--- a/core/src/toga/widgets/box.py
+++ b/core/src/toga/widgets/box.py
@@ -12,8 +12,6 @@ class Box(Widget):
     ):
         """Create a new Box container widget.
 
-        Inherits from :class:`toga.Widget`.
-
         :param id: The ID for the widget.
         :param style: A style object. If no style is provided, a default style
             will be applied to the widget.

--- a/core/src/toga/widgets/button.py
+++ b/core/src/toga/widgets/button.py
@@ -31,8 +31,6 @@ class Button(Widget):
     ):
         """Create a new button widget.
 
-        Inherits from :class:`toga.Widget`.
-
         :param text: The text to display on the button.
         :param id: The ID for the widget.
         :param style: A style object. If no style is provided, a default style

--- a/core/src/toga/widgets/dateinput.py
+++ b/core/src/toga/widgets/dateinput.py
@@ -29,8 +29,6 @@ class DateInput(Widget):
     ):
         """Create a new DateInput widget.
 
-        Inherits from :class:`toga.Widget`.
-
         :param id: The ID for the widget.
         :param style: A style object. If no style is provided, a default style
             will be applied to the widget.

--- a/core/src/toga/widgets/divider.py
+++ b/core/src/toga/widgets/divider.py
@@ -17,8 +17,6 @@ class Divider(Widget):
     ):
         """Create a new divider line.
 
-        Inherits from :class:`toga.Widget`.
-
         :param id: The ID for the widget.
         :param style: A style object. If no style is provided, a default style will be
             applied to the widget.

--- a/core/src/toga/widgets/imageview.py
+++ b/core/src/toga/widgets/imageview.py
@@ -70,8 +70,6 @@ class ImageView(Widget):
         """
         Create a new image view.
 
-        Inherits from :class:`toga.Widget`.
-
         :param image: The image to display.
         :param id: The ID for the widget.
         :param style: A style object. If no style is provided, a default style will be

--- a/core/src/toga/widgets/label.py
+++ b/core/src/toga/widgets/label.py
@@ -12,8 +12,6 @@ class Label(Widget):
     ):
         """Create a new text label.
 
-        Inherits from :class:`toga.Widget`.
-
         :param text: Text of the label.
         :param id: The ID for the widget.
         :param style: A style object. If no style is provided, a default style

--- a/core/src/toga/widgets/multilinetextinput.py
+++ b/core/src/toga/widgets/multilinetextinput.py
@@ -17,8 +17,6 @@ class MultilineTextInput(Widget):
     ):
         """Create a new multi-line text input widget.
 
-        Inherits from :class:`toga.Widget`.
-
         :param id: The ID for the widget.
         :param style: A style object. If no style is provided, a default style
             will be applied to the widget.

--- a/core/src/toga/widgets/numberinput.py
+++ b/core/src/toga/widgets/numberinput.py
@@ -77,8 +77,6 @@ class NumberInput(Widget):
     ):
         """Create a new number input widget.
 
-        Inherits from :class:`toga.Widget`.
-
         :param id: The ID for the widget.
         :param style: A style object. If no style is provided, a default style will be
             applied to the widget.

--- a/core/src/toga/widgets/optioncontainer.py
+++ b/core/src/toga/widgets/optioncontainer.py
@@ -178,8 +178,6 @@ class OptionContainer(Widget):
     ):
         """Create a new OptionContainer.
 
-        Inherits from :class:`toga.Widget`.
-
         :param id: The ID for the widget.
         :param style: A style object. If no style is provided, a default style will be
             applied to the widget.

--- a/core/src/toga/widgets/passwordinput.py
+++ b/core/src/toga/widgets/passwordinput.py
@@ -4,10 +4,7 @@ from .textinput import TextInput
 
 
 class PasswordInput(TextInput):
-    """Create a new password input widget.
-
-    Inherits from :class:`~toga.TextInput`.
-    """
+    """Create a new password input widget."""
 
     def _create(self):
         self._impl = self.factory.PasswordInput(interface=self)

--- a/core/src/toga/widgets/progressbar.py
+++ b/core/src/toga/widgets/progressbar.py
@@ -16,8 +16,6 @@ class ProgressBar(Widget):
     ):
         """Create a new Progress Bar widget.
 
-        Inherits from :class:`toga.Widget`.
-
         :param id: The ID for the widget.
         :param style: A style object. If no style is provided, a default style
             will be applied to the widget.

--- a/core/src/toga/widgets/scrollcontainer.py
+++ b/core/src/toga/widgets/scrollcontainer.py
@@ -17,8 +17,6 @@ class ScrollContainer(Widget):
     ):
         """Create a new Scroll Container.
 
-        Inherits from :class:`toga.Widget`.
-
         :param id: The ID for the widget.
         :param style: A style object. If no style is provided, a default style
             will be applied to the widget.

--- a/core/src/toga/widgets/selection.py
+++ b/core/src/toga/widgets/selection.py
@@ -22,8 +22,6 @@ class Selection(Widget):
     ):
         """Create a new Selection widget.
 
-        Inherits from :class:`~toga.widgets.base.Widget`.
-
         :param id: The ID for the widget.
         :param style: A style object. If no style is provided, a default style will be
             applied to the widget.

--- a/core/src/toga/widgets/slider.py
+++ b/core/src/toga/widgets/slider.py
@@ -26,8 +26,6 @@ class Slider(Widget):
     ):
         """Create a new Slider widget.
 
-        Inherits from :class:`toga.Widget`.
-
         :param id: The ID for the widget.
         :param style: A style object. If no style is provided, a default style will be
             applied to the widget.

--- a/core/src/toga/widgets/splitcontainer.py
+++ b/core/src/toga/widgets/splitcontainer.py
@@ -18,8 +18,6 @@ class SplitContainer(Widget):
     ):
         """Create a new SplitContainer.
 
-        Inherits from :class:`toga.Widget`.
-
         :param id: The ID for the widget.
         :param style: A style object. If no style is provided, a default style will be
             applied to the widget.

--- a/core/src/toga/widgets/switch.py
+++ b/core/src/toga/widgets/switch.py
@@ -17,8 +17,6 @@ class Switch(Widget):
     ):
         """Create a new Switch widget.
 
-        Inherits from :class:`toga.Widget`.
-
         :param text: The text to display beside the switch.
         :param id: The ID for the widget.
         :param style: A style object. If no style is provided, a default style

--- a/core/src/toga/widgets/textinput.py
+++ b/core/src/toga/widgets/textinput.py
@@ -6,10 +6,7 @@ from .base import Widget
 
 
 class TextInput(Widget):
-    """Create a new single-line text input widget.
-
-    Inherits from :class:`toga.Widget`.
-    """
+    """Create a new single-line text input widget."""
 
     def __init__(
         self,

--- a/core/src/toga/widgets/timeinput.py
+++ b/core/src/toga/widgets/timeinput.py
@@ -20,8 +20,6 @@ class TimeInput(Widget):
     ):
         """Create a new TimeInput widget.
 
-        Inherits from :class:`toga.Widget`.
-
         :param id: The ID for the widget.
         :param style: A style object. If no style is provided, a default style
             will be applied to the widget.

--- a/core/src/toga/widgets/webview.py
+++ b/core/src/toga/widgets/webview.py
@@ -22,8 +22,6 @@ class WebView(Widget):
     ):
         """Create a new WebView widget.
 
-        Inherits from :class:`toga.Widget`.
-
         :param id: The ID for the widget.
         :param style: A style object. If no style is provided, a default style
             will be applied to the widget.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,6 +68,7 @@ os.environ["TOGA_BACKEND"] = "toga_dummy"
 autoclass_content = "both"
 autodoc_preserve_defaults = True
 autodoc_default_options = {
+    # For show-inheritance, see autodoc-process-signature below.
     "members": True,
     "undoc-members": True,
 }
@@ -115,6 +116,27 @@ rst_prolog = """
 """
 
 intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
+
+# -- Local extensions ----------------------------------------------------------
+
+
+def setup(app):
+    app.connect("autodoc-process-signature", autodoc_process_signature)
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }
+
+
+# Adding show-inheritance to autodoc_default_options adds a Bases line to ALL classes,
+# even those that only inherit from `object`, or whose bases have all been filtered out
+# by autodoc-process-bases. Instead, we enable the option here.
+def autodoc_process_signature(
+    app, what, name, obj, options, signature, return_annotation
+):
+    if (what == "class") and (obj.__bases__ != (object,)):
+        options.show_inheritance = True
+
 
 # -- Options for link checking -------------------------------------------------
 

--- a/docs/reference/api/app.rst
+++ b/docs/reference/api/app.rst
@@ -52,8 +52,6 @@ Reference
 ---------
 
 .. autoclass:: toga.App
-   :members:
-   :undoc-members:
 
 .. autoprotocol:: toga.app.AppStartupMethod
 .. autoprotocol:: toga.app.BackgroundTask

--- a/docs/reference/api/constants.rst
+++ b/docs/reference/api/constants.rst
@@ -2,5 +2,3 @@ Constants
 =========
 
 .. automodule:: toga.constants
-   :members:
-   :undoc-members:

--- a/docs/reference/api/mainwindow.rst
+++ b/docs/reference/api/mainwindow.rst
@@ -27,5 +27,3 @@ Reference
 ---------
 
 .. autoclass:: toga.MainWindow
-   :members:
-   :undoc-members:

--- a/docs/reference/api/resources/app_paths.rst
+++ b/docs/reference/api/resources/app_paths.rst
@@ -47,5 +47,3 @@ Reference
 ---------
 
 .. autoclass:: toga.paths.Paths
-   :members:
-   :undoc-members:

--- a/docs/reference/api/resources/command.rst
+++ b/docs/reference/api/resources/command.rst
@@ -16,5 +16,3 @@ Reference
 ---------
 
 .. autoclass:: toga.Command
-   :members:
-   :undoc-members:

--- a/docs/reference/api/resources/fonts.rst
+++ b/docs/reference/api/resources/fonts.rst
@@ -14,5 +14,3 @@ Reference
 ---------
 
 .. autoclass:: toga.Font
-   :members:
-   :undoc-members:

--- a/docs/reference/api/resources/group.rst
+++ b/docs/reference/api/resources/group.rst
@@ -17,5 +17,3 @@ Reference
 ---------
 
 .. autoclass:: toga.Group
-   :members:
-   :undoc-members:

--- a/docs/reference/api/resources/icons.rst
+++ b/docs/reference/api/resources/icons.rst
@@ -37,5 +37,3 @@ Reference
 ---------
 
 .. autoclass:: toga.Icon
-   :members:
-   :undoc-members:

--- a/docs/reference/api/resources/images.rst
+++ b/docs/reference/api/resources/images.rst
@@ -43,5 +43,3 @@ Reference
 ---------
 
 .. autoclass:: toga.Image
-   :members:
-   :undoc-members:

--- a/docs/reference/api/resources/sources/list_source.rst
+++ b/docs/reference/api/resources/sources/list_source.rst
@@ -85,9 +85,5 @@ Reference
 ---------
 
 .. autoclass:: toga.sources.Row
-   :members:
-   :undoc-members:
 
 .. autoclass:: toga.sources.ListSource
-   :members:
-   :undoc-members:

--- a/docs/reference/api/resources/sources/source.rst
+++ b/docs/reference/api/resources/sources/source.rst
@@ -19,9 +19,5 @@ Reference
 ---------
 
 .. autoclass:: toga.sources.Listener
-   :members:
-   :undoc-members:
 
 .. autoclass:: toga.sources.Source
-   :members:
-   :undoc-members:

--- a/docs/reference/api/resources/sources/tree_source.rst
+++ b/docs/reference/api/resources/sources/tree_source.rst
@@ -41,9 +41,5 @@ Reference
 ---------
 
 .. autoclass:: toga.sources.Node
-   :members:
-   :undoc-members:
 
 .. autoclass:: toga.sources.TreeSource
-   :members:
-   :undoc-members:

--- a/docs/reference/api/resources/sources/value_source.rst
+++ b/docs/reference/api/resources/sources/value_source.rst
@@ -37,5 +37,3 @@ Reference
 ---------
 
 .. autoclass:: toga.sources.ValueSource
-   :members:
-   :undoc-members:

--- a/docs/reference/api/resources/validators.rst
+++ b/docs/reference/api/resources/validators.rst
@@ -47,5 +47,3 @@ Reference
 ---------
 
 .. automodule:: toga.validators
-   :members:
-   :undoc-members:

--- a/docs/reference/api/widgets/activityindicator.rst
+++ b/docs/reference/api/widgets/activityindicator.rst
@@ -40,5 +40,3 @@ Reference
 ---------
 
 .. autoclass:: toga.ActivityIndicator
-   :members:
-   :undoc-members:

--- a/docs/reference/api/widgets/button.rst
+++ b/docs/reference/api/widgets/button.rst
@@ -43,7 +43,5 @@ Reference
 ---------
 
 .. autoclass:: toga.Button
-   :members:
-   :undoc-members:
 
 .. autoprotocol:: toga.widgets.button.OnPressHandler

--- a/docs/reference/api/widgets/canvas.rst
+++ b/docs/reference/api/widgets/canvas.rst
@@ -68,14 +68,10 @@ Main Interface
 ^^^^^^^^^^^^^^
 
 .. autoclass:: toga.Canvas
-   :members:
-   :undoc-members:
    :exclude-members: canvas, add_draw_obj
 
 Lower-Level Classes
 ^^^^^^^^^^^^^^^^^^^
 
 .. automodule:: toga.widgets.canvas
-   :members:
-   :undoc-members:
    :exclude-members: Canvas, add_draw_obj

--- a/docs/reference/api/widgets/dateinput.rst
+++ b/docs/reference/api/widgets/dateinput.rst
@@ -37,5 +37,3 @@ Reference
 ---------
 
 .. autoclass:: toga.DateInput
-   :members:
-   :undoc-members:

--- a/docs/reference/api/widgets/detailedlist.rst
+++ b/docs/reference/api/widgets/detailedlist.rst
@@ -17,5 +17,3 @@ Reference
 ---------
 
 .. autoclass:: toga.DetailedList
-   :members:
-   :undoc-members:

--- a/docs/reference/api/widgets/divider.rst
+++ b/docs/reference/api/widgets/divider.rst
@@ -39,5 +39,3 @@ Reference
 ---------
 
 .. autoclass:: toga.Divider
-   :members:
-   :undoc-members:

--- a/docs/reference/api/widgets/imageview.rst
+++ b/docs/reference/api/widgets/imageview.rst
@@ -50,5 +50,3 @@ Reference
 ---------
 
 .. autoclass:: toga.ImageView
-   :members:
-   :undoc-members:

--- a/docs/reference/api/widgets/label.rst
+++ b/docs/reference/api/widgets/label.rst
@@ -32,5 +32,3 @@ Reference
 ---------
 
 .. autoclass:: toga.Label
-   :members:
-   :undoc-members:

--- a/docs/reference/api/widgets/multilinetextinput.rst
+++ b/docs/reference/api/widgets/multilinetextinput.rst
@@ -42,5 +42,3 @@ Reference
 ---------
 
 .. autoclass:: toga.MultilineTextInput
-   :members:
-   :undoc-members:

--- a/docs/reference/api/widgets/numberinput.rst
+++ b/docs/reference/api/widgets/numberinput.rst
@@ -31,5 +31,3 @@ Reference
 ---------
 
 .. autoclass:: toga.NumberInput
-   :members:
-   :undoc-members:

--- a/docs/reference/api/widgets/passwordinput.rst
+++ b/docs/reference/api/widgets/passwordinput.rst
@@ -47,5 +47,3 @@ Reference
 ---------
 
 .. autoclass:: toga.PasswordInput
-   :members:
-   :undoc-members:

--- a/docs/reference/api/widgets/progressbar.rst
+++ b/docs/reference/api/widgets/progressbar.rst
@@ -66,5 +66,3 @@ Reference
 ---------
 
 .. autoclass:: toga.ProgressBar
-   :members:
-   :undoc-members:

--- a/docs/reference/api/widgets/selection.rst
+++ b/docs/reference/api/widgets/selection.rst
@@ -90,5 +90,3 @@ Reference
 ---------
 
 .. autoclass:: toga.Selection
-   :members:
-   :undoc-members:

--- a/docs/reference/api/widgets/slider.rst
+++ b/docs/reference/api/widgets/slider.rst
@@ -40,5 +40,3 @@ Reference
 ---------
 
 .. autoclass:: toga.Slider
-   :members:
-   :undoc-members:

--- a/docs/reference/api/widgets/switch.rst
+++ b/docs/reference/api/widgets/switch.rst
@@ -51,5 +51,3 @@ Reference
 ---------
 
 .. autoclass:: toga.Switch
-   :members:
-   :undoc-members:

--- a/docs/reference/api/widgets/table.rst
+++ b/docs/reference/api/widgets/table.rst
@@ -55,5 +55,3 @@ Reference
 ---------
 
 .. autoclass:: toga.Table
-   :members:
-   :undoc-members:

--- a/docs/reference/api/widgets/textinput.rst
+++ b/docs/reference/api/widgets/textinput.rst
@@ -55,5 +55,3 @@ Reference
 ---------
 
 .. autoclass:: toga.TextInput
-   :members:
-   :undoc-members:

--- a/docs/reference/api/widgets/timeinput.rst
+++ b/docs/reference/api/widgets/timeinput.rst
@@ -41,5 +41,3 @@ Reference
 ---------
 
 .. autoclass:: toga.TimeInput
-   :members:
-   :undoc-members:

--- a/docs/reference/api/widgets/tree.rst
+++ b/docs/reference/api/widgets/tree.rst
@@ -35,5 +35,3 @@ Reference
 ---------
 
 .. autoclass:: toga.Tree
-   :members:
-   :undoc-members:

--- a/docs/reference/api/widgets/webview.rst
+++ b/docs/reference/api/widgets/webview.rst
@@ -61,5 +61,3 @@ Reference
 ---------
 
 .. autoclass:: toga.WebView
-   :members:
-   :undoc-members:

--- a/docs/reference/api/window.rst
+++ b/docs/reference/api/window.rst
@@ -45,8 +45,6 @@ Reference
 ---------
 
 .. autoclass:: toga.Window
-   :members:
-   :undoc-members:
 
 .. autoprotocol:: toga.window.OnCloseHandler
 .. autoprotocol:: toga.window.DialogResultHandler


### PR DESCRIPTION
`members` and `undoc-members` were previously enabled in #1996; this PR cleans up all the redundant per-class copies.

It also enables `show-inheritance` on all classes except those that inherit only from `object`.


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
