### PR TITLE
Set Content When Initializing Window

### DIFF
--- a/changes/2307.feature.rst
+++ b/changes/2307.feature.rst
@@ -1,0 +1,1 @@
+Allow setting content when instantiating MainWindow.

--- a/core/src/toga/app.py
+++ b/core/src/toga/app.py
@@ -144,7 +144,7 @@ class MainWindow(Window):
         minimizable: bool = True,
         resizeable=None,  # DEPRECATED
         closeable=None,  # DEPRECATED
-        content=None,
+        content: Widget | None = None,
     ):
         """Create a new main window.
 

--- a/core/src/toga/app.py
+++ b/core/src/toga/app.py
@@ -144,6 +144,7 @@ class MainWindow(Window):
         minimizable: bool = True,
         resizeable=None,  # DEPRECATED
         closeable=None,  # DEPRECATED
+        content=None
     ):
         """Create a new main window.
 
@@ -158,6 +159,7 @@ class MainWindow(Window):
         :param minimizable: Can the window be minimized by the user?
         :param resizeable: **DEPRECATED** - Use ``resizable``.
         :param closeable: **DEPRECATED** - Use ``closable``.
+        :param content: Window content
         """
         super().__init__(
             id=id,
@@ -167,6 +169,7 @@ class MainWindow(Window):
             resizable=resizable,
             closable=True,
             minimizable=minimizable,
+            content=content,
             # Deprecated arguments
             resizeable=resizeable,
             closeable=closeable,

--- a/core/src/toga/app.py
+++ b/core/src/toga/app.py
@@ -144,7 +144,7 @@ class MainWindow(Window):
         minimizable: bool = True,
         resizeable=None,  # DEPRECATED
         closeable=None,  # DEPRECATED
-        content=None
+        content=None,
     ):
         """Create a new main window.
 

--- a/core/src/toga/window.py
+++ b/core/src/toga/window.py
@@ -73,7 +73,7 @@ class Window:
         on_close: OnCloseHandler | None = None,
         resizeable=None,  # DEPRECATED
         closeable=None,  # DEPRECATED
-        content: Widget | None = None
+        content: Widget | None = None,
     ) -> None:
         """Create a new Window.
 

--- a/core/src/toga/window.py
+++ b/core/src/toga/window.py
@@ -73,6 +73,7 @@ class Window:
         on_close: OnCloseHandler | None = None,
         resizeable=None,  # DEPRECATED
         closeable=None,  # DEPRECATED
+        content: Widget | None = None
     ) -> None:
         """Create a new Window.
 
@@ -117,7 +118,6 @@ class Window:
 
         self._id = str(id if id else identifier(self))
         self._impl = None
-        self._content = None
         self._is_full_screen = False
         self._closed = False
 
@@ -143,6 +143,11 @@ class Window:
         self._toolbar = CommandSet(on_change=self._impl.create_toolbar, app=self._app)
 
         self.on_close = on_close
+
+        if content:
+            self.content(content)
+        else:
+            self._content = None
 
     @property
     def id(self) -> str:

--- a/core/src/toga/window.py
+++ b/core/src/toga/window.py
@@ -144,10 +144,7 @@ class Window:
 
         self.on_close = on_close
 
-        if content:
-            self.content(content)
-        else:
-            self._content = None
+        self._content = content
 
     @property
     def id(self) -> str:

--- a/core/tests/test_window.py
+++ b/core/tests/test_window.py
@@ -99,6 +99,14 @@ def test_set_app_with_content(window, app):
     assert content.app == app
 
 
+def test_set_app_with_content_at_instantiation(app):
+    """A window can be created with content"""
+    content = toga.Box()
+    window = toga.Window(content=content)
+
+    assert window.content == content
+
+
 @pytest.mark.parametrize(
     "value, expected",
     [

--- a/testbed/tests/test_window.py
+++ b/testbed/tests/test_window.py
@@ -744,3 +744,10 @@ async def test_select_folder_dialog(
     ):
         result = result[-1:]
     await assert_dialog_result(main_window, dialog_result, on_result_handler, result)
+
+
+async def test_instantiate_window_with_content(app):
+    content = toga.Box()
+    window = toga.Window(content=content)
+
+    assert window.content == content


### PR DESCRIPTION
* Fixes #2307 

This change allows for initializing a window with content, rather than setting it after the window has been created.

```python
main_box = toga.Box()

# was
main_window = toga.MainWindow(title="Window title!")
main_window.content = main_box

# now
main_window = toga.MainWindow(
	title="Window title!",
	content=main_box
)
```

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
