### PR TITLE
Merge the handling of on_result and async result handling

### DIFF
--- a/android/src/toga_android/dialogs.py
+++ b/android/src/toga_android/dialogs.py
@@ -31,10 +31,8 @@ class TextDialog(BaseDialog):
         positive_text,
         negative_text=None,
         icon=None,
-        on_result=None,
     ):
         super().__init__(interface=interface)
-        self.on_result = on_result
 
         self.native = AlertDialog.Builder(interface.window._impl.app.native)
         self.native.setCancelable(False)
@@ -57,54 +55,49 @@ class TextDialog(BaseDialog):
         self.native.show()
 
     def completion_handler(self, return_value: bool) -> None:
-        self.on_result(return_value)
-        self.interface.future.set_result(return_value)
+        self.interface.set_result(return_value)
 
 
 class InfoDialog(TextDialog):
-    def __init__(self, interface, title, message, on_result=None):
+    def __init__(self, interface, title, message):
         super().__init__(
             interface=interface,
             title=title,
             message=message,
             positive_text="OK",
-            on_result=on_result,
         )
 
 
 class QuestionDialog(TextDialog):
-    def __init__(self, interface, title, message, on_result=None):
+    def __init__(self, interface, title, message):
         super().__init__(
             interface=interface,
             title=title,
             message=message,
             positive_text="Yes",
             negative_text="No",
-            on_result=on_result,
         )
 
 
 class ConfirmDialog(TextDialog):
-    def __init__(self, interface, title, message, on_result=None):
+    def __init__(self, interface, title, message):
         super().__init__(
             interface=interface,
             title=title,
             message=message,
             positive_text="OK",
             negative_text="Cancel",
-            on_result=on_result,
         )
 
 
 class ErrorDialog(TextDialog):
-    def __init__(self, interface, title, message, on_result=None):
+    def __init__(self, interface, title, message):
         super().__init__(
             interface=interface,
             title=title,
             message=message,
             positive_text="OK",
             icon=R.drawable.ic_dialog_alert,
-            on_result=on_result,
         )
 
 
@@ -114,7 +107,6 @@ class StackTraceDialog(BaseDialog):
         interface,
         title,
         message,
-        on_result=None,
         **kwargs,
     ):
         super().__init__(interface=interface)
@@ -129,7 +121,6 @@ class SaveFileDialog(BaseDialog):
         filename,
         initial_directory,
         file_types=None,
-        on_result=None,
     ):
         super().__init__(interface=interface)
         interface.window.factory.not_implemented("Window.save_file_dialog()")
@@ -143,7 +134,6 @@ class OpenFileDialog(BaseDialog):
         initial_directory,
         file_types,
         multiple_select,
-        on_result=None,
     ):
         super().__init__(interface=interface)
         interface.window.factory.not_implemented("Window.open_file_dialog()")
@@ -156,7 +146,6 @@ class SelectFolderDialog(BaseDialog):
         title,
         initial_directory,
         multiple_select,
-        on_result=None,
     ):
         super().__init__(interface=interface)
         interface.window.factory.not_implemented("Window.select_folder_dialog()")

--- a/changes/2264.misc.rst
+++ b/changes/2264.misc.rst
@@ -1,0 +1,1 @@
+Synchronous ``on_result`` handling was merged into AsyncResult.

--- a/changes/2264.removal.rst
+++ b/changes/2264.removal.rst
@@ -1,0 +1,1 @@
+The use of synchronous ``on_result`` callbacks on dialogs and ``Webview.evaluate_javascript()`` calls has been deprecated. These methods should be used in their asynchronous form.

--- a/cocoa/src/toga_cocoa/dialogs.py
+++ b/cocoa/src/toga_cocoa/dialogs.py
@@ -31,11 +31,9 @@ class NSAlertDialog(BaseDialog):
         message,
         alert_style,
         completion_handler,
-        on_result=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(interface=interface)
-        self.on_result = on_result
 
         self.native = NSAlert.alloc().init()
         self.native.icon = interface.app.icon._impl.native
@@ -54,39 +52,31 @@ class NSAlertDialog(BaseDialog):
         pass
 
     def completion_handler(self, return_value: int) -> None:
-        self.on_result(None)
-
-        self.interface.future.set_result(None)
+        self.interface.set_result(None)
 
     def bool_completion_handler(self, return_value: int) -> None:
-        result = return_value == NSAlertFirstButtonReturn
-
-        self.on_result(result)
-
-        self.interface.future.set_result(result)
+        self.interface.set_result(return_value == NSAlertFirstButtonReturn)
 
 
 class InfoDialog(NSAlertDialog):
-    def __init__(self, interface, title, message, on_result=None):
+    def __init__(self, interface, title, message):
         super().__init__(
             interface=interface,
             title=title,
             message=message,
             alert_style=NSAlertStyle.Informational,
             completion_handler=self.completion_handler,
-            on_result=on_result,
         )
 
 
 class QuestionDialog(NSAlertDialog):
-    def __init__(self, interface, title, message, on_result=None):
+    def __init__(self, interface, title, message):
         super().__init__(
             interface=interface,
             title=title,
             message=message,
             alert_style=NSAlertStyle.Informational,
             completion_handler=self.bool_completion_handler,
-            on_result=on_result,
         )
 
     def build_dialog(self):
@@ -95,14 +85,13 @@ class QuestionDialog(NSAlertDialog):
 
 
 class ConfirmDialog(NSAlertDialog):
-    def __init__(self, interface, title, message, on_result=None):
+    def __init__(self, interface, title, message):
         super().__init__(
             interface=interface,
             title=title,
             message=message,
             alert_style=NSAlertStyle.Informational,
             completion_handler=self.bool_completion_handler,
-            on_result=on_result,
         )
 
     def build_dialog(self):
@@ -111,19 +100,18 @@ class ConfirmDialog(NSAlertDialog):
 
 
 class ErrorDialog(NSAlertDialog):
-    def __init__(self, interface, title, message, on_result=None):
+    def __init__(self, interface, title, message):
         super().__init__(
             interface=interface,
             title=title,
             message=message,
             alert_style=NSAlertStyle.Critical,
             completion_handler=self.completion_handler,
-            on_result=on_result,
         )
 
 
 class StackTraceDialog(NSAlertDialog):
-    def __init__(self, interface, title, message, on_result=None, **kwargs):
+    def __init__(self, interface, title, message, **kwargs):
         if kwargs.get("retry"):
             completion_handler = self.bool_completion_handler
         else:
@@ -135,7 +123,6 @@ class StackTraceDialog(NSAlertDialog):
             message=message,
             alert_style=NSAlertStyle.Critical,
             completion_handler=completion_handler,
-            on_result=on_result,
             **kwargs,
         )
 
@@ -216,8 +203,7 @@ class FileDialog(BaseDialog):
         else:
             result = None
 
-        self.on_result(result)
-        self.interface.future.set_result(result)
+        self.interface.set_result(result)
 
     def multi_path_completion_handler(self, return_value: int) -> None:
         if return_value == NSModalResponseOK:
@@ -225,9 +211,7 @@ class FileDialog(BaseDialog):
         else:
             result = None
 
-        self.on_result(result)
-
-        self.interface.future.set_result(result)
+        self.interface.set_result(result)
 
 
 class SaveFileDialog(FileDialog):
@@ -247,7 +231,6 @@ class SaveFileDialog(FileDialog):
             initial_directory=initial_directory,
             file_types=None,  # File types aren't offered by Cocoa save panels.
             multiple_select=False,
-            on_result=on_result,
         )
 
     def create_panel(self, multiple_select):
@@ -271,7 +254,6 @@ class OpenFileDialog(FileDialog):
             initial_directory=initial_directory,
             file_types=file_types,
             multiple_select=multiple_select,
-            on_result=on_result,
         )
 
     def create_panel(self, multiple_select):
@@ -298,7 +280,6 @@ class SelectFolderDialog(FileDialog):
             initial_directory=initial_directory,
             file_types=None,
             multiple_select=multiple_select,
-            on_result=on_result,
         )
 
     def create_panel(self, multiple_select):

--- a/cocoa/src/toga_cocoa/widgets/webview.py
+++ b/cocoa/src/toga_cocoa/widgets/webview.py
@@ -7,19 +7,14 @@ from ..libs import NSURL, NSURLRequest, WKWebView
 from .base import Widget
 
 
-def js_completion_handler(future, on_result=None):
+def js_completion_handler(result):
     def _completion_handler(res: objc_id, error: objc_id) -> None:
         if error:
             error = py_from_ns(error)
             exc = RuntimeError(str(error))
-            future.set_exception(exc)
-            if on_result:
-                on_result(None, exception=exc)
+            result.set_exception(exc)
         else:
-            result = py_from_ns(res)
-            future.set_result(result)
-            if on_result:
-                on_result(result)
+            result.set_result(py_from_ns(res))
 
     return _completion_handler
 
@@ -84,13 +79,10 @@ class WebView(Widget):
         self.native.customUserAgent = value
 
     def evaluate_javascript(self, javascript: str, on_result=None) -> str:
-        result = JavaScriptResult()
+        result = JavaScriptResult(on_result=on_result)
         self.native.evaluateJavaScript(
             javascript,
-            completionHandler=js_completion_handler(
-                future=result.future,
-                on_result=on_result,
-            ),
+            completionHandler=js_completion_handler(result),
         )
 
         return result

--- a/core/src/toga/handlers.py
+++ b/core/src/toga/handlers.py
@@ -120,14 +120,14 @@ class AsyncResult(ABC):
     def set_result(self, result):
         if not self.future.cancelled():
             self.future.set_result(result)
-        if self.on_result:
-            self.on_result(result)
+            if self.on_result:
+                self.on_result(result)
 
     def set_exception(self, exc):
         if not self.future.cancelled():
             self.future.set_exception(exc)
-        if self.on_result:
-            self.on_result(None, exception=exc)
+            if self.on_result:
+                self.on_result(None, exception=exc)
 
     def __repr__(self):
         return f"<Async {self.RESULT_TYPE} result; future={self.future}>"

--- a/core/src/toga/handlers.py
+++ b/core/src/toga/handlers.py
@@ -112,9 +112,22 @@ def wrapped_handler(interface, handler, cleanup=None):
 
 
 class AsyncResult(ABC):
-    def __init__(self):
+    def __init__(self, on_result):
         loop = asyncio.get_event_loop()
         self.future = loop.create_future()
+        self.on_result = on_result
+
+    def set_result(self, result):
+        if not self.future.cancelled():
+            self.future.set_result(result)
+        if self.on_result:
+            self.on_result(result)
+
+    def set_exception(self, exc):
+        if not self.future.cancelled():
+            self.future.set_exception(exc)
+        if self.on_result:
+            self.on_result(None, exception=exc)
 
     def __repr__(self):
         return f"<Async {self.RESULT_TYPE} result; future={self.future}>"

--- a/core/src/toga/handlers.py
+++ b/core/src/toga/handlers.py
@@ -2,6 +2,7 @@ import asyncio
 import inspect
 import sys
 import traceback
+import warnings
 from abc import ABC
 
 
@@ -112,10 +113,25 @@ def wrapped_handler(interface, handler, cleanup=None):
 
 
 class AsyncResult(ABC):
-    def __init__(self, on_result):
+    def __init__(self, on_result=None):
         loop = asyncio.get_event_loop()
         self.future = loop.create_future()
-        self.on_result = on_result
+
+        ######################################################################
+        # 2023-12: Backwards compatibility
+        ######################################################################
+        if on_result:
+            warnings.warn(
+                "Synchronous `on_result` handlers have been deprecated; use `await` on the asynchronous result",
+                DeprecationWarning,
+            )
+
+            self.on_result = on_result
+        else:
+            self.on_result = None
+        ######################################################################
+        # End backwards compatibility.
+        ######################################################################
 
     def set_result(self, result):
         if not self.future.cancelled():

--- a/core/src/toga/widgets/webview.py
+++ b/core/src/toga/widgets/webview.py
@@ -126,13 +126,13 @@ class WebView(Widget):
     def evaluate_javascript(self, javascript, on_result=None) -> JavaScriptResult:
         """Evaluate a JavaScript expression.
 
-        There is no guarantee that the JavaScript has finished evaluating when this
-        method returns. The object returned by this method can be awaited to obtain the
-        value of the expression, or you can provide an ``on_result`` callback.
+        **This is an asynchronous method**. There is no guarantee that the JavaScript
+        has finished evaluating when this method returns. The object returned by this
+        method can be awaited to obtain the value of the expression.
 
-        **Note:** On Android and Windows, *no exception handling is performed*.
-        If a JavaScript error occurs, a return value of None will be reported,
-        but no exception will be provided.
+        **Note:** On Android and Windows, *no exception handling is performed*. If a
+        JavaScript error occurs, a return value of None will be reported, but no
+        exception will be provided.
 
         :param javascript: The JavaScript expression to evaluate.
         :param on_result: **DEPRECATED** ``await`` the return value of this method.

--- a/core/src/toga/widgets/webview.py
+++ b/core/src/toga/widgets/webview.py
@@ -135,12 +135,6 @@ class WebView(Widget):
         but no exception will be provided.
 
         :param javascript: The JavaScript expression to evaluate.
-        :param on_result: A callback that will be invoked when the JavaScript
-            completes. It should take one positional argument, which is the
-            value of the expression.
-
-            If evaluation fails, the positional argument will be ``None``, and a
-            keyword argument ``exception`` will be passed with an exception
-            object.
+        :param on_result: **DEPRECATED** ``await`` the return value of this method.
         """
         return self._impl.evaluate_javascript(javascript, on_result=on_result)

--- a/core/src/toga/window.py
+++ b/core/src/toga/window.py
@@ -52,8 +52,8 @@ class DialogResultHandler(Protocol[T]):
 class Dialog(AsyncResult):
     RESULT_TYPE = "dialog"
 
-    def __init__(self, window: Window):
-        super().__init__()
+    def __init__(self, window: Window, on_result: DialogResultHandler[Any]):
+        super().__init__(on_result=on_result)
         self.window = window
         self.app = window.app
 
@@ -360,10 +360,8 @@ class Window:
         :returns: An awaitable Dialog object. The Dialog object returns
             ``None`` when the user presses the 'OK' button.
         """
-        dialog = Dialog(self)
-        self.factory.dialogs.InfoDialog(
-            dialog, title, message, on_result=wrapped_handler(self, on_result)
-        )
+        dialog = Dialog(self, on_result=wrapped_handler(self, on_result))
+        self.factory.dialogs.InfoDialog(dialog, title, message)
         return dialog
 
     def question_dialog(
@@ -384,10 +382,8 @@ class Window:
             ``True`` when the "Yes" button is pressed, ``False`` when
             the "No" button is pressed.
         """
-        dialog = Dialog(self)
-        self.factory.dialogs.QuestionDialog(
-            dialog, title, message, on_result=wrapped_handler(self, on_result)
-        )
+        dialog = Dialog(self, on_result=wrapped_handler(self, on_result))
+        self.factory.dialogs.QuestionDialog(dialog, title, message)
         return dialog
 
     def confirm_dialog(
@@ -409,10 +405,8 @@ class Window:
             ``True`` when the "OK" button is pressed, ``False`` when
             the "Cancel" button is pressed.
         """
-        dialog = Dialog(self)
-        self.factory.dialogs.ConfirmDialog(
-            dialog, title, message, on_result=wrapped_handler(self, on_result)
-        )
+        dialog = Dialog(self, on_result=wrapped_handler(self, on_result))
+        self.factory.dialogs.ConfirmDialog(dialog, title, message)
         return dialog
 
     def error_dialog(
@@ -432,10 +426,8 @@ class Window:
         :returns: An awaitable Dialog object. The Dialog object returns
             ``None`` when the user presses the "OK" button.
         """
-        dialog = Dialog(self)
-        self.factory.dialogs.ErrorDialog(
-            dialog, title, message, on_result=wrapped_handler(self, on_result)
-        )
+        dialog = Dialog(self, on_result=wrapped_handler(self, on_result))
+        self.factory.dialogs.ErrorDialog(dialog, title, message)
         return dialog
 
     @overload
@@ -493,14 +485,13 @@ class Window:
             returns ``True`` when the user selects "Retry", and ``False`` when they
             select "Quit". If ``retry`` is false, the Dialog object returns ``None``.
         """
-        dialog = Dialog(self)
+        dialog = Dialog(self, on_result=wrapped_handler(self, on_result))
         self.factory.dialogs.StackTraceDialog(
             dialog,
             title,
             message=message,
             content=content,
             retry=retry,
-            on_result=wrapped_handler(self, on_result),
         )
         return dialog
 
@@ -525,7 +516,7 @@ class Window:
             for the selected file location, or ``None`` if the user cancelled the save
             operation.
         """
-        dialog = Dialog(self)
+        dialog = Dialog(self, on_result=wrapped_handler(self, on_result))
         # Convert suggested filename to a path (if it isn't already),
         # and break it into a filename and a directory
         suggested_path = Path(suggested_filename)
@@ -540,7 +531,6 @@ class Window:
             filename=filename,
             initial_directory=initial_directory,
             file_types=file_types,
-            on_result=wrapped_handler(self, on_result),
         )
         return dialog
 
@@ -622,14 +612,13 @@ class Window:
         # End Backwards compatibility
         ######################################################################
 
-        dialog = Dialog(self)
+        dialog = Dialog(self, on_result=wrapped_handler(self, on_result))
         self.factory.dialogs.OpenFileDialog(
             dialog,
             title,
             initial_directory=Path(initial_directory) if initial_directory else None,
             file_types=file_types,
             multiple_select=multiple_select,
-            on_result=wrapped_handler(self, on_result),
         )
         return dialog
 
@@ -706,13 +695,12 @@ class Window:
         # End Backwards compatibility
         ######################################################################
 
-        dialog = Dialog(self)
+        dialog = Dialog(self, on_result=wrapped_handler(self, on_result))
         self.factory.dialogs.SelectFolderDialog(
             dialog,
             title,
             initial_directory=Path(initial_directory) if initial_directory else None,
             multiple_select=multiple_select,
-            on_result=wrapped_handler(self, on_result),
         )
         return dialog
 

--- a/core/src/toga/window.py
+++ b/core/src/toga/window.py
@@ -353,11 +353,15 @@ class Window:
 
         Presents as a dialog with a single "OK" button to close the dialog.
 
+        **This is an asynchronous method**. If you invoke this method in synchronous
+        context, it will show the dialog, but will return *immediately*. The object
+        returned by this method can be awaited to obtain the result of the dialog.
+
         :param title: The title of the dialog window.
         :param message: The message to display.
         :param on_result: **DEPRECATED** ``await`` the return value of this method.
-        :returns: An awaitable Dialog object. The Dialog object returns
-            ``None`` when the user presses the 'OK' button.
+        :returns: An awaitable Dialog object. The Dialog object returns ``None`` when
+            the user presses the 'OK' button.
         """
         dialog = Dialog(
             self,
@@ -376,12 +380,15 @@ class Window:
 
         Presents as a dialog with "Yes" and "No" buttons.
 
+        **This is an asynchronous method**. If you invoke this method in synchronous
+        context, it will show the dialog, but will return *immediately*. The object
+        returned by this method can be awaited to obtain the result of the dialog.
+
         :param title: The title of the dialog window.
         :param message: The question to be answered.
         :param on_result: **DEPRECATED** ``await`` the return value of this method.
-        :returns: An awaitable Dialog object. The Dialog object returns
-            ``True`` when the "Yes" button is pressed, ``False`` when
-            the "No" button is pressed.
+        :returns: An awaitable Dialog object. The Dialog object returns ``True`` when
+            the "Yes" button is pressed, ``False`` when the "No" button is pressed.
         """
         dialog = Dialog(
             self,
@@ -398,15 +405,18 @@ class Window:
     ) -> Dialog:
         """Ask the user to confirm if they wish to proceed with an action.
 
-        Presents as a dialog with "Cancel" and "OK" buttons (or whatever labels
-        are appropriate on the current platform).
+        Presents as a dialog with "Cancel" and "OK" buttons (or whatever labels are
+        appropriate on the current platform).
+
+        **This is an asynchronous method**. If you invoke this method in synchronous
+        context, it will show the dialog, but will return *immediately*. The object
+        returned by this method can be awaited to obtain the result of the dialog.
 
         :param title: The title of the dialog window.
         :param message: A message describing the action to be confirmed.
         :param on_result: **DEPRECATED** ``await`` the return value of this method.
-        :returns: An awaitable Dialog object. The Dialog object returns
-            ``True`` when the "OK" button is pressed, ``False`` when
-            the "Cancel" button is pressed.
+        :returns: An awaitable Dialog object. The Dialog object returns ``True`` when
+            the "OK" button is pressed, ``False`` when the "Cancel" button is pressed.
         """
         dialog = Dialog(
             self,
@@ -425,11 +435,15 @@ class Window:
 
         Presents as an error dialog with a "OK" button to close the dialog.
 
+        **This is an asynchronous method**. If you invoke this method in synchronous
+        context, it will show the dialog, but will return *immediately*. The object
+        returned by this method can be awaited to obtain the result of the dialog.
+
         :param title: The title of the dialog window.
         :param message: The error message to display.
         :param on_result: **DEPRECATED** ``await`` the return value of this method.
-        :returns: An awaitable Dialog object. The Dialog object returns
-            ``None`` when the user presses the "OK" button.
+        :returns: An awaitable Dialog object. The Dialog object returns ``None`` when
+            the user presses the "OK" button.
         """
         dialog = Dialog(
             self,
@@ -481,12 +495,15 @@ class Window:
     ) -> Dialog:
         """Open a dialog to display a large block of text, such as a stack trace.
 
+        **This is an asynchronous method**. If you invoke this method in synchronous
+        context, it will show the dialog, but will return *immediately*. The object
+        returned by this method can be awaited to obtain the result of the dialog.
+
         :param title: The title of the dialog window.
         :param message: Contextual information about the source of the stack trace.
         :param content: The stack trace, pre-formatted as a multi-line string.
-        :param retry: If true, the user will be given options to "Retry" or
-            "Quit"; if false, a single option to acknowledge the error will
-            be displayed.
+        :param retry: If true, the user will be given options to "Retry" or "Quit"; if
+            false, a single option to acknowledge the error will be displayed.
         :param on_result: **DEPRECATED** ``await`` the return value of this method.
         :returns: An awaitable Dialog object. If ``retry`` is true, the Dialog object
             returns ``True`` when the user selects "Retry", and ``False`` when they
@@ -516,10 +533,14 @@ class Window:
 
         This dialog is not currently supported on Android or iOS.
 
+        **This is an asynchronous method**. If you invoke this method in synchronous
+        context, it will show the dialog, but will return *immediately*. The object
+        returned by this method can be awaited to obtain the result of the dialog.
+
         :param title: The title of the dialog window
         :param suggested_filename: A default filename
-        :param file_types: The allowed filename extensions, without leading dots. If
-            not provided, any extension will be allowed.
+        :param file_types: The allowed filename extensions, without leading dots. If not
+            provided, any extension will be allowed.
         :param on_result: **DEPRECATED** ``await`` the return value of this method.
         :returns: An awaitable Dialog object. The Dialog object returns a path object
             for the selected file location, or ``None`` if the user cancelled the save
@@ -595,20 +616,23 @@ class Window:
 
         This dialog is not currently supported on Android or iOS.
 
+        **This is an asynchronous method**. If you invoke this method in synchronous
+        context, it will show the dialog, but will return *immediately*. The object
+        returned by this method can be awaited to obtain the result of the dialog.
+
         :param title: The title of the dialog window
-        :param initial_directory: The initial folder in which to open the dialog.
-            If ``None``, use the default location provided by the operating system
-            (which will often be the last used location)
-        :param file_types: The allowed filename extensions, without leading dots. If
-            not provided, all files will be shown.
-        :param multiple_select: If True, the user will be able to select multiple
-            files; if False, the selection will be restricted to a single file.
+        :param initial_directory: The initial folder in which to open the dialog. If
+            ``None``, use the default location provided by the operating system (which
+            will often be the last used location)
+        :param file_types: The allowed filename extensions, without leading dots. If not
+            provided, all files will be shown.
+        :param multiple_select: If True, the user will be able to select multiple files;
+            if False, the selection will be restricted to a single file.
         :param on_result: **DEPRECATED** ``await`` the return value of this method.
         :param multiselect: **DEPRECATED** Use ``multiple_select``.
-        :returns: An awaitable Dialog object. The Dialog object returns
-            a list of ``Path`` objects if ``multiple_select`` is ``True``, or a single
-            ``Path`` otherwise. Returns ``None`` if the open operation is
-            cancelled by the user.
+        :returns: An awaitable Dialog object. The Dialog object returns a list of
+            ``Path`` objects if ``multiple_select`` is ``True``, or a single ``Path``
+            otherwise. Returns ``None`` if the open operation is cancelled by the user.
         """
         ######################################################################
         # 2023-08: Backwards compatibility
@@ -681,19 +705,22 @@ class Window:
 
         This dialog is not currently supported on Android or iOS.
 
+        **This is an asynchronous method**. If you invoke this method in synchronous
+        context, it will show the dialog, but will return *immediately*. The object
+        returned by this method can be awaited to obtain the result of the dialog.
+
         :param title: The title of the dialog window
-        :param initial_directory: The initial folder in which to open the dialog.
-            If ``None``, use the default location provided by the operating system
-            (which will often be "last used location")
+        :param initial_directory: The initial folder in which to open the dialog. If
+            ``None``, use the default location provided by the operating system (which
+            will often be "last used location")
         :param multiple_select: If True, the user will be able to select multiple
             directories; if False, the selection will be restricted to a single
             directory. This option is not supported on WinForms.
         :param on_result: **DEPRECATED** ``await`` the return value of this method.
         :param multiselect: **DEPRECATED** Use ``multiple_select``.
-        :returns: An awaitable Dialog object. The Dialog object returns
-            a list of ``Path`` objects if ``multiple_select`` is ``True``, or a single
-            ``Path`` otherwise. Returns ``None`` if the open operation is
-            cancelled by the user.
+        :returns: An awaitable Dialog object. The Dialog object returns a list of
+            ``Path`` objects if ``multiple_select`` is ``True``, or a single ``Path``
+            otherwise. Returns ``None`` if the open operation is cancelled by the user.
         """
         ######################################################################
         # 2023-08: Backwards compatibility

--- a/core/src/toga/window.py
+++ b/core/src/toga/window.py
@@ -355,8 +355,7 @@ class Window:
 
         :param title: The title of the dialog window.
         :param message: The message to display.
-        :param on_result: A callback that will be invoked when the user
-            selects an option on the dialog.
+        :param on_result: **DEPRECATED** ``await`` the return value of this method.
         :returns: An awaitable Dialog object. The Dialog object returns
             ``None`` when the user presses the 'OK' button.
         """
@@ -376,8 +375,7 @@ class Window:
 
         :param title: The title of the dialog window.
         :param message: The question to be answered.
-        :param on_result: A callback that will be invoked when the user
-            selects an option on the dialog.
+        :param on_result: **DEPRECATED** ``await`` the return value of this method.
         :returns: An awaitable Dialog object. The Dialog object returns
             ``True`` when the "Yes" button is pressed, ``False`` when
             the "No" button is pressed.
@@ -399,8 +397,7 @@ class Window:
 
         :param title: The title of the dialog window.
         :param message: A message describing the action to be confirmed.
-        :param on_result: A callback that will be invoked when the user
-            selects an option on the dialog.
+        :param on_result: **DEPRECATED** ``await`` the return value of this method.
         :returns: An awaitable Dialog object. The Dialog object returns
             ``True`` when the "OK" button is pressed, ``False`` when
             the "Cancel" button is pressed.
@@ -421,8 +418,7 @@ class Window:
 
         :param title: The title of the dialog window.
         :param message: The error message to display.
-        :param on_result: A callback that will be invoked when the user
-            selects an option on the dialog.
+        :param on_result: **DEPRECATED** ``await`` the return value of this method.
         :returns: An awaitable Dialog object. The Dialog object returns
             ``None`` when the user presses the "OK" button.
         """
@@ -479,8 +475,7 @@ class Window:
         :param retry: If true, the user will be given options to "Retry" or
             "Quit"; if false, a single option to acknowledge the error will
             be displayed.
-        :param on_result: A callback that will be invoked when the user
-            selects an option on the dialog.
+        :param on_result: **DEPRECATED** ``await`` the return value of this method.
         :returns: An awaitable Dialog object. If ``retry`` is true, the Dialog object
             returns ``True`` when the user selects "Retry", and ``False`` when they
             select "Quit". If ``retry`` is false, the Dialog object returns ``None``.
@@ -510,8 +505,7 @@ class Window:
         :param suggested_filename: A default filename
         :param file_types: The allowed filename extensions, without leading dots. If
             not provided, any extension will be allowed.
-        :param on_result: A callback that will be invoked when the user selects an
-            option on the dialog.
+        :param on_result: **DEPRECATED** ``await`` the return value of this method.
         :returns: An awaitable Dialog object. The Dialog object returns a path object
             for the selected file location, or ``None`` if the user cancelled the save
             operation.
@@ -591,8 +585,7 @@ class Window:
             not provided, all files will be shown.
         :param multiple_select: If True, the user will be able to select multiple
             files; if False, the selection will be restricted to a single file.
-        :param on_result: A callback that will be invoked when the user
-            selects an option on the dialog.
+        :param on_result: **DEPRECATED** ``await`` the return value of this method.
         :param multiselect: **DEPRECATED** Use ``multiple_select``.
         :returns: An awaitable Dialog object. The Dialog object returns
             a list of ``Path`` objects if ``multiple_select`` is ``True``, or a single
@@ -674,8 +667,7 @@ class Window:
         :param multiple_select: If True, the user will be able to select multiple
             directories; if False, the selection will be restricted to a single
             directory. This option is not supported on WinForms.
-        :param on_result: A callback that will be invoked when the user
-            selects an option on the dialog.
+        :param on_result: **DEPRECATED** ``await`` the return value of this method.
         :param multiselect: **DEPRECATED** Use ``multiple_select``.
         :returns: An awaitable Dialog object. The Dialog object returns
             a list of ``Path`` objects if ``multiple_select`` is ``True``, or a single

--- a/core/src/toga/window.py
+++ b/core/src/toga/window.py
@@ -359,7 +359,10 @@ class Window:
         :returns: An awaitable Dialog object. The Dialog object returns
             ``None`` when the user presses the 'OK' button.
         """
-        dialog = Dialog(self, on_result=wrapped_handler(self, on_result))
+        dialog = Dialog(
+            self,
+            on_result=wrapped_handler(self, on_result) if on_result else None,
+        )
         self.factory.dialogs.InfoDialog(dialog, title, message)
         return dialog
 
@@ -380,7 +383,10 @@ class Window:
             ``True`` when the "Yes" button is pressed, ``False`` when
             the "No" button is pressed.
         """
-        dialog = Dialog(self, on_result=wrapped_handler(self, on_result))
+        dialog = Dialog(
+            self,
+            on_result=wrapped_handler(self, on_result) if on_result else None,
+        )
         self.factory.dialogs.QuestionDialog(dialog, title, message)
         return dialog
 
@@ -402,7 +408,10 @@ class Window:
             ``True`` when the "OK" button is pressed, ``False`` when
             the "Cancel" button is pressed.
         """
-        dialog = Dialog(self, on_result=wrapped_handler(self, on_result))
+        dialog = Dialog(
+            self,
+            on_result=wrapped_handler(self, on_result) if on_result else None,
+        )
         self.factory.dialogs.ConfirmDialog(dialog, title, message)
         return dialog
 
@@ -422,7 +431,10 @@ class Window:
         :returns: An awaitable Dialog object. The Dialog object returns
             ``None`` when the user presses the "OK" button.
         """
-        dialog = Dialog(self, on_result=wrapped_handler(self, on_result))
+        dialog = Dialog(
+            self,
+            on_result=wrapped_handler(self, on_result) if on_result else None,
+        )
         self.factory.dialogs.ErrorDialog(dialog, title, message)
         return dialog
 
@@ -480,7 +492,10 @@ class Window:
             returns ``True`` when the user selects "Retry", and ``False`` when they
             select "Quit". If ``retry`` is false, the Dialog object returns ``None``.
         """
-        dialog = Dialog(self, on_result=wrapped_handler(self, on_result))
+        dialog = Dialog(
+            self,
+            on_result=wrapped_handler(self, on_result) if on_result else None,
+        )
         self.factory.dialogs.StackTraceDialog(
             dialog,
             title,
@@ -510,7 +525,10 @@ class Window:
             for the selected file location, or ``None`` if the user cancelled the save
             operation.
         """
-        dialog = Dialog(self, on_result=wrapped_handler(self, on_result))
+        dialog = Dialog(
+            self,
+            on_result=wrapped_handler(self, on_result) if on_result else None,
+        )
         # Convert suggested filename to a path (if it isn't already),
         # and break it into a filename and a directory
         suggested_path = Path(suggested_filename)
@@ -605,7 +623,10 @@ class Window:
         # End Backwards compatibility
         ######################################################################
 
-        dialog = Dialog(self, on_result=wrapped_handler(self, on_result))
+        dialog = Dialog(
+            self,
+            on_result=wrapped_handler(self, on_result) if on_result else None,
+        )
         self.factory.dialogs.OpenFileDialog(
             dialog,
             title,
@@ -687,7 +708,10 @@ class Window:
         # End Backwards compatibility
         ######################################################################
 
-        dialog = Dialog(self, on_result=wrapped_handler(self, on_result))
+        dialog = Dialog(
+            self,
+            on_result=wrapped_handler(self, on_result) if on_result else None,
+        )
         self.factory.dialogs.SelectFolderDialog(
             dialog,
             title,

--- a/core/tests/test_handlers.py
+++ b/core/tests/test_handlers.py
@@ -591,8 +591,8 @@ def test_async_result_cancelled(event_loop):
     with pytest.raises(asyncio.CancelledError):
         event_loop.run_until_complete(result.future)
 
-    # The answer was still passed to the callback
-    on_result.assert_called_once_with(42)
+    # The callback wasn't called
+    on_result.assert_not_called()
 
 
 def test_async_result_no_sync(event_loop):
@@ -641,10 +641,8 @@ def test_async_exception_cancelled(event_loop):
     with pytest.raises(asyncio.CancelledError):
         event_loop.run_until_complete(result.future)
 
-    # The answer was returned, and passed to the callback
-    on_result.assert_called_once()
-    assert on_result.call_args[0] == (None,)
-    assert isinstance(on_result.call_args[1]["exception"], ValueError)
+    # The callback wasn't called
+    on_result.assert_not_called()
 
 
 def test_async_exception_no_sync(event_loop):

--- a/core/tests/test_window.py
+++ b/core/tests/test_window.py
@@ -358,7 +358,12 @@ def test_as_image(window):
 def test_info_dialog(window, app):
     """An info dialog can be shown"""
     on_result_handler = Mock()
-    dialog = window.info_dialog("Title", "Body", on_result=on_result_handler)
+
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"Synchronous `on_result` handlers have been deprecated;",
+    ):
+        dialog = window.info_dialog("Title", "Body", on_result=on_result_handler)
 
     assert dialog.window == window
     assert dialog.app == app
@@ -372,9 +377,9 @@ def test_info_dialog(window, app):
 
     async def run_dialog(dialog):
         dialog._impl.simulate_result(None)
-        assert await dialog is None
+        return await dialog
 
-    app._impl.loop.run_until_complete(run_dialog(dialog))
+    assert app._impl.loop.run_until_complete(run_dialog(dialog)) is None
 
     assert_action_performed_with(
         window,
@@ -388,7 +393,12 @@ def test_info_dialog(window, app):
 def test_question_dialog(window, app):
     """A question dialog can be shown"""
     on_result_handler = Mock()
-    dialog = window.question_dialog("Title", "Body", on_result=on_result_handler)
+
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"Synchronous `on_result` handlers have been deprecated;",
+    ):
+        dialog = window.question_dialog("Title", "Body", on_result=on_result_handler)
 
     assert dialog.window == window
     assert dialog.app == app
@@ -402,9 +412,9 @@ def test_question_dialog(window, app):
 
     async def run_dialog(dialog):
         dialog._impl.simulate_result(True)
-        assert await dialog is True
+        return await dialog
 
-    app._impl.loop.run_until_complete(run_dialog(dialog))
+    assert app._impl.loop.run_until_complete(run_dialog(dialog))
 
     assert_action_performed_with(
         window,
@@ -418,7 +428,12 @@ def test_question_dialog(window, app):
 def test_confirm_dialog(window, app):
     """A confirm dialog can be shown"""
     on_result_handler = Mock()
-    dialog = window.confirm_dialog("Title", "Body", on_result=on_result_handler)
+
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"Synchronous `on_result` handlers have been deprecated;",
+    ):
+        dialog = window.confirm_dialog("Title", "Body", on_result=on_result_handler)
 
     assert dialog.window == window
     assert dialog.app == app
@@ -432,9 +447,9 @@ def test_confirm_dialog(window, app):
 
     async def run_dialog(dialog):
         dialog._impl.simulate_result(True)
-        assert await dialog is True
+        return await dialog
 
-    app._impl.loop.run_until_complete(run_dialog(dialog))
+    assert app._impl.loop.run_until_complete(run_dialog(dialog))
 
     assert_action_performed_with(
         window,
@@ -448,7 +463,12 @@ def test_confirm_dialog(window, app):
 def test_error_dialog(window, app):
     """An error dialog can be shown"""
     on_result_handler = Mock()
-    dialog = window.error_dialog("Title", "Body", on_result=on_result_handler)
+
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"Synchronous `on_result` handlers have been deprecated;",
+    ):
+        dialog = window.error_dialog("Title", "Body", on_result=on_result_handler)
 
     assert dialog.window == window
     assert dialog.app == app
@@ -462,9 +482,9 @@ def test_error_dialog(window, app):
 
     async def run_dialog(dialog):
         dialog._impl.simulate_result(None)
-        assert await dialog is None
+        return await dialog
 
-    app._impl.loop.run_until_complete(run_dialog(dialog))
+    assert app._impl.loop.run_until_complete(run_dialog(dialog)) is None
 
     assert_action_performed_with(
         window,
@@ -478,12 +498,17 @@ def test_error_dialog(window, app):
 def test_stack_trace_dialog(window, app):
     """A stack trace dialog can be shown"""
     on_result_handler = Mock()
-    dialog = window.stack_trace_dialog(
-        "Title",
-        "Body",
-        "The error",
-        on_result=on_result_handler,
-    )
+
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"Synchronous `on_result` handlers have been deprecated;",
+    ):
+        dialog = window.stack_trace_dialog(
+            "Title",
+            "Body",
+            "The error",
+            on_result=on_result_handler,
+        )
 
     assert dialog.window == window
     assert dialog.app == app
@@ -497,9 +522,9 @@ def test_stack_trace_dialog(window, app):
 
     async def run_dialog(dialog):
         dialog._impl.simulate_result(None)
-        assert await dialog is None
+        return await dialog
 
-    app._impl.loop.run_until_complete(run_dialog(dialog))
+    assert app._impl.loop.run_until_complete(run_dialog(dialog)) is None
 
     assert_action_performed_with(
         window,
@@ -515,11 +540,16 @@ def test_stack_trace_dialog(window, app):
 def test_save_file_dialog(window, app):
     """A save file dialog can be shown"""
     on_result_handler = Mock()
-    dialog = window.save_file_dialog(
-        "Title",
-        Path("/path/to/initial_file.txt"),
-        on_result=on_result_handler,
-    )
+
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"Synchronous `on_result` handlers have been deprecated;",
+    ):
+        dialog = window.save_file_dialog(
+            "Title",
+            Path("/path/to/initial_file.txt"),
+            on_result=on_result_handler,
+        )
 
     assert dialog.window == window
     assert dialog.app == app
@@ -535,9 +565,9 @@ def test_save_file_dialog(window, app):
 
     async def run_dialog(dialog):
         dialog._impl.simulate_result(saved_file)
-        assert await dialog is saved_file
+        return await dialog
 
-    app._impl.loop.run_until_complete(run_dialog(dialog))
+    assert app._impl.loop.run_until_complete(run_dialog(dialog)) is saved_file
 
     assert_action_performed_with(
         window,
@@ -553,12 +583,17 @@ def test_save_file_dialog(window, app):
 def test_save_file_dialog_default_directory(window, app):
     """If no path is provided, a save file dialog will use the default directory"""
     on_result_handler = Mock()
-    dialog = window.save_file_dialog(
-        "Title",
-        "initial_file.txt",
-        file_types=[".txt", ".pdf"],
-        on_result=on_result_handler,
-    )
+
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"Synchronous `on_result` handlers have been deprecated;",
+    ):
+        dialog = window.save_file_dialog(
+            "Title",
+            "initial_file.txt",
+            file_types=[".txt", ".pdf"],
+            on_result=on_result_handler,
+        )
 
     assert dialog.window == window
     assert dialog.app == app
@@ -574,9 +609,9 @@ def test_save_file_dialog_default_directory(window, app):
 
     async def run_dialog(dialog):
         dialog._impl.simulate_result(saved_file)
-        assert await dialog is saved_file
+        return await dialog
 
-    app._impl.loop.run_until_complete(run_dialog(dialog))
+    assert app._impl.loop.run_until_complete(run_dialog(dialog)) is saved_file
 
     assert_action_performed_with(
         window,
@@ -592,11 +627,16 @@ def test_save_file_dialog_default_directory(window, app):
 def test_open_file_dialog(window, app):
     """A open file dialog can be shown"""
     on_result_handler = Mock()
-    dialog = window.open_file_dialog(
-        "Title",
-        "/path/to/folder",
-        on_result=on_result_handler,
-    )
+
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"Synchronous `on_result` handlers have been deprecated;",
+    ):
+        dialog = window.open_file_dialog(
+            "Title",
+            "/path/to/folder",
+            on_result=on_result_handler,
+        )
 
     assert dialog.window == window
     assert dialog.app == app
@@ -612,9 +652,9 @@ def test_open_file_dialog(window, app):
 
     async def run_dialog(dialog):
         dialog._impl.simulate_result(opened_file)
-        assert await dialog is opened_file
+        return await dialog
 
-    app._impl.loop.run_until_complete(run_dialog(dialog))
+    assert app._impl.loop.run_until_complete(run_dialog(dialog)) is opened_file
 
     assert_action_performed_with(
         window,
@@ -630,12 +670,17 @@ def test_open_file_dialog(window, app):
 def test_open_file_dialog_default_directory(window, app):
     """If no path is provided, a open file dialog will use the default directory"""
     on_result_handler = Mock()
-    dialog = window.open_file_dialog(
-        "Title",
-        file_types=[".txt", ".pdf"],
-        multiple_select=True,
-        on_result=on_result_handler,
-    )
+
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"Synchronous `on_result` handlers have been deprecated;",
+    ):
+        dialog = window.open_file_dialog(
+            "Title",
+            file_types=[".txt", ".pdf"],
+            multiple_select=True,
+            on_result=on_result_handler,
+        )
 
     assert dialog.window == window
     assert dialog.app == app
@@ -654,9 +699,9 @@ def test_open_file_dialog_default_directory(window, app):
 
     async def run_dialog(dialog):
         dialog._impl.simulate_result(opened_files)
-        assert await dialog is opened_files
+        return await dialog
 
-    app._impl.loop.run_until_complete(run_dialog(dialog))
+    assert app._impl.loop.run_until_complete(run_dialog(dialog)) is opened_files
 
     assert_action_performed_with(
         window,
@@ -672,11 +717,16 @@ def test_open_file_dialog_default_directory(window, app):
 def test_select_folder_dialog(window, app):
     """A select folder dialog can be shown"""
     on_result_handler = Mock()
-    dialog = window.select_folder_dialog(
-        "Title",
-        Path("/path/to/folder"),
-        on_result=on_result_handler,
-    )
+
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"Synchronous `on_result` handlers have been deprecated;",
+    ):
+        dialog = window.select_folder_dialog(
+            "Title",
+            Path("/path/to/folder"),
+            on_result=on_result_handler,
+        )
 
     assert dialog.window == window
     assert dialog.app == app
@@ -692,9 +742,9 @@ def test_select_folder_dialog(window, app):
 
     async def run_dialog(dialog):
         dialog._impl.simulate_result(opened_file)
-        assert await dialog is opened_file
+        return await dialog
 
-    app._impl.loop.run_until_complete(run_dialog(dialog))
+    assert app._impl.loop.run_until_complete(run_dialog(dialog)) is opened_file
 
     assert_action_performed_with(
         window,
@@ -709,11 +759,16 @@ def test_select_folder_dialog(window, app):
 def test_select_folder_dialog_default_directory(window, app):
     """If no path is provided, a select folder dialog will use the default directory"""
     on_result_handler = Mock()
-    dialog = window.select_folder_dialog(
-        "Title",
-        multiple_select=True,
-        on_result=on_result_handler,
-    )
+
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"Synchronous `on_result` handlers have been deprecated;",
+    ):
+        dialog = window.select_folder_dialog(
+            "Title",
+            multiple_select=True,
+            on_result=on_result_handler,
+        )
 
     assert dialog.window == window
     assert dialog.app == app
@@ -732,9 +787,9 @@ def test_select_folder_dialog_default_directory(window, app):
 
     async def run_dialog(dialog):
         dialog._impl.simulate_result(opened_files)
-        assert await dialog is opened_files
+        return await dialog
 
-    app._impl.loop.run_until_complete(run_dialog(dialog))
+    assert app._impl.loop.run_until_complete(run_dialog(dialog)) is opened_files
 
     assert_action_performed_with(
         window,
@@ -749,6 +804,7 @@ def test_select_folder_dialog_default_directory(window, app):
 def test_deprecated_names_open_file_dialog(window, app):
     """Deprecated names still work on open file dialogs."""
     on_result_handler = Mock()
+
     with pytest.warns(
         DeprecationWarning,
         match=r"open_file_dialog\(multiselect\) has been renamed multiple_select",
@@ -762,7 +818,11 @@ def test_deprecated_names_open_file_dialog(window, app):
 
     opened_files = [Path("/opened/path/filename.txt")]
 
-    dialog._impl.simulate_result(opened_files)
+    async def run_dialog(dialog):
+        dialog._impl.simulate_result(opened_files)
+        return await dialog
+
+    assert app._impl.loop.run_until_complete(run_dialog(dialog)) is opened_files
 
     assert_action_performed_with(
         window,
@@ -778,6 +838,7 @@ def test_deprecated_names_open_file_dialog(window, app):
 def test_deprecated_names_select_folder_dialog(window, app):
     """Deprecated names still work on open file dialogs."""
     on_result_handler = Mock()
+
     with pytest.warns(
         DeprecationWarning,
         match=r"select_folder_dialog\(multiselect\) has been renamed multiple_select",
@@ -791,7 +852,11 @@ def test_deprecated_names_select_folder_dialog(window, app):
 
     opened_files = [Path("/opened/path")]
 
-    dialog._impl.simulate_result(opened_files)
+    async def run_dialog(dialog):
+        dialog._impl.simulate_result(opened_files)
+        return await dialog
+
+    assert app._impl.loop.run_until_complete(run_dialog(dialog)) is opened_files
 
     assert_action_performed_with(
         window,

--- a/dummy/src/toga_dummy/dialogs.py
+++ b/dummy/src/toga_dummy/dialogs.py
@@ -1,17 +1,15 @@
 class BaseDialog:
-    def __init__(self, interface, on_result):
+    def __init__(self, interface):
         self.interface = interface
         self.interface._impl = self
-        self.on_result = on_result
 
     def simulate_result(self, result):
-        self.on_result(result)
-        self.interface.future.set_result(result)
+        self.interface.set_result(result)
 
 
 class InfoDialog(BaseDialog):
-    def __init__(self, interface, title, message, on_result=None):
-        super().__init__(interface, on_result=on_result)
+    def __init__(self, interface, title, message):
+        super().__init__(interface)
         interface.window._impl._action(
             "show info dialog",
             title=title,
@@ -20,8 +18,8 @@ class InfoDialog(BaseDialog):
 
 
 class QuestionDialog(BaseDialog):
-    def __init__(self, interface, title, message, on_result=None):
-        super().__init__(interface, on_result=on_result)
+    def __init__(self, interface, title, message):
+        super().__init__(interface)
         interface.window._impl._action(
             "show question dialog",
             title=title,
@@ -30,8 +28,8 @@ class QuestionDialog(BaseDialog):
 
 
 class ConfirmDialog(BaseDialog):
-    def __init__(self, interface, title, message, on_result=None):
-        super().__init__(interface, on_result=on_result)
+    def __init__(self, interface, title, message):
+        super().__init__(interface)
         interface.window._impl._action(
             "show confirm dialog",
             title=title,
@@ -40,8 +38,8 @@ class ConfirmDialog(BaseDialog):
 
 
 class ErrorDialog(BaseDialog):
-    def __init__(self, interface, title, message, on_result=None):
-        super().__init__(interface, on_result=on_result)
+    def __init__(self, interface, title, message):
+        super().__init__(interface)
         interface.window._impl._action(
             "show error dialog",
             title=title,
@@ -50,8 +48,8 @@ class ErrorDialog(BaseDialog):
 
 
 class StackTraceDialog(BaseDialog):
-    def __init__(self, interface, title, message, content, retry, on_result=None):
-        super().__init__(interface, on_result=on_result)
+    def __init__(self, interface, title, message, content, retry):
+        super().__init__(interface)
         interface.window._impl._action(
             "show stack trace dialog",
             title=title,
@@ -71,7 +69,7 @@ class SaveFileDialog(BaseDialog):
         file_types=None,
         on_result=None,
     ):
-        super().__init__(interface, on_result=on_result)
+        super().__init__(interface)
         interface.window._impl._action(
             "show save file dialog",
             title=title,
@@ -91,7 +89,7 @@ class OpenFileDialog(BaseDialog):
         multiple_select,
         on_result=None,
     ):
-        super().__init__(interface, on_result=on_result)
+        super().__init__(interface)
         interface.window._impl._action(
             "show open file dialog",
             title=title,
@@ -110,7 +108,7 @@ class SelectFolderDialog(BaseDialog):
         multiple_select,
         on_result=None,
     ):
-        super().__init__(interface, on_result=on_result)
+        super().__init__(interface)
         interface.window._impl._action(
             "show select folder dialog",
             title=title,

--- a/dummy/src/toga_dummy/widgets/webview.py
+++ b/dummy/src/toga_dummy/widgets/webview.py
@@ -26,7 +26,7 @@ class WebView(Widget):
 
     def evaluate_javascript(self, javascript, on_result=None):
         self._action("evaluate_javascript", javascript=javascript)
-        self._js_result = JavaScriptResult()
+        self._js_result = JavaScriptResult(on_result)
         return self._js_result
 
     def simulate_page_loaded(self):

--- a/dummy/src/toga_dummy/widgets/webview.py
+++ b/dummy/src/toga_dummy/widgets/webview.py
@@ -38,4 +38,4 @@ class WebView(Widget):
             self._set_value("loaded_future", None)
 
     def simulate_javascript_result(self, value):
-        self._js_result.future.set_result(42)
+        self._js_result.set_result(42)

--- a/gtk/src/toga_gtk/dialogs.py
+++ b/gtk/src/toga_gtk/dialogs.py
@@ -18,11 +18,9 @@ class MessageDialog(BaseDialog):
         message_type,
         buttons,
         success_result=None,
-        on_result=None,
         **kwargs,
     ):
         super().__init__(interface=interface)
-        self.on_result = on_result
         self.success_result = success_result
 
         self.native = Gtk.MessageDialog(
@@ -46,26 +44,24 @@ class MessageDialog(BaseDialog):
         else:
             result = None
 
-        self.on_result(result)
-        self.interface.future.set_result(result)
+        self.interface.set_result(result)
 
         self.native.destroy()
 
 
 class InfoDialog(MessageDialog):
-    def __init__(self, interface, title, message, on_result=None):
+    def __init__(self, interface, title, message):
         super().__init__(
             interface=interface,
             title=title,
             message=message,
             message_type=Gtk.MessageType.INFO,
             buttons=Gtk.ButtonsType.OK,
-            on_result=on_result,
         )
 
 
 class QuestionDialog(MessageDialog):
-    def __init__(self, interface, title, message, on_result=None):
+    def __init__(self, interface, title, message):
         super().__init__(
             interface=interface,
             title=title,
@@ -73,12 +69,11 @@ class QuestionDialog(MessageDialog):
             message_type=Gtk.MessageType.QUESTION,
             buttons=Gtk.ButtonsType.YES_NO,
             success_result=Gtk.ResponseType.YES,
-            on_result=on_result,
         )
 
 
 class ConfirmDialog(MessageDialog):
-    def __init__(self, interface, title, message, on_result=None):
+    def __init__(self, interface, title, message):
         super().__init__(
             interface=interface,
             title=title,
@@ -86,24 +81,22 @@ class ConfirmDialog(MessageDialog):
             message_type=Gtk.MessageType.WARNING,
             buttons=Gtk.ButtonsType.OK_CANCEL,
             success_result=Gtk.ResponseType.OK,
-            on_result=on_result,
         )
 
 
 class ErrorDialog(MessageDialog):
-    def __init__(self, interface, title, message, on_result=None):
+    def __init__(self, interface, title, message):
         super().__init__(
             interface=interface,
             title=title,
             message=message,
             message_type=Gtk.MessageType.ERROR,
             buttons=Gtk.ButtonsType.CANCEL,
-            on_result=on_result,
         )
 
 
 class StackTraceDialog(MessageDialog):
-    def __init__(self, interface, title, on_result=None, **kwargs):
+    def __init__(self, interface, title, **kwargs):
         super().__init__(
             interface=interface,
             title=title,
@@ -112,7 +105,6 @@ class StackTraceDialog(MessageDialog):
                 Gtk.ButtonsType.CANCEL if kwargs.get("retry") else Gtk.ButtonsType.OK
             ),
             success_result=Gtk.ResponseType.OK if kwargs.get("retry") else None,
-            on_result=on_result,
             **kwargs,
         )
 
@@ -168,10 +160,8 @@ class FileDialog(BaseDialog):
         multiple_select,
         action,
         ok_icon,
-        on_result=None,
     ):
         super().__init__(interface=interface)
-        self.on_result = on_result
 
         self.native = Gtk.FileChooserDialog(
             transient_for=interface.window._impl.native,
@@ -218,8 +208,7 @@ class FileDialog(BaseDialog):
         else:
             result = None
 
-        self.on_result(result)
-        self.interface.future.set_result(result)
+        self.interface.set_result(result)
 
         self.native.destroy()
 
@@ -232,7 +221,6 @@ class SaveFileDialog(FileDialog):
         filename,
         initial_directory,
         file_types=None,
-        on_result=None,
     ):
         super().__init__(
             interface=interface,
@@ -243,7 +231,6 @@ class SaveFileDialog(FileDialog):
             multiple_select=False,
             action=Gtk.FileChooserAction.SAVE,
             ok_icon=Gtk.STOCK_SAVE,
-            on_result=on_result,
         )
 
 
@@ -255,7 +242,6 @@ class OpenFileDialog(FileDialog):
         initial_directory,
         file_types,
         multiple_select,
-        on_result=None,
     ):
         super().__init__(
             interface=interface,
@@ -266,7 +252,6 @@ class OpenFileDialog(FileDialog):
             multiple_select=multiple_select,
             action=Gtk.FileChooserAction.OPEN,
             ok_icon=Gtk.STOCK_OPEN,
-            on_result=on_result,
         )
 
 
@@ -277,7 +262,6 @@ class SelectFolderDialog(FileDialog):
         title,
         initial_directory,
         multiple_select,
-        on_result=None,
     ):
         super().__init__(
             interface=interface,
@@ -288,5 +272,4 @@ class SelectFolderDialog(FileDialog):
             multiple_select=multiple_select,
             action=Gtk.FileChooserAction.SELECT_FOLDER,
             ok_icon=Gtk.STOCK_OPEN,
-            on_result=on_result,
         )

--- a/gtk/src/toga_gtk/widgets/webview.py
+++ b/gtk/src/toga_gtk/widgets/webview.py
@@ -75,7 +75,7 @@ class WebView(Widget):
 
     def evaluate_javascript(self, javascript, on_result=None):
         # Construct a future on the event loop
-        result = JavaScriptResult()
+        result = JavaScriptResult(on_result)
 
         # Define a callback that will update the future when
         # the Javascript is complete.
@@ -91,14 +91,10 @@ class WebView(Widget):
                 else:
                     value = value.to_string()
 
-                result.future.set_result(value)
-                if on_result:
-                    on_result(value)
+                result.set_result(value)
             except Exception as e:
                 exc = RuntimeError(str(e))
-                result.future.set_exception(exc)
-                if on_result:
-                    on_result(None, exception=exc)
+                result.set_exception(exc)
 
         # Invoke the javascript method, with a callback that will set
         # the future when a result is available.

--- a/iOS/src/toga_iOS/dialogs.py
+++ b/iOS/src/toga_iOS/dialogs.py
@@ -17,9 +17,8 @@ class BaseDialog(ABC):
 
 
 class AlertDialog(BaseDialog):
-    def __init__(self, interface, title, message, on_result=None):
+    def __init__(self, interface, title, message):
         super().__init__(interface=interface)
-        self.on_result = on_result
 
         self.native = UIAlertController.alertControllerWithTitle(
             title, message=message, preferredStyle=UIAlertControllerStyle.Alert
@@ -38,8 +37,7 @@ class AlertDialog(BaseDialog):
         ...
 
     def response(self, value):
-        self.on_result(value)
-        self.interface.future.set_result(value)
+        self.interface.set_result(value)
 
     def null_response(self, action: objc_id) -> None:
         self.response(None)
@@ -79,16 +77,16 @@ class AlertDialog(BaseDialog):
 
 
 class InfoDialog(AlertDialog):
-    def __init__(self, interface, title, message, on_result=None):
-        super().__init__(interface, title, message, on_result=on_result)
+    def __init__(self, interface, title, message):
+        super().__init__(interface, title, message)
 
     def populate_dialog(self):
         self.add_null_response_button("OK")
 
 
 class QuestionDialog(AlertDialog):
-    def __init__(self, interface, title, message, on_result=None):
-        super().__init__(interface, title, message, on_result=on_result)
+    def __init__(self, interface, title, message):
+        super().__init__(interface, title, message)
 
     def populate_dialog(self):
         self.add_true_response_button("Yes")
@@ -96,8 +94,8 @@ class QuestionDialog(AlertDialog):
 
 
 class ConfirmDialog(AlertDialog):
-    def __init__(self, interface, title, message, on_result=None):
-        super().__init__(interface, title, message, on_result=on_result)
+    def __init__(self, interface, title, message):
+        super().__init__(interface, title, message)
 
     def populate_dialog(self):
         self.add_true_response_button("OK")
@@ -105,15 +103,15 @@ class ConfirmDialog(AlertDialog):
 
 
 class ErrorDialog(AlertDialog):
-    def __init__(self, interface, title, message, on_result=None):
-        super().__init__(interface, title, message, on_result=on_result)
+    def __init__(self, interface, title, message):
+        super().__init__(interface, title, message)
 
     def populate_dialog(self):
         self.add_null_response_button("OK")
 
 
 class StackTraceDialog(BaseDialog):
-    def __init__(self, interface, title, message, on_result=None, **kwargs):
+    def __init__(self, interface, title, message, **kwargs):
         super().__init__(interface=interface)
         interface.window.factory.not_implemented("Window.stack_trace_dialog()")
 
@@ -126,7 +124,6 @@ class SaveFileDialog(BaseDialog):
         filename,
         initial_directory,
         file_types=None,
-        on_result=None,
     ):
         super().__init__(interface=interface)
         interface.window.factory.not_implemented("Window.save_file_dialog()")
@@ -140,7 +137,6 @@ class OpenFileDialog(BaseDialog):
         initial_directory,
         file_types,
         multiple_select,
-        on_result=None,
     ):
         super().__init__(interface=interface)
         interface.window.factory.not_implemented("Window.open_file_dialog()")
@@ -153,7 +149,6 @@ class SelectFolderDialog(BaseDialog):
         title,
         initial_directory,
         multiple_select,
-        on_result=None,
     ):
         super().__init__(interface=interface)
         interface.window.factory.not_implemented("Window.select_folder_dialog()")

--- a/iOS/src/toga_iOS/widgets/webview.py
+++ b/iOS/src/toga_iOS/widgets/webview.py
@@ -6,19 +6,14 @@ from toga_iOS.libs import NSURL, NSURLRequest, WKWebView
 from toga_iOS.widgets.base import Widget
 
 
-def js_completion_handler(future, on_result=None):
+def js_completion_handler(result):
     def _completion_handler(res: objc_id, error: objc_id) -> None:
         if error:
             error = py_from_ns(error)
             exc = RuntimeError(str(error))
-            future.set_exception(exc)
-            if on_result:
-                on_result(None, exception=exc)
+            result.set_exception(exc)
         else:
-            result = py_from_ns(res)
-            future.set_result(result)
-            if on_result:
-                on_result(result)
+            result.set_result(py_from_ns(res))
 
     return _completion_handler
 
@@ -75,13 +70,10 @@ class WebView(Widget):
         self.native.customUserAgent = value
 
     def evaluate_javascript(self, javascript, on_result=None):
-        result = JavaScriptResult()
+        result = JavaScriptResult(on_result)
         self.native.evaluateJavaScript(
             javascript,
-            completionHandler=js_completion_handler(
-                future=result.future,
-                on_result=on_result,
-            ),
+            completionHandler=js_completion_handler(result),
         )
 
         return result

--- a/testbed/tests/test_window.py
+++ b/testbed/tests/test_window.py
@@ -508,9 +508,13 @@ async def assert_dialog_result(window, dialog, on_result, expected):
 async def test_info_dialog(main_window, main_window_probe):
     """An info dialog can be displayed and acknowledged."""
     on_result_handler = Mock()
-    dialog_result = main_window.info_dialog(
-        "Info", "Some info", on_result=on_result_handler
-    )
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"Synchronous `on_result` handlers have been deprecated;",
+    ):
+        dialog_result = main_window.info_dialog(
+            "Info", "Some info", on_result=on_result_handler
+        )
     await main_window_probe.redraw("Info dialog displayed")
     await main_window_probe.close_info_dialog(dialog_result._impl)
     await assert_dialog_result(main_window, dialog_result, on_result_handler, None)
@@ -520,11 +524,15 @@ async def test_info_dialog(main_window, main_window_probe):
 async def test_question_dialog(main_window, main_window_probe, result):
     """An question dialog can be displayed and acknowledged."""
     on_result_handler = Mock()
-    dialog_result = main_window.question_dialog(
-        "Question",
-        "Some question",
-        on_result=on_result_handler,
-    )
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"Synchronous `on_result` handlers have been deprecated;",
+    ):
+        dialog_result = main_window.question_dialog(
+            "Question",
+            "Some question",
+            on_result=on_result_handler,
+        )
     await main_window_probe.redraw("Question dialog displayed")
     await main_window_probe.close_question_dialog(dialog_result._impl, result)
     await assert_dialog_result(main_window, dialog_result, on_result_handler, result)
@@ -534,11 +542,15 @@ async def test_question_dialog(main_window, main_window_probe, result):
 async def test_confirm_dialog(main_window, main_window_probe, result):
     """A confirmation dialog can be displayed and acknowledged."""
     on_result_handler = Mock()
-    dialog_result = main_window.confirm_dialog(
-        "Confirm",
-        "Some confirmation",
-        on_result=on_result_handler,
-    )
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"Synchronous `on_result` handlers have been deprecated;",
+    ):
+        dialog_result = main_window.confirm_dialog(
+            "Confirm",
+            "Some confirmation",
+            on_result=on_result_handler,
+        )
     await main_window_probe.redraw("Confirmation dialog displayed")
     await main_window_probe.close_confirm_dialog(dialog_result._impl, result)
     await assert_dialog_result(main_window, dialog_result, on_result_handler, result)
@@ -547,9 +559,13 @@ async def test_confirm_dialog(main_window, main_window_probe, result):
 async def test_error_dialog(main_window, main_window_probe):
     """An error dialog can be displayed and acknowledged."""
     on_result_handler = Mock()
-    dialog_result = main_window.error_dialog(
-        "Error", "Some error", on_result=on_result_handler
-    )
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"Synchronous `on_result` handlers have been deprecated;",
+    ):
+        dialog_result = main_window.error_dialog(
+            "Error", "Some error", on_result=on_result_handler
+        )
     await main_window_probe.redraw("Error dialog displayed")
     await main_window_probe.close_error_dialog(dialog_result._impl)
     await assert_dialog_result(main_window, dialog_result, on_result_handler, None)
@@ -561,13 +577,17 @@ async def test_stack_trace_dialog(main_window, main_window_probe, result):
     on_result_handler = Mock()
     stack = io.StringIO()
     traceback.print_stack(file=stack)
-    dialog_result = main_window.stack_trace_dialog(
-        "Stack Trace",
-        "Some stack trace",
-        stack.getvalue(),
-        retry=result is not None,
-        on_result=on_result_handler,
-    )
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"Synchronous `on_result` handlers have been deprecated;",
+    ):
+        dialog_result = main_window.stack_trace_dialog(
+            "Stack Trace",
+            "Some stack trace",
+            stack.getvalue(),
+            retry=result is not None,
+            on_result=on_result_handler,
+        )
     await main_window_probe.redraw(
         f"Stack trace dialog (with{'out' if result is None else ''} retry) displayed"
     )
@@ -593,12 +613,16 @@ async def test_save_file_dialog(
 ):
     """A file open dialog can be displayed and acknowledged."""
     on_result_handler = Mock()
-    dialog_result = main_window.save_file_dialog(
-        "Save file",
-        suggested_filename=filename,
-        file_types=file_types,
-        on_result=on_result_handler,
-    )
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"Synchronous `on_result` handlers have been deprecated;",
+    ):
+        dialog_result = main_window.save_file_dialog(
+            "Save file",
+            suggested_filename=filename,
+            file_types=file_types,
+            on_result=on_result_handler,
+        )
     await main_window_probe.redraw("Save File dialog displayed")
     await main_window_probe.close_save_file_dialog(dialog_result._impl, result)
 
@@ -655,13 +679,17 @@ async def test_open_file_dialog(
 ):
     """A file open dialog can be displayed and acknowledged."""
     on_result_handler = Mock()
-    dialog_result = main_window.open_file_dialog(
-        "Open file",
-        initial_directory=initial_directory,
-        file_types=file_types,
-        multiple_select=multiple_select,
-        on_result=on_result_handler,
-    )
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"Synchronous `on_result` handlers have been deprecated;",
+    ):
+        dialog_result = main_window.open_file_dialog(
+            "Open file",
+            initial_directory=initial_directory,
+            file_types=file_types,
+            multiple_select=multiple_select,
+            on_result=on_result_handler,
+        )
     await main_window_probe.redraw("Open File dialog displayed")
     await main_window_probe.close_open_file_dialog(
         dialog_result._impl, result, multiple_select
@@ -695,12 +723,16 @@ async def test_select_folder_dialog(
 ):
     """A folder selection dialog can be displayed and acknowledged."""
     on_result_handler = Mock()
-    dialog_result = main_window.select_folder_dialog(
-        "Select folder",
-        initial_directory=initial_directory,
-        multiple_select=multiple_select,
-        on_result=on_result_handler,
-    )
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"Synchronous `on_result` handlers have been deprecated;",
+    ):
+        dialog_result = main_window.select_folder_dialog(
+            "Select folder",
+            initial_directory=initial_directory,
+            multiple_select=multiple_select,
+            on_result=on_result_handler,
+        )
     await main_window_probe.redraw("Select Folder dialog displayed")
     await main_window_probe.close_select_folder_dialog(
         dialog_result._impl, result, multiple_select

--- a/testbed/tests/testbed.py
+++ b/testbed/tests/testbed.py
@@ -34,6 +34,9 @@ def run_tests(app, cov, args, report_coverage, run_slow):
                 "--no-header",
                 "--tb=native",
                 "--color=no",
+                # Convert all warnings into errors
+                "-W",
+                "error",
                 # Run all async tests and fixtures using pytest-asyncio.
                 "--asyncio-mode=auto",
                 # Override the cache directory to be somewhere known writable

--- a/testbed/tests/widgets/test_webview.py
+++ b/testbed/tests/widgets/test_webview.py
@@ -223,10 +223,14 @@ async def test_evaluate_javascript(widget, probe):
         # reset the mock for each pass
         on_result_handler.reset_mock()
 
-        result = await wait_for(
-            widget.evaluate_javascript(expression, on_result=on_result_handler),
-            JS_TIMEOUT,
-        )
+        with pytest.warns(
+            DeprecationWarning,
+            match=r"Synchronous `on_result` handlers have been deprecated;",
+        ):
+            result = await wait_for(
+                widget.evaluate_javascript(expression, on_result=on_result_handler),
+                JS_TIMEOUT,
+            )
 
         # The resulting value has been converted into Python
         assert result == expected
@@ -257,10 +261,14 @@ async def test_evaluate_javascript_error(widget, probe):
     on_result_handler = Mock()
 
     with javascript_error_context(probe):
-        result = await wait_for(
-            widget.evaluate_javascript("not valid js", on_result=on_result_handler),
-            JS_TIMEOUT,
-        )
+        with pytest.warns(
+            DeprecationWarning,
+            match=r"Synchronous `on_result` handlers have been deprecated;",
+        ):
+            result = await wait_for(
+                widget.evaluate_javascript("not valid js", on_result=on_result_handler),
+                JS_TIMEOUT,
+            )
         # If the backend supports exceptions, the previous line should have raised one.
         assert not probe.javascript_supports_exception
         assert result is None

--- a/textual/src/toga_textual/dialogs.py
+++ b/textual/src/toga_textual/dialogs.py
@@ -49,10 +49,9 @@ class TextualDialog(ModalScreen[bool]):
 
 
 class BaseDialog(ABC):
-    def __init__(self, interface, title, message, on_result):
+    def __init__(self, interface, title, message):
         self.interface = interface
         self.interface._impl = self
-        self.on_result = on_result
         self.title = title
         self.message = message
 
@@ -75,8 +74,7 @@ class BaseDialog(ABC):
         self.native.dismiss(None)
 
     def on_close(self, result: bool):
-        self.on_result(self, result)
-        self.interface.future.set_result(result)
+        self.interface.set_result(result)
 
 
 class InfoDialog(BaseDialog):
@@ -121,7 +119,6 @@ class StackTraceDialog(BaseDialog):
         interface,
         title,
         message,
-        on_result=None,
         retry=False,
         content="",
     ):
@@ -129,7 +126,6 @@ class StackTraceDialog(BaseDialog):
             interface=interface,
             title=title,
             message=message,
-            on_result=on_result,
         )
         self.retry = retry
         self.content = content
@@ -229,13 +225,11 @@ class SaveFileDialog(BaseDialog):
         filename,
         initial_directory,
         file_types=None,
-        on_result=None,
     ):
         super().__init__(
             interface=interface,
             title=title,
             message=None,
-            on_result=on_result,
         )
         self.initial_filename = filename
         self.initial_directory = initial_directory if initial_directory else Path.cwd()
@@ -299,13 +293,11 @@ class OpenFileDialog(BaseDialog):
         initial_directory,
         file_types,
         multiselect,
-        on_result=None,
     ):
         super().__init__(
             interface=interface,
             title=title,
             message=None,
-            on_result=on_result,
         )
 
         self.initial_directory = initial_directory if initial_directory else Path.cwd()
@@ -360,13 +352,11 @@ class SelectFolderDialog(BaseDialog):
         title,
         initial_directory,
         multiselect,
-        on_result=None,
     ):
         super().__init__(
             interface=interface,
             title=title,
             message=None,
-            on_result=on_result,
         )
         self.initial_directory = initial_directory if initial_directory else Path.cwd()
         self.filter_func = lambda path: path.is_dir()

--- a/web/src/toga_web/dialogs.py
+++ b/web/src/toga_web/dialogs.py
@@ -10,7 +10,7 @@ class BaseDialog(ABC):
 
 
 class InfoDialog(BaseDialog):
-    def __init__(self, interface, title, message, on_result=None):
+    def __init__(self, interface, title, message):
         super().__init__(interface=interface)
         self.native = create_element(
             "sl-dialog",
@@ -21,7 +21,6 @@ class InfoDialog(BaseDialog):
             ]
             + self.create_buttons(),
         )
-        self.on_result = on_result
 
         # Add the dialog to the DOM.
         interface.window.app._impl.native.appendChild(self.native)
@@ -41,52 +40,43 @@ class InfoDialog(BaseDialog):
         self.native.hide()
         self.native.parentElement.removeChild(self.native)
 
-        self.on_result(None)
-        self.interface.future.set_result(None)
+        self.interface.set_result(None)
 
 
 class QuestionDialog(BaseDialog):
-    def __init__(self, interface, title, message, on_result=None):
+    def __init__(self, interface, title, message):
         super().__init__(interface=interface)
-        self.on_result = on_result
 
         interface.window.factory.not_implemented("Window.question_dialog()")
 
-        self.on_result(None)
-        self.interface.future.set_result(None)
+        self.interface.set_result(None)
 
 
 class ConfirmDialog(BaseDialog):
-    def __init__(self, interface, title, message, on_result=None):
+    def __init__(self, interface, title, message):
         super().__init__(interface=interface)
-        self.on_result = on_result
 
         interface.window.factory.not_implemented("Window.confirm_dialog()")
 
-        self.on_result(None)
-        self.interface.future.set_result(None)
+        self.interface.set_result(None)
 
 
 class ErrorDialog(BaseDialog):
-    def __init__(self, interface, title, message, on_result=None):
+    def __init__(self, interface, title, message):
         super().__init__(interface=interface)
-        self.on_result = on_result
 
         interface.window.factory.not_implemented("Window.error_dialog()")
 
-        self.on_result(None)
-        self.interface.future.set_result(None)
+        self.interface.set_result(None)
 
 
 class StackTraceDialog(BaseDialog):
-    def __init__(self, interface, title, message, on_result=None, **kwargs):
+    def __init__(self, interface, title, message, **kwargs):
         super().__init__(interface=interface)
-        self.on_result = on_result
 
         interface.window.factory.not_implemented("Window.stack_trace_dialog()")
 
-        self.on_result(None)
-        self.interface.future.set_result(None)
+        self.interface.set_result(None)
 
 
 class SaveFileDialog(BaseDialog):
@@ -97,15 +87,12 @@ class SaveFileDialog(BaseDialog):
         filename,
         initial_directory,
         file_types=None,
-        on_result=None,
     ):
         super().__init__(interface=interface)
-        self.on_result = on_result
 
         interface.window.factory.not_implemented("Window.save_file_dialog()")
 
-        self.on_result(None)
-        self.interface.future.set_result(None)
+        self.interface.set_result(None)
 
 
 class OpenFileDialog(BaseDialog):
@@ -116,15 +103,12 @@ class OpenFileDialog(BaseDialog):
         initial_directory,
         file_types,
         multiselect,
-        on_result=None,
     ):
         super().__init__(interface=interface)
-        self.on_result = on_result
 
         interface.window.factory.not_implemented("Window.open_file_dialog()")
 
-        self.on_result(None)
-        self.interface.future.set_result(None)
+        self.interface.set_result(None)
 
 
 class SelectFolderDialog(BaseDialog):
@@ -134,12 +118,9 @@ class SelectFolderDialog(BaseDialog):
         title,
         initial_directory,
         multiselect,
-        on_result=None,
     ):
         super().__init__(interface=interface)
-        self.on_result = on_result
 
         interface.window.factory.not_implemented("Window.select_folder_dialog()")
 
-        self.on_result(None)
-        self.interface.future.set_result(None)
+        self.interface.set_result(None)

--- a/winforms/src/toga_winforms/dialogs.py
+++ b/winforms/src/toga_winforms/dialogs.py
@@ -16,25 +16,29 @@ from .libs.wrapper import WeakrefCallable
 
 
 class BaseDialog(ABC):
-    def __init__(self, interface, on_result):
+    def __init__(self, interface):
         self.interface = interface
         self.interface._impl = self
-        self.on_result = on_result
 
     # See libs/proactor.py
     def start_inner_loop(self, callback, *args):
         asyncio.get_event_loop().start_inner_loop(callback, *args)
 
     def set_result(self, result):
-        self.on_result(result)
-        self.interface.future.set_result(result)
+        self.interface.set_result(result)
 
 
 class MessageDialog(BaseDialog):
     def __init__(
-        self, interface, title, message, buttons, icon, on_result, success_result=None
+        self,
+        interface,
+        title,
+        message,
+        buttons,
+        icon,
+        success_result=None,
     ):
-        super().__init__(interface, on_result)
+        super().__init__(interface)
 
         def show():
             return_value = WinForms.MessageBox.Show(message, title, buttons, icon)
@@ -47,58 +51,54 @@ class MessageDialog(BaseDialog):
 
 
 class InfoDialog(MessageDialog):
-    def __init__(self, interface, title, message, on_result):
+    def __init__(self, interface, title, message):
         super().__init__(
             interface,
             title,
             message,
             MessageBoxButtons.OK,
             MessageBoxIcon.Information,
-            on_result,
         )
 
 
 class QuestionDialog(MessageDialog):
-    def __init__(self, interface, title, message, on_result):
+    def __init__(self, interface, title, message):
         super().__init__(
             interface,
             title,
             message,
             MessageBoxButtons.YesNo,
             MessageBoxIcon.Information,
-            on_result,
             success_result=DialogResult.Yes,
         )
 
 
 class ConfirmDialog(MessageDialog):
-    def __init__(self, interface, title, message, on_result):
+    def __init__(self, interface, title, message):
         super().__init__(
             interface,
             title,
             message,
             MessageBoxButtons.OKCancel,
             MessageBoxIcon.Warning,
-            on_result,
             success_result=DialogResult.OK,
         )
 
 
 class ErrorDialog(MessageDialog):
-    def __init__(self, interface, title, message, on_result=None):
+    def __init__(self, interface, title, message=None):
         super().__init__(
             interface,
             title,
             message,
             WinForms.MessageBoxButtons.OK,
             WinForms.MessageBoxIcon.Error,
-            on_result,
         )
 
 
 class StackTraceDialog(BaseDialog):
-    def __init__(self, interface, title, message, content, retry, on_result):
-        super().__init__(interface, on_result)
+    def __init__(self, interface, title, message, content, retry):
+        super().__init__(interface)
 
         self.native = WinForms.Form()
         self.native.MinimizeBox = False
@@ -198,12 +198,11 @@ class FileDialog(BaseDialog):
         interface,
         title,
         initial_directory,
-        on_result,
         *,
         filename=None,
         file_types=None,
     ):
-        super().__init__(interface, on_result)
+        super().__init__(interface)
         self.native = native
 
         self._set_title(title)
@@ -241,15 +240,12 @@ class FileDialog(BaseDialog):
 
 
 class SaveFileDialog(FileDialog):
-    def __init__(
-        self, interface, title, filename, initial_directory, file_types, on_result
-    ):
+    def __init__(self, interface, title, filename, initial_directory, file_types):
         super().__init__(
             WinForms.SaveFileDialog(),
             interface,
             title,
             initial_directory,
-            on_result,
             filename=filename,
             file_types=file_types,
         )
@@ -266,14 +262,12 @@ class OpenFileDialog(FileDialog):
         initial_directory,
         file_types,
         multiple_select,
-        on_result,
     ):
         super().__init__(
             WinForms.OpenFileDialog(),
             interface,
             title,
             initial_directory,
-            on_result,
             file_types=file_types,
         )
         if multiple_select:
@@ -287,13 +281,12 @@ class OpenFileDialog(FileDialog):
 
 
 class SelectFolderDialog(FileDialog):
-    def __init__(self, interface, title, initial_directory, multiple_select, on_result):
+    def __init__(self, interface, title, initial_directory, multiple_select):
         super().__init__(
             WinForms.FolderBrowserDialog(),
             interface,
             title,
             initial_directory,
-            on_result,
         )
 
         # The native dialog doesn't support multiple selection, so the only effect

--- a/winforms/src/toga_winforms/widgets/webview.py
+++ b/winforms/src/toga_winforms/widgets/webview.py
@@ -155,16 +155,14 @@ class WebView(Widget):
         )
 
     def evaluate_javascript(self, javascript, on_result=None):
-        result = JavaScriptResult()
+        result = JavaScriptResult(on_result)
         task_scheduler = TaskScheduler.FromCurrentSynchronizationContext()
 
         def callback(task):
             # If the evaluation fails, task.Result will be "null", with no way to
             # distinguish it from an actual null return value.
             value = json.loads(task.Result)
-            result.future.set_result(value)
-            if on_result:
-                on_result(value)
+            result.set_result(value)
 
         def execute():
             self.native.ExecuteScriptAsync(javascript).ContinueWith(


### PR DESCRIPTION
Another discovery in the process of developing a Camera API.

Toga has an internal AsyncResult handler that is used for methods that need to operate in an async context, but need to retain synchronous calling semantics. Whenever an AsyncResult is defined, there is an on_result lurking nearby; however, everywhere that this is done, the "handle async result, then handle on_result" logic is duplicated.

This PR merges the on_result handler into the AsyncResult, so that any time a result is reported, it is passed to both the synchronous and asynchronous contexts.

This also:
* moves one of the safety catches that was present in the Android backend - preventing a future result being set if the future has been cancelled - into the core API.
* Begins the process of deprecating `on_result` entirely; users will be encouraged to use `await`.
* Enabled warnings-as-errors in the testbed, to make sure we're catching those warnings.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
