### PR TITLE
Make container automatically resize on orientation change

### DIFF
--- a/changes/2161.bugfix.rst
+++ b/changes/2161.bugfix.rst
@@ -1,0 +1,1 @@
+iOS container views are now set to automatically resize with their parent view

--- a/iOS/src/toga_iOS/container.py
+++ b/iOS/src/toga_iOS/container.py
@@ -3,6 +3,12 @@ from .libs import (
     UINavigationController,
     UIView,
     UIViewController,
+    UIViewAutoresizingFlexibleLeftMargin,
+    UIViewAutoresizingFlexibleWidth,
+    UIViewAutoresizingFlexibleRightMargin,
+    UIViewAutoresizingFlexibleTopMargin,
+    UIViewAutoresizingFlexibleHeight,
+    UIViewAutoresizingFlexibleBottomMargin,
 )
 
 #######################################################################################
@@ -65,7 +71,14 @@ class Container(BaseContainer):
         super().__init__(content=content, on_refresh=on_refresh)
         self.native = UIView.alloc().init()
         self.native.translatesAutoresizingMaskIntoConstraints = True
-        self.native.autoresizingMask = 63
+        self.native.autoresizingMask = (
+            UIViewAutoresizingFlexibleLeftMargin
+            | UIViewAutoresizingFlexibleWidth
+            | UIViewAutoresizingFlexibleRightMargin
+            | UIViewAutoresizingFlexibleTopMargin
+            | UIViewAutoresizingFlexibleHeight
+            | UIViewAutoresizingFlexibleBottomMargin
+        )
 
         self.layout_native = self.native if layout_native is None else layout_native
 

--- a/iOS/src/toga_iOS/container.py
+++ b/iOS/src/toga_iOS/container.py
@@ -2,13 +2,13 @@ from .libs import (
     UIApplication,
     UINavigationController,
     UIView,
-    UIViewController,
+    UIViewAutoresizingFlexibleBottomMargin,
+    UIViewAutoresizingFlexibleHeight,
     UIViewAutoresizingFlexibleLeftMargin,
-    UIViewAutoresizingFlexibleWidth,
     UIViewAutoresizingFlexibleRightMargin,
     UIViewAutoresizingFlexibleTopMargin,
-    UIViewAutoresizingFlexibleHeight,
-    UIViewAutoresizingFlexibleBottomMargin,
+    UIViewAutoresizingFlexibleWidth,
+    UIViewController,
 )
 
 #######################################################################################

--- a/iOS/src/toga_iOS/container.py
+++ b/iOS/src/toga_iOS/container.py
@@ -2,12 +2,7 @@ from .libs import (
     UIApplication,
     UINavigationController,
     UIView,
-    UIViewAutoresizingFlexibleBottomMargin,
-    UIViewAutoresizingFlexibleHeight,
-    UIViewAutoresizingFlexibleLeftMargin,
-    UIViewAutoresizingFlexibleRightMargin,
-    UIViewAutoresizingFlexibleTopMargin,
-    UIViewAutoresizingFlexibleWidth,
+    UIViewAutoresizing,
     UIViewController,
 )
 
@@ -72,12 +67,7 @@ class Container(BaseContainer):
         self.native = UIView.alloc().init()
         self.native.translatesAutoresizingMaskIntoConstraints = True
         self.native.autoresizingMask = (
-            UIViewAutoresizingFlexibleLeftMargin
-            | UIViewAutoresizingFlexibleWidth
-            | UIViewAutoresizingFlexibleRightMargin
-            | UIViewAutoresizingFlexibleTopMargin
-            | UIViewAutoresizingFlexibleHeight
-            | UIViewAutoresizingFlexibleBottomMargin
+            UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleHeight
         )
 
         self.layout_native = self.native if layout_native is None else layout_native

--- a/iOS/src/toga_iOS/container.py
+++ b/iOS/src/toga_iOS/container.py
@@ -65,6 +65,7 @@ class Container(BaseContainer):
         super().__init__(content=content, on_refresh=on_refresh)
         self.native = UIView.alloc().init()
         self.native.translatesAutoresizingMaskIntoConstraints = True
+        self.native.autoresizingMask = 63
 
         self.layout_native = self.native if layout_native is None else layout_native
 

--- a/iOS/src/toga_iOS/libs/uikit.py
+++ b/iOS/src/toga_iOS/libs/uikit.py
@@ -451,7 +451,8 @@ class UIViewContentMode(Enum):
     BottomLeft = 11
     BottomRight = 12
 
-#UIViewAutoresizing
+
+# UIViewAutoresizing
 UIViewAutoresizingNone = 0
 UIViewAutoresizingFlexibleLeftMargin = 1 << 0
 UIViewAutoresizingFlexibleWidth = 1 << 1

--- a/iOS/src/toga_iOS/libs/uikit.py
+++ b/iOS/src/toga_iOS/libs/uikit.py
@@ -451,6 +451,15 @@ class UIViewContentMode(Enum):
     BottomLeft = 11
     BottomRight = 12
 
+#UIViewAutoresizing
+UIViewAutoresizingNone = 0
+UIViewAutoresizingFlexibleLeftMargin = 1 << 0
+UIViewAutoresizingFlexibleWidth = 1 << 1
+UIViewAutoresizingFlexibleRightMargin = 1 << 2
+UIViewAutoresizingFlexibleTopMargin = 1 << 3
+UIViewAutoresizingFlexibleHeight = 1 << 4
+UIViewAutoresizingFlexibleBottomMargin = 1 << 5
+
 
 ######################################################################
 # UIViewController.h

--- a/iOS/src/toga_iOS/libs/uikit.py
+++ b/iOS/src/toga_iOS/libs/uikit.py
@@ -2,7 +2,7 @@
 # System/Library/Frameworks/UIKit.framework
 ##########################################################################
 from ctypes import POINTER, c_char_p, c_int, c_void_p, cdll, util
-from enum import Enum
+from enum import Enum, IntEnum
 
 from rubicon.objc import ObjCClass, ObjCProtocol, objc_const
 
@@ -452,14 +452,14 @@ class UIViewContentMode(Enum):
     BottomRight = 12
 
 
-# UIViewAutoresizing
-UIViewAutoresizingNone = 0
-UIViewAutoresizingFlexibleLeftMargin = 1 << 0
-UIViewAutoresizingFlexibleWidth = 1 << 1
-UIViewAutoresizingFlexibleRightMargin = 1 << 2
-UIViewAutoresizingFlexibleTopMargin = 1 << 3
-UIViewAutoresizingFlexibleHeight = 1 << 4
-UIViewAutoresizingFlexibleBottomMargin = 1 << 5
+class UIViewAutoresizing(IntEnum):
+    NoResizing = 0
+    FlexibleLeftMargin = 1 << 0
+    FlexibleWidth = 1 << 1
+    FlexibleRightMargin = 1 << 2
+    FlexibleTopMargin = 1 << 3
+    FlexibleHeight = 1 << 4
+    FlexibleBottomMargin = 1 << 5
 
 
 ######################################################################


### PR DESCRIPTION
<!--- Describe your changes in detail -->
This sets the [autoResizingMask](https://developer.apple.com/documentation/uikit/uiview/1622559-autoresizingmask?language=objc) property of the container.native UIView so that all possible resizing options (i.e. margin, height, and width) are set.
<!--- What problem does this change solve? -->
On iOS14 and iOS15 the container.native UIView doesn't always resize properly on orientation change.  This is not a problem on iOS16 and iOS17 for some reason.  You can see this behavior on the positron-django example.
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x ] All new features have been tested
- [x ] All new features have been documented
- [x ] I have read the **CONTRIBUTING.md** file
- [x ] I will abide by the code of conduct
