### PR TITLE
Modified WinForms backend to prevent error when window content is not set.

### DIFF
--- a/changes/2095.bugfix.rst
+++ b/changes/2095.bugfix.rst
@@ -1,0 +1,1 @@
+Added empty window content error messages to prevent non meanigful error messages from showing up.

--- a/changes/2095.bugfix.rst
+++ b/changes/2095.bugfix.rst
@@ -1,1 +1,1 @@
-Added empty window content error messages to prevent non meanigful error messages from showing up.
+Modified WinForms backend to prevent error when window content is not set.

--- a/core/src/toga/window.py
+++ b/core/src/toga/window.py
@@ -224,6 +224,10 @@ class Window:
             raise AttributeError(
                 "Can't show a window that doesn't have an associated app"
             )
+        elif self.content is None:
+            raise AttributeError(
+                "Can't show a window that doesn't have an associated content"
+            )
         self._impl.show()
 
     def hide(self) -> None:
@@ -231,6 +235,10 @@ class Window:
         if self.app is None:
             raise AttributeError(
                 "Can't hide a window that doesn't have an associated app"
+            )
+        elif self.content is None:
+            raise AttributeError(
+                "Can't hide a window that doesn't have an associated content"
             )
         self._impl.hide()
 

--- a/core/src/toga/window.py
+++ b/core/src/toga/window.py
@@ -224,10 +224,6 @@ class Window:
             raise AttributeError(
                 "Can't show a window that doesn't have an associated app"
             )
-        elif self.content is None:
-            raise AttributeError(
-                "Can't show a window that doesn't have an associated content"
-            )
         self._impl.show()
 
     def hide(self) -> None:
@@ -235,10 +231,6 @@ class Window:
         if self.app is None:
             raise AttributeError(
                 "Can't hide a window that doesn't have an associated app"
-            )
-        elif self.content is None:
-            raise AttributeError(
-                "Can't hide a window that doesn't have an associated content"
             )
         self._impl.hide()
 

--- a/winforms/src/toga_winforms/window.py
+++ b/winforms/src/toga_winforms/window.py
@@ -119,7 +119,8 @@ class Window(Container, Scalable):
         self.native.MinimumSize = decor_size + min_client_size
 
     def show(self):
-        self.interface.content.refresh()
+        if self.interface.content is not None:
+            self.interface.content.refresh()
         if self.interface is not self.interface.app._main_window:
             self.native.Icon = self.interface.app.icon._impl.native
         self.native.Show()


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Modified WinForms backend to prevent error when window content is not set.

Prevents non meaningful error messages like the following from showing up:
```
...
  File "...\winforms\src\toga_winforms\window.py", line 124, in show
    self.interface.content.refresh()
AttributeError: 'NoneType' object has no attribute 'refresh'

```
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
