### PR TITLE
Prevent drag operations (and thus crash) on macOS TableView

### DIFF
--- a/changes/1156.bugfix.rst
+++ b/changes/1156.bugfix.rst
@@ -1,0 +1,1 @@
+TableViews on macOS will no longer crash if a drag operation is initiated from inside the table.

--- a/cocoa/src/toga_cocoa/widgets/table.py
+++ b/cocoa/src/toga_cocoa/widgets/table.py
@@ -1,4 +1,4 @@
-from rubicon.objc import SEL, at, objc_method, objc_property
+from rubicon.objc import SEL, NSPoint, at, objc_method, objc_property
 from travertino.size import at_least
 
 import toga
@@ -20,6 +20,16 @@ from .internal.cells import TogaIconView
 class TogaTable(NSTableView):
     interface = objc_property(object, weak=True)
     impl = objc_property(object, weak=True)
+
+    # NSTableView methods
+    @objc_method
+    def canDragRowsWithIndexes_atPoint_(
+        self,
+        rowIndexes,
+        mouseDownPoint: NSPoint,
+    ) -> bool:
+        # Disable all drags
+        return False
 
     # TableDataSource methods
     @objc_method
@@ -140,6 +150,7 @@ class Table(Widget):
         )
         self.native_table.usesAlternatingRowBackgroundColors = True
         self.native_table.allowsMultipleSelection = self.interface.multiple_select
+        self.native_table.allowsColumnReordering = False
 
         # Create columns for the table
         self.columns = []

--- a/examples/table/table/app.py
+++ b/examples/table/table/app.py
@@ -11,7 +11,7 @@ class ExampleTableApp(toga.App):
     lbl_fontsize = None
 
     def load_data(self):
-        yak = toga.Icon.TOGA_ICON
+        yak = toga.Icon.DEFAULT_ICON
         red = toga.Icon("icons/red")
         green = toga.Icon("icons/green")
 

--- a/examples/tutorial2/tutorial/app.py
+++ b/examples/tutorial2/tutorial/app.py
@@ -92,7 +92,7 @@ class Tutorial2App(toga.App):
             action2,
             text="Action 2",
             tooltip="Perform action 2",
-            icon=toga.Icon.TOGA_ICON,
+            icon=toga.Icon.DEFAULT_ICON,
             group=things,
         )
 


### PR DESCRIPTION
macOS TableViews would crash if you initiated a drag operation from within the table's extents. This PR explicitly disables drag operations, thereby preventing the crash.

Fixes #1156.

Explicitly disabling the drag operation. 
## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
