### PR TITLE
Allow macOS Selection widgets to include duplicate labels.

### DIFF
--- a/changes/2319.bugfix.rst
+++ b/changes/2319.bugfix.rst
@@ -1,0 +1,1 @@
+Selection widgets on macOS can now include duplicated titles.

--- a/changes/2319.removal.rst
+++ b/changes/2319.removal.rst
@@ -1,0 +1,1 @@
+If the label for a Selection contains newlines, only the text up to the first newline will be displayed.

--- a/cocoa/src/toga_cocoa/widgets/selection.py
+++ b/cocoa/src/toga_cocoa/widgets/selection.py
@@ -33,10 +33,16 @@ class Selection(Widget):
         )
 
     def insert(self, index, item):
+        # Issue 2319 - if item titles are not unique, macOS will move the existing item,
+        # rather than creating a duplicate item. To work around this, create an item
+        # with a temporary but unique name, then change the name. `_title_for_item()`
+        # can't return newlines, so the use of a newline guarantees the name for the
+        # initial item is unique.
         self.native.insertItemWithTitle(
-            self.interface._title_for_item(item),
+            "\n<temp>",
             atIndex=index,
         )
+        self.native.itemAtIndex(index).title = self.interface._title_for_item(item)
 
         # If this is the first time item in the list, it will be automatically
         # selected; trigger a change event.

--- a/core/src/toga/widgets/selection.py
+++ b/core/src/toga/widgets/selection.py
@@ -120,7 +120,7 @@ class Selection(Widget):
         else:
             title = item.value
 
-        return str(title)
+        return str(title).split("\n")[0]
 
     @property
     def value(self):

--- a/core/tests/widgets/test_selection.py
+++ b/core/tests/widgets/test_selection.py
@@ -73,12 +73,12 @@ def test_create_with_value():
 
 
 @pytest.mark.parametrize(
-    "items, value",
+    "items, title, value",
     [
         # list of strings
-        (["first", "second", "third"], "second"),
+        (["first", "second", "third"], "second", "second"),
         # list of non-strings
-        ([111, 222, 333], 222),
+        ([111, 222, 333], "222", 222),
         # List of dictionaries; implied use of "value" key
         (
             [
@@ -86,6 +86,7 @@ def test_create_with_value():
                 {"key": "second", "value": 222},
                 {"key": "third", "value": 333},
             ],
+            "222",
             222,
         ),
         # List of tuples; only the first item is used.
@@ -96,10 +97,15 @@ def test_create_with_value():
                 ("third", 333),
             ],
             "second",
+            "second",
         ),
+        # List of strings with a newline in value
+        (["first", "second\nitem", "third"], "second", "second\nitem"),
+        # List of strings with a duplicate entry
+        (["first", "second", "third", "first", "second"], "second", "second"),
     ],
 )
-def test_value_no_accessor(items, value):
+def test_value_no_accessor(items, title, value):
     "If there's no accessor, the items can be set and values will be dereferenced"
     on_change_handler = Mock()
     widget = toga.Selection(on_change=on_change_handler)
@@ -124,17 +130,17 @@ def test_value_no_accessor(items, value):
     assert widget.value == value
 
     # The value renders as a string
-    assert widget._title_for_item(widget.items[1]) == str(value)
+    assert widget._title_for_item(widget.items[1]) == title
 
     # Change handler was invoked
     on_change_handler.assert_called_once_with(widget)
 
 
 @pytest.mark.parametrize(
-    "accessor, items, value",
+    "accessor, items, title, value",
     [
         # List of strings with a custom accessor name
-        ("key", ["first", "second", "third"], "second"),
+        ("key", ["first", "second", "third"], "second", "second"),
         # List of dictionaries selecting non-default key
         (
             "key",
@@ -143,6 +149,7 @@ def test_value_no_accessor(items, value):
                 {"key": "second", "value": 222},
                 {"key": "third", "value": 333},
             ],
+            "second",
             "second",
         ),
         # List of tuples; accessor name is altered.
@@ -153,6 +160,7 @@ def test_value_no_accessor(items, value):
                 ("second", 222),
                 ("third", 333),
             ],
+            "second",
             "second",
         ),
         (
@@ -166,10 +174,15 @@ def test_value_no_accessor(items, value):
                 ],
             ),
             "second",
+            "second",
         ),
+        # List of strings with a newline in a title
+        ("key", ["first", "second\nitem", "third"], "second", "second\nitem"),
+        # List of strings with a duplicate entry
+        ("key", ["first", "second", "third", "first", "second"], "second", "second"),
     ],
 )
-def test_value_with_accessor(accessor, items, value):
+def test_value_with_accessor(accessor, items, title, value):
     "If an accessor is used, item lookup semantics are different"
     on_change_handler = Mock()
     widget = toga.Selection(accessor=accessor, on_change=on_change_handler)
@@ -195,7 +208,7 @@ def test_value_with_accessor(accessor, items, value):
     assert getattr(widget.value, accessor) == value
 
     # The value renders as a string
-    assert widget._title_for_item(widget.items[1]) == str(value)
+    assert widget._title_for_item(widget.items[1]) == title
 
     # Change handler was invoked
     on_change_handler.assert_called_once_with(widget)

--- a/docs/reference/api/widgets/selection.rst
+++ b/docs/reference/api/widgets/selection.rst
@@ -50,10 +50,11 @@ The Selection uses a :class:`~toga.sources.ListSource` to manage the list of
 options. If ``items`` is not specified as a ListSource, it will be converted
 into a ListSource at runtime.
 
-The simplest instantiation of a Selection is to use a list of strings. If a list
-of non-string objects are provided, they will be converted into a string for
-display purposes, but the original data type will be retained when returning the
-current value.
+The simplest instantiation of a Selection is to use a list of strings. If a list of
+non-string objects are provided, they will be converted into a string for display
+purposes, but the original data type will be retained when returning the current value.
+If the string value contains newlines, only the substring up to the first newline will
+be displayed.
 
 .. code-block:: python
 

--- a/examples/selection/selection/app.py
+++ b/examples/selection/selection/app.py
@@ -70,7 +70,14 @@ class SelectionApp(toga.App):
                         ),
                         toga.Selection(
                             on_change=self.my_on_change,
-                            items=["Dubnium", "Holmium", "Zirconium"],
+                            items=[
+                                "Dubnium",
+                                "Holmium",
+                                "Zirconium",
+                                "Dubnium",
+                                "Holmium",
+                                "Zirconium",
+                            ],
                         ),
                     ],
                 ),

--- a/testbed/tests/widgets/test_selection.py
+++ b/testbed/tests/widgets/test_selection.py
@@ -91,6 +91,20 @@ async def test_item_titles(widget, probe):
                 111,
                 "111",
             ),
+            # List of strings with newlines
+            (
+                ["first\nitem", "second\nitem", "third\nitem"],
+                ["first", "second", "third"],
+                "first\nitem",
+                "first",
+            ),
+            # List of strings with duplicates
+            (
+                ["first", "second", "third", "first", "second"],
+                ["first", "second", "third", "first", "second"],
+                "first",
+                "first",
+            ),
         ],
         start=1,
     ):


### PR DESCRIPTION
The Cocoa API `[NSPopUpButton insertItemWithTitle:atIndex:]` (used to populate Selection widgets) does not allow duplicate items; duplicates are moved to the end of the list, rather than creating new items. This leads to a crash when inserting the item *after* the duplicate because the widget will attempt to insert an item at an index that doesn't exist.

This modifies the Cocoa implementation to create an item with a unique label, then rename that item to the final name. This allows duplicates to be inserted, as long as the label itself is unique.

To ensure that the label is unique, the contract for Selection labels has been modified slightly, only displaying the content up to the first newline. This is consistent with the API for Button; and also allows us to create a temporary item label with a newline that we can guarantee is unique.

Fixes #2319 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
