### PR TITLE
Correct scaling of MIN_WIDTH and MIN_HEIGHT on Android and WinForms

### DIFF
--- a/android/src/toga_android/widgets/base.py
+++ b/android/src/toga_android/widgets/base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from decimal import ROUND_HALF_EVEN, ROUND_UP, Decimal
+from decimal import ROUND_HALF_EVEN, Decimal
 
 from android.graphics import PorterDuff, PorterDuffColorFilter, Rect
 from android.graphics.drawable import ColorDrawable, InsetDrawable
@@ -182,18 +182,13 @@ class Widget(ABC, Scalable):
     # TODO: consider calling requestLayout or forceLayout here
     # (https://github.com/beeware/toga/issues/1289#issuecomment-1453096034)
     def refresh(self):
-        intrinsic = self.interface.intrinsic
-        intrinsic.width = intrinsic.height = None
+        # Default values; may be overwritten by rehint().
+        self.interface.intrinsic.width = at_least(self.interface._MIN_WIDTH)
+        self.interface.intrinsic.height = at_least(self.interface._MIN_HEIGHT)
         self.rehint()
-        assert intrinsic.width is not None, self
-        assert intrinsic.height is not None, self
 
-        intrinsic.width = self.scale_out(intrinsic.width, ROUND_UP)
-        intrinsic.height = self.scale_out(intrinsic.height, ROUND_UP)
-
-    @abstractmethod
     def rehint(self):
-        ...
+        pass
 
 
 def align(value):

--- a/android/src/toga_android/widgets/box.py
+++ b/android/src/toga_android/widgets/box.py
@@ -1,5 +1,4 @@
 from android.widget import RelativeLayout
-from travertino.size import at_least
 
 from .base import Widget
 
@@ -10,7 +9,3 @@ class Box(Widget):
 
     def set_background_color(self, value):
         self.set_background_simple(value)
-
-    def rehint(self):
-        self.interface.intrinsic.width = at_least(0)
-        self.interface.intrinsic.height = at_least(0)

--- a/android/src/toga_android/widgets/button.py
+++ b/android/src/toga_android/widgets/button.py
@@ -1,3 +1,5 @@
+from decimal import ROUND_UP
+
 from android.view import View
 from android.widget import Button as A_Button
 from java import dynamic_proxy
@@ -40,5 +42,9 @@ class Button(TextViewWidget):
             View.MeasureSpec.UNSPECIFIED,
             View.MeasureSpec.UNSPECIFIED,
         )
-        self.interface.intrinsic.width = at_least(self.native.getMeasuredWidth())
-        self.interface.intrinsic.height = self.native.getMeasuredHeight()
+        self.interface.intrinsic.width = self.scale_out(
+            at_least(self.native.getMeasuredWidth()), ROUND_UP
+        )
+        self.interface.intrinsic.height = self.scale_out(
+            self.native.getMeasuredHeight(), ROUND_UP
+        )

--- a/android/src/toga_android/widgets/canvas.py
+++ b/android/src/toga_android/widgets/canvas.py
@@ -12,7 +12,6 @@ from android.view import MotionEvent, View
 from java import dynamic_proxy, jint
 from java.io import ByteArrayOutputStream
 from org.beeware.android import DrawHandlerView, IDrawHandler
-from travertino.size import at_least
 
 from toga.widgets.canvas import Baseline, FillRule
 
@@ -265,7 +264,3 @@ class Canvas(Widget):
 
     def set_background_color(self, value):
         self.set_background_simple(value)
-
-    def rehint(self):
-        self.interface.intrinsic.width = at_least(0)
-        self.interface.intrinsic.height = at_least(0)

--- a/android/src/toga_android/widgets/detailedlist.py
+++ b/android/src/toga_android/widgets/detailedlist.py
@@ -8,7 +8,6 @@ from android.view import Gravity, View
 from android.widget import ImageView, LinearLayout, RelativeLayout, ScrollView, TextView
 from androidx.swiperefreshlayout.widget import SwipeRefreshLayout
 from java import dynamic_proxy
-from travertino.size import at_least
 
 from .base import Widget
 
@@ -243,7 +242,3 @@ class DetailedList(Widget):
             hit_rect,
             True,  # Immediate, not animated
         )
-
-    def rehint(self):
-        self.interface.intrinsic.width = at_least(self.interface._MIN_WIDTH)
-        self.interface.intrinsic.height = at_least(self.interface._MIN_HEIGHT)

--- a/android/src/toga_android/widgets/imageview.py
+++ b/android/src/toga_android/widgets/imageview.py
@@ -1,3 +1,5 @@
+from decimal import ROUND_UP
+
 from android.widget import ImageView as A_ImageView
 
 from toga.widgets.imageview import rehint_imageview
@@ -21,7 +23,7 @@ class ImageView(Widget):
 
     def rehint(self):
         # User specified sizes are in "pixels", which is DP;
-        # we need to convert all sizes into SP.
+        # we need to convert all sizes into physical pixels.
         dpi = self.native.getContext().getResources().getDisplayMetrics().densityDpi
         # Toga needs to know how the current DPI compares to the platform default,
         # which is 160: https://developer.android.com/training/multiscreen/screendensities
@@ -30,8 +32,8 @@ class ImageView(Widget):
         width, height, aspect_ratio = rehint_imageview(
             image=self.interface.image, style=self.interface.style, scale=scale
         )
-        self.interface.intrinsic.width = width
-        self.interface.intrinsic.height = height
+        self.interface.intrinsic.width = self.scale_out(width, ROUND_UP)
+        self.interface.intrinsic.height = self.scale_out(height, ROUND_UP)
         if aspect_ratio is not None:
             self.native.setScaleType(A_ImageView.ScaleType.FIT_CENTER)
         else:

--- a/android/src/toga_android/widgets/internal/pickers.py
+++ b/android/src/toga_android/widgets/internal/pickers.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from decimal import ROUND_UP
 
 from android.view import View
 from android.widget import EditText
@@ -42,4 +43,6 @@ class PickerBase(TextViewWidget, ABC):
     def rehint(self):
         self.interface.intrinsic.width = at_least(300)
         self.native.measure(View.MeasureSpec.UNSPECIFIED, View.MeasureSpec.UNSPECIFIED)
-        self.interface.intrinsic.height = self.native.getMeasuredHeight()
+        self.interface.intrinsic.height = self.scale_out(
+            self.native.getMeasuredHeight(), ROUND_UP
+        )

--- a/android/src/toga_android/widgets/label.py
+++ b/android/src/toga_android/widgets/label.py
@@ -1,3 +1,5 @@
+from decimal import ROUND_UP
+
 from android.os import Build
 from android.text import Layout
 from android.util import TypedValue
@@ -68,13 +70,15 @@ class Label(TextViewWidget):
         # This is the height with word-wrapping disabled.
         self.native.measure(View.MeasureSpec.UNSPECIFIED, View.MeasureSpec.UNSPECIFIED)
         min_height = self.native.getMeasuredHeight()
-        self.interface.intrinsic.height = min_height
+        self.interface.intrinsic.height = self.scale_out(min_height, ROUND_UP)
         # Ask it how wide it would be if it had to be the minimum height.
         self.native.measure(
             View.MeasureSpec.UNSPECIFIED,
             View.MeasureSpec.makeMeasureSpec(min_height, View.MeasureSpec.AT_MOST),
         )
-        self.interface.intrinsic.width = at_least(self.native.getMeasuredWidth())
+        self.interface.intrinsic.width = self.scale_out(
+            at_least(self.native.getMeasuredWidth()), ROUND_UP
+        )
 
     def set_alignment(self, value):
         self.set_textview_alignment(value, Gravity.TOP)

--- a/android/src/toga_android/widgets/multilinetextinput.py
+++ b/android/src/toga_android/widgets/multilinetextinput.py
@@ -26,6 +26,7 @@ class MultilineTextInput(TextInput):
     def set_alignment(self, value):
         self.set_textview_alignment(value, Gravity.TOP)
 
+    # This method is necessary to override the TextInput base class.
     def rehint(self):
         self.interface.intrinsic.width = at_least(self.interface._MIN_WIDTH)
         self.interface.intrinsic.height = at_least(self.interface._MIN_HEIGHT)

--- a/android/src/toga_android/widgets/progressbar.py
+++ b/android/src/toga_android/widgets/progressbar.py
@@ -1,3 +1,5 @@
+from decimal import ROUND_UP
+
 from android import R
 from android.view import View
 from android.widget import ProgressBar as A_ProgressBar
@@ -92,5 +94,9 @@ class ProgressBar(Widget):
             View.MeasureSpec.UNSPECIFIED,
             View.MeasureSpec.UNSPECIFIED,
         )
-        self.interface.intrinsic.width = at_least(self.native.getMeasuredWidth())
-        self.interface.intrinsic.height = self.native.getMeasuredHeight()
+        self.interface.intrinsic.width = self.scale_out(
+            at_least(self.native.getMeasuredWidth()), ROUND_UP
+        )
+        self.interface.intrinsic.height = self.scale_out(
+            self.native.getMeasuredHeight(), ROUND_UP
+        )

--- a/android/src/toga_android/widgets/scrollcontainer.py
+++ b/android/src/toga_android/widgets/scrollcontainer.py
@@ -3,7 +3,6 @@ from decimal import ROUND_DOWN
 from android.view import Gravity, View
 from android.widget import HorizontalScrollView, LinearLayout, ScrollView
 from java import dynamic_proxy
-from travertino.size import at_least
 
 from ..container import Container
 from .base import Widget
@@ -103,7 +102,3 @@ class ScrollContainer(Widget, Container):
 
     def set_background_color(self, value):
         self.set_background_simple(value)
-
-    def rehint(self):
-        self.interface.intrinsic.width = at_least(0)
-        self.interface.intrinsic.height = at_least(0)

--- a/android/src/toga_android/widgets/selection.py
+++ b/android/src/toga_android/widgets/selection.py
@@ -1,3 +1,5 @@
+from decimal import ROUND_UP
+
 from android import R
 from android.view import View
 from android.widget import AdapterView, ArrayAdapter, Spinner
@@ -84,5 +86,9 @@ class Selection(Widget):
 
     def rehint(self):
         self.native.measure(View.MeasureSpec.UNSPECIFIED, View.MeasureSpec.UNSPECIFIED)
-        self.interface.intrinsic.width = at_least(self.native.getMeasuredWidth())
-        self.interface.intrinsic.height = self.native.getMeasuredHeight()
+        self.interface.intrinsic.width = self.scale_out(
+            at_least(self.native.getMeasuredWidth()), ROUND_UP
+        )
+        self.interface.intrinsic.height = self.scale_out(
+            self.native.getMeasuredHeight(), ROUND_UP
+        )

--- a/android/src/toga_android/widgets/slider.py
+++ b/android/src/toga_android/widgets/slider.py
@@ -1,3 +1,5 @@
+from decimal import ROUND_UP
+
 from android import R
 from android.view import View
 from android.widget import SeekBar
@@ -67,5 +69,9 @@ class Slider(Widget, toga.widgets.slider.IntSliderImpl):
 
     def rehint(self):
         self.native.measure(View.MeasureSpec.UNSPECIFIED, View.MeasureSpec.UNSPECIFIED)
-        self.interface.intrinsic.width = at_least(self.native.getMeasuredWidth())
-        self.interface.intrinsic.height = self.native.getMeasuredHeight()
+        self.interface.intrinsic.width = self.scale_out(
+            at_least(self.native.getMeasuredWidth()), ROUND_UP
+        )
+        self.interface.intrinsic.height = self.scale_out(
+            self.native.getMeasuredHeight(), ROUND_UP
+        )

--- a/android/src/toga_android/widgets/switch.py
+++ b/android/src/toga_android/widgets/switch.py
@@ -1,3 +1,5 @@
+from decimal import ROUND_UP
+
 from android.view import View
 from android.widget import CompoundButton, Switch as A_Switch
 from java import dynamic_proxy
@@ -43,5 +45,9 @@ class Switch(TextViewWidget):
 
     def rehint(self):
         self.native.measure(View.MeasureSpec.UNSPECIFIED, View.MeasureSpec.UNSPECIFIED)
-        self.interface.intrinsic.width = at_least(self.native.getMeasuredWidth())
-        self.interface.intrinsic.height = self.native.getMeasuredHeight()
+        self.interface.intrinsic.width = self.scale_out(
+            at_least(self.native.getMeasuredWidth()), ROUND_UP
+        )
+        self.interface.intrinsic.height = self.scale_out(
+            self.native.getMeasuredHeight(), ROUND_UP
+        )

--- a/android/src/toga_android/widgets/table.py
+++ b/android/src/toga_android/widgets/table.py
@@ -5,7 +5,6 @@ from android.graphics import Rect, Typeface
 from android.view import Gravity, View
 from android.widget import LinearLayout, ScrollView, TableLayout, TableRow, TextView
 from java import dynamic_proxy
-from travertino.size import at_least
 
 import toga
 
@@ -221,7 +220,3 @@ class Table(Widget):
     def set_font(self, font):
         self._font_impl = font._impl
         self.change_source(self.interface.data)
-
-    def rehint(self):
-        self.interface.intrinsic.width = at_least(self.interface._MIN_WIDTH)
-        self.interface.intrinsic.height = at_least(self.interface._MIN_HEIGHT)

--- a/android/src/toga_android/widgets/textinput.py
+++ b/android/src/toga_android/widgets/textinput.py
@@ -1,8 +1,9 @@
+from decimal import ROUND_UP
+
 from android.text import InputType, TextWatcher
 from android.view import Gravity, View
 from android.widget import EditText
 from java import dynamic_proxy
-from travertino.size import at_least
 
 from toga_android.keys import toga_key
 
@@ -123,6 +124,7 @@ class TextInput(TextViewWidget):
         self.interface.on_lose_focus()
 
     def rehint(self):
-        self.interface.intrinsic.width = at_least(self.interface._MIN_WIDTH)
         self.native.measure(View.MeasureSpec.UNSPECIFIED, View.MeasureSpec.UNSPECIFIED)
-        self.interface.intrinsic.height = self.native.getMeasuredHeight()
+        self.interface.intrinsic.height = self.scale_out(
+            self.native.getMeasuredHeight(), ROUND_UP
+        )

--- a/android/src/toga_android/widgets/webview.py
+++ b/android/src/toga_android/widgets/webview.py
@@ -2,7 +2,6 @@ import json
 
 from android.webkit import ValueCallback, WebView as A_WebView, WebViewClient
 from java import dynamic_proxy
-from travertino.size import at_least
 
 from toga.widgets.webview import JavaScriptResult
 
@@ -81,7 +80,3 @@ class WebView(Widget):
             javascript, ReceiveString(result.future, on_result)
         )
         return result
-
-    def rehint(self):
-        self.interface.intrinsic.width = at_least(self.interface._MIN_WIDTH)
-        self.interface.intrinsic.height = at_least(self.interface._MIN_HEIGHT)

--- a/changes/2186.misc.rst
+++ b/changes/2186.misc.rst
@@ -1,0 +1,1 @@
+Correct scaling of MIN_WIDTH and MIN_HEIGHT on Android and WinForms

--- a/core/src/toga/widgets/box.py
+++ b/core/src/toga/widgets/box.py
@@ -4,6 +4,9 @@ from .base import Widget
 
 
 class Box(Widget):
+    _MIN_WIDTH = 0
+    _MIN_HEIGHT = 0
+
     def __init__(
         self,
         id: str | None = None,

--- a/core/src/toga/widgets/canvas.py
+++ b/core/src/toga/widgets/canvas.py
@@ -1181,6 +1181,9 @@ class OnResizeHandler(Protocol):
 
 
 class Canvas(Widget):
+    _MIN_WIDTH = 0
+    _MIN_HEIGHT = 0
+
     def __init__(
         self,
         id=None,

--- a/core/src/toga/widgets/scrollcontainer.py
+++ b/core/src/toga/widgets/scrollcontainer.py
@@ -6,6 +6,9 @@ from .base import Widget
 
 
 class ScrollContainer(Widget):
+    _MIN_WIDTH = 0
+    _MIN_HEIGHT = 0
+
     def __init__(
         self,
         id=None,

--- a/winforms/src/toga_winforms/widgets/base.py
+++ b/winforms/src/toga_winforms/widgets/base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from decimal import ROUND_HALF_EVEN, ROUND_UP, Decimal
+from decimal import ROUND_HALF_EVEN, Decimal
 
 from System.Drawing import (
     Color,
@@ -144,15 +144,10 @@ class Widget(ABC, Scalable):
         child.container = None
 
     def refresh(self):
-        intrinsic = self.interface.intrinsic
-        intrinsic.width = intrinsic.height = None
+        # Default values; may be overwritten by rehint().
+        self.interface.intrinsic.width = at_least(self.interface._MIN_WIDTH)
+        self.interface.intrinsic.height = at_least(self.interface._MIN_HEIGHT)
         self.rehint()
-        assert intrinsic.width is not None
-        assert intrinsic.height is not None
 
-        intrinsic.width = self.scale_out(intrinsic.width, ROUND_UP)
-        intrinsic.height = self.scale_out(intrinsic.height, ROUND_UP)
-
-    @abstractmethod
     def rehint(self):
-        ...
+        pass

--- a/winforms/src/toga_winforms/widgets/box.py
+++ b/winforms/src/toga_winforms/widgets/box.py
@@ -1,5 +1,4 @@
 import System.Windows.Forms as WinForms
-from travertino.size import at_least
 
 from .base import Widget
 
@@ -7,7 +6,3 @@ from .base import Widget
 class Box(Widget):
     def create(self):
         self.native = WinForms.Panel()
-
-    def rehint(self):
-        self.interface.intrinsic.width = at_least(0)
-        self.interface.intrinsic.height = at_least(0)

--- a/winforms/src/toga_winforms/widgets/button.py
+++ b/winforms/src/toga_winforms/widgets/button.py
@@ -1,3 +1,5 @@
+from decimal import ROUND_UP
+
 import System.Windows.Forms as WinForms
 from travertino.size import at_least
 
@@ -31,7 +33,9 @@ class Button(Widget):
         self.native.Text = text
 
     def rehint(self):
-        # self.native.Size = Size(0, 0)
-        # print("REHINT Button", self, self.native.PreferredSize)
-        self.interface.intrinsic.width = at_least(self.native.PreferredSize.Width)
-        self.interface.intrinsic.height = self.native.PreferredSize.Height
+        self.interface.intrinsic.width = self.scale_out(
+            at_least(self.native.PreferredSize.Width), ROUND_UP
+        )
+        self.interface.intrinsic.height = self.scale_out(
+            self.native.PreferredSize.Height, ROUND_UP
+        )

--- a/winforms/src/toga_winforms/widgets/dateinput.py
+++ b/winforms/src/toga_winforms/widgets/dateinput.py
@@ -1,8 +1,8 @@
 import datetime
+from decimal import ROUND_UP
 
 import System.Windows.Forms as WinForms
 from System import DateTime as WinDateTime
-from travertino.size import at_least
 
 from ..libs.wrapper import WeakrefCallable
 from .base import Widget
@@ -42,8 +42,9 @@ class DateInput(Widget):
         self.native.MaxDate = native_date(value)
 
     def rehint(self):
-        self.interface.intrinsic.width = at_least(self.interface._MIN_WIDTH)
-        self.interface.intrinsic.height = self.native.PreferredSize.Height
+        self.interface.intrinsic.height = self.scale_out(
+            self.native.PreferredSize.Height, ROUND_UP
+        )
 
     def winforms_value_changed(self, sender, event):
         self.interface.on_change()

--- a/winforms/src/toga_winforms/widgets/divider.py
+++ b/winforms/src/toga_winforms/widgets/divider.py
@@ -1,3 +1,5 @@
+from decimal import ROUND_UP
+
 import System.Windows.Forms as WinForms
 from travertino.size import at_least
 
@@ -26,8 +28,14 @@ class Divider(Widget):
 
     def rehint(self):
         if self.get_direction() == self.interface.HORIZONTAL:
-            self.interface.intrinsic.width = at_least(self.native.Width)
-            self.interface.intrinsic.height = self.native.Height
+            self.interface.intrinsic.width = self.scale_out(
+                at_least(self.native.Width), ROUND_UP
+            )
+            self.interface.intrinsic.height = self.scale_out(
+                self.native.Height, ROUND_UP
+            )
         else:
-            self.interface.intrinsic.width = self.native.Width
-            self.interface.intrinsic.height = at_least(self.native.Height)
+            self.interface.intrinsic.width = self.scale_out(self.native.Width, ROUND_UP)
+            self.interface.intrinsic.height = self.scale_out(
+                at_least(self.native.Height), ROUND_UP
+            )

--- a/winforms/src/toga_winforms/widgets/imageview.py
+++ b/winforms/src/toga_winforms/widgets/imageview.py
@@ -1,3 +1,5 @@
+from decimal import ROUND_UP
+
 import System.Windows.Forms as WinForms
 from System.Drawing import Bitmap
 
@@ -32,8 +34,8 @@ class ImageView(Widget):
         width, height, aspect_ratio = rehint_imageview(
             self.interface.image, self.interface.style, self.dpi_scale
         )
-        self.interface.intrinsic.width = width
-        self.interface.intrinsic.height = height
+        self.interface.intrinsic.width = self.scale_out(width, ROUND_UP)
+        self.interface.intrinsic.height = self.scale_out(height, ROUND_UP)
         if aspect_ratio is not None:
             self.native.SizeMode = WinForms.PictureBoxSizeMode.Zoom
         else:

--- a/winforms/src/toga_winforms/widgets/label.py
+++ b/winforms/src/toga_winforms/widgets/label.py
@@ -1,3 +1,5 @@
+from decimal import ROUND_UP
+
 import System.Windows.Forms as WinForms
 from travertino.size import at_least
 
@@ -21,8 +23,9 @@ class Label(Widget):
         self.native.Text = value
 
     def rehint(self):
-        # Width & height of a label is known and fixed.
-        # self.native.Size = Size(0, 0)
-        # print("REHINT label", self, self.native.PreferredSize)
-        self.interface.intrinsic.width = at_least(self.native.PreferredSize.Width)
-        self.interface.intrinsic.height = self.native.PreferredSize.Height
+        self.interface.intrinsic.width = self.scale_out(
+            at_least(self.native.PreferredSize.Width), ROUND_UP
+        )
+        self.interface.intrinsic.height = self.scale_out(
+            self.native.PreferredSize.Height, ROUND_UP
+        )

--- a/winforms/src/toga_winforms/widgets/multilinetextinput.py
+++ b/winforms/src/toga_winforms/widgets/multilinetextinput.py
@@ -61,6 +61,7 @@ class MultilineTextInput(TextInput):
             self._set_placeholder_visible(False)
             self.native.Text = value
 
+    # This method is necessary to override the TextInput base class.
     def rehint(self):
         self.interface.intrinsic.width = at_least(self.interface._MIN_WIDTH)
         self.interface.intrinsic.height = at_least(self.interface._MIN_HEIGHT)

--- a/winforms/src/toga_winforms/widgets/numberinput.py
+++ b/winforms/src/toga_winforms/widgets/numberinput.py
@@ -1,9 +1,8 @@
 import sys
-from decimal import Decimal, InvalidOperation
+from decimal import ROUND_UP, Decimal, InvalidOperation
 
 import System.Windows.Forms as WinForms
 from System import Convert, String
-from travertino.size import at_least
 
 from toga.widgets.numberinput import _clean_decimal
 from toga_winforms.libs.fonts import HorizontalTextAlignment
@@ -68,5 +67,6 @@ class NumberInput(Widget):
         self.native.TextAlign = HorizontalTextAlignment(value)
 
     def rehint(self):
-        self.interface.intrinsic.width = at_least(self.interface._MIN_WIDTH)
-        self.interface.intrinsic.height = self.native.PreferredSize.Height
+        self.interface.intrinsic.height = self.scale_out(
+            self.native.PreferredSize.Height, ROUND_UP
+        )

--- a/winforms/src/toga_winforms/widgets/optioncontainer.py
+++ b/winforms/src/toga_winforms/widgets/optioncontainer.py
@@ -1,5 +1,4 @@
 from System.Windows.Forms import TabControl, TabPage
-from travertino.size import at_least
 
 from ..container import Container
 from ..libs.wrapper import WeakrefCallable
@@ -67,7 +66,3 @@ class OptionContainer(Widget):
     def resize_content(self, panel):
         size = panel.native_parent.ClientSize
         panel.resize_content(size.Width, size.Height)
-
-    def rehint(self):
-        self.interface.intrinsic.width = at_least(self.interface._MIN_WIDTH)
-        self.interface.intrinsic.height = at_least(self.interface._MIN_HEIGHT)

--- a/winforms/src/toga_winforms/widgets/progressbar.py
+++ b/winforms/src/toga_winforms/widgets/progressbar.py
@@ -1,5 +1,6 @@
+from decimal import ROUND_UP
+
 import System.Windows.Forms as WinForms
-from travertino.size import at_least
 
 from .base import Widget
 
@@ -78,7 +79,6 @@ class ProgressBar(Widget):
         self.native.Value = int(value * self.TOGA_SCALE)
 
     def rehint(self):
-        # Height must be non-zero
-        # Set a sensible min-width
-        self.interface.intrinsic.width = at_least(self.interface._MIN_WIDTH)
-        self.interface.intrinsic.height = self.native.PreferredSize.Height
+        self.interface.intrinsic.height = self.scale_out(
+            self.native.PreferredSize.Height, ROUND_UP
+        )

--- a/winforms/src/toga_winforms/widgets/scrollcontainer.py
+++ b/winforms/src/toga_winforms/widgets/scrollcontainer.py
@@ -3,7 +3,6 @@ from decimal import ROUND_DOWN
 from System.Drawing import Point
 from System.Windows.Forms import Panel, SystemInformation
 from travertino.node import Node
-from travertino.size import at_least
 
 from toga_winforms.container import Container
 
@@ -128,7 +127,3 @@ class ScrollContainer(Widget, Container):
             self.scale_in(vertical_position),
         )
         self.interface.on_scroll()
-
-    def rehint(self):
-        self.interface.intrinsic.width = at_least(self.interface._MIN_WIDTH)
-        self.interface.intrinsic.height = at_least(self.interface._MIN_HEIGHT)

--- a/winforms/src/toga_winforms/widgets/selection.py
+++ b/winforms/src/toga_winforms/widgets/selection.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from decimal import ROUND_UP
 
 import System.Windows.Forms as WinForms
 from travertino.size import at_least
@@ -77,5 +78,9 @@ class Selection(Widget):
         return None if index == -1 else index
 
     def rehint(self):
-        self.interface.intrinsic.width = at_least(self.native.PreferredSize.Width)
-        self.interface.intrinsic.height = self.native.PreferredSize.Height
+        self.interface.intrinsic.width = self.scale_out(
+            at_least(self.native.PreferredSize.Width), ROUND_UP
+        )
+        self.interface.intrinsic.height = self.scale_out(
+            self.native.PreferredSize.Height, ROUND_UP
+        )

--- a/winforms/src/toga_winforms/widgets/slider.py
+++ b/winforms/src/toga_winforms/widgets/slider.py
@@ -1,3 +1,5 @@
+from decimal import ROUND_UP
+
 import System.Windows.Forms as WinForms
 from travertino.size import at_least
 
@@ -55,5 +57,9 @@ class Slider(Widget, IntSliderImpl):
         self.native.TickStyle = BOTTOM_RIGHT_TICK_STYLE if visible else NONE_TICK_STYLE
 
     def rehint(self):
-        self.interface.intrinsic.width = at_least(self.native.PreferredSize.Width)
-        self.interface.intrinsic.height = self.native.PreferredSize.Height
+        self.interface.intrinsic.width = self.scale_out(
+            at_least(self.native.PreferredSize.Width), ROUND_UP
+        )
+        self.interface.intrinsic.height = self.scale_out(
+            self.native.PreferredSize.Height, ROUND_UP
+        )

--- a/winforms/src/toga_winforms/widgets/splitcontainer.py
+++ b/winforms/src/toga_winforms/widgets/splitcontainer.py
@@ -3,7 +3,6 @@ from System.Windows.Forms import (
     Orientation,
     SplitContainer as NativeSplitContainer,
 )
-from travertino.size import at_least
 
 from toga.constants import Direction
 
@@ -82,7 +81,3 @@ class SplitContainer(Widget):
         for panel in self.panels:
             size = panel.native_parent.ClientSize
             panel.resize_content(size.Width, size.Height, **kwargs)
-
-    def rehint(self):
-        self.interface.intrinsic.width = at_least(self.interface._MIN_WIDTH)
-        self.interface.intrinsic.height = at_least(self.interface._MIN_HEIGHT)

--- a/winforms/src/toga_winforms/widgets/switch.py
+++ b/winforms/src/toga_winforms/widgets/switch.py
@@ -1,3 +1,5 @@
+from decimal import ROUND_UP
+
 import System.Windows.Forms as WinForms
 from travertino.size import at_least
 
@@ -34,5 +36,9 @@ class Switch(Widget):
         self.native.Checked = value
 
     def rehint(self):
-        self.interface.intrinsic.width = at_least(self.native.PreferredSize.Width)
-        self.interface.intrinsic.height = self.native.PreferredSize.Height
+        self.interface.intrinsic.width = self.scale_out(
+            at_least(self.native.PreferredSize.Width), ROUND_UP
+        )
+        self.interface.intrinsic.height = self.scale_out(
+            self.native.PreferredSize.Height, ROUND_UP
+        )

--- a/winforms/src/toga_winforms/widgets/table.py
+++ b/winforms/src/toga_winforms/widgets/table.py
@@ -1,7 +1,6 @@
 from warnings import warn
 
 import System.Windows.Forms as WinForms
-from travertino.size import at_least
 
 import toga
 
@@ -216,10 +215,6 @@ class Table(Widget):
 
     def scroll_to_row(self, index):
         self.native.EnsureVisible(index)
-
-    def rehint(self):
-        self.interface.intrinsic.width = at_least(self.interface._MIN_WIDTH)
-        self.interface.intrinsic.height = at_least(self.interface._MIN_HEIGHT)
 
     def remove_column(self, index):
         self.native.Columns.RemoveAt(index)

--- a/winforms/src/toga_winforms/widgets/textinput.py
+++ b/winforms/src/toga_winforms/widgets/textinput.py
@@ -1,8 +1,8 @@
 from ctypes import c_uint, windll
 from ctypes.wintypes import HWND, WPARAM
+from decimal import ROUND_UP
 
 import System.Windows.Forms as WinForms
-from travertino.size import at_least
 
 from toga_winforms.colors import native_color
 from toga_winforms.libs.fonts import HorizontalTextAlignment
@@ -71,11 +71,9 @@ class TextInput(Widget):
             self.native.ForeColor = self.native.DefaultForeColor
 
     def rehint(self):
-        # Height of a text input is known and fixed.
-        # Width must be > 100
-        # print("REHINT TextInput", self, self.native.PreferredSize)
-        self.interface.intrinsic.width = at_least(self.interface._MIN_WIDTH)
-        self.interface.intrinsic.height = self.native.PreferredSize.Height
+        self.interface.intrinsic.height = self.scale_out(
+            self.native.PreferredSize.Height, ROUND_UP
+        )
 
     def winforms_text_changed(self, sender, event):
         self.interface.on_change()

--- a/winforms/src/toga_winforms/widgets/timeinput.py
+++ b/winforms/src/toga_winforms/widgets/timeinput.py
@@ -1,8 +1,8 @@
 import datetime
+from decimal import ROUND_UP
 
 import System.Windows.Forms as WinForms
 from System import DateTime as WinDateTime
-from travertino.size import at_least
 
 from ..libs.wrapper import WeakrefCallable
 from .base import Widget
@@ -46,8 +46,9 @@ class TimeInput(Widget):
         self.native.MaxDate = native_time(value)
 
     def rehint(self):
-        self.interface.intrinsic.width = at_least(self.interface._MIN_WIDTH)
-        self.interface.intrinsic.height = self.native.PreferredSize.Height
+        self.interface.intrinsic.height = self.scale_out(
+            self.native.PreferredSize.Height, ROUND_UP
+        )
 
     def winforms_value_changed(self, sender, event):
         self.interface.on_change()

--- a/winforms/src/toga_winforms/widgets/webview.py
+++ b/winforms/src/toga_winforms/widgets/webview.py
@@ -9,7 +9,6 @@ from System import (
 )
 from System.Drawing import Color
 from System.Threading.Tasks import Task, TaskScheduler
-from travertino.size import at_least
 
 import toga
 from toga.widgets.webview import JavaScriptResult
@@ -174,7 +173,3 @@ class WebView(Widget):
 
         self.run_after_initialization(execute)
         return result
-
-    def rehint(self):
-        self.interface.intrinsic.width = at_least(self.interface._MIN_WIDTH)
-        self.interface.intrinsic.height = at_least(self.interface._MIN_HEIGHT)


### PR DESCRIPTION
The minimum sizes were being converted to CSS pixels even though that's what they already were. This caused them to be too small.

Also took the opportunity to reduce duplicated code by assigning default `intrinsic.width` and `intrinsic.height` values in the base class.