### PR TITLE
Correct the creation of menubars in the web backend.

### DIFF
--- a/changes/2103.docs.rst
+++ b/changes/2103.docs.rst
@@ -1,1 +1,0 @@
-The widget screenshots were updated to provide examples of widgets on every platform.

--- a/changes/2194.bugfix.rst
+++ b/changes/2194.bugfix.rst
@@ -1,0 +1,1 @@
+The web backend no longer generates a duplicate titlebar.

--- a/changes/2195.bugfix.rst
+++ b/changes/2195.bugfix.rst
@@ -1,0 +1,1 @@
+An issue with the display of the About dialog on the web backend was corrected.

--- a/web/src/toga_web/app.py
+++ b/web/src/toga_web/app.py
@@ -23,7 +23,7 @@ class App:
         self.interface.commands.add(
             # ---- Help menu ----------------------------------
             toga.Command(
-                lambda _: self.interface.about(),
+                self._menu_about,
                 "About " + formal_name,
                 group=toga.Group.HELP,
             ),
@@ -34,7 +34,9 @@ class App:
             ),
         )
 
-        # Create the menus.
+        # Create the menus. This is done before main window content to ensure
+        # the <header> for the menubar is inserted before the <main> for the
+        # main window.
         self.create_menus()
 
         # Call user code to populate the main window
@@ -103,8 +105,10 @@ class App:
             else:
                 help_menu_container.appendChild(submenu)
 
+        menubar_id = f"{self.interface.app_id}-header"
         self.menubar = create_element(
             "header",
+            id=menubar_id,
             classes=["toga"],
             children=[
                 create_element(
@@ -124,8 +128,15 @@ class App:
             ],
         )
 
-        # Menubar exists at the app level.
-        self.native.appendChild(self.menubar)
+        # If there's an existing menubar, replace it.
+        old_menubar = js.document.getElementById(menubar_id)
+        if old_menubar:
+            old_menubar.replaceWith(self.menubar)
+        else:
+            self.native.append(self.menubar)
+
+    def _menu_about(self, event, widget, **kwargs):
+        self.interface.about()
 
     def main_loop(self):
         self.create()


### PR DESCRIPTION
Fixes #2194.

The web backend would unconditionally create a new menubar whenever create_menus was triggered. This lead to 2 menubars being created on most simple examples, and would cause more menus if user commands were added.

Also corrects an issue with the about dialog not displaying correctly due to the event handler being incorrect.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
