### PR TITLE
Simplified Path declarations

### DIFF
--- a/android/tests_backend/icons.py
+++ b/android/tests_backend/icons.py
@@ -16,16 +16,14 @@ class IconProbe(BaseProbe):
     def assert_icon_content(self, path):
         if path == "resources/icons/green":
             assert (
-                self.icon._impl.path
-                == self.app.paths.app / "resources" / "icons" / "green.png"
+                self.icon._impl.path == self.app.paths.app / "resources/icons/green.png"
             )
         elif path == "resources/icons/blue":
             assert (
-                self.icon._impl.path
-                == self.app.paths.app / "resources" / "icons" / "blue.png"
+                self.icon._impl.path == self.app.paths.app / "resources/icons/blue.png"
             )
         else:
             pytest.fail("Unknown icon resource")
 
     def assert_default_icon_content(self):
-        assert self.icon._impl.path == self.app.paths.toga / "resources" / "toga.png"
+        assert self.icon._impl.path == self.app.paths.toga / "resources/toga.png"

--- a/changes/2246.misc.txt
+++ b/changes/2246.misc.txt
@@ -1,0 +1,1 @@
+Path declarations across the project have been simplified, with unneeded slash operators removed.

--- a/cocoa/src/toga_cocoa/paths.py
+++ b/cocoa/src/toga_cocoa/paths.py
@@ -8,13 +8,13 @@ class Paths:
         self.interface = interface
 
     def get_config_path(self):
-        return Path.home() / "Library" / "Preferences" / App.app.app_id
+        return Path.home() / "Library/Preferences" / App.app.app_id
 
     def get_data_path(self):
-        return Path.home() / "Library" / "Application Support" / App.app.app_id
+        return Path.home() / "Library/Application Support" / App.app.app_id
 
     def get_cache_path(self):
-        return Path.home() / "Library" / "Caches" / App.app.app_id
+        return Path.home() / "Library/Caches" / App.app.app_id
 
     def get_logs_path(self):
-        return Path.home() / "Library" / "Logs" / App.app.app_id
+        return Path.home() / "Library/Logs" / App.app.app_id

--- a/cocoa/tests_backend/app.py
+++ b/cocoa/tests_backend/app.py
@@ -29,21 +29,19 @@ class AppProbe(BaseProbe):
 
     @property
     def config_path(self):
-        return Path.home() / "Library" / "Preferences" / "org.beeware.toga.testbed"
+        return Path.home() / "Library/Preferences/org.beeware.toga.testbed"
 
     @property
     def data_path(self):
-        return (
-            Path.home() / "Library" / "Application Support" / "org.beeware.toga.testbed"
-        )
+        return Path.home() / "Library/Application Support/org.beeware.toga.testbed"
 
     @property
     def cache_path(self):
-        return Path.home() / "Library" / "Caches" / "org.beeware.toga.testbed"
+        return Path.home() / "Library/Caches/org.beeware.toga.testbed"
 
     @property
     def logs_path(self):
-        return Path.home() / "Library" / "Logs" / "org.beeware.toga.testbed"
+        return Path.home() / "Library/Logs/org.beeware.toga.testbed"
 
     @property
     def is_cursor_visible(self):

--- a/cocoa/tests_backend/icons.py
+++ b/cocoa/tests_backend/icons.py
@@ -18,15 +18,14 @@ class IconProbe(BaseProbe):
         if path == "resources/icons/green":
             assert (
                 self.icon._impl.path
-                == self.app.paths.app / "resources" / "icons" / "green.icns"
+                == self.app.paths.app / "resources/icons/green.icns"
             )
         elif path == "resources/icons/blue":
             assert (
-                self.icon._impl.path
-                == self.app.paths.app / "resources" / "icons" / "blue.png"
+                self.icon._impl.path == self.app.paths.app / "resources/icons/blue.png"
             )
         else:
             pytest.fail("Unknown icon resource")
 
     def assert_default_icon_content(self):
-        assert self.icon._impl.path == self.app.paths.toga / "resources" / "toga.icns"
+        assert self.icon._impl.path == self.app.paths.toga / "resources/toga.icns"

--- a/core/tests/test_fonts.py
+++ b/core/tests/test_fonts.py
@@ -151,11 +151,11 @@ def test_registered_font_key(app, family, style, weight, variant, key):
         # Relative path
         (
             Path("path/to/custom/font.otf"),
-            Path(toga.__file__).parent / "path" / "to" / "custom" / "font.otf",
+            Path(toga.__file__).parent / "path/to/custom/font.otf",
         ),
         (
             "path/to/custom/font.otf",
-            Path(toga.__file__).parent / "path" / "to" / "custom" / "font.otf",
+            Path(toga.__file__).parent / "path/to/custom/font.otf",
         ),
     ],
 )
@@ -180,11 +180,11 @@ def test_register_font(app, path, registered):
         # Relative path
         (
             Path("path/to/custom/font.otf"),
-            Path(toga.__file__).parent / "path" / "to" / "custom" / "font.otf",
+            Path(toga.__file__).parent / "path/to/custom/font.otf",
         ),
         (
             str(Path("path/to/custom/font.otf")),
-            Path(toga.__file__).parent / "path" / "to" / "custom" / "font.otf",
+            Path(toga.__file__).parent / "path/to/custom/font.otf",
         ),
     ],
 )

--- a/core/tests/test_icons.py
+++ b/core/tests/test_icons.py
@@ -26,11 +26,11 @@ def app():
         # Absolute path (points at a file in the system resource folder,
         # but that's just because it's a location we know exists.)
         (
-            Path(__file__).parent.parent / "src" / "toga" / "resources" / "toga",
+            Path(__file__).parent.parent / "src/toga/resources/toga",
             False,
             None,
             [".png"],
-            Path(__file__).parent.parent / "src" / "toga" / "resources" / "toga.png",
+            Path(__file__).parent.parent / "src/toga/resources/toga.png",
         ),
         # PNG format
         ("resources/red", False, None, [".png"], APP_RESOURCES / "red.png"),

--- a/core/tests/test_images.py
+++ b/core/tests/test_images.py
@@ -5,8 +5,8 @@ import pytest
 import toga
 from toga_dummy.utils import assert_action_performed_with
 
-RELATIVE_FILE_PATH = Path("resources") / "toga.png"
-ABSOLUTE_FILE_PATH = Path(toga.__file__).parent / "resources" / "toga.png"
+RELATIVE_FILE_PATH = Path("resources/toga.png")
+ABSOLUTE_FILE_PATH = Path(toga.__file__).parent / "resources/toga.png"
 
 
 @pytest.mark.parametrize(
@@ -39,8 +39,8 @@ def test_create_from_file(app, args, kwargs):
     assert image._impl.interface.path == ABSOLUTE_FILE_PATH
 
 
-MISSING_ABSOLUTE_PATH = Path.home() / "does" / "not" / "exist" / "image.jpg"
-MISSING_RELATIVE_PATH = Path("does") / "not" / "exist" / "image.jpg"
+MISSING_ABSOLUTE_PATH = Path.home() / "does/not/exist/image.jpg"
+MISSING_RELATIVE_PATH = Path("does/not/exist/image.jpg")
 
 
 @pytest.mark.parametrize(

--- a/core/tests/test_paths.py
+++ b/core/tests/test_paths.py
@@ -16,7 +16,7 @@ def run_app(args, cwd):
             "COVERAGE_PROCESS_START": str(
                 Path(__file__).parent.parent / "pyproject.toml"
             ),
-            "PYTHONPATH": str(Path(__file__).parent / "testbed" / "customize"),
+            "PYTHONPATH": str(Path(__file__).parent / "testbed/customize"),
             "TOGA_BACKEND": "toga_dummy",
         }
     )
@@ -68,7 +68,7 @@ def test_simple_as_file_in_module():
     """When a simple app is started as `python app.py` inside a runnable module, the
     app path is the folder holding app.py."""
     # Spawn the simple testbed app using `app.py`
-    cwd = Path(__file__).parent / "testbed" / "simple"
+    cwd = Path(__file__).parent / "testbed/simple"
     output = run_app(["app.py"], cwd=cwd)
     assert_paths(output, app_path=Path(toga.__file__).parent, app_name="simple-app")
 
@@ -77,7 +77,7 @@ def test_simple_as_module():
     """When a simple apps is started as `python -m app` inside a runnable module,
     the app path is the folder holding app.py."""
     # Spawn the simple testbed app using `-m app`
-    cwd = Path(__file__).parent / "testbed" / "simple"
+    cwd = Path(__file__).parent / "testbed/simple"
     output = run_app(["-m", "app"], cwd=cwd)
     assert_paths(output, app_path=Path(toga.__file__).parent, app_name="simple-app")
 
@@ -102,7 +102,7 @@ def test_subclassed_as_file_in_module():
     """When a subclassed app is started as `python app.py` inside a runnable module, the
     app path is the folder holding app.py."""
     # Spawn the simple testbed app using `app.py`
-    cwd = Path(__file__).parent / "testbed" / "subclassed"
+    cwd = Path(__file__).parent / "testbed/subclassed"
     output = run_app(["app.py"], cwd=cwd)
     assert_paths(output, app_path=cwd, app_name="subclassed-app")
 
@@ -111,7 +111,7 @@ def test_subclassed_as_module():
     """When a subclassed app is started as `python -m app` inside a runnable module,
     the app path is the folder holding app.py."""
     # Spawn the subclassed testbed app using `-m app`
-    cwd = Path(__file__).parent / "testbed" / "subclassed"
+    cwd = Path(__file__).parent / "testbed/subclassed"
     output = run_app(["-m", "app"], cwd=cwd)
     assert_paths(output, app_path=cwd, app_name="subclassed-app")
 

--- a/core/tests/widgets/test_imageview.py
+++ b/core/tests/widgets/test_imageview.py
@@ -33,7 +33,7 @@ def test_widget_created(widget):
 
 def test_widget_created_with_args(app):
     "An ImageView can be created with argumentgs"
-    image = toga.Image(Path("resources") / "toga.png")
+    image = toga.Image(Path("resources/toga.png"))
     widget = toga.ImageView(image=image)
 
     # interface/impl round trips
@@ -73,22 +73,22 @@ def test_set_image_str(widget):
     assert_action_performed(widget, "refresh")
 
     assert isinstance(widget.image, toga.Image)
-    assert widget.image.path == Path(toga.__file__).parent / "resources" / "toga.png"
+    assert widget.image.path == Path(toga.__file__).parent / "resources/toga.png"
 
 
 def test_set_image_path(widget):
     "The image can be set with a Path"
-    widget.image = Path("resources") / "toga.png"
+    widget.image = Path("resources/toga.png")
     assert_action_performed_with(widget, "set image", image=ANY)
     assert_action_performed(widget, "refresh")
 
     assert isinstance(widget.image, toga.Image)
-    assert widget.image.path == Path(toga.__file__).parent / "resources" / "toga.png"
+    assert widget.image.path == Path(toga.__file__).parent / "resources/toga.png"
 
 
 def test_set_image(widget):
     "The image can be set with an Image instance"
-    image = toga.Image(Path("resources") / "toga.png")
+    image = toga.Image(Path("resources/toga.png"))
 
     widget.image = image
     assert_action_performed_with(widget, "set image", image=image)

--- a/docs/reference/api/resources/images.rst
+++ b/docs/reference/api/resources/images.rst
@@ -23,10 +23,10 @@ Usage
     my_image = toga.Image("brutus.png")
 
     # Load an image at an absolute path
-    my_image = toga.Image(Path.home() / "path" / "to" / "brutus.png")
+    my_image = toga.Image(Path.home() / "path/to/brutus.png")
 
     # Create an image from raw data
-    with (Path.home() / "path" / "to" / "brutus.png").open("rb") as f:
+    with (Path.home() / "path/to/brutus.png").open("rb") as f:
         my_image = toga.Image(data=f.read())
 
 Notes

--- a/examples/imageview/imageview/app.py
+++ b/examples/imageview/imageview/app.py
@@ -46,7 +46,7 @@ class ImageViewApp(toga.App):
         # image from pathlib.Path object
         # same as the above image, just with a different argument type
         image_from_pathlib_path = toga.Image(
-            self.paths.app / "resources" / "pride-brutus.png"
+            self.paths.app / "resources/pride-brutus.png"
         )
 
         # Scale BOTH of the width or height, and the aspect ratio should be overridden.

--- a/examples/positron-static/src/positron/app.py
+++ b/examples/positron-static/src/positron/app.py
@@ -19,7 +19,7 @@ class LocalHTTPServer(ThreadingHTTPServer):
 class Positron(toga.App):
     def web_server(self):
         print("Starting server...")
-        self._httpd = LocalHTTPServer(self.paths.app / "resources" / "webapp")
+        self._httpd = LocalHTTPServer(self.paths.app / "resources/webapp")
         # The server is now listening, but connections will block until
         # serve_forever is run.
         self.server_exists.set()

--- a/gtk/src/toga_gtk/paths.py
+++ b/gtk/src/toga_gtk/paths.py
@@ -11,10 +11,10 @@ class Paths:
         return Path.home() / ".config" / App.app.app_name
 
     def get_data_path(self):
-        return Path.home() / ".local" / "share" / App.app.app_name
+        return Path.home() / ".local/share" / App.app.app_name
 
     def get_cache_path(self):
         return Path.home() / ".cache" / App.app.app_name
 
     def get_logs_path(self):
-        return Path.home() / ".local" / "state" / App.app.app_name / "log"
+        return Path.home() / ".local/state" / App.app.app_name / "log"

--- a/gtk/tests_backend/app.py
+++ b/gtk/tests_backend/app.py
@@ -19,19 +19,19 @@ class AppProbe(BaseProbe):
 
     @property
     def config_path(self):
-        return Path.home() / ".config" / "testbed"
+        return Path.home() / ".config/testbed"
 
     @property
     def data_path(self):
-        return Path.home() / ".local" / "share" / "testbed"
+        return Path.home() / ".local/share/testbed"
 
     @property
     def cache_path(self):
-        return Path.home() / ".cache" / "testbed"
+        return Path.home() / ".cache/testbed"
 
     @property
     def logs_path(self):
-        return Path.home() / ".local" / "state" / "testbed" / "log"
+        return Path.home() / ".local/state/testbed/log"
 
     @property
     def is_cursor_visible(self):

--- a/gtk/tests_backend/icons.py
+++ b/gtk/tests_backend/icons.py
@@ -19,22 +19,22 @@ class IconProbe(BaseProbe):
     def assert_icon_content(self, path):
         if path == "resources/icons/green":
             assert self.icon._impl.paths == {
-                16: self.app.paths.app / "resources" / "icons" / "green-16.png",
-                32: self.app.paths.app / "resources" / "icons" / "green-32.png",
-                72: self.app.paths.app / "resources" / "icons" / "green-72.png",
+                16: self.app.paths.app / "resources/icons/green-16.png",
+                32: self.app.paths.app / "resources/icons/green-32.png",
+                72: self.app.paths.app / "resources/icons/green-72.png",
             }
         elif path == "resources/icons/orange":
             assert self.icon._impl.paths == {
-                16: self.app.paths.app / "resources" / "icons" / "orange.ico",
-                32: self.app.paths.app / "resources" / "icons" / "orange.ico",
-                72: self.app.paths.app / "resources" / "icons" / "orange.ico",
+                16: self.app.paths.app / "resources/icons/orange.ico",
+                32: self.app.paths.app / "resources/icons/orange.ico",
+                72: self.app.paths.app / "resources/icons/orange.ico",
             }
         else:
             pytest.fail("Unknown icon resource")
 
     def assert_default_icon_content(self):
         assert self.icon._impl.paths == {
-            16: self.app.paths.toga / "resources" / "toga.png",
-            32: self.app.paths.toga / "resources" / "toga.png",
-            72: self.app.paths.toga / "resources" / "toga.png",
+            16: self.app.paths.toga / "resources/toga.png",
+            32: self.app.paths.toga / "resources/toga.png",
+            72: self.app.paths.toga / "resources/toga.png",
         }

--- a/iOS/tests_backend/icons.py
+++ b/iOS/tests_backend/icons.py
@@ -18,15 +18,14 @@ class IconProbe(BaseProbe):
         if path == "resources/icons/green":
             assert (
                 self.icon._impl.path
-                == self.app.paths.app / "resources" / "icons" / "green.icns"
+                == self.app.paths.app / "resources/icons/green.icns"
             )
         elif path == "resources/icons/blue":
             assert (
-                self.icon._impl.path
-                == self.app.paths.app / "resources" / "icons" / "blue.png"
+                self.icon._impl.path == self.app.paths.app / "resources/icons/blue.png"
             )
         else:
             pytest.fail("Unknown icon resource")
 
     def assert_default_icon_content(self):
-        assert self.icon._impl.path == self.app.paths.toga / "resources" / "toga.icns"
+        assert self.icon._impl.path == self.app.paths.toga / "resources/toga.icns"

--- a/testbed/tests/test_fonts.py
+++ b/testbed/tests/test_fonts.py
@@ -154,7 +154,7 @@ async def test_non_existent_font_file(widget: toga.Label, app: toga.App):
     "Invalid font files fail registration"
     Font.register(
         family="non-existent",
-        path=app.paths.app / "resources" / "fonts" / "nonexistent.ttf",
+        path=app.paths.app / "resources/fonts/nonexistent.ttf",
     )
     with pytest.raises(
         ValueError, match=r"Font file .*nonexistent.ttf could not be found"
@@ -173,7 +173,7 @@ async def test_corrupted_font_file(
 
     Font.register(
         family="corrupted",
-        path=app.paths.app / "resources" / "fonts" / "Corrupted.ttf",
+        path=app.paths.app / "resources/fonts/Corrupted.ttf",
     )
     with pytest.raises(ValueError, match=r"Unable to load font file .*Corrupted.ttf"):
         widget.style.font_family = "corrupted"

--- a/testbed/tests/widgets/test_canvas.py
+++ b/testbed/tests/widgets/test_canvas.py
@@ -242,7 +242,7 @@ def assert_reference(probe, reference, threshold=0.0):
 
     # Look for a platform-specific reference variant.
     reference_variant = probe.reference_variant(reference)
-    path = toga.App.app.paths.app / "resources" / "canvas" / f"{reference_variant}.png"
+    path = toga.App.app.paths.app / "resources/canvas" / f"{reference_variant}.png"
     save_dir = toga.App.app.paths.data / "canvas"
 
     def save():

--- a/textual/src/toga_textual/paths.py
+++ b/textual/src/toga_textual/paths.py
@@ -10,16 +10,16 @@ if sys.platform == "darwin":
             self.interface = interface
 
         def get_config_path(self):
-            return Path.home() / "Library" / "Preferences" / App.app.app_id
+            return Path.home() / "Library/Preferences" / App.app.app_id
 
         def get_data_path(self):
-            return Path.home() / "Library" / "Application Support" / App.app.app_id
+            return Path.home() / "Library/Application Support" / App.app.app_id
 
         def get_cache_path(self):
-            return Path.home() / "Library" / "Caches" / App.app.app_id
+            return Path.home() / "Library/Caches" / App.app.app_id
 
         def get_logs_path(self):
-            return Path.home() / "Library" / "Logs" / App.app.app_id
+            return Path.home() / "Library/Logs" / App.app.app_id
 
 elif sys.platform == "win32":
 
@@ -85,10 +85,10 @@ else:
             return Path.home() / ".config" / App.app.app_name
 
         def get_data_path(self):
-            return Path.home() / ".local" / "share" / App.app.app_name
+            return Path.home() / ".local/share" / App.app.app_name
 
         def get_cache_path(self):
             return Path.home() / ".cache" / App.app.app_name
 
         def get_logs_path(self):
-            return Path.home() / ".local" / "state" / App.app.app_name / "log"
+            return Path.home() / ".local/state" / App.app.app_name / "log"

--- a/winforms/tests_backend/app.py
+++ b/winforms/tests_backend/app.py
@@ -37,9 +37,7 @@ class AppProbe(BaseProbe):
 
     @property
     def data_path(self):
-        return (
-            Path.home() / "AppData" / "Local" / "Tiberius Yak" / "Toga Testbed" / "Data"
-        )
+        return Path.home() / "AppData/Local/Tiberius Yak/Toga Testbed/Data"
 
     @property
     def cache_path(self):
@@ -54,9 +52,7 @@ class AppProbe(BaseProbe):
 
     @property
     def logs_path(self):
-        return (
-            Path.home() / "AppData" / "Local" / "Tiberius Yak" / "Toga Testbed" / "Logs"
-        )
+        return Path.home() / "AppData/Local/Tiberius Yak/Toga Testbed/Logs"
 
     @property
     def is_cursor_visible(self):

--- a/winforms/tests_backend/icons.py
+++ b/winforms/tests_backend/icons.py
@@ -16,16 +16,14 @@ class IconProbe(BaseProbe):
     def assert_icon_content(self, path):
         if path == "resources/icons/green":
             assert (
-                self.icon._impl.path
-                == self.app.paths.app / "resources" / "icons" / "green.ico"
+                self.icon._impl.path == self.app.paths.app / "resources/icons/green.ico"
             )
         elif path == "resources/icons/blue":
             assert (
-                self.icon._impl.path
-                == self.app.paths.app / "resources" / "icons" / "blue.png"
+                self.icon._impl.path == self.app.paths.app / "resources/icons/blue.png"
             )
         else:
             pytest.fail("Unknown icon resource")
 
     def assert_default_icon_content(self):
-        assert self.icon._impl.path == self.app.paths.toga / "resources" / "toga.ico"
+        assert self.icon._impl.path == self.app.paths.toga / "resources/toga.ico"


### PR DESCRIPTION
This might very well be a solution for a non-problem, but I noticed that a lot of paths in the codebase are written with all slash operators, like this:

```python
Path.home() / "does" / "not" / "exist" / "image.jpg"
Path("does") / "not" / "exist" / "image.jpg"
```

All this PR does is simplify all such instances , e.g.:

```python
Path.home() / "does/not/exist/image.jpg"
Path("does/not/exist/image.jpg")
```

This avoids creating and discarding intermediate Path objects along the way, and at least personally I find it more readable too.

In the event that this is an intentional style decision, I could submit a PR that instead changes all of the latter style to the former, for consistency.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
