### PR TITLE
Specify app user data path for testbed on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
 
           - backend: macOS
             runs-on: macos-12
-            app-user-data-path: /Users/runner/Library/Application Support/org.beeware.toga.testbed
+            app-user-data-path: $HOME/Library/Application Support/org.beeware.toga.testbed
 
           # We use a fixed Ubuntu version rather than `-latest` because at some point,
           # `-latest` will be updated, but it will be a soft changeover, which would cause
@@ -180,22 +180,23 @@ jobs:
 
             briefcase-run-prefix: 'DISPLAY=:99'
             setup-python: false  # Use the system Python packages.
-            app-user-data-path: /home/runner/.local/share/testbed
+            app-user-data-path: $HOME/.local/share/testbed
 
           - backend: windows
             runs-on: windows-latest
+            app-user-data-path: $HOME\AppData\Local\Tiberius Yak\Toga Testbed\Data
 
           - backend: iOS
             runs-on: macos-12
             briefcase-run-args: ' -d "iPhone SE (3rd generation)"'
-            # app data path is determined at runtime, as the path contains the Simulator and app ID.
+            app-user-data-path: $(xcrun simctl get_app_container booted org.beeware.toga.testbed data)/Documents
 
           - backend: android
             runs-on: ubuntu-latest
             briefcase-run-args: " -d '{\"avd\":\"beePhone\"}' --Xemulator=-no-window --Xemulator=-no-snapshot --Xemulator=-no-audio --Xemulator=-no-boot-anim --shutdown-on-exit"
             pre-command: |
               # check if virtualization is supported...
-              sudo apt install -y --no-install-recommends cpu-checker coreutils && echo "CPUs=$(nproc --all)" && kvm-ok
+              sudo apt install -qq --no-install-recommends cpu-checker coreutils && echo "CPUs=$(nproc --all)" && kvm-ok
               # allow access to KVM to run the emulator
               echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
                 | sudo tee /etc/udev/rules.d/99-kvm4all.rules
@@ -205,46 +206,47 @@ jobs:
     - uses: actions/checkout@v4.1.1
       with:
         fetch-depth: 0
+
     - name: Set up Python
       uses: actions/setup-python@v4.7.1
-      if: ${{ matrix.setup-python }}
+      if: matrix.setup-python
       with:
         # We're not using Python 3.11 yet, because:
         # * The testbed's ProxyEventLoop has some problems with it
         #   (https://github.com/beeware/toga/issues/1982).
         # * It doesn't have an Android build of Pillow yet.
         python-version: "3.10"
+
     - name: Install dependencies
       run: |
         ${{ matrix.pre-command }}
         # Use the development version of Briefcase
         python -m pip install git+https://github.com/beeware/briefcase.git
+
     - name: Test App
-      run: |
-        cd testbed
-        ${{ matrix.briefcase-run-prefix }} briefcase run ${{ matrix.backend }} --test ${{ matrix.briefcase-run-args }}
+      working-directory: testbed
+      run: ${{ matrix.briefcase-run-prefix }} briefcase run ${{ matrix.backend }} --test ${{ matrix.briefcase-run-args }}
+
     - name: Upload logs
       uses: actions/upload-artifact@v3.1.3
       if: failure()
       with:
         name: testbed-failure-logs-${{ matrix.backend }}
         path: testbed/logs/*
+
     - name: Copy app generated user data
-      if: failure()
+      if: failure() && matrix.backend != 'android'
       run: |
-        mkdir testbed/app_data
-        if [ "${{ matrix.backend }}" = "iOS" ]; then
-          APP_DATA_PATH="$(xcrun simctl get_app_container booted org.beeware.toga.testbed data)/Documents"
-        else
-          APP_DATA_PATH="${{ matrix.app-user-data-path }}"
-        fi
-        cp -r "$APP_DATA_PATH" testbed/app_data/testbed-app_data-${{ matrix.backend }}
+        mkdir -p testbed/app_data
+        cp -r "${{ matrix.app-user-data-path }}" testbed/app_data/testbed-app_data-${{ matrix.backend }}
+
     - name: Upload app data
       uses: actions/upload-artifact@v3.1.3
-      if: failure()
+      if: failure() && matrix.backend != 'android'
       with:
         name: testbed-failure-app-data-${{ matrix.backend }}
         path: testbed/app_data/*
+
     # This step is only needed if you're trying to diagnose test failures that
     # only occur in CI, and can't be reproduced locally. When it runs, it will
     # open an SSH server (URL reported in the logs) so you can ssh into the CI

--- a/changes/2235.misc.rst
+++ b/changes/2235.misc.rst
@@ -1,0 +1,1 @@
+If the testbed fails on Windows, the user's app data path contents are now uploaded.


### PR DESCRIPTION
## Changes
- Adds an app data path for testbed failures on Windows
- Demonstration: https://github.com/beeware/toga/actions/runs/6915247187

## Notes
- I just excluded android instead of trying to figure out the right `adb` command...it's not even really clear to me how valuable this data is...
- Example of previous behavior: https://github.com/beeware/toga/actions/runs/6906873154/job/18792969335

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct