### PR TITLE
Remove copyright year from docs (re: beeware/briefcase#1431)

### DIFF
--- a/changes/2128.misc.rst
+++ b/changes/2128.misc.rst
@@ -1,0 +1,1 @@
+The copyright year was removed from the documentation footer.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,7 +51,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "Toga"
-copyright = "2013, Russell Keith-Magee"
+copyright = "Russell Keith-Magee"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
## Changes
- The footer in the docs no longer include a copyright year
- IIUC, this was the desired outcome from beeware/briefcase#1431

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
