### PR TITLE
Improve macOS HIG compliance of Close and Close All menu items.

### DIFF
--- a/changes/2214.bugfix.rst
+++ b/changes/2214.bugfix.rst
@@ -1,0 +1,1 @@
+Compliance with Apple's HIG regarding the naming and shortcuts for the Close and Close All menu items was improved.

--- a/cocoa/src/toga_cocoa/app.py
+++ b/cocoa/src/toga_cocoa/app.py
@@ -199,24 +199,23 @@ class App:
                 section=sys.maxsize,
             ),
             # ---- File menu ----------------------------------
-            # This is a bit of an oddity. Safari has 2 distinct "Close Window" and
-            # "Close All Windows" menu items (partially to differentiate from "Close
-            # Tab"). Most other Apple HIG apps have a "Close" item that becomes
-            # "Close All" when you press Option (MOD_2). That behavior isn't something
-            # we're currently set up to implement, so we live with a separate menu item
-            # for now.
+            # This is a bit of an oddity. Apple HIG apps that don't have tabs as
+            # part of their interface (so, Preview and Numbers, but not Safari)
+            # have a "Close" item that becomes "Close All" when you press Option
+            # (MOD_2). That behavior isn't something we're currently set up to
+            # implement, so we live with a separate menu item for now.
             toga.Command(
                 self._menu_close_window,
-                "Close Window",
-                shortcut=toga.Key.MOD_1 + "W",
+                "Close",
+                shortcut=toga.Key.MOD_1 + "w",
                 group=toga.Group.FILE,
                 order=1,
                 section=50,
             ),
             toga.Command(
                 self._menu_close_all_windows,
-                "Close All Windows",
-                shortcut=toga.Key.MOD_2 + toga.Key.MOD_1 + "W",
+                "Close All",
+                shortcut=toga.Key.MOD_2 + toga.Key.MOD_1 + "w",
                 group=toga.Group.FILE,
                 order=2,
                 section=50,

--- a/cocoa/tests_backend/app.py
+++ b/cocoa/tests_backend/app.py
@@ -117,8 +117,8 @@ class AppProbe(BaseProbe):
         self.assert_menu_item(["*", "Show All"], enabled=True)
         self.assert_menu_item(["*", "Quit Toga Testbed"], enabled=True)
 
-        self.assert_menu_item(["File", "Close Window"], enabled=True)
-        self.assert_menu_item(["File", "Close All Windows"], enabled=True)
+        self.assert_menu_item(["File", "Close"], enabled=True)
+        self.assert_menu_item(["File", "Close All"], enabled=True)
 
         self.assert_menu_item(["Edit", "Undo"], enabled=True)
         self.assert_menu_item(["Edit", "Redo"], enabled=True)
@@ -134,10 +134,10 @@ class AppProbe(BaseProbe):
         self.assert_menu_item(["Help", "Visit homepage"], enabled=True)
 
     def activate_menu_close_window(self):
-        self._activate_menu_item(["File", "Close Window"])
+        self._activate_menu_item(["File", "Close"])
 
     def activate_menu_close_all_windows(self):
-        self._activate_menu_item(["File", "Close All Windows"])
+        self._activate_menu_item(["File", "Close All"])
 
     def activate_menu_minimize(self):
         self._activate_menu_item(["Window", "Minimize"])


### PR DESCRIPTION
The menu items used for Close and Close All follow the example of Safari, which is a bit of an oddity when compared to *most* other macOS apps. 

This PR changes the default macOS menu items to match the more common naming and shortcuts:
* "Close Window" (CMD-SHIFT-W) -> "Close" (CMD-W)
* "Close All Windows" (CMD-OPT-SHIFT-W) -> "Close" (CMD-OPT-W)

Fixes #2214.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
