### PR TITLE
Test undo/redo behaviour of text input widgets on macOS.

### DIFF
--- a/android/tests_backend/widgets/base.py
+++ b/android/tests_backend/widgets/base.py
@@ -1,5 +1,6 @@
 import asyncio
 
+import pytest
 from java import dynamic_proxy
 from pytest import approx
 
@@ -232,10 +233,10 @@ class SimpleProbe(BaseProbe, FontMixin):
         return self.widget.app._impl.native.getCurrentFocus() == self.native
 
     async def undo(self):
-        raise NotImplementedError()
+        pytest.skip("Undo not supported on this platform")
 
     async def redo(self):
-        raise NotImplementedError()
+        pytest.skip("Redo not supported on this platform")
 
 
 def find_view_by_type(root, cls):

--- a/android/tests_backend/widgets/base.py
+++ b/android/tests_backend/widgets/base.py
@@ -231,6 +231,12 @@ class SimpleProbe(BaseProbe, FontMixin):
     def has_focus(self):
         return self.widget.app._impl.native.getCurrentFocus() == self.native
 
+    async def undo(self):
+        raise NotImplementedError()
+
+    async def redo(self):
+        raise NotImplementedError()
+
 
 def find_view_by_type(root, cls):
     assert isinstance(root, View)

--- a/android/tests_backend/widgets/numberinput.py
+++ b/android/tests_backend/widgets/numberinput.py
@@ -1,4 +1,4 @@
-from pytest import xfail
+import pytest
 
 from .textinput import TextInputProbe
 
@@ -16,7 +16,10 @@ class NumberInputProbe(TextInputProbe):
         self.native.setText("")
 
     async def increment(self):
-        xfail("This backend doesn't support stepped increments")
+        pytest.xfail("This backend doesn't support stepped increments")
 
     async def decrement(self):
-        xfail("This backend doesn't support stepped increments")
+        pytest.xfail("This backend doesn't support stepped increments")
+
+    def set_cursor_at_end(self):
+        pytest.skip("Cursor positioning not supported on this platform")

--- a/android/tests_backend/widgets/textinput.py
+++ b/android/tests_backend/widgets/textinput.py
@@ -1,3 +1,4 @@
+import pytest
 from java import jclass
 
 from android.os import SystemClock
@@ -80,3 +81,6 @@ class TextInputProbe(LabelProbe):
                         0,  # metaState
                     )
                 )
+
+    def set_cursor_at_end(self):
+        pytest.skip("Cursor positioning not supported on this platform")

--- a/changes/2151.feature.rst
+++ b/changes/2151.feature.rst
@@ -1,1 +1,1 @@
-The cocoa MultilineTextInput widget has been updated to enable undo
+Text input widgets on macOS now support undo and redo.

--- a/changes/2151.feature.rst
+++ b/changes/2151.feature.rst
@@ -1,0 +1,1 @@
+The cocoa MultilineTextInput widget has been updated to enable undo

--- a/cocoa/src/toga_cocoa/widgets/multilinetextinput.py
+++ b/cocoa/src/toga_cocoa/widgets/multilinetextinput.py
@@ -41,6 +41,7 @@ class MultilineTextInput(Widget):
 
         self.native_text.editable = True
         self.native_text.selectable = True
+        self.native_text.allowsUndo = True
         self.native_text.verticallyResizable = True
         self.native_text.horizontallyResizable = False
         self.native_text.usesAdaptiveColorMappingForDarkAppearance = True

--- a/cocoa/tests_backend/widgets/base.py
+++ b/cocoa/tests_backend/widgets/base.py
@@ -1,6 +1,7 @@
 from rubicon.objc import NSPoint
 
 from toga.colors import TRANSPARENT
+from toga_cocoa.keys import NSEventModifierFlagCommand, NSEventModifierFlagShift
 from toga_cocoa.libs import NSEvent, NSEventType
 
 from ..fonts import FontMixin
@@ -111,6 +112,7 @@ class SimpleProbe(BaseProbe, FontMixin):
         # Convert the requested character into a Cocoa keycode.
         # This table is incomplete, but covers all the basics.
         key_code = {
+            "<backspace>": 51,
             "<esc>": 53,
             " ": 49,
             "\n": 36,
@@ -141,6 +143,9 @@ class SimpleProbe(BaseProbe, FontMixin):
             "y": 16,
             "z": 6,
         }.get(char.lower(), 0)
+
+        if modifierFlags:
+            char = None
 
         # This posts a single keyDown followed by a keyUp, matching "normal" keyboard operation.
         await self.post_event(
@@ -193,4 +198,12 @@ class SimpleProbe(BaseProbe, FontMixin):
                 pressure=1.0 if event_type == NSEventType.LeftMouseDown else 0.0,
             ),
             delay=delay,
+        )
+
+    async def undo(self):
+        await self.type_character("z", modifierFlags=NSEventModifierFlagCommand)
+
+    async def redo(self):
+        await self.type_character(
+            "z", modifierFlags=NSEventModifierFlagCommand | NSEventModifierFlagShift
         )

--- a/cocoa/tests_backend/widgets/multilinetextinput.py
+++ b/cocoa/tests_backend/widgets/multilinetextinput.py
@@ -1,5 +1,5 @@
 from toga.colors import TRANSPARENT
-from toga_cocoa.libs import NSScrollView, NSTextView
+from toga_cocoa.libs import NSRange, NSScrollView, NSTextView
 
 from .base import SimpleProbe
 from .properties import toga_alignment, toga_color
@@ -96,3 +96,6 @@ class MultilineTextInputProbe(SimpleProbe):
     async def wait_for_scroll_completion(self):
         # No animation associated with scroll, so this is a no-op
         pass
+
+    def set_cursor_at_end(self):
+        self.native.selectedRange = NSRange(len(self.value), 0)

--- a/cocoa/tests_backend/widgets/numberinput.py
+++ b/cocoa/tests_backend/widgets/numberinput.py
@@ -3,6 +3,7 @@ from rubicon.objc import NSPoint
 from toga.colors import TRANSPARENT
 from toga_cocoa.libs import (
     NSEventType,
+    NSRange,
     NSStepper,
     NSTextField,
     NSTextView,
@@ -107,3 +108,6 @@ class NumberInputProbe(SimpleProbe):
         return isinstance(self.native.window.firstResponder, NSTextView) and (
             self.native_input.window.firstResponder.delegate == self.native_input
         )
+
+    def set_cursor_at_end(self):
+        self.native_input.currentEditor().selectedRange = NSRange(len(self.value), 0)

--- a/cocoa/tests_backend/widgets/textinput.py
+++ b/cocoa/tests_backend/widgets/textinput.py
@@ -2,6 +2,7 @@ from toga.colors import TRANSPARENT
 from toga.constants import RIGHT
 from toga_cocoa.libs import (
     NSLeftTextAlignment,
+    NSRange,
     NSRightTextAlignment,
     NSTextField,
     NSTextView,
@@ -82,3 +83,6 @@ class TextInputProbe(SimpleProbe):
         return isinstance(self.native.window.firstResponder, NSTextView) and (
             self.native.window.firstResponder.delegate == self.native
         )
+
+    def set_cursor_at_end(self):
+        self.native.currentEditor().selectedRange = NSRange(len(self.value), 0)

--- a/gtk/tests_backend/widgets/base.py
+++ b/gtk/tests_backend/widgets/base.py
@@ -167,3 +167,9 @@ class SimpleProbe(BaseProbe, FontMixin):
         # caused by typing a character doesn't fully propegate. A
         # short delay fixes this.
         await asyncio.sleep(0.04)
+
+    async def undo(self):
+        raise NotImplementedError()
+
+    async def redo(self):
+        raise NotImplementedError()

--- a/gtk/tests_backend/widgets/base.py
+++ b/gtk/tests_backend/widgets/base.py
@@ -1,6 +1,8 @@
 import asyncio
 from threading import Event
 
+import pytest
+
 from toga_gtk.libs import Gdk, Gtk
 
 from ..fonts import FontMixin
@@ -169,7 +171,7 @@ class SimpleProbe(BaseProbe, FontMixin):
         await asyncio.sleep(0.04)
 
     async def undo(self):
-        raise NotImplementedError()
+        pytest.skip("Undo not supported on this platform")
 
     async def redo(self):
-        raise NotImplementedError()
+        pytest.skip("Redo not supported on this platform")

--- a/gtk/tests_backend/widgets/multilinetextinput.py
+++ b/gtk/tests_backend/widgets/multilinetextinput.py
@@ -1,3 +1,5 @@
+import pytest
+
 from toga_gtk.libs import Gtk
 
 from .base import SimpleProbe
@@ -113,3 +115,6 @@ class MultilineTextInputProbe(SimpleProbe):
 
     async def wait_for_scroll_completion(self):
         pass
+
+    def set_cursor_at_end(self):
+        pytest.skip("Cursor positioning not supported on this platform")

--- a/gtk/tests_backend/widgets/numberinput.py
+++ b/gtk/tests_backend/widgets/numberinput.py
@@ -1,3 +1,5 @@
+import pytest
+
 from toga.constants import JUSTIFY, LEFT
 from toga_gtk.libs import Gtk
 
@@ -45,3 +47,6 @@ class NumberInputProbe(SimpleProbe):
     @property
     def readonly(self):
         return not self.native.get_property("editable")
+
+    def set_cursor_at_end(self):
+        pytest.skip("Cursor positioning not supported on this platform")

--- a/gtk/tests_backend/widgets/textinput.py
+++ b/gtk/tests_backend/widgets/textinput.py
@@ -1,3 +1,5 @@
+import pytest
+
 from toga.constants import JUSTIFY, LEFT
 from toga_gtk.libs import Gtk
 
@@ -47,3 +49,6 @@ class TextInputProbe(SimpleProbe):
     @property
     def readonly(self):
         return not self.native.get_property("editable")
+
+    def set_cursor_at_end(self):
+        pytest.skip("Cursor positioning not supported on this platform")

--- a/iOS/tests_backend/widgets/base.py
+++ b/iOS/tests_backend/widgets/base.py
@@ -1,3 +1,4 @@
+import pytest
 from rubicon.objc import ObjCClass
 
 from toga_iOS.libs import UIApplication
@@ -168,7 +169,7 @@ class SimpleProbe(BaseProbe, FontMixin):
                 self.native.insertText("")
 
     async def undo(self):
-        raise NotImplementedError()
+        pytest.skip("Undo not supported on this platform")
 
     async def redo(self):
-        raise NotImplementedError()
+        pytest.skip("Redo not supported on this platform")

--- a/iOS/tests_backend/widgets/base.py
+++ b/iOS/tests_backend/widgets/base.py
@@ -166,3 +166,9 @@ class SimpleProbe(BaseProbe, FontMixin):
                 self.native.insertText(char)
             else:
                 self.native.insertText("")
+
+    async def undo(self):
+        raise NotImplementedError()
+
+    async def redo(self):
+        raise NotImplementedError()

--- a/iOS/tests_backend/widgets/numberinput.py
+++ b/iOS/tests_backend/widgets/numberinput.py
@@ -1,4 +1,4 @@
-from pytest import xfail
+import pytest
 from rubicon.objc import NSRange
 
 from toga_iOS.libs import UITextField
@@ -19,10 +19,10 @@ class NumberInputProbe(SimpleProbe):
         return str(self.native.text)
 
     async def increment(self):
-        xfail("iOS doesn't support stepped increments")
+        pytest.xfail("iOS doesn't support stepped increments")
 
     async def decrement(self):
-        xfail("iOS doesn't support stepped increments")
+        pytest.xfail("iOS doesn't support stepped increments")
 
     @property
     def color(self):
@@ -48,3 +48,6 @@ class NumberInputProbe(SimpleProbe):
             shouldChangeCharactersInRange=NSRange(len(self.native.text), 0),
             replacementString=char,
         )
+
+    def set_cursor_at_end(self):
+        pytest.skip("Cursor positioning not supported on this platform")

--- a/iOS/tests_backend/widgets/textinput.py
+++ b/iOS/tests_backend/widgets/textinput.py
@@ -1,3 +1,4 @@
+import pytest
 from rubicon.objc import SEL, send_message
 
 from toga_iOS.libs import UITextField
@@ -56,3 +57,6 @@ class TextInputProbe(SimpleProbe):
     def type_return(self):
         # Invoke the return handler explicitly.
         self.native.textFieldShouldReturn(self.native)
+
+    def set_cursor_at_end(self):
+        pytest.skip("Cursor positioning not supported on this platform")

--- a/testbed/tests/widgets/test_multilinetextinput.py
+++ b/testbed/tests/widgets/test_multilinetextinput.py
@@ -26,6 +26,7 @@ from .test_textinput import (  # noqa: F401
     test_on_change_focus,
     test_on_change_programmatic,
     test_on_change_user,
+    test_undo_redo,
     test_value_not_hidden,
 )
 

--- a/testbed/tests/widgets/test_passwordinput.py
+++ b/testbed/tests/widgets/test_passwordinput.py
@@ -26,6 +26,7 @@ from .test_textinput import (  # noqa: F401
     test_on_change_user,
     test_on_confirm,
     test_text_value,
+    test_undo_redo,
     test_validation,
     verify_focus_handlers,
     verify_vertical_alignment,

--- a/testbed/tests/widgets/test_textinput.py
+++ b/testbed/tests/widgets/test_textinput.py
@@ -5,7 +5,6 @@ import pytest
 import toga
 from toga.constants import CENTER
 
-from ..conftest import skip_on_platforms
 from ..data import TEXTS
 from .properties import (  # noqa: F401
     test_alignment,
@@ -218,7 +217,6 @@ async def test_text_value(widget, probe):
 
 async def test_undo_redo(widget, probe):
     "The widget supports undo and redo."
-    skip_on_platforms("android", "iOS", "linux", "windows")
 
     text_0 = str(widget.value)
     text_extra = " World!"

--- a/testbed/tests/widgets/test_textinput.py
+++ b/testbed/tests/widgets/test_textinput.py
@@ -5,6 +5,7 @@ import pytest
 import toga
 from toga.constants import CENTER
 
+from ..conftest import skip_on_platforms
 from ..data import TEXTS
 from .properties import (  # noqa: F401
     test_alignment,
@@ -213,3 +214,34 @@ async def test_text_value(widget, probe):
 
         assert widget.value == str(text).replace("\n", " ")
         assert probe.value == str(text).replace("\n", " ")
+
+
+async def test_undo_redo(widget, probe):
+    "The widget supports undo and redo."
+    skip_on_platforms("android", "iOS", "linux", "windows")
+
+    text_0 = str(widget.value)
+    text_extra = " World!"
+    text_1 = text_0 + text_extra
+
+    widget.focus()
+    probe.set_cursor_at_end()
+
+    # type more text
+    for char in text_extra:
+        await probe.type_character(char)
+    await probe.redraw(f"Widget value should be {text_1!r}")
+    assert widget.value == text_1
+    assert probe.value == text_1
+
+    # undo
+    await probe.undo()
+    await probe.redraw(f"Widget value should be {text_0!r}")
+    assert widget.value == text_0
+    assert probe.value == text_0
+
+    # redo
+    await probe.redo()
+    await probe.redraw(f"Widget value should be {text_1!r}")
+    assert widget.value == text_1
+    assert probe.value == text_1

--- a/winforms/tests_backend/widgets/base.py
+++ b/winforms/tests_backend/widgets/base.py
@@ -142,3 +142,9 @@ class SimpleProbe(BaseProbe, FontMixin):
     @property
     def has_focus(self):
         return self.native.ContainsFocus
+
+    async def undo(self):
+        raise NotImplementedError()
+
+    async def redo(self):
+        raise NotImplementedError()

--- a/winforms/tests_backend/widgets/base.py
+++ b/winforms/tests_backend/widgets/base.py
@@ -1,3 +1,4 @@
+import pytest
 from pytest import approx
 from System import EventArgs, Object
 from System.Drawing import Color, SystemColors
@@ -144,7 +145,7 @@ class SimpleProbe(BaseProbe, FontMixin):
         return self.native.ContainsFocus
 
     async def undo(self):
-        raise NotImplementedError()
+        pytest.skip("Undo not supported on this platform")
 
     async def redo(self):
-        raise NotImplementedError()
+        pytest.skip("Redo not supported on this platform")

--- a/winforms/tests_backend/widgets/numberinput.py
+++ b/winforms/tests_backend/widgets/numberinput.py
@@ -1,3 +1,4 @@
+import pytest
 from System.Windows.Forms import NumericUpDown
 
 from .base import SimpleProbe
@@ -38,3 +39,6 @@ class NumberInputProbe(SimpleProbe):
     def assert_vertical_alignment(self, expected):
         # Vertical alignment isn't configurable in this native widget.
         pass
+
+    def set_cursor_at_end(self):
+        pytest.skip("Cursor positioning not supported on this platform")

--- a/winforms/tests_backend/widgets/textinput.py
+++ b/winforms/tests_backend/widgets/textinput.py
@@ -2,6 +2,7 @@ import ctypes
 from ctypes import c_uint
 from ctypes.wintypes import HWND, LPARAM
 
+import pytest
 from System.Windows.Forms import TextBox
 
 from .base import SimpleProbe
@@ -53,3 +54,6 @@ class TextInputProbe(SimpleProbe):
     def assert_vertical_alignment(self, expected):
         # Vertical alignment isn't configurable in this native widget.
         pass
+
+    def set_cursor_at_end(self):
+        pytest.skip("Cursor positioning not supported on this platform")


### PR DESCRIPTION
Widgets tested are:
- TextInput
- MultilineTextInput
- PasswordInput
- NumberInput

The cocoa MultilineTextInput widget has been updated to enable undo.

Replaces PR https://github.com/beeware/toga/pull/2037

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
