### PR TITLE
Updated macOS minimum version to 11, matching Briefcase

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Minimum requirements
 
 * Toga requires **Python 3.8 or higher**. Python 2 is not supported.
 
-* If you're on macOS, you need to be on 10.10 (Yosemite) or newer.
+* If you're on macOS, you need to be on 11 (Big Sur) or newer.
 
 * If you're on Windows, you'll need Windows 10 or newer. If you are using
   Windows 10 and want to use a WebView to display web content, you will also

--- a/changes/2228.doc.rst
+++ b/changes/2228.doc.rst
@@ -1,1 +1,0 @@
-Toga on macOS now supports a minimum version of 11 (Big Sur).

--- a/changes/2228.doc.rst
+++ b/changes/2228.doc.rst
@@ -1,0 +1,1 @@
+Toga on macOS now supports a minimum version of 11 (Big Sur).

--- a/changes/2228.removal.rst
+++ b/changes/2228.removal.rst
@@ -1,0 +1,1 @@
+Support for macOS release prior to Big Sur (11) has been dropped.

--- a/cocoa/src/toga_cocoa/libs/appkit.py
+++ b/cocoa/src/toga_cocoa/libs/appkit.py
@@ -56,29 +56,21 @@ NSApplicationDidUnhideNotification = c_void_p.in_dll(
     appkit, "NSApplicationDidUnhideNotification"
 )
 
-# NSAboutPanelOption* keys are available only 10.13+
-try:
-    NSAboutPanelOptionApplicationIcon = NSString(
-        c_void_p.in_dll(appkit, "NSAboutPanelOptionApplicationIcon")
-    )
-    NSAboutPanelOptionApplicationName = NSString(
-        c_void_p.in_dll(appkit, "NSAboutPanelOptionApplicationName")
-    )
-    NSAboutPanelOptionApplicationVersion = NSString(
-        c_void_p.in_dll(appkit, "NSAboutPanelOptionApplicationVersion")
-    )
-    NSAboutPanelOptionCredits = NSString(
-        c_void_p.in_dll(appkit, "NSAboutPanelOptionCredits")
-    )
-    NSAboutPanelOptionVersion = NSString(
-        c_void_p.in_dll(appkit, "NSAboutPanelOptionVersion")
-    )
-except ValueError:  # pragma: no cover
-    NSAboutPanelOptionApplicationIcon = None
-    NSAboutPanelOptionApplicationName = None
-    NSAboutPanelOptionApplicationVersion = None
-    NSAboutPanelOptionCredits = None
-    NSAboutPanelOptionVersion = None
+NSAboutPanelOptionApplicationIcon = NSString(
+    c_void_p.in_dll(appkit, "NSAboutPanelOptionApplicationIcon")
+)
+NSAboutPanelOptionApplicationName = NSString(
+    c_void_p.in_dll(appkit, "NSAboutPanelOptionApplicationName")
+)
+NSAboutPanelOptionApplicationVersion = NSString(
+    c_void_p.in_dll(appkit, "NSAboutPanelOptionApplicationVersion")
+)
+NSAboutPanelOptionCredits = NSString(
+    c_void_p.in_dll(appkit, "NSAboutPanelOptionCredits")
+)
+NSAboutPanelOptionVersion = NSString(
+    c_void_p.in_dll(appkit, "NSAboutPanelOptionVersion")
+)
 
 ######################################################################
 # NSAttributedString.h
@@ -98,9 +90,7 @@ NSStrokeColorAttributeName = objc_const(appkit, "NSStrokeColorAttributeName")
 NSStrokeWidthAttributeName = objc_const(appkit, "NSStrokeWidthAttributeName")
 NSShadowAttributeName = objc_const(appkit, "NSShadowAttributeName")
 
-# NSTextEffectAttributeName is supported in OS 10.10+
-# goes against minimum requirements: current support is for OS 10.7+
-# NSTextEffectAttributeName = objc_const(appkit, "NSTextEffectAttributeName")
+NSTextEffectAttributeName = objc_const(appkit, "NSTextEffectAttributeName")
 
 NSAttachmentAttributeName = objc_const(appkit, "NSAttachmentAttributeName")
 NSLinkAttributeName = objc_const(appkit, "NSLinkAttributeName")

--- a/docs/reference/platforms/macOS.rst
+++ b/docs/reference/platforms/macOS.rst
@@ -12,7 +12,7 @@ The Toga backend for macOS is `toga-cocoa
 Prerequisites
 -------------
 
-``toga-cocoa`` requires macOS 10.10 (Yosemite) or newer.
+``toga-cocoa`` requires macOS 11 (Big Sur) or newer.
 
 Installation
 ------------

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -67,6 +67,7 @@ subclasses
 Subclasses
 substring
 substrings
+Sur
 testbed
 Todo
 toolbar


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Updated documentation to list minimum macOS version as 11 (Big Sur) rather than 10.10 (Yosemite). Also cleaned up places where Cocoa classes were commented out or conditionally defined due to lack of availability in older OS versions.
<!--- What problem does this change solve? -->
As mentioned [here](https://github.com/beeware/toga/pull/2227#discussion_r1390616671), Briefcase supports a minimum of 11 (Big Sur), so the documentation is misleading and the avoided / conditional Cocoa definitions are unnecessary.

Since [#2227](https://github.com/beeware/toga/pull/2227) is nowhere near as simple as I'd first thought,  I'm putting this in separately rather than wait for resolution on that.

...What category should this changenote be? Docs? It does change code, but doesn't actually fix a bug.
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
