### PR TITLE
Bump isort from 5.12.0 to 5.13.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
       - id: pyupgrade
         args: [--py38-plus]
   - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
+    rev: 5.13.0
     hooks:
       - id: isort
   - repo: https://github.com/psf/black-pre-commit-mirror

--- a/changes/2269.misc.rst
+++ b/changes/2269.misc.rst
@@ -1,0 +1,1 @@
+The ``pre-commit`` hook for ``isort`` was updated to its latest version.


### PR DESCRIPTION
Bumps `pre-commit` hook for `isort` from 5.12.0 to 5.13.0 and ran the update against the repo.