### PR TITLE
Prerelease bugs

### DIFF
--- a/changes/2294.misc.rst
+++ b/changes/2294.misc.rst
@@ -1,0 +1,1 @@
+Some minor bugs and inconsistencies discovered during pre-release testing were corrected.

--- a/demo/toga_demo/app.py
+++ b/demo/toga_demo/app.py
@@ -72,7 +72,7 @@ class TogaDemo(toga.App):
             self.action2,
             "Action 2",
             tooltip="Perform action 2",
-            icon=toga.Icon.TOGA_ICON,
+            icon=toga.Icon.DEFAULT_ICON,
         )
 
         self.main_window.toolbar.add(cmd1, cmd2)

--- a/web/src/toga_web/app.py
+++ b/web/src/toga_web/app.py
@@ -1,5 +1,5 @@
 import toga
-from toga.command import GROUP_BREAK, SECTION_BREAK
+from toga.command import Separator
 from toga_web.libs import create_element, js
 from toga_web.window import Window
 
@@ -66,9 +66,7 @@ class App:
         submenu = None
 
         for cmd in self.interface.commands:
-            if cmd == GROUP_BREAK:
-                submenu = None
-            elif cmd == SECTION_BREAK:
+            if isinstance(cmd, Separator):
                 # TODO - add a section break
                 pass
             else:


### PR DESCRIPTION
Some minor bugs picked up during pre-release testing.

* toga-demo uses the deprecated TOGA_ICON.
* toga-web wasn't updated to use the new Separator handling.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
