### PR TITLE
Android: moved app command creation to method _create_app_commands()

### DIFF
--- a/android/src/toga_android/app.py
+++ b/android/src/toga_android/app.py
@@ -177,7 +177,12 @@ class App:
         self._listener = TogaApp(self)
         # Call user code to populate the main window
         self.interface._startup()
+        self._create_app_commands()
 
+    def create_menus(self):
+        self.native.invalidateOptionsMenu()  # Triggers onPrepareOptionsMenu
+
+    def _create_app_commands(self):
         self.interface.commands.add(
             # About should be the last item in the menu, in a section on its own.
             Command(
@@ -186,9 +191,6 @@ class App:
                 section=sys.maxsize,
             ),
         )
-
-    def create_menus(self):
-        self.native.invalidateOptionsMenu()  # Triggers onPrepareOptionsMenu
 
     def main_loop(self):
         # In order to support user asyncio code, start the Python/Android cooperative event loop.

--- a/changes/2215.misc.rst
+++ b/changes/2215.misc.rst
@@ -1,0 +1,1 @@
+On Android the creation of the app commands has been moved to the method _create_app_commands()


### PR DESCRIPTION
This PR moves the Android app command creation into the method _create_app_commands() like it is for the other platforms

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
