### PR TITLE
WinForms: take borders and title bar into account when setting window size

### DIFF
--- a/changes/2180.misc.rst
+++ b/changes/2180.misc.rst
@@ -1,0 +1,1 @@
+On WinForms, the ``Window.size`` property no longer includes the title bar and the invisible borders.


### PR DESCRIPTION
Although modern versions of Windows only draw a 1-pixel border around windows, the invisible resize area surrounding it is still counted as part of `native.Size`. This was causing the window of tutorial4 to be too narrow to contain the image.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
