### PR TITLE
Fixed argument name for Command handlers

### DIFF
--- a/changes/2222.misc.rst
+++ b/changes/2222.misc.rst
@@ -1,0 +1,1 @@
+Corrected "command" argument name in command handler definitions.

--- a/cocoa/src/toga_cocoa/app.py
+++ b/cocoa/src/toga_cocoa/app.py
@@ -298,26 +298,26 @@ class App:
             ),
         )
 
-    def _menu_about(self, app, **kwargs):
+    def _menu_about(self, command, **kwargs):
         self.interface.about()
 
-    def _menu_quit(self, app, **kwargs):
+    def _menu_quit(self, command, **kwargs):
         self.interface.on_exit()
 
-    def _menu_close_window(self, app, **kwargs):
+    def _menu_close_window(self, command, **kwargs):
         if self.interface.current_window:
             self.interface.current_window._impl.native.performClose(None)
 
-    def _menu_close_all_windows(self, app, **kwargs):
+    def _menu_close_all_windows(self, command, **kwargs):
         # Convert to a list to so that we're not altering a set while iterating
         for window in list(self.interface.windows):
             window._impl.native.performClose(None)
 
-    def _menu_minimize(self, app, **kwargs):
+    def _menu_minimize(self, command, **kwargs):
         if self.interface.current_window:
             self.interface.current_window._impl.native.miniaturize(None)
 
-    def _menu_visit_homepage(self, app, **kwargs):
+    def _menu_visit_homepage(self, command, **kwargs):
         self.interface.visit_homepage()
 
     def create_menus(self):

--- a/gtk/src/toga_gtk/app.py
+++ b/gtk/src/toga_gtk/app.py
@@ -114,10 +114,10 @@ class App:
     def gtk_activate(self, data=None):
         pass
 
-    def _menu_about(self, app, **kwargs):
+    def _menu_about(self, command, **kwargs):
         self.interface.about()
 
-    def _menu_quit(self, app, **kwargs):
+    def _menu_quit(self, command, **kwargs):
         self.interface.on_exit()
 
     def create_menus(self):

--- a/web/src/toga_web/app.py
+++ b/web/src/toga_web/app.py
@@ -135,7 +135,7 @@ class App:
         else:
             self.native.append(self.menubar)
 
-    def _menu_about(self, widget, **kwargs):
+    def _menu_about(self, command, **kwargs):
         self.interface.about()
 
     def main_loop(self):


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Changed the first non-`self` parameter name in Command handlers to `command`.
<!--- What problem does this change solve? -->
The `ActionHandler` protocol is defined as accepting `self, command: Command, **kwargs`, where `command` is the command that triggered the action. In the codebase, handlers were defined with this parameter named `app` and in one case `widget`. Especially since none of the defined handlers reference the argument, this is an entirely semantic fix with no runtime significance.
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
