### PR TITLE
Update all development dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,10 +19,11 @@ repos:
     hooks:
       - id: pyupgrade
         args: [--py38-plus]
-  - repo: https://github.com/psf/black
-    rev: 23.10.1
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 23.11.0
     hooks:
-    - id: black
+      - id: black
+        language_version: python3
   - repo: https://github.com/PyCQA/flake8
     rev: 6.1.0
     hooks:
@@ -31,5 +32,4 @@ repos:
     rev: v2.2.6
     hooks:
     - id: codespell
-      additional_dependencies:
-        - tomli
+      additional_dependencies: [tomli]

--- a/changes/2224.misc.rst
+++ b/changes/2224.misc.rst
@@ -1,0 +1,1 @@
+The development dependencies were all updated to their latest versions.

--- a/core/setup.cfg
+++ b/core/setup.cfg
@@ -51,8 +51,8 @@ keywords =
 
 [options]
 install_requires =
-    travertino>=0.3.0
-    importlib_metadata>=4.4.0; python_version <= "3.9"
+    travertino >= 0.3.0
+    importlib_metadata >= 4.4.0; python_version <= "3.9"
 packages = find:
 package_dir =
     = src
@@ -63,24 +63,26 @@ zip_safe = False
 # Extras used by developers *of* briefcase are pinned to specific versions to
 # ensure environment consistency.
 dev =
-    coverage[toml] == 7.0.5
-    pre-commit == 3.0.2
-    pytest == 7.3.1
-    pytest-asyncio == 0.21.0
+    coverage[toml] == 7.3.2
+    pre-commit == 3.5.0
+    pytest == 7.4.3
+    pytest-asyncio == 0.21.1
     pytest-freezer == 0.4.8
-    setuptools-scm[toml] == 7.0.5
-    tox == 4.3.5
+    setuptools-scm[toml] == 8.0.4
+    tox == 4.11.3
 docs =
-    furo == 2022.12.7
+    furo == 2023.9.10
     pyenchant == 3.2.2
-    sphinx == 6.1.3
-    sphinx_tabs == 3.4.1
+    # Sphinx 7.2 deprecated support for Python 3.8
+    sphinx == 7.1.2 ; python_version < '3.9'
+    sphinx == 7.2.6 ; python_version >= '3.9'
+    sphinx_tabs == 3.4.4
     sphinx-autobuild == 2021.3.14
-    sphinx-autodoc-typehints == 1.22
+    sphinx-autodoc-typehints == 1.25.2
     sphinx-csv-filter == 0.4.1
     sphinx-copybutton == 0.5.2
-    sphinx-toolbox == 3.4.0
-    sphinxcontrib-spelling == 7.7.0
+    sphinx-toolbox == 3.5.0
+    sphinxcontrib-spelling == 8.0.0
 
 [options.package_data]
 toga.resources =


### PR DESCRIPTION
## Changes
- Dependabot is seemingly unable to update dependencies if a directory contains both a `setup.cfg` and `setup.py`
- Currently the dependencies are about 9 months out of date....this brings them all to their latest version

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
