### PR TITLE
Bump black from 23.9.1 to 23.10.0.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       - id: pyupgrade
         args: [--py38-plus]
   - repo: https://github.com/psf/black
-    rev: 23.9.1
+    rev: 23.10.0
     hooks:
     - id: black
   - repo: https://github.com/PyCQA/flake8

--- a/changes/2165.misc.rst
+++ b/changes/2165.misc.rst
@@ -1,0 +1,1 @@
+The ``pre-commit`` hook for ``black`` was updated to its latest version.


### PR DESCRIPTION
Bumps `pre-commit` hook for `black` from 23.9.1 to 23.10.0. and ran the update against the repo.