### PR TITLE
Clarify imports that are dependent on the version of Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,7 @@ jobs:
 
           - backend: android
             runs-on: ubuntu-latest
-            briefcase-run-args: " -d '{\"avd\":\"beePhone\"}' --Xemulator=-no-window --Xemulator=-no-snapshot --Xemulator=-no-audio --Xemulator=-no-boot-anim --shutdown-on-exit"
+            briefcase-run-args: " -d '{\"avd\":\"beePhone\",\"skin\":\"pixel_3a\"}' --Xemulator=-no-window --Xemulator=-no-snapshot --Xemulator=-no-audio --Xemulator=-no-boot-anim --shutdown-on-exit"
             pre-command: |
               # check if virtualization is supported...
               sudo apt install -qq --no-install-recommends cpu-checker coreutils && echo "CPUs=$(nproc --all)" && kvm-ok
@@ -222,8 +222,7 @@ jobs:
         ${{ matrix.pre-command }}
         # Use the development version of Briefcase
         python -m pip install -U pip
-        # python -m pip install git+https://github.com/beeware/briefcase.git
-        python -m pip install git+https://github.com/beeware/briefcase.git@018931b3c6428896edb7ebffb76680602ad5d06b
+        python -m pip install git+https://github.com/beeware/briefcase.git
 
     - name: Test App
       working-directory: testbed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,8 @@ jobs:
         ${{ matrix.pre-command }}
         # Use the development version of Briefcase
         python -m pip install -U pip
-        python -m pip install git+https://github.com/beeware/briefcase.git
+        # python -m pip install git+https://github.com/beeware/briefcase.git
+        python -m pip install git+https://github.com/beeware/briefcase.git@018931b3c6428896edb7ebffb76680602ad5d06b
 
     - name: Test App
       working-directory: testbed

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,16 +9,15 @@ repos:
       - id: check-docstring-first
       - id: end-of-file-fixer
       - id: trailing-whitespace
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-        additional_dependencies: [toml]
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.15.0
     hooks:
       - id: pyupgrade
         args: [--py38-plus]
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 23.11.0
     hooks:
@@ -32,4 +31,5 @@ repos:
     rev: v2.2.6
     hooks:
     - id: codespell
-      additional_dependencies: [tomli]
+      # remove toml extra once Python 3.10 is no longer supported
+      additional_dependencies: ['.[toml]']

--- a/changes/2249.misc.rst
+++ b/changes/2249.misc.rst
@@ -1,0 +1,1 @@
+Module imports that are dependent on the version of Python are now explicitly structured to declare the Python versions they are dependent on.

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -57,6 +57,7 @@ classifiers = [
 ]
 dependencies = [
     "travertino >= 0.3.0",
+    # limited to <=3.9 for the `group` argument for `entry_points()`
     "importlib_metadata >= 4.4.0; python_version <= '3.9'",
 ]
 

--- a/core/src/toga/__init__.py
+++ b/core/src/toga/__init__.py
@@ -105,11 +105,11 @@ def _package_version(file, name):
         # If it *is* in the environment, but the code isn't a git checkout (e.g.,
         # it's been pip installed non-editable) the call to get_version() will fail.
         # If either of these occurs, read version from the installer metadata.
-        from importlib import metadata as importlib_metadata
+        import importlib.metadata
 
         # The Toga package names as defined in setup.cfg all use dashes.
         package = "toga-core" if name == "toga" else name.replace("_", "-")
-        return importlib_metadata.version(package)
+        return importlib.metadata.version(package)
 
 
 __version__ = _package_version(__file__, __name__)

--- a/core/src/toga/platform.py
+++ b/core/src/toga/platform.py
@@ -3,15 +3,12 @@ import os
 import sys
 from functools import lru_cache
 
-try:
-    # Usually, the pattern is "import module; if it doesn't exist,
-    # import the shim". However, we need the 3.10 API for entry_points,
-    # as the 3.8 didn't support the `groups` argument to entry_points.
-    # Therefore, we try to import the compatibility shim first; and fall
-    # back to the stdlib module if the shim isn't there.
-    from importlib_metadata import entry_points
-except ImportError:
+if sys.version_info >= (3, 10):
     from importlib.metadata import entry_points
+else:
+    # Before Python 3.10, entry_points did not support the group argument;
+    # so, the backport package must be used on older versions.
+    from importlib_metadata import entry_points
 
 
 # Map python sys.platform with toga platforms names

--- a/core/tests/test_platform.py
+++ b/core/tests/test_platform.py
@@ -5,15 +5,12 @@ import pytest
 
 import toga_dummy
 
-try:
-    # Usually, the pattern is "import module; if it doesn't exist,
-    # import the shim". However, we need the 3.10 API for entry_points,
-    # as the 3.8 didn't support the `groups` argument to entry_points.
-    # Therefore, we try to import the compatibility shim first; and fall
-    # back to the stdlib module if the shim isn't there.
-    from importlib_metadata import EntryPoint
-except ImportError:
+if sys.version_info >= (3, 10):
     from importlib.metadata import EntryPoint
+else:
+    # Before Python 3.10, entry_points did not support the group argument;
+    # so, the backport package must be used on older versions.
+    from importlib_metadata import EntryPoint
 
 import toga.platform
 from toga.platform import current_platform, get_current_platform, get_platform_factory

--- a/web/src/toga_web/libs.py
+++ b/web/src/toga_web/libs.py
@@ -1,18 +1,16 @@
 try:
-    # Try to import js from the PyScript namespace.
+    # Try to import js from the PyScript namespace
     import js
 except ModuleNotFoundError:
-    # To ensure the code can be imported, provide a js symbol
-    # as a fallback
+    # To ensure the code can be imported, provide a js symbol as a fallback
     js = None
 
 
 try:
-    # Try to import pyodide from the PyScript namespace.
+    # Try to import pyodide from the PyScript namespace
     import pyodide
 except ModuleNotFoundError:
-    # To ensure the code can be imported, provide a js symbol
-    # as a fallback
+    # To ensure the code can be imported, provide a pyodide symbol as a fallback
     pyodide = None
 
 


### PR DESCRIPTION
## Changes
- For imports that are dependent on the version of Python, make that explicit and use a syntax that `pyupgrade` can automatically handle for Python EOLs
- Given that `pyupgrade` can change imports, run it before `isort` runs in pre-commit
- Installing `toml` package is no longer necessary to run `isort` in `pre-commit`
- Instead of assuming knowledge about `codespell`'s usage of TOML (such as the fact it uses the `tomli` package), instruct pre-commit to install the `toml` extra for `codespell`

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
