### PR TITLE
Upgrade `upload-artifact` and `download-artifact` actions to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,8 @@ jobs:
 
   package:
     name: Python Package
-    uses: beeware/.github/.github/workflows/python-package-create.yml@main
+#    uses: beeware/.github/.github/workflows/python-package-create.yml@main
+    uses: rmartin16/.github-beeware/.github/workflows/python-package-create.yml@artifacts
     with:
       tox-source: "./core[dev]"
       build-subdirectory: ${{ matrix.subdir }}
@@ -85,7 +86,8 @@ jobs:
     - name: Get packages
       uses: actions/download-artifact@v4.1.0
       with:
-        name: ${{ needs.package.outputs.artifact-name }}
+        pattern: ${{ needs.package.outputs.artifact-name }}-*
+        merge-multiple: true
     - name: Test
       run: |
         # The $(ls ...) shell expansion is done in the Github environment;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,7 @@ jobs:
 
   package:
     name: Python Package
-#    uses: beeware/.github/.github/workflows/python-package-create.yml@main
-    uses: rmartin16/.github-beeware/.github/workflows/python-package-create.yml@artifacts
+    uses: beeware/.github/.github/workflows/python-package-create.yml@main
     with:
       tox-source: "./core[dev]"
       build-subdirectory: ${{ matrix.subdir }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
         # we just want the dev extras so we have a known version of tox and coverage
         python -m pip install ./core[dev]
     - name: Get packages
-      uses: actions/download-artifact@v3.0.2
+      uses: actions/download-artifact@v4.1.0
       with:
         name: ${{ needs.package.outputs.artifact-name }}
     - name: Test
@@ -94,9 +94,9 @@ jobs:
         TOGA_INSTALL_COMMAND="python -m pip install ../$(ls core/dist/toga_core-*.whl)[dev] ../$(ls dummy/dist/toga_dummy-*.whl)" tox -e py
         mv core/.coverage core/.coverage.${{ matrix.platform }}.${{ matrix.python-version }}
     - name: Store coverage data
-      uses: actions/upload-artifact@v3.1.3
+      uses: actions/upload-artifact@v4.0.0
       with:
-        name: core-coverage-data
+        name: core-coverage-data-${{ matrix.platform }}-${{ matrix.python-version }}
         path: "core/.coverage.*"
         if-no-files-found: error
 
@@ -118,10 +118,11 @@ jobs:
         # we just want the dev extras so we have a known version of coverage
         python -m pip install ./core[dev]
     - name: Retrieve coverage data
-      uses: actions/download-artifact@v3.0.2
+      uses: actions/download-artifact@v4.1.0
       with:
-        name: core-coverage-data
+        pattern: core-coverage-data-*
         path: core
+        merge-multiple: true
     - name: Generate coverage report
       run: |
         cd core
@@ -129,11 +130,11 @@ jobs:
         python -m coverage html --skip-covered --skip-empty
         python -m coverage report --rcfile ../pyproject.toml --fail-under=100
     - name: Upload HTML report if check failed.
-      uses: actions/upload-artifact@v3.1.3
+      uses: actions/upload-artifact@v4.0.0
+      if: failure()
       with:
         name: html-coverage-report
         path: core/htmlcov
-      if: ${{ failure() }}
 
   testbed:
     runs-on: ${{ matrix.runs-on }}
@@ -229,7 +230,7 @@ jobs:
       run: ${{ matrix.briefcase-run-prefix }} briefcase run ${{ matrix.backend }} --test ${{ matrix.briefcase-run-args }}
 
     - name: Upload logs
-      uses: actions/upload-artifact@v3.1.3
+      uses: actions/upload-artifact@v4.0.0
       if: failure()
       with:
         name: testbed-failure-logs-${{ matrix.backend }}
@@ -242,7 +243,7 @@ jobs:
         cp -r "${{ matrix.app-user-data-path }}" testbed/app_data/testbed-app_data-${{ matrix.backend }}
 
     - name: Upload app data
-      uses: actions/upload-artifact@v3.1.3
+      uses: actions/upload-artifact@v4.0.0
       if: failure() && matrix.backend != 'android'
       with:
         name: testbed-failure-app-data-${{ matrix.backend }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,8 @@ jobs:
       - name: Get packages
         uses: actions/download-artifact@v4.1.0
         with:
-          name: ${{ needs.ci.outputs.artifact-name }}
+          pattern: ${{ needs.ci.outputs.artifact-name }}-*
+          merge-multiple: true
 
       - name: Create release
         uses: ncipollo/release-action@v1.13.0
@@ -64,9 +65,10 @@ jobs:
         - "toga_winforms"
     steps:
       - name: Get packages
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4.1.0
         with:
-          name: ${{ needs.ci.outputs.artifact-name }}
+          pattern: ${{ needs.ci.outputs.artifact-name }}-*
+          merge-multiple: true
 
       - name: Extract ${{ matrix.package }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
 
       - name: Get packages
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4.1.0
         with:
           name: ${{ needs.ci.outputs.artifact-name }}
 

--- a/changes/2318.misc.rst
+++ b/changes/2318.misc.rst
@@ -1,0 +1,1 @@
+The ``upload-artifact`` and ``download-artifact`` CI actions were upgraded to v4.


### PR DESCRIPTION
## Changes
- RE: https://github.com/beeware/.github/issues/77
- Bump `upload-artifact` and `download-artifact` actions to v4
- To accommodate v4:
  - Artifacts must have unique names since multiple uploads cannot contribute to a single artifact
  - Use a wildcard pattern to download all artifacts and merge in to a single directory
- 🚨 Dependent on https://github.com/beeware/.github/pull/78 🚨 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct