### PR TITLE
Corrected `toga.Window.title` backend for winforms

### DIFF
--- a/changes/2094.bugfix.rst
+++ b/changes/2094.bugfix.rst
@@ -1,0 +1,1 @@
+Fixes `TypeError` when `toga.Window.title` is invoked on WinForms.

--- a/winforms/src/toga_winforms/window.py
+++ b/winforms/src/toga_winforms/window.py
@@ -98,7 +98,6 @@ class Window(Container, Scalable):
             return
         self.native.Icon = icon_impl.native
 
-    @property
     def get_title(self):
         return self.native.Text
 


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Modified the `WinForms` backend to enable correct behavior of `toga.Window.title`.

Prevents the error:`TypeError: 'str' object is not callable` when `toga.Window.title` is invoked on WinForms.
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
