### PR TITLE
Updated invalid anchor section in webview download link in windows docs

### DIFF
--- a/changes/2219.bugfix.rst
+++ b/changes/2219.bugfix.rst
@@ -1,1 +1,0 @@
-An invalid anchor in webview download link of windows docs was removed.

--- a/changes/2219.bugfix.rst
+++ b/changes/2219.bugfix.rst
@@ -1,0 +1,1 @@
+An invalid anchor in webview download link of windows docs was removed.

--- a/changes/2219.misc.rst
+++ b/changes/2219.misc.rst
@@ -1,0 +1,1 @@
+An invalid anchor in webview download link of windows docs was corrected.

--- a/docs/reference/api/widgets/webview.rst
+++ b/docs/reference/api/widgets/webview.rst
@@ -70,7 +70,7 @@ Notes
 
 * Using WebView on Windows 10 requires that your users have installed the `Edge
   WebView2 Evergreen Runtime
-  <https://developer.microsoft.com/en-us/microsoft-edge/webview2/#download-section>`__.
+  <https://developer.microsoft.com/en-us/microsoft-edge/webview2/>`__.
   This is installed by default on Windows 11.
 
 * Using WebView on Linux requires that the user has installed the system packages

--- a/docs/reference/api/widgets/webview.rst
+++ b/docs/reference/api/widgets/webview.rst
@@ -70,7 +70,7 @@ Notes
 
 * Using WebView on Windows 10 requires that your users have installed the `Edge
   WebView2 Evergreen Runtime
-  <https://developer.microsoft.com/en-us/microsoft-edge/webview2/>`__.
+  <https://developer.microsoft.com/en-us/microsoft-edge/webview2/#download>`__.
   This is installed by default on Windows 11.
 
 * Using WebView on Linux requires that the user has installed the system packages

--- a/docs/reference/platforms/windows.rst
+++ b/docs/reference/platforms/windows.rst
@@ -18,7 +18,7 @@ Prerequisites
 
 If you are using Windows 10 and want to use a WebView to display web content, you will
 also need to install the `Edge WebView2 Evergreen Runtime.
-<https://developer.microsoft.com/en-us/microsoft-edge/webview2/#download-section>`__
+<https://developer.microsoft.com/en-us/microsoft-edge/webview2/>`__
 Windows 11 has this runtime installed by default.
 
 Installation

--- a/docs/reference/platforms/windows.rst
+++ b/docs/reference/platforms/windows.rst
@@ -18,7 +18,7 @@ Prerequisites
 
 If you are using Windows 10 and want to use a WebView to display web content, you will
 also need to install the `Edge WebView2 Evergreen Runtime.
-<https://developer.microsoft.com/en-us/microsoft-edge/webview2/>`__
+<https://developer.microsoft.com/en-us/microsoft-edge/webview2/#download>`__
 Windows 11 has this runtime installed by default.
 
 Installation


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Updated the anchor `#download-section` in link `https://developer.microsoft.com/en-us/microsoft-edge/webview2/#download-section` as it's invalid and causes the CI to fail.
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
