### PR TITLE
Added tabbingIdentifier to Window in Cocoa

### DIFF
--- a/android/tests_backend/app.py
+++ b/android/tests_backend/app.py
@@ -106,3 +106,7 @@ class AppProbe(BaseProbe):
         self.native.findViewById(
             R.id.content
         ).getViewTreeObserver().dispatchOnGlobalLayout()
+
+    @property
+    def tabbing_enabled(self):
+        xfail("Tabbed windows not implemented for this backend.")

--- a/android/tests_backend/app.py
+++ b/android/tests_backend/app.py
@@ -110,3 +110,7 @@ class AppProbe(BaseProbe):
     @property
     def tabbing_enabled(self):
         xfail("Tabbed windows not implemented for this backend.")
+
+    @tabbing_enabled.setter
+    def tabbing_enabled(self, value):
+        xfail("Tabbed windows not implemented for this backend.")

--- a/android/tests_backend/window.py
+++ b/android/tests_backend/window.py
@@ -91,6 +91,3 @@ class WindowProbe(BaseProbe):
     @property
     def tabs(self):
         pytest.xfail("Tabbed windows not implemented for this backend.")
-
-    def merge_all_windows(self):
-        pytest.xfail("Tabbed windows not implemented for this backend.")

--- a/android/tests_backend/window.py
+++ b/android/tests_backend/window.py
@@ -87,3 +87,10 @@ class WindowProbe(BaseProbe):
 
     def press_toolbar_button(self, index):
         self.native.onOptionsItemSelected(self._toolbar_items()[index])
+
+    @property
+    def tabs(self):
+        pytest.xfail("Tabbed windows not implemented for this backend.")
+
+    def merge_all_windows(self):
+        pytest.xfail("Tabbed windows not implemented for this backend.")

--- a/changes/2311.feature.rst
+++ b/changes/2311.feature.rst
@@ -1,0 +1,1 @@
+On macOS, windows now only tab with others of the same class.

--- a/cocoa/src/toga_cocoa/app.py
+++ b/cocoa/src/toga_cocoa/app.py
@@ -289,6 +289,12 @@ class App:
                 shortcut=toga.Key.MOD_1 + "m",
                 group=toga.Group.WINDOW,
             ),
+            toga.Command(
+                self._menu_merge_all_windows,
+                "Merge All Windows",
+                group=toga.Group.WINDOW,
+                section=10,
+            ),
             # ---- Help menu ----------------------------------
             toga.Command(
                 self._menu_visit_homepage,
@@ -316,6 +322,10 @@ class App:
     def _menu_minimize(self, command, **kwargs):
         if self.interface.current_window:
             self.interface.current_window._impl.native.miniaturize(None)
+
+    def _menu_merge_all_windows(self, command, **kwargs):
+        native_window = self.interface.current_window._impl.native
+        native_window.mergeAllWindows(native_window)
 
     def _menu_visit_homepage(self, command, **kwargs):
         self.interface.visit_homepage()

--- a/cocoa/src/toga_cocoa/app.py
+++ b/cocoa/src/toga_cocoa/app.py
@@ -290,7 +290,7 @@ class App:
                 group=toga.Group.WINDOW,
             ),
             toga.Command(
-                self._menu_merge_all_windows,
+                NativeHandler(SEL("mergeAllWindows:")),
                 "Merge All Windows",
                 group=toga.Group.WINDOW,
                 section=10,
@@ -322,10 +322,6 @@ class App:
     def _menu_minimize(self, command, **kwargs):
         if self.interface.current_window:
             self.interface.current_window._impl.native.miniaturize(None)
-
-    def _menu_merge_all_windows(self, command, **kwargs):
-        native_window = self.interface.current_window._impl.native
-        native_window.mergeAllWindows(native_window)
 
     def _menu_visit_homepage(self, command, **kwargs):
         self.interface.visit_homepage()

--- a/cocoa/src/toga_cocoa/window.py
+++ b/cocoa/src/toga_cocoa/window.py
@@ -148,6 +148,9 @@ class Window:
         self.native.interface = self.interface
         self.native.impl = self
 
+        # This causes windows to only tab together with others of the same class.
+        self.native.tabbingIdentifier = str(self.__class__)
+
         # Cocoa releases windows when they are closed; this causes havoc with
         # Toga's widget cleanup because the ObjC runtime thinks there's no
         # references to the object left. Add a reference that can be released
@@ -163,7 +166,7 @@ class Window:
         self.container = Container(on_refresh=self.content_refreshed)
         self.native.contentView = self.container.native
 
-        # Ensure that the container renders it's background in the same color as the window.
+        # Ensure that the container renders its background in the same color as the window.
         self.native.wantsLayer = True
         self.container.native.backgroundColor = self.native.backgroundColor
 

--- a/cocoa/src/toga_cocoa/window.py
+++ b/cocoa/src/toga_cocoa/window.py
@@ -149,7 +149,7 @@ class Window:
         self.native.impl = self
 
         # This causes windows to only tab together with others of the same class.
-        self.native.tabbingIdentifier = str(self.__class__)
+        self.native.tabbingIdentifier = str(self.interface.__class__)
 
         # Cocoa releases windows when they are closed; this causes havoc with
         # Toga's widget cleanup because the ObjC runtime thinks there's no

--- a/cocoa/tests_backend/app.py
+++ b/cocoa/tests_backend/app.py
@@ -24,7 +24,7 @@ class AppProbe(BaseProbe):
         super().__init__()
         self.app = app
         # Prevents erroneous test fails from secondary windows opening as tabs
-        NSWindow.allowsAutomaticWindowTabbing = False
+        self.tabbing_enabled = False
         assert isinstance(self.app._impl.native, NSApplication)
 
     @property
@@ -175,3 +175,11 @@ class AppProbe(BaseProbe):
             keyCode=key_code,
         )
         return toga_key(event)
+
+    @property
+    def tabbing_enabled(self):
+        return NSWindow.allowsAutomaticWindowTabbing
+
+    @tabbing_enabled.setter
+    def tabbing_enabled(self, value):
+        NSWindow.allowsAutomaticWindowTabbing = value

--- a/cocoa/tests_backend/window.py
+++ b/cocoa/tests_backend/window.py
@@ -267,4 +267,5 @@ class WindowProbe(BaseProbe):
         return self.native.tabbedWindows
 
     def merge_all_windows(self):
-        self.native.mergeAllWindows(self.native)
+        self.app.current_window = self.window
+        self.app._impl._menu_merge_all_windows(None)

--- a/cocoa/tests_backend/window.py
+++ b/cocoa/tests_backend/window.py
@@ -261,3 +261,10 @@ class WindowProbe(BaseProbe):
             restype=None,
             argtypes=[objc_id],
         )
+
+    @property
+    def tabs(self):
+        return self.native.tabbedWindows
+
+    def merge_all_windows(self):
+        self.native.mergeAllWindows(self.native)

--- a/cocoa/tests_backend/window.py
+++ b/cocoa/tests_backend/window.py
@@ -265,7 +265,3 @@ class WindowProbe(BaseProbe):
     @property
     def tabs(self):
         return self.native.tabbedWindows
-
-    def merge_all_windows(self):
-        self.app.current_window = self.window
-        self.app._impl._menu_merge_all_windows(None)

--- a/gtk/tests_backend/app.py
+++ b/gtk/tests_backend/app.py
@@ -154,3 +154,7 @@ class AppProbe(BaseProbe):
         event.state = state
 
         return toga_key(event)
+
+    @property
+    def tabbing_enabled(self):
+        pytest.xfail("Tabbed windows not implemented for this backend.")

--- a/gtk/tests_backend/app.py
+++ b/gtk/tests_backend/app.py
@@ -158,3 +158,7 @@ class AppProbe(BaseProbe):
     @property
     def tabbing_enabled(self):
         pytest.xfail("Tabbed windows not implemented for this backend.")
+
+    @tabbing_enabled.setter
+    def tabbing_enabled(self, value):
+        pytest.xfail("Tabbed windows not implemented for this backend.")

--- a/gtk/tests_backend/window.py
+++ b/gtk/tests_backend/window.py
@@ -257,6 +257,3 @@ class WindowProbe(BaseProbe):
     @property
     def tabs(self):
         xfail("Tabbed windows not implemented for this backend.")
-
-    def merge_all_windows(self):
-        xfail("Tabbed windows not implemented for this backend.")

--- a/gtk/tests_backend/window.py
+++ b/gtk/tests_backend/window.py
@@ -2,6 +2,8 @@ import asyncio
 from pathlib import Path
 from unittest.mock import Mock
 
+from pytest import xfail
+
 from toga_gtk.libs import Gdk, Gtk
 
 from .probe import BaseProbe
@@ -251,3 +253,10 @@ class WindowProbe(BaseProbe):
     def press_toolbar_button(self, index):
         item = self.impl.native_toolbar.get_nth_item(index)
         item.emit("clicked")
+
+    @property
+    def tabs(self):
+        xfail("Tabbed windows not implemented for this backend.")
+
+    def merge_all_windows(self):
+        xfail("Tabbed windows not implemented for this backend.")

--- a/iOS/tests_backend/app.py
+++ b/iOS/tests_backend/app.py
@@ -73,3 +73,7 @@ class AppProbe(BaseProbe):
     @property
     def tabbing_enabled(self):
         pytest.xfail("Tabbed windows not implemented for this backend.")
+
+    @tabbing_enabled.setter
+    def tabbing_enabled(self, value):
+        pytest.xfail("Tabbed windows not implemented for this backend.")

--- a/iOS/tests_backend/app.py
+++ b/iOS/tests_backend/app.py
@@ -69,3 +69,7 @@ class AppProbe(BaseProbe):
     def rotate(self):
         self.native = self.app._impl.native
         self.native.delegate.application(self.native, didChangeStatusBarOrientation=0)
+
+    @property
+    def tabbing_enabled(self):
+        pytest.xfail("Tabbed windows not implemented for this backend.")

--- a/iOS/tests_backend/window.py
+++ b/iOS/tests_backend/window.py
@@ -81,6 +81,3 @@ class WindowProbe(BaseProbe):
     @property
     def tabs(self):
         pytest.xfail("Tabbed windows not implemented for this backend.")
-
-    def merge_all_windows(self):
-        pytest.xfail("Tabbed windows not implemented for this backend.")

--- a/iOS/tests_backend/window.py
+++ b/iOS/tests_backend/window.py
@@ -77,3 +77,10 @@ class WindowProbe(BaseProbe):
 
     def has_toolbar(self):
         pytest.skip("Toolbars not implemented on iOS")
+
+    @property
+    def tabs(self):
+        pytest.xfail("Tabbed windows not implemented for this backend.")
+
+    def merge_all_windows(self):
+        pytest.xfail("Tabbed windows not implemented for this backend.")

--- a/testbed/tests/test_window.py
+++ b/testbed/tests/test_window.py
@@ -238,7 +238,10 @@ else:
             assert not base_probe.tabs
             assert not subclass_probe.tabs
 
-            main_window_probe.merge_all_windows()
+            # Merge All Windows command operates based on which window is active.
+            app.current_window = main_window
+            await main_window_probe.wait_for_window("Switched to MainWindow")
+            app_probe._activate_menu_item(["Window", "Merge All Windows"])
             await main_window_probe.wait_for_window(
                 "Merge All Windows called on MainWindow"
             )
@@ -247,7 +250,9 @@ else:
             assert not base_probe.tabs
             assert not subclass_probe.tabs
 
-            base_probe.merge_all_windows()
+            app.current_window = base_probe.window
+            await main_window_probe.wait_for_window("Switched to base Window")
+            app_probe._activate_menu_item(["Window", "Merge All Windows"])
             await main_window_probe.wait_for_window(
                 "Merge All Windows called on base Window"
             )
@@ -255,7 +260,9 @@ else:
             assert len(base_probe.tabs) == 2
             assert not subclass_probe.tabs
 
-            subclass_probe.merge_all_windows()
+            app.current_window = subclass_probe.window
+            await main_window_probe.wait_for_window("Switched to subclassed Window")
+            app_probe._activate_menu_item(["Window", "Merge All Windows"])
             await main_window_probe.wait_for_window(
                 "Merge All Windows called on Window subclass"
             )

--- a/winforms/tests_backend/app.py
+++ b/winforms/tests_backend/app.py
@@ -154,3 +154,7 @@ class AppProbe(BaseProbe):
 
     def keystroke(self, combination):
         return winforms_to_toga_key(toga_to_winforms_key(combination))
+
+    @property
+    def tabbing_enabled(self):
+        pytest.xfail("Tabbed windows not implemented for this backend.")

--- a/winforms/tests_backend/app.py
+++ b/winforms/tests_backend/app.py
@@ -158,3 +158,7 @@ class AppProbe(BaseProbe):
     @property
     def tabbing_enabled(self):
         pytest.xfail("Tabbed windows not implemented for this backend.")
+
+    @tabbing_enabled.setter
+    def tabbing_enabled(self, value):
+        pytest.xfail("Tabbed windows not implemented for this backend.")

--- a/winforms/tests_backend/window.py
+++ b/winforms/tests_backend/window.py
@@ -1,6 +1,7 @@
 import asyncio
 from unittest.mock import Mock
 
+from pytest import xfail
 from System import EventArgs
 from System.Windows.Forms import (
     Form,
@@ -148,3 +149,10 @@ class WindowProbe(BaseProbe):
 
     def press_toolbar_button(self, index):
         self._native_toolbar_item(index).OnClick(EventArgs.Empty)
+
+    @property
+    def tabs(self):
+        xfail("Tabbed windows not implemented for this backend.")
+
+    def merge_all_windows(self):
+        xfail("Tabbed windows not implemented for this backend.")

--- a/winforms/tests_backend/window.py
+++ b/winforms/tests_backend/window.py
@@ -153,6 +153,3 @@ class WindowProbe(BaseProbe):
     @property
     def tabs(self):
         xfail("Tabbed windows not implemented for this backend.")
-
-    def merge_all_windows(self):
-        xfail("Tabbed windows not implemented for this backend.")


### PR DESCRIPTION
Based on discussion on #2227, I've tried out the [`tabbingIdentifer`](https://developer.apple.com/documentation/appkit/nswindow/1644704-tabbingidentifier) property of NSWindow and found that it works as one would expect; setting it to a string of the window's class does indeed make it so that windows only tab together with others of the same class, which solves the "main window is special but gets lost as a normal tab" issue.

I'm a little unsure how best to design the API used to test this, so wanted to check in before implementing. Ultimately it would make sense for a Window object to have access to its tabs, but since it's only implemented at all yet on macOS, would it make sense to leave core Window unaltered and only put ways to check on tabbing status in WindowProbe (with xfails on other platforms)?

I'm also not positive whether it would make more sense to have something like `tabs` which is a list including the calling window, or `tabbed_with` which only includes the *other* windows; each would be empty when there aren't any tabs, so there wouldn't necessarily need to be a separate `has_tabs` boolean unless we want it for legibility.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
