### PR TITLE
Fixed `App.current_window` on Gtk

### DIFF
--- a/changes/2211.bugfix.rst
+++ b/changes/2211.bugfix.rst
@@ -1,0 +1,1 @@
+`App.current_window` on Gtk now returns `None` when all windows are hidden.

--- a/gtk/src/toga_gtk/app.py
+++ b/gtk/src/toga_gtk/app.py
@@ -222,7 +222,8 @@ class App:
         self.native.quit()
 
     def get_current_window(self):
-        return self.native.get_active_window()._impl
+        current_window = self.native.get_active_window()._impl
+        return current_window if current_window.interface.visible else None
 
     def set_current_window(self, window):
         window._impl.native.present()


### PR DESCRIPTION
<!--- Describe your changes in detail -->
`App.current_window` on Gtk now returns `None` when all windows are hidden.
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Fixes #2211 
Tested on Arch
## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
