### PR TITLE
Added notes section to app documentation to include note about title …

### DIFF
--- a/changes/2255.doc.rst
+++ b/changes/2255.doc.rst
@@ -1,1 +1,1 @@
-Documentation note about Wayland compatibility for app title added
+Some limitations on App presentation imposed by Wayland have been documented.

--- a/changes/2255.doc.rst
+++ b/changes/2255.doc.rst
@@ -1,1 +1,1 @@
-Documentation note about Wayland compatability for app title added
+Documentation note about Wayland compatibility for app title added

--- a/changes/2255.doc.rst
+++ b/changes/2255.doc.rst
@@ -1,0 +1,1 @@
+Documentation note about Wayland compatability for app title added

--- a/docs/reference/api/app.rst
+++ b/docs/reference/api/app.rst
@@ -73,10 +73,12 @@ format compatible with :any:`importlib.metadata`. If you deploy your app with `B
 Notes
 -----
 
-* Apps ran in a Gnome Wayland environment with python -m or briefcase dev will not show
-  the formal app name in the title bar. In order to make the title show properly, you
-  will need to build or package your app with `Briefcase
-  <https://briefcase.readthedocs.io/en/stable>`__.
+* Apps executed under Wayland on Linux environment may not show the app's formal name
+  correctly. Wayland considers many aspects of app operation to be the domain of the
+  windowing environment, not the app; as a result, some API requests will be ignored
+  under a Wayland environment. Correctly displaying the app's formal name requires the
+  use of a desktop metadata that Wayland can read. Packaging your app with `Briefcase
+  <https://briefcase.readthedocs.io/en/stable>`__ is one way to produce this metadata.
 
 Reference
 ---------

--- a/docs/reference/api/app.rst
+++ b/docs/reference/api/app.rst
@@ -70,6 +70,14 @@ details, along with many of the other constructor arguments, as packaging metada
 format compatible with :any:`importlib.metadata`. If you deploy your app with `Briefcase
 <https://briefcase.readthedocs.io/en/stable>`__, this will be done automatically.
 
+Notes
+-----
+
+* Apps ran in a Gnome Wayland environment with python -m or briefcase dev will not show
+  the formal app name in the title bar. In order to make the title show properly, you
+  will need to build or package your app with `Briefcase
+  <https://briefcase.readthedocs.io/en/stable>`__.
+
 Reference
 ---------
 

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -85,6 +85,7 @@ Ventura
 verbing
 viewport
 watchOS
+Wayland
 WebKit
 whitespace
 Winforms


### PR DESCRIPTION


<!--- Describe your changes in detail -->
Added notes section to app documentation to include note about title bar name not displaying properly on gnome wayland when ran with briefcase dev or python -m
<!--- What problem does this change solve? -->
Adds important information for app devs to curb troubleshooting known issues
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Fixes #1862

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
