### PR TITLE
Correct some discrepancies and inconsistencies in widget support docs.

### DIFF
--- a/changes/2204.misc.rst
+++ b/changes/2204.misc.rst
@@ -1,0 +1,1 @@
+Some inconsistencies in widget support documentation were corrected.

--- a/docs/reference/api/documentapp.rst
+++ b/docs/reference/api/documentapp.rst
@@ -7,7 +7,7 @@ The top-level representation of an application that manages documents.
 .. csv-filter:: Availability (:ref:`Key <api-status-key>`)
    :header-rows: 1
    :file: ../data/widgets_by_platform.csv
-   :included_cols: 4,5,6,7,8,9
+   :included_cols: 4,5,6,7,8,9,10
    :exclude: {0: '(?!(DocumentApp|Component))'}
 
 

--- a/docs/reference/api/mainwindow.rst
+++ b/docs/reference/api/mainwindow.rst
@@ -35,6 +35,22 @@ The main window of the application.
        :align: center
        :width: 450px
 
+  .. group-tab:: Web |beta|
+
+    .. .. figure:: /reference/images/mainwindow-web.png
+    ..    :align: center
+    ..    :width: 300px
+
+    Screenshot not available
+
+  .. group-tab:: Textual |beta|
+
+    .. .. figure:: /reference/images/mainwindow-textual.png
+    ..    :align: center
+    ..    :width: 300px
+
+    Screenshot not available
+
 Usage
 -----
 

--- a/docs/reference/api/widgets/multilinetextinput.rst
+++ b/docs/reference/api/widgets/multilinetextinput.rst
@@ -43,13 +43,6 @@ A scrollable panel that allows for the display and editing of multiple lines of 
 
     Not supported
 
-.. rst-class:: widget-support
-.. csv-filter:: Availability (:ref:`Key <api-status-key>`)
-   :header-rows: 1
-   :file: ../../data/widgets_by_platform.csv
-   :included_cols: 4,5,6,7,8,9,10
-   :exclude: {0: '(?!^(MultilineTextInput|Component)$)'}
-
 Usage
 -----
 

--- a/docs/reference/api/widgets/selection.rst
+++ b/docs/reference/api/widgets/selection.rst
@@ -35,21 +35,13 @@ A widget to select a single option from a list of alternatives.
        :align: center
        :width: 300px
 
-  .. group-tab:: Web
+  .. group-tab:: Web |no|
 
     Not supported
 
-  .. group-tab:: Textual
+  .. group-tab:: Textual |no|
 
     Not supported
-
-.. rst-class:: widget-support
-.. csv-filter:: Availability (:ref:`Key <api-status-key>`)
-   :header-rows: 1
-   :file: ../../data/widgets_by_platform.csv
-   :included_cols: 4,5,6,7,8,9,10
-   :exclude: {0: '(?!^(Selection|Component)$)'}
-
 
 Usage
 -----

--- a/docs/reference/api/window.rst
+++ b/docs/reference/api/window.rst
@@ -31,6 +31,14 @@ An operating system-managed container of widgets.
 
     Not supported
 
+  .. group-tab:: Web |no|
+
+    Not supported
+
+  .. group-tab:: Textual |no|
+
+    Not supported
+
 Usage
 -----
 

--- a/docs/reference/data/widgets_by_platform.csv
+++ b/docs/reference/data/widgets_by_platform.csv
@@ -1,7 +1,7 @@
 Component,Type,Component,Description,macOS,GTK,Windows,iOS,Android,Web,Terminal
 Application,Core Component,:class:`~toga.App`,The application itself,|y|,|y|,|y|,|y|,|y|,|b|,|b|
 DocumentApp,Core Component,:class:`~toga.DocumentApp`,An application that manages documents.,|b|,|b|,,,,,
-Window,Core Component,:class:`~toga.Window`,An operating system-managed container of widgets.,|y|,|y|,|y|,|y|,|y|,|b|,|b|
+Window,Core Component,:class:`~toga.Window`,An operating system-managed container of widgets.,|y|,|y|,|y|,,,,
 MainWindow,Core Component,:class:`~toga.MainWindow`,The main window of the application.,|y|,|y|,|y|,|y|,|y|,|b|,|b|
 ActivityIndicator,General Widget,:class:`~toga.ActivityIndicator`,A spinning activity animation,|y|,|y|,,,,|b|,
 Button,General Widget,:class:`~toga.Button`,Basic clickable Button,|y|,|y|,|y|,|y|,|y|,|b|,|b|


### PR DESCRIPTION
Doesn't matter how many times you look at something, you'll miss something.

Corrects some inconsistencies in markup for widget support.

Biggest change is marking Window as not supported on iOS, Android, Web and Textual. While the class exists and it's tested (on iOS and Android anyway), it only functionally exists in as much as there's a MainWindow, so it seemed like we should reflect that.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
