### PR TITLE
Bump pre-commit-hooks from v4.4.0 to v4.5.0.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: "^(attic|examples/.template|nursery)/"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: check-toml
       - id: check-yaml

--- a/changes/2146.misc.rst
+++ b/changes/2146.misc.rst
@@ -1,0 +1,1 @@
+The ``pre-commit`` hook for ``pre-commit-hooks`` was updated to its latest version.


### PR DESCRIPTION
Bumps `pre-commit` hook for `pre-commit-hooks` from v4.4.0 to v4.5.0. and ran the update against the repo.