### PR TITLE
Added pinch-to-zoom in WebView on Android

### DIFF
--- a/android/src/toga_android/widgets/webview.py
+++ b/android/src/toga_android/widgets/webview.py
@@ -41,6 +41,9 @@ class WebView(Widget):
         self.settings = self.native.getSettings()
         self.default_user_agent = self.settings.getUserAgentString()
         self.settings.setJavaScriptEnabled(True)
+        # enable pinch-to-zoom without the deprecated on-screen controls
+        self.settings.setBuiltInZoomControls(True)
+        self.settings.setDisplayZoomControls(False)
 
     def get_url(self):
         url = self.native.getUrl()

--- a/changes/2261.misc.rst
+++ b/changes/2261.misc.rst
@@ -1,0 +1,1 @@
+The pinch-to-zoom feature has been added to WebView on Android.


### PR DESCRIPTION
This PR adds the pinch-to-zoom feature in WebView for Android (see bug #2258)
The on-screen zoom controls are deactivated because they are deprecated.

It can be tested in the Android emulator with the webview example by pressing and holding the CTRL button and dragging the mouse.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
