### PR TITLE
Tighten the spacing on Android DetailedList.

### DIFF
--- a/android/src/toga_android/widgets/detailedlist.py
+++ b/android/src/toga_android/widgets/detailedlist.py
@@ -122,7 +122,7 @@ class DetailedList(Widget):
         container.addView(row_view)
         row_view.setOnClickListener(DetailedListOnClickListener(self, i))
         row_view.setOnLongClickListener(DetailedListOnLongClickListener(self, i))
-        row_height = self.scale_in(80)
+        row_height = self.scale_in(64)
 
         title, subtitle, icon = (
             getattr(row, attr, None) for attr in self.interface.accessors
@@ -136,8 +136,8 @@ class DetailedList(Widget):
             RelativeLayout.LayoutParams.WRAP_CONTENT,
             RelativeLayout.LayoutParams.WRAP_CONTENT,
         )
-        icon_width = self.scale_in(50)
-        icon_margin = self.scale_in(10)
+        icon_width = self.scale_in(48)
+        icon_margin = self.scale_in(8)
         icon_layout_params.width = icon_width
         icon_layout_params.setMargins(icon_margin, 0, icon_margin, 0)
         icon_layout_params.height = row_height

--- a/changes/2338.bugfix.rst
+++ b/changes/2338.bugfix.rst
@@ -1,0 +1,1 @@
+The padding around DetailedList on Android has been reduced.


### PR DESCRIPTION
Reported via beeware/briefcase#1600

The padding around DetailedList on Android is a little too generous. With the recent Icon Button changes converging on "48px" as the default size for an icon, allowing for 8px padding on each side, the row need only be 56px tall. The icon was previously 50px, with 10px padding - but the row was 80px tall, so there's effectively 30 px between icons.

Old  | New
<image src="https://github.com/beeware/toga/assets/37345/5ed0b138-8d61-450a-a5fb-c2b08e7ee331" width=300><image src="https://github.com/beeware/toga/assets/37345/a6d4524f-d654-41a3-8e15-65b427c8d279" width=300>


Functionally, it means an extra 2 rows can be displayed on a standard phone.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
