### PR TITLE
Correct ImageView handling of flex=1 sizing

### DIFF
--- a/changes/2275.bugfix.rst
+++ b/changes/2275.bugfix.rst
@@ -1,0 +1,1 @@
+ImageViews with ``flex=1`` will now shrink to fit if the image is larger than the available space.

--- a/core/src/toga/widgets/imageview.py
+++ b/core/src/toga/widgets/imageview.py
@@ -42,22 +42,22 @@ def rehint_imageview(image, style, scale=1):
             width = int(style.width * scale)
             height = int(style.width * scale / aspect_ratio)
             if style.flex:
-                height = at_least(height)
+                height = at_least(0)
         elif style.height != NONE:
             # Explicit height, implicit width. Preserve aspect ratio.
             aspect_ratio = image.width / image.height
             width = int(style.height * scale * aspect_ratio)
             height = int(style.height * scale)
             if style.flex:
-                width = at_least(width)
+                width = at_least(0)
         else:
             # Use the image's actual size.
             aspect_ratio = image.width / image.height
             width = int(image.width * scale)
             height = int(image.height * scale)
             if style.flex:
-                width = at_least(width)
-                height = at_least(height)
+                width = at_least(0)
+                height = at_least(0)
     else:
         # No image. Hinted size is 0.
         width = 0

--- a/core/tests/widgets/test_imageview.py
+++ b/core/tests/widgets/test_imageview.py
@@ -138,14 +138,14 @@ def test_set_image_none(app):
         (dict(style=Pack(width=37, height=42)), 37, 42, None),
         (dict(style=Pack(width=37, height=42), scale=2), 74, 84, None),
         # Intrinsic image size, flex widget
-        (dict(style=Pack(flex=1)), at_least(144), at_least(72), 2),
-        (dict(style=Pack(flex=1), scale=2), at_least(288), at_least(144), 2),
+        (dict(style=Pack(flex=1)), at_least(0), at_least(0), 2),
+        (dict(style=Pack(flex=1), scale=2), at_least(0), at_least(0), 2),
         # Fixed width, flex widget
-        (dict(style=Pack(width=150, flex=1)), 150, at_least(75), 2),
-        (dict(style=Pack(width=150, flex=1), scale=2), 300, at_least(150), 2),
+        (dict(style=Pack(width=150, flex=1)), 150, at_least(0), 2),
+        (dict(style=Pack(width=150, flex=1), scale=2), 300, at_least(0), 2),
         # Fixed height, flex widget
-        (dict(style=Pack(height=80, flex=1)), at_least(160), 80, 2),
-        (dict(style=Pack(height=80, flex=1), scale=2), at_least(320), 160, 2),
+        (dict(style=Pack(height=80, flex=1)), at_least(0), 80, 2),
+        (dict(style=Pack(height=80, flex=1), scale=2), at_least(0), 160, 2),
         # Explicit image size, flex widget
         (dict(style=Pack(width=37, height=42, flex=1)), 37, 42, None),
         (dict(style=Pack(width=37, height=42, flex=1), scale=2), 74, 84, None),


### PR DESCRIPTION
Fixes #2275.

The documentation for ImageView suggests that image should shrink if they're marked `flex=1`. However, the imposed size constraint of `at_least(size)` prevents shrinking. 

This PR changes the `at_least` constraints to all be `at_least(0)`, which allows images to *reduce* in size in that axis. Any explicit or undeclared image size continues to be handled as before.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
