### PR TITLE
Ensure pip is updated before installing Briefcase.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,10 @@ jobs:
     - name: Install dependencies
       run: |
         ${{ matrix.pre-command }}
+        # Make sure we have an up-to-date pip; Old pip doesn't deal well with projects
+        # that use pure PEP621 metadata.
+        python -m pip install -U pip
+
         # Use the development version of Briefcase
         python -m pip install git+https://github.com/beeware/briefcase.git
 

--- a/changes/2241.misc.rst
+++ b/changes/2241.misc.rst
@@ -1,0 +1,1 @@
+The testbed environment now ensures that pip has been updated before installing Briefcase.


### PR DESCRIPTION
The recent change to Briefcase using PEP621 metadata requires that pip is up-to-date. Ensure this is the case before installing Briefcase.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
