### PR TITLE
Ensure Winforms menu/toolbar handlers aren't garbage collected

### DIFF
--- a/changes/2163.misc.rst
+++ b/changes/2163.misc.rst
@@ -1,0 +1,1 @@
+Winforms command event handlers were made persistent objects, rather than on-demand closures.

--- a/winforms/src/toga_winforms/app.py
+++ b/winforms/src/toga_winforms/app.py
@@ -155,7 +155,7 @@ class App:
                 item = WinForms.ToolStripMenuItem(cmd.text)
 
                 if cmd.action:
-                    item.Click += WeakrefCallable(cmd._impl.as_handler())
+                    item.Click += WeakrefCallable(cmd._impl.winforms_handler)
                 item.Enabled = cmd.enabled
 
                 if cmd.shortcut is not None:

--- a/winforms/src/toga_winforms/command.py
+++ b/winforms/src/toga_winforms/command.py
@@ -8,8 +8,5 @@ class Command:
             for widget in self.native:
                 widget.Enabled = self.interface.enabled
 
-    def as_handler(self):
-        def handler(sender, event):
-            return self.interface.action(None)
-
-        return handler
+    def winforms_handler(self, sender, event):
+        return self.interface.action(None)

--- a/winforms/src/toga_winforms/window.py
+++ b/winforms/src/toga_winforms/window.py
@@ -61,7 +61,7 @@ class Window(Container, Scalable):
                         )
                     else:
                         item = WinForms.ToolStripMenuItem(cmd.text)
-                    item.Click += cmd._impl.as_handler()
+                    item.Click += WeakrefCallable(cmd._impl.winforms_handler)
                     cmd._impl.native.append(item)
                 self.toolbar_native.Items.Add(item)
 


### PR DESCRIPTION
Fixes #2163.

The change to make event handlers weakrefs added in #2066 had the unintended side effect of breaking menu items, because `Command.as_handler()` was producing a transient callable that was being garbage collected immediately.

This PR modifies the handler to be a direct method on Command, so it isn't garbage collected.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
