### PR TITLE
Upgrade pip before installing Briefcase from GitHub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,7 @@ jobs:
       run: |
         ${{ matrix.pre-command }}
         # Use the development version of Briefcase
+        python -m pip install -U pip
         python -m pip install git+https://github.com/beeware/briefcase.git
 
     - name: Test App

--- a/changes/2240.misc.rst
+++ b/changes/2240.misc.rst
@@ -1,0 +1,1 @@
+Ensure ``pip`` is upgraded to the latest version before installing Briefcase for running testbed tests.


### PR DESCRIPTION
## Changes
- When Briefcase moved to "pyproject only", it now requires a newer pip to build and install it
- So, upgrade pip before installing Briefcase directly from GitHub

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct