### PR TITLE
Enable webkit inspector for iOS and Cococa.

### DIFF
--- a/cocoa/src/toga_cocoa/widgets/webview.py
+++ b/cocoa/src/toga_cocoa/widgets/webview.py
@@ -48,6 +48,14 @@ class WebView(Widget):
         self.native.interface = self.interface
         self.native.impl = self
 
+        # Enable the content inspector. This was added in macOS 13.3 (Ventura). It will
+        # be a no-op on newer versions of macOS; you need to package the app, then run:
+        #
+        #     defaults write com.example.appname WebKitDeveloperExtras -bool true
+        #
+        # from the command line.
+        self.native.inspectable = True
+
         self.native.navigationDelegate = self.native
         self.native.uIDelegate = self.native
 

--- a/docs/reference/api/widgets/webview.rst
+++ b/docs/reference/api/widgets/webview.rst
@@ -46,16 +46,20 @@ Notes
 * Using WebView on Linux requires that the user has installed the system packages
   for WebKit2, plus the GObject Introspection bindings for WebKit2.
 
-* On macOS, the "inspect element" feature is not enabled by default. WebView
-  debugging is only available when your code is packaged as a full macOS app
-  (e.g., with Briefcase). To enable debugging, run:
+* On macOS 13.3 (Ventura) and later, the content inspector for your app can be opened by
+  running Safari, `enabling the developer tools
+  <https://support.apple.com/en-au/guide/safari/sfri20948/mac>`__, and selecting your
+  app's window from the "Develop" menu.
+
+  On macOS versions prior to Ventura, the content inspector is not enabled by default,
+  and is only available when your code is packaged as a full macOS app (e.g., with
+  Briefcase). To enable debugging, run:
 
     .. code-block:: console
 
         $ defaults write com.example.appname WebKitDeveloperExtras -bool true
 
-    Substituting ``com.example.appname`` with the bundle ID for your packaged
-    app.
+    Substituting ``com.example.appname`` with the bundle ID for your packaged app.
 
 Reference
 ---------

--- a/iOS/src/toga_iOS/widgets/webview.py
+++ b/iOS/src/toga_iOS/widgets/webview.py
@@ -43,6 +43,10 @@ class WebView(Widget):
         self.native.interface = self.interface
         self.native.impl = self
 
+        # Enable the content inspector. This was added in iOS 16.4.
+        # It is a no-op on earlier versions.
+        self.native.inspectable = True
+
         self.native.navigationDelegate = self.native
         self.native.uIDelegate = self.native
 


### PR DESCRIPTION
macOS Ventura / iOS 16.4 added an explicit API to enable the inspector in embedded WKWebViews.

Since we're setting a property, this will be a no-op on older versions of macOS/iOS (well - the property will be set, but it will be attached as a meaningless Python attribute, not an invocation of the macOS/iOS API).

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
