### PR TITLE
Remove Android get_terminal_size monkey patch

### DIFF
--- a/changes/2336.misc.rst
+++ b/changes/2336.misc.rst
@@ -1,0 +1,1 @@
+Remove Android get_terminal_size monkey patch

--- a/testbed/tests/testbed.py
+++ b/testbed/tests/testbed.py
@@ -1,4 +1,3 @@
-import errno
 import os
 import sys
 import tempfile
@@ -107,15 +106,6 @@ if __name__ == "__main__":
                 "emscripten": "toga_web",
                 "win32": "toga_winforms",
             }.get(sys.platform)
-
-    if toga_backend == "toga_android":
-        # Prevent the log being cluttered with "avc: denied" messages
-        # (https://github.com/beeware/toga/issues/1962).
-        def get_terminal_size(*args, **kwargs):
-            error = errno.ENOTTY
-            raise OSError(error, os.strerror(error))
-
-        os.get_terminal_size = get_terminal_size
 
     # Start coverage tracking.
     # This needs to happen in the main thread, before the app has been created


### PR DESCRIPTION
This monkey patch was to prevent the "avc: denied" log spam from #1962. It's now been incorporated into Chaquopy 15, so it can be removed from the testbed after https://github.com/beeware/briefcase-android-gradle-template/pull/78 is merged.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
