### PR TITLE
Correct handling of separators.

### DIFF
--- a/android/src/toga_android/app.py
+++ b/android/src/toga_android/app.py
@@ -104,17 +104,19 @@ class TogaApp(dynamic_proxy(IPythonApp)):
             if cmd in self._impl.interface.main_window.toolbar:
                 continue
 
-            if cmd.group.key in menulist:
+            try:
+                # Find the menu representing the group for this command
                 menugroup = menulist[cmd.group.key]
-            else:
-                # create all missing submenus
+            except KeyError:
+                # Menu doesn't exist yet; create it.
                 parentmenu = menu
                 groupkey = ()
+                # Iterate over the full key, creating submenus as needed
                 for section, order, text in cmd.group.key:
                     groupkey += ((section, order, text),)
-                    if groupkey in menulist:
+                    try:
                         menugroup = menulist[groupkey]
-                    else:
+                    except KeyError:
                         if len(groupkey) == 1 and text == Group.COMMANDS.text:
                             # Add this group directly to the top-level menu
                             menulist[groupkey] = menu
@@ -127,20 +129,30 @@ class TogaApp(dynamic_proxy(IPythonApp)):
                             menulist[groupkey] = menugroup
                     parentmenu = menugroup
 
-            # create menu item
+            # Create menu item
             menuitem = menugroup.add(groupid, itemid, Menu.NONE, cmd.text)
             menuitem.setShowAsActionFlags(MenuItem.SHOW_AS_ACTION_NEVER)
             menuitem.setEnabled(cmd.enabled)
             self.menuitem_mapping[itemid] = cmd
             itemid += 1
 
-        # create toolbar actions
+        # Create toolbar actions
         if self._impl.interface.main_window:  # pragma: no branch
+            prev_group = None
             for cmd in self._impl.interface.main_window.toolbar:
                 if isinstance(cmd, Separator):
                     groupid += 1
+                    prev_group = None
                     continue
 
+                # A change in group requires adding a toolbar separator
+                if prev_group is not None and cmd.group != prev_group:
+                    groupid += 1
+                    prev_group = None
+                else:
+                    prev_group = cmd.group
+
+                # Add a menu item for the toolbar command
                 menuitem = menu.add(groupid, itemid, Menu.NONE, cmd.text)
                 # SHOW_AS_ACTION_IF_ROOM is too conservative, showing only 2 items on
                 # a medium-size screen in portrait.

--- a/android/src/toga_android/app.py
+++ b/android/src/toga_android/app.py
@@ -7,7 +7,7 @@ from android.view import Menu, MenuItem
 from java import dynamic_proxy
 from org.beeware.android import IPythonApp, MainActivity
 
-from toga.command import GROUP_BREAK, SECTION_BREAK, Command, Group
+from toga.command import Command, Group, Separator
 
 from .libs import events
 from .window import Window
@@ -96,7 +96,7 @@ class TogaApp(dynamic_proxy(IPythonApp)):
 
         # create option menu
         for cmd in self._impl.interface.commands:
-            if cmd == SECTION_BREAK or cmd == GROUP_BREAK:
+            if isinstance(cmd, Separator):
                 groupid += 1
                 continue
 
@@ -137,7 +137,7 @@ class TogaApp(dynamic_proxy(IPythonApp)):
         # create toolbar actions
         if self._impl.interface.main_window:  # pragma: no branch
             for cmd in self._impl.interface.main_window.toolbar:
-                if cmd == SECTION_BREAK or cmd == GROUP_BREAK:
+                if isinstance(cmd, Separator):
                     groupid += 1
                     continue
 

--- a/changes/2193.bugfix.rst
+++ b/changes/2193.bugfix.rst
@@ -1,0 +1,1 @@
+Separators before and after command sub-groups are now included in menus.

--- a/cocoa/src/toga_cocoa/app.py
+++ b/cocoa/src/toga_cocoa/app.py
@@ -8,7 +8,7 @@ from urllib.parse import unquote, urlparse
 from rubicon.objc.eventloop import CocoaLifecycle, EventLoopPolicy
 
 import toga
-from toga.command import GROUP_BREAK, SECTION_BREAK
+from toga.command import Separator
 from toga.handlers import NativeHandler
 
 from .keys import cocoa_key
@@ -333,13 +333,10 @@ class App:
         self._menu_items = {}
 
         for cmd in self.interface.commands:
-            if cmd == GROUP_BREAK:
-                submenu = None
-            elif cmd == SECTION_BREAK:
+            submenu = self._submenu(cmd.group, menubar)
+            if isinstance(cmd, Separator):
                 submenu.addItem(NSMenuItem.separatorItem())
             else:
-                submenu = self._submenu(cmd.group, menubar)
-
                 if cmd.shortcut:
                     key, modifier = cocoa_key(cmd.shortcut)
                 else:

--- a/cocoa/src/toga_cocoa/window.py
+++ b/cocoa/src/toga_cocoa/window.py
@@ -1,4 +1,4 @@
-from toga.command import Command
+from toga.command import Command, Separator
 from toga_cocoa.container import Container
 from toga_cocoa.images import nsdata_to_bytes
 from toga_cocoa.libs import (
@@ -20,10 +20,7 @@ from toga_cocoa.libs import (
 
 
 def toolbar_identifier(cmd):
-    if isinstance(cmd, Command):
-        return "ToolbarItem-%s" % id(cmd)
-    else:
-        return "ToolbarSeparator-%s" % id(cmd)
+    return f"Toolbar-{type(cmd).__name__}-{id(cmd)}"
 
 
 class TogaWindow(NSWindow):
@@ -59,8 +56,16 @@ class TogaWindow(NSWindow):
     def toolbarDefaultItemIdentifiers_(self, toolbar):
         """Determine the list of toolbar items that will display by default."""
         default = NSMutableArray.alloc().init()
+        prev_group = None
         for item in self.interface.toolbar:
+            # If there's been a group change, and this item isn't a separator,
+            # add a separator between groups.
+            if prev_group is not None:
+                if item.group != prev_group and not isinstance(item, Separator):
+                    default.addObject_(toolbar_identifier(prev_group))
             default.addObject_(toolbar_identifier(item))
+            prev_group = item.group
+
         return default
 
     @objc_method

--- a/cocoa/tests_backend/window.py
+++ b/cocoa/tests_backend/window.py
@@ -240,7 +240,9 @@ class WindowProbe(BaseProbe):
 
     def assert_is_toolbar_separator(self, index, section=False):
         item = self.native.toolbar.items[index]
-        assert str(item.itemIdentifier).startswith("ToolbarSeparator-")
+        assert str(item.itemIdentifier).startswith(
+            f"Toolbar-{'Separator' if section else 'Group'}"
+        )
 
     def assert_toolbar_item(self, index, label, tooltip, has_icon, enabled):
         item = self.native.toolbar.items[index]

--- a/core/src/toga/command.py
+++ b/core/src/toga/command.py
@@ -93,16 +93,16 @@ class Group:
             return False
         return parent.is_parent_of(self)
 
-    def descendent(self, parent: Group | None) -> Group | None:
-        """Return the immediate descendent of parent used by this group.
+    def descendant(self, parent: Group | None) -> Group | None:
+        """Return the immediate descendant of parent used by this group.
 
         :param parent: The parent to check
-        :returns: The descendent, or None if no descendent exists
+        :returns: The descendant, or None if no descendant exists
         """
         if self.parent == parent:
             return self
         if self.parent:
-            return self.parent.descendent(parent)
+            return self.parent.descendant(parent)
         return None
 
     def __hash__(self) -> int:
@@ -391,22 +391,22 @@ class CommandSet:
                     except StopIteration:
                         finished = True
                 else:
-                    # The command isn't in this group. If the command is in descendent
-                    # group, yield items from the group. If it's not a descendent, then
+                    # The command isn't in this group. If the command is in descendant
+                    # group, yield items from the group. If it's not a descendant, then
                     # there are no more commands in this group; we can return to the
                     # previous group for processing.
-                    descendent = command.group.descendent(parent)
-                    if descendent:
-                        # If the descendent group changes section from something other
+                    descendant = command.group.descendant(parent)
+                    if descendant:
+                        # If the descendant group changes section from something other
                         # than None, insert a section break.
                         if section is not None:
-                            if section != descendent.section:
+                            if section != descendant.section:
                                 yield Separator(parent)
-                                section = descendent.section
+                                section = descendant.section
                         else:
                             section = command.section
 
-                        yield from _iter_group(descendent)
+                        yield from _iter_group(descendant)
                     else:
                         return
 

--- a/core/tests/command/conftest.py
+++ b/core/tests/command/conftest.py
@@ -5,24 +5,34 @@ import toga
 
 @pytest.fixture
 def parent_group_1():
-    return toga.Group("P", order=1)
+    return toga.Group("P1", order=1)
 
 
 @pytest.fixture
 def child_group_1(parent_group_1):
-    return toga.Group("C", order=2, parent=parent_group_1)
+    return toga.Group("C1", order=2, parent=parent_group_1)
 
 
 @pytest.fixture
 def child_group_2(parent_group_1):
-    return toga.Group("B", order=4, parent=parent_group_1)
+    return toga.Group("C2", order=4, parent=parent_group_1)
 
 
 @pytest.fixture
 def parent_group_2():
-    return toga.Group("O", order=2)
+    return toga.Group("P2", order=2)
 
 
 @pytest.fixture
 def child_group_3(parent_group_2):
-    return toga.Group("A", order=2, parent=parent_group_2)
+    return toga.Group("C3", section=2, order=2, parent=parent_group_2)
+
+
+@pytest.fixture
+def child_group_4(parent_group_2):
+    return toga.Group("C4", section=2, order=1, parent=parent_group_2)
+
+
+@pytest.fixture
+def child_group_5(parent_group_2):
+    return toga.Group("C5", section=1, order=1, parent=parent_group_2)

--- a/core/tests/command/test_command.py
+++ b/core/tests/command/test_command.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 import pytest
 
 import toga
-from toga.command import Break
+from toga.command import Separator
 from toga_dummy.utils import assert_action_performed_with
 
 
@@ -21,11 +21,28 @@ def assert_order(*items):
             assert not items[i] > 42
 
 
-def test_break():
-    """A break can be created"""
+def test_separator(parent_group_1):
+    """A separator can be created"""
 
-    example_break = Break("Example")
-    assert repr(example_break) == "<Example break>"
+    separator = Separator(group=parent_group_1)
+    assert repr(separator) == "<Separator group=P1>"
+
+
+def test_separator_eq(parent_group_1, parent_group_2):
+    """Separator objects can be compared for equality"""
+
+    separator_1a = Separator(parent_group_1)
+    separator_1b = Separator(parent_group_1)
+    separator_2 = Separator(parent_group_2)
+
+    # Separators are equal to breaks in the same section, but not to other
+    # sections
+    assert separator_1a == separator_1a
+    assert separator_1a == separator_1b
+    assert separator_1a != separator_2
+
+    # Separators aren't equal to non-separator objects
+    assert separator_1a != 3
 
 
 def test_create():

--- a/core/tests/command/test_commandset.py
+++ b/core/tests/command/test_commandset.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 import pytest
 
 import toga
-from toga.command import GROUP_BREAK, SECTION_BREAK, CommandSet
+from toga.command import CommandSet, Separator
 
 
 def test_create():
@@ -114,17 +114,54 @@ def test_add_clear_with_app(app, change_handler):
         change_handler.assert_called_once()
         change_handler.reset_mock()
 
-    # Command set no commands.
+    # Command set has no commands.
     assert list(cs) == []
 
     # App command set hasn't changed.
     assert list(app.commands) == [cmd_a, cmd1b, cmd2, cmd1a, cmd_b]
 
 
-def test_ordering(parent_group_1, parent_group_2, child_group_1, child_group_2):
-    """Ordering of groups, breaks and commands is preserved"""
+def test_ordering(
+    parent_group_1,
+    parent_group_2,
+    child_group_1,
+    child_group_2,
+    child_group_3,
+    child_group_4,
+    child_group_5,
+):
+    """Ordering of groups, separators and commands is preserved"""
 
-    command_a = toga.Command(None, "A", group=parent_group_2, order=1)
+    # Menu structure is:
+    # - parent group 1
+    #   - Z                 - a group that starts with a command
+    #   - child group 1
+    #     - Y
+    #     - X
+    #     - W
+    #     ---               - a separator between two items
+    #     - B
+    #   - V
+    #   - child group 2
+    #     - U
+    #     - T
+    #   - S
+    # - parent group 2
+    #   - child group 5     - a group that starts with a child group
+    #     - G
+    #   - A
+    #   ---
+    #   - child group 4     - a child group with a separator before it
+    #     - E
+    #   - child group 3     - a child group with a separator after it
+    #     - D
+    #   ---
+    #   - F
+    command_a = toga.Command(None, "A", group=parent_group_2, section=1, order=2)
+    command_d = toga.Command(None, "D", group=child_group_3)
+    command_e = toga.Command(None, "E", group=child_group_4)
+    command_f = toga.Command(None, "F", group=parent_group_2, section=3)
+    command_g = toga.Command(None, "G", group=child_group_5, section=1)
     command_b = toga.Command(None, "B", group=child_group_1, section=2, order=1)
     command_s = toga.Command(None, "S", group=parent_group_1, order=5)
     command_t = toga.Command(None, "T", group=child_group_2, order=2)
@@ -145,30 +182,37 @@ def test_ordering(parent_group_1, parent_group_2, child_group_1, child_group_2):
         command_u,
         command_t,
         command_s,
+        command_e,
+        command_f,
+        command_d,
         command_a,
+        command_g,
     ]
 
-    # Do this a couple of times to make sure insertion order doesn't matter
-    for _ in range(0, 10):
-        random.shuffle(commands)
+    # First iteration, use the order as defined. Then repeat multiple times
+    # to validate insertion order doesn't matter.
+    for attempt in range(0, 10):
+        if attempt:
+            random.shuffle(commands)
         cs = CommandSet()
         cs.add(*commands)
 
         assert list(cs) == [
             command_z,
-            GROUP_BREAK,
             command_y,
             command_x,
             command_w,
-            SECTION_BREAK,
+            Separator(group=child_group_1),
             command_b,
-            GROUP_BREAK,
             command_v,
-            GROUP_BREAK,
             command_u,
             command_t,
-            GROUP_BREAK,
             command_s,
-            GROUP_BREAK,
+            command_g,
             command_a,
+            Separator(group=parent_group_2),
+            command_e,
+            command_d,
+            Separator(group=parent_group_2),
+            command_f,
         ]

--- a/gtk/src/toga_gtk/app.py
+++ b/gtk/src/toga_gtk/app.py
@@ -7,7 +7,7 @@ import gbulb
 
 import toga
 from toga import App as toga_App
-from toga.command import GROUP_BREAK, SECTION_BREAK, Command
+from toga.command import Command, Separator
 
 from .keys import gtk_accel
 from .libs import TOGA_DEFAULT_STYLES, Gdk, Gio, GLib, Gtk
@@ -129,12 +129,12 @@ class App:
         menubar = Gio.Menu()
         section = None
         for cmd in self.interface.commands:
-            if cmd == GROUP_BREAK:
-                section = None
-            elif cmd == SECTION_BREAK:
+            if isinstance(cmd, Separator):
                 section = None
             else:
-                submenu = self._submenu(cmd.group, menubar)
+                submenu, created = self._submenu(cmd.group, menubar)
+                if created:
+                    section = None
 
                 if section is None:
                     section = Gio.Menu()
@@ -162,26 +162,24 @@ class App:
 
     def _submenu(self, group, menubar):
         try:
-            return self._menu_groups[group]
+            return self._menu_groups[group], False
         except KeyError:
             if group is None:
                 submenu = menubar
             else:
-                parent_menu = self._submenu(group.parent, menubar)
-
+                parent_menu, _ = self._submenu(group.parent, menubar)
                 submenu = Gio.Menu()
                 self._menu_groups[group] = submenu
 
                 text = group.text
                 if text == "*":
                     text = self.interface.formal_name
-
                 parent_menu.append_submenu(text, submenu)
 
             # Install the item in the group cache.
             self._menu_groups[group] = submenu
 
-            return submenu
+            return submenu, True
 
     def main_loop(self):
         # Modify signal handlers to make sure Ctrl-C is caught and handled.

--- a/gtk/src/toga_gtk/window.py
+++ b/gtk/src/toga_gtk/window.py
@@ -1,4 +1,4 @@
-from toga.command import GROUP_BREAK, SECTION_BREAK
+from toga.command import Separator
 
 from .container import TogaContainer
 from .libs import Gdk, Gtk
@@ -76,12 +76,9 @@ class Window:
         # Create the new toolbar items
         self.toolbar_items = {}
         for cmd in self.interface.toolbar:
-            if cmd == GROUP_BREAK:
+            if isinstance(cmd, Separator):
                 item_impl = Gtk.SeparatorToolItem()
                 item_impl.set_draw(True)
-            elif cmd == SECTION_BREAK:
-                item_impl = Gtk.SeparatorToolItem()
-                item_impl.set_draw(False)
             else:
                 item_impl = Gtk.ToolButton()
                 if cmd.icon:

--- a/gtk/src/toga_gtk/window.py
+++ b/gtk/src/toga_gtk/window.py
@@ -39,6 +39,7 @@ class Window:
         self.native_toolbar.set_style(Gtk.ToolbarStyle.BOTH)
         self.native_toolbar.set_visible(False)
         self.toolbar_items = {}
+        self.toolbar_separators = set()
         self.layout.pack_start(self.native_toolbar, expand=False, fill=False, padding=0)
 
         # Because expand and fill are True, the container will fill the available
@@ -61,25 +62,39 @@ class Window:
         app.native.add_window(self.native)
 
     def create_toolbar(self):
-        # Remove any pre-existing toolbar content
+        # If there's an existing toolbar, hide it until we know we need it.
         if self.toolbar_items:
             self.native_toolbar.set_visible(False)
 
+        # Deregister any toolbar buttons from their commands, and remove them from the toolbar
         for cmd, item_impl in self.toolbar_items.items():
             self.native_toolbar.remove(item_impl)
-            try:
-                cmd._impl.native.remove(item_impl)
-            except AttributeError:
-                # Breaks don't have _impls, so there's no native to clean up
-                pass
+            cmd._impl.native.remove(item_impl)
+        # Remove any toolbar separators
+        for sep in self.toolbar_separators:
+            self.native_toolbar.remove(sep)
 
         # Create the new toolbar items
         self.toolbar_items = {}
+        self.toolbar_separators = set()
+        prev_group = None
         for cmd in self.interface.toolbar:
             if isinstance(cmd, Separator):
                 item_impl = Gtk.SeparatorToolItem()
-                item_impl.set_draw(True)
+                item_impl.set_draw(False)
+                self.toolbar_separators.add(item_impl)
+                prev_group = None
             else:
+                # A change in group requires adding a toolbar separator
+                if prev_group is not None and prev_group != cmd.group:
+                    group_sep = Gtk.SeparatorToolItem()
+                    group_sep.set_draw(True)
+                    self.toolbar_separators.add(group_sep)
+                    self.native_toolbar.insert(group_sep, -1)
+                    prev_group = None
+                else:
+                    prev_group = cmd.group
+
                 item_impl = Gtk.ToolButton()
                 if cmd.icon:
                     item_impl.set_icon_widget(
@@ -90,7 +105,8 @@ class Window:
                     item_impl.set_tooltip_text(cmd.tooltip)
                 item_impl.connect("clicked", cmd._impl.gtk_clicked)
                 cmd._impl.native.append(item_impl)
-            self.toolbar_items[cmd] = item_impl
+                self.toolbar_items[cmd] = item_impl
+
             self.native_toolbar.insert(item_impl, -1)
 
         if self.toolbar_items:

--- a/winforms/src/toga_winforms/app.py
+++ b/winforms/src/toga_winforms/app.py
@@ -13,7 +13,7 @@ from System.Windows.Threading import Dispatcher
 
 import toga
 from toga import Key
-from toga.command import GROUP_BREAK, SECTION_BREAK
+from toga.command import Separator
 
 from .keys import toga_to_winforms_key
 from .libs.proactor import WinformsProactorEventLoop
@@ -139,9 +139,8 @@ class App:
 
         submenu = None
         for cmd in self.interface.commands:
-            if cmd == GROUP_BREAK:
-                submenu = None
-            elif cmd == SECTION_BREAK:
+            submenu = self._submenu(cmd.group, menubar)
+            if isinstance(cmd, Separator):
                 submenu.DropDownItems.Add("-")
             else:
                 submenu = self._submenu(cmd.group, menubar)

--- a/winforms/src/toga_winforms/window.py
+++ b/winforms/src/toga_winforms/window.py
@@ -3,7 +3,7 @@ from System.Drawing import Bitmap, Graphics, Point, Size
 from System.Drawing.Imaging import ImageFormat
 from System.IO import MemoryStream
 
-from toga.command import GROUP_BREAK, SECTION_BREAK
+from toga.command import Separator
 
 from .container import Container
 from .libs.wrapper import WeakrefCallable
@@ -52,9 +52,7 @@ class Window(Container, Scalable):
                 self.toolbar_native.BringToFront()  # In a dock, "front" means "bottom".
 
             for cmd in self.interface.toolbar:
-                if cmd == GROUP_BREAK:
-                    item = WinForms.ToolStripSeparator()
-                elif cmd == SECTION_BREAK:
+                if isinstance(cmd, Separator):
                     item = WinForms.ToolStripSeparator()
                 else:
                     item = WinForms.ToolStripMenuItem(cmd.text)

--- a/winforms/src/toga_winforms/window.py
+++ b/winforms/src/toga_winforms/window.py
@@ -51,10 +51,19 @@ class Window(Container, Scalable):
                 self.native.Controls.Add(self.toolbar_native)
                 self.toolbar_native.BringToFront()  # In a dock, "front" means "bottom".
 
+            prev_group = None
             for cmd in self.interface.toolbar:
                 if isinstance(cmd, Separator):
                     item = WinForms.ToolStripSeparator()
+                    prev_group = None
                 else:
+                    # A change in group requires adding a toolbar separator
+                    if prev_group is not None and prev_group != cmd.group:
+                        self.toolbar_native.Items.Add(WinForms.ToolStripSeparator())
+                        prev_group = None
+                    else:
+                        prev_group = cmd.group
+
                     item = WinForms.ToolStripMenuItem(cmd.text)
                     if cmd.tooltip is not None:
                         item.ToolTipText = cmd.tooltip


### PR DESCRIPTION
Reworks the handling of separators in command groups.

Previously, the process of iterating over commands yielded both Group and Section breaks. This modifies the handling to *only* yield section breaks; the group for a command can be determined by lookup on the group for any given command. However, it now yields section breaks that are caused when a *sub group* is in a new section.

Fixes #2193.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
