### PR TITLE
Update release note for recent OptionList changes

### DIFF
--- a/changes/2302.misc.rst
+++ b/changes/2302.misc.rst
@@ -1,0 +1,1 @@
+The release note describing the backwards-incompatible changes to OptionList was updated.

--- a/docs/background/project/releases.rst
+++ b/docs/background/project/releases.rst
@@ -38,7 +38,7 @@ Backward Incompatible Changes
 * The ``toga.Image`` constructor now takes a single argument (``src``); the ``path`` and ``data`` arguments are deprecated. (`#2142 <https://github.com/beeware/toga/issues/2142>`__)
 * The use of Caps Lock as a keyboard modifier for commands was removed. (`#2198 <https://github.com/beeware/toga/issues/2198>`__)
 * Support for macOS release prior to Big Sur (11) has been dropped. (`#2228 <https://github.com/beeware/toga/issues/2228>`__)
-* When inserting or appending a tab to an OptionContainer, the ``enabled`` argument must now be provided as a keyword argument. (`#2259 <https://github.com/beeware/toga/issues/2259>`__)
+* When inserting or appending a tab to an OptionContainer, the ``enabled`` argument must now be provided as a keyword argument. The name of the first argument has been also been renamed (from ``text`` to ``text_or_item``); it should generally be passed as a positional, rather than keyword argument. (`#2259 <https://github.com/beeware/toga/issues/2259>`__)
 * The use of synchronous ``on_result`` callbacks on dialogs and ``Webview.evaluate_javascript()`` calls has been deprecated. These methods should be used in their asynchronous form. (`#2264 <https://github.com/beeware/toga/issues/2264>`__)
 
 Documentation


### PR DESCRIPTION
Clarifies the backwards incompatible change to OptionList introduced in #2359.

Once merged, the notes attached to the 0.4.1 release should be updated to also include this text.

Fixes #2302.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
