### PR TITLE
Add macOS merge all windows command

### DIFF
--- a/changes/2227.feature.rst
+++ b/changes/2227.feature.rst
@@ -1,0 +1,1 @@
+Apps on macOS 10.12+ now have a Window > Merge All Windows menu command.

--- a/testbed/tests/test_window.py
+++ b/testbed/tests/test_window.py
@@ -481,9 +481,7 @@ else:
         assert second_window_probe.content_size == initial_content_size
 
     @pytest.mark.parametrize("second_window_kwargs", [{}])
-    async def test_merge_all_windows(
-        app, main_window, second_window, second_window_probe
-    ):
+    async def test_merge_all_windows(app, second_window, second_window_probe):
         if toga.platform.current_platform != "macOS":
             pytest.xfail("Merging all windows is only implemented for macOS.")
 

--- a/testbed/tests/test_window.py
+++ b/testbed/tests/test_window.py
@@ -486,11 +486,11 @@ else:
         if toga.platform.current_platform != "macOS":
             pytest.xfail("Merging all windows is only implemented for macOS.")
 
-        tab_group = second_window._impl.native.tabGroup
-        assert len(tab_group.windows) == 1
+        native = second_window._impl.native
+        assert native.tabbedWindows is None
 
         app._impl._menu_merge_all_windows(None)
-        assert len(tab_group.windows) == 2
+        assert len(native.tabbedWindows) == 2
 
 
 async def test_as_image(main_window, main_window_probe):

--- a/testbed/tests/test_window.py
+++ b/testbed/tests/test_window.py
@@ -492,6 +492,7 @@ else:
         assert native.tabbedWindows is None
 
         app._impl._menu_merge_all_windows(None)
+        await second_window_probe.wait_for_window("Windows have been merged.")
         assert len(native.tabbedWindows) == 2
 
 

--- a/testbed/tests/test_window.py
+++ b/testbed/tests/test_window.py
@@ -479,6 +479,19 @@ else:
         assert not second_window_probe.is_full_screen
         assert second_window_probe.content_size == initial_content_size
 
+    @pytest.mark.parametrize("second_window_kwargs", [{}])
+    async def test_merge_all_windows(
+        app, main_window, second_window, second_window_probe
+    ):
+        if toga.platform.current_platform != "macOS":
+            pytest.xfail("Merging all windows is only implemented for macOS.")
+
+        tab_group = second_window._impl.native.tabGroup
+        assert len(tab_group.windows) == 1
+
+        app._impl._menu_merge_all_windows(None)
+        assert len(tab_group.windows) == 2
+
 
 async def test_as_image(main_window, main_window_probe):
     """The window can be captured as a screenshot"""

--- a/testbed/tests/test_window.py
+++ b/testbed/tests/test_window.py
@@ -13,6 +13,7 @@ import pytest
 import toga
 from toga.colors import CORNFLOWERBLUE, GOLDENROD, REBECCAPURPLE
 from toga.style.pack import COLUMN, Pack
+from toga_cocoa.app import macos_version_at_least
 
 
 def window_probe(app, window):
@@ -485,6 +486,9 @@ else:
     ):
         if toga.platform.current_platform != "macOS":
             pytest.xfail("Merging all windows is only implemented for macOS.")
+
+        if not macos_version_at_least(10, 12):
+            pytest.xfail("Merging all windows is unsupported on macOS prior to 10.12.")
 
         native = second_window._impl.native
         assert native.tabbedWindows is None


### PR DESCRIPTION
<!--- Describe your changes in detail -->
I've added a menu item, Window > Merge All Windows, that merges all windows into one tabs on the main window, like how it works in Finder and Safari.
<!--- What problem does this change solve? -->
If the user's OS-level "Prefer tabs when opening documents" setting is "Always", Toga gets tab creation for free, as well as the ability to drag tabs to reorder them and even move them to an existing tab bar on another window. However, this UI experience is oddly incomplete, and inconsistent with native apps, without the ability to merge existing windows into tabs.

Potential issues:
- [`NSWindow.mergeAllWindows`](https://developer.apple.com/documentation/appkit/nswindow/1644639-mergeallwindows) is only available in macOS 10.12+. I've put in a check to only add the menu item when the method is available, but since the CI never runs on macOS older than 10.12, it never exercises the branch where it's not added. I marked it for Coverage to skip — hope that's okay.
- I'm not sure my macOS-version-checking function should go in `app.py`. I'm amenable to putting it anywhere that would make more sense.
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
