### PR TITLE
Correct issues with event handlers and app startup in Textual backend

### DIFF
--- a/changes/2267.misc.rst
+++ b/changes/2267.misc.rst
@@ -1,0 +1,1 @@
+Corrected event handling and app impl assignment on the Textual backend.

--- a/textual/pyproject.toml
+++ b/textual/pyproject.toml
@@ -63,7 +63,7 @@ root = ".."
 
 [tool.setuptools_dynamic_dependencies]
 dependencies = [
-    "textual",
+    "textual >= 0.44.0",
     "toga-core == {version}",
 ]
 

--- a/textual/src/toga_textual/app.py
+++ b/textual/src/toga_textual/app.py
@@ -7,7 +7,7 @@ from .window import Window
 
 class MainWindow(Window):
     def textual_close(self):
-        self.interface.app.on_exit(None)
+        self.interface.app.on_exit()
 
 
 class TogaApp(TextualApp):

--- a/textual/src/toga_textual/app.py
+++ b/textual/src/toga_textual/app.py
@@ -23,6 +23,8 @@ class TogaApp(TextualApp):
 class App:
     def __init__(self, interface):
         self.interface = interface
+        self.interface._impl = self
+
         self.loop = asyncio.new_event_loop()
         self.native = TogaApp(self)
 

--- a/textual/src/toga_textual/dialogs.py
+++ b/textual/src/toga_textual/dialogs.py
@@ -15,12 +15,12 @@ class TextualDialog(ModalScreen[bool]):
         self.impl = impl
 
     def compose(self) -> ComposeResult:
-        self.title = TitleBar(self.impl.title)
+        self.titlebar = TitleBar(self.impl.title)
         self.impl.compose_content(self)
         self.buttons = self.impl.create_buttons()
         self.button_box = Horizontal(*self.buttons)
         self.container = Vertical(
-            self.title,
+            self.titlebar,
             self.content,
             self.button_box,
             id="dialog",
@@ -75,7 +75,7 @@ class BaseDialog(ABC):
         self.native.dismiss(None)
 
     def on_close(self, result: bool):
-        self.on_result(self, result)
+        self.on_result(result)
         self.interface.future.set_result(result)
 
 
@@ -298,7 +298,7 @@ class OpenFileDialog(BaseDialog):
         title,
         initial_directory,
         file_types,
-        multiselect,
+        multiple_select,
         on_result=None,
     ):
         super().__init__(
@@ -315,7 +315,7 @@ class OpenFileDialog(BaseDialog):
         else:
             self.filter_func = None
 
-        self.multiselect = multiselect
+        self.multiple_select = multiple_select
 
     def compose_content(self, dialog):
         dialog.directory_tree = FilteredDirectoryTree(self)
@@ -359,7 +359,7 @@ class SelectFolderDialog(BaseDialog):
         interface,
         title,
         initial_directory,
-        multiselect,
+        multiple_select,
         on_result=None,
     ):
         super().__init__(
@@ -370,7 +370,7 @@ class SelectFolderDialog(BaseDialog):
         )
         self.initial_directory = initial_directory if initial_directory else Path.cwd()
         self.filter_func = lambda path: path.is_dir()
-        self.multiselect = multiselect
+        self.multiple_select = multiple_select
 
     def compose_content(self, dialog):
         dialog.directory_tree = FilteredDirectoryTree(self)

--- a/textual/src/toga_textual/widgets/button.py
+++ b/textual/src/toga_textual/widgets/button.py
@@ -12,7 +12,7 @@ class TogaButton(TextualButton):
         self.impl = impl
 
     def on_button_pressed(self, event: TextualButton.Pressed) -> None:
-        self.interface.on_press(None)
+        self.interface.on_press()
 
 
 class Button(Widget):

--- a/textual/src/toga_textual/widgets/textinput.py
+++ b/textual/src/toga_textual/widgets/textinput.py
@@ -12,13 +12,13 @@ class TogaInput(TextualInput):
         self.impl = impl
 
     def on_focus(self, event: TextualInput.Changed) -> None:
-        self.interface.on_gain_focus(None)
+        self.interface.on_gain_focus()
 
     def on_input_changed(self, event: TextualInput.Changed) -> None:
-        self.interface.on_change(None)
+        self.interface.on_change()
 
     def on_input_submitted(self, event: TextualInput.Submitted) -> None:
-        self.interface.on_confirm(None)
+        self.interface.on_confirm()
 
 
 class TextInput(Widget):

--- a/textual/src/toga_textual/window.py
+++ b/textual/src/toga_textual/window.py
@@ -161,7 +161,7 @@ class Window:
         return True
 
     def textual_close(self):
-        self.interface.on_close(self)
+        self.interface.on_close()
 
     def close(self):
         self.native.dismiss(None)


### PR DESCRIPTION
Some of the changes made late in 0.3.X development weren't fully reflected in the Textual backend. This corrects those oversights.

* The App impl needs to explicitly set the reference to self on the interface
* Event handlers no longer need the initial "self" argument
* Textual now appears to use `title` as a protected attribute on modal screens. 
* The name change of the `multiselect` argument on file dialogs has been made.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
