### PR TITLE
Fixed pixbuf bug in gtk icons.

### DIFF
--- a/changes/2116.bugfix.rst
+++ b/changes/2116.bugfix.rst
@@ -1,0 +1,1 @@
+The pixbuf bug present in gtk icons was fixed.

--- a/changes/2116.bugfix.rst
+++ b/changes/2116.bugfix.rst
@@ -1,1 +1,0 @@
-The pixbuf bug present in gtk icons was fixed.

--- a/changes/2116.misc.rst
+++ b/changes/2116.misc.rst
@@ -1,0 +1,1 @@
+An error raised when displaying a GTK About dialog was resolved.

--- a/gtk/src/toga_gtk/app.py
+++ b/gtk/src/toga_gtk/app.py
@@ -202,7 +202,7 @@ class App:
         about = Gtk.AboutDialog()
 
         icon_impl = toga_App.app.icon._impl
-        about.set_logo(icon_impl.native_72.get_pixbuf())
+        about.set_logo(icon_impl.native_72)
 
         if self.interface.name is not None:
             about.set_program_name(self.interface.name)


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Fixed a pixbuf bug present in gtk icons. Prevents the error:
```
AttributeError: 'Pixbuf' object has no attribute 'get_pixbuf'
```
With this bug, it would be impossible to show the about dialog on gtk.
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
