### PR TITLE
Bump codespell from v2.2.5 to v2.2.6.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.5
+    rev: v2.2.6
     hooks:
     - id: codespell
       additional_dependencies:


### PR DESCRIPTION
Bumps `pre-commit` hook for `codespell` from v2.2.5 to v2.2.6. and ran the update against the repo.