### PR TITLE
Update examples to explicitly list gradle dependencies.

### DIFF
--- a/changes/2363.misc.rst
+++ b/changes/2363.misc.rst
@@ -1,0 +1,1 @@
+Examples were updated to explicitly list Android Gradle dependencies.

--- a/demo/pyproject.toml
+++ b/demo/pyproject.toml
@@ -109,3 +109,10 @@ requires = [
 requires = [
     "../android",
 ]
+
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]

--- a/demo/pyproject.toml
+++ b/demo/pyproject.toml
@@ -113,6 +113,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -127,7 +127,7 @@ We can then define a button. When we create the button, we can set the button
 text, and we also set the behavior that we want to invoke when the button is
 pressed, referencing the handler that we defined earlier::
 
-        button = toga.Button('Hello world', on_press=button_handler)
+        button = toga.Button("Hello world", on_press=button_handler)
 
 Now we have to define how the button will appear in the window. By default,
 Toga uses a style algorithm called ``Pack``, which is a bit like "CSS-lite".
@@ -173,13 +173,13 @@ method defining the main window contents. We wrap this creation process into a
 method called ``main()``, which returns a new instance of our application::
 
     def main():
-        return toga.App('First App', 'org.beeware.helloworld', startup=build)
+        return toga.App("First App", "org.beeware.toga.tutorial", startup=build)
 
 The entry point for the project then needs to instantiate this entry point
 and start the main app loop. The call to ``main_loop()`` is a blocking call;
 it won't return until you quit the main app::
 
-    if __name__ == '__main__':
+    if __name__ == "__main__":
         main().main_loop()
 
 And that's it! Save this script as ``helloworld.py``, and you're ready to go.

--- a/examples/.template/{{ cookiecutter.name }}/pyproject.toml
+++ b/examples/.template/{{ cookiecutter.name }}/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "{{ cookiecutter.formal_name }}"
-bundle = "org.beeware"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
@@ -50,6 +50,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/.template/{{ cookiecutter.name }}/pyproject.toml
+++ b/examples/.template/{{ cookiecutter.name }}/pyproject.toml
@@ -46,3 +46,17 @@ requires = [
 requires = [
     '../../android',
 ]
+
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]
+
+# Web deployment
+[tool.briefcase.app.{{ cookiecutter.name }}.web]
+requires = [
+    "../../web",
+]
+style_framework = "Shoelace v2.3"

--- a/examples/.template/{{ cookiecutter.name }}/{{ cookiecutter.name }}/__init__.py
+++ b/examples/.template/{{ cookiecutter.name }}/{{ cookiecutter.name }}/__init__.py
@@ -1,9 +1,9 @@
 # Examples of valid version strings
-# __version__ = '1.2.3.dev1'  # Development release 1
-# __version__ = '1.2.3a1'     # Alpha Release 1
-# __version__ = '1.2.3b1'     # Beta Release 1
-# __version__ = '1.2.3rc1'    # RC Release 1
-# __version__ = '1.2.3'       # Final Release
-# __version__ = '1.2.3.post1' # Post Release 1
+# __version__ = "1.2.3.dev1"  # Development release 1
+# __version__ = "1.2.3a1"     # Alpha Release 1
+# __version__ = "1.2.3b1"     # Beta Release 1
+# __version__ = "1.2.3rc1"    # RC Release 1
+# __version__ = "1.2.3"       # Final Release
+# __version__ = "1.2.3.post1" # Post Release 1
 
-__version__ = '0.0.1'
+__version__ = "0.0.1"

--- a/examples/.template/{{ cookiecutter.name }}/{{ cookiecutter.name }}/__main__.py
+++ b/examples/.template/{{ cookiecutter.name }}/{{ cookiecutter.name }}/__main__.py
@@ -1,4 +1,4 @@
 from {{ cookiecutter.name }}.app import main
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main().main_loop()

--- a/examples/.template/{{ cookiecutter.name }}/{{ cookiecutter.name }}/app.py
+++ b/examples/.template/{{ cookiecutter.name }}/{{ cookiecutter.name }}/app.py
@@ -16,14 +16,14 @@ class Example{{ cookiecutter.widget_name }}App(toga.App):
         self.main_window = toga.MainWindow()
 
         # Label to show responses.
-        self.label = toga.Label('Ready.')
+        self.label = toga.Label("Ready.")
 
         widget = toga.{{ cookiecutter.widget_name }}()
 
         # Buttons
         btn_style = Pack(flex=1)
-        btn_do_stuff = toga.Button('Do stuff', on_press=self.do_stuff, style=btn_style)
-        btn_clear = toga.Button('Clear', on_press=self.do_clear, style=btn_style)
+        btn_do_stuff = toga.Button("Do stuff", on_press=self.do_stuff, style=btn_style)
+        btn_clear = toga.Button("Clear", on_press=self.do_clear, style=btn_style)
         btn_box = toga.Box(
             children=[
                 btn_do_stuff,
@@ -52,9 +52,9 @@ class Example{{ cookiecutter.widget_name }}App(toga.App):
 
 
 def main():
-    return Example{{ cookiecutter.widget_name }}App('{{ cookiecutter.formal_name }}', 'org.beeware.widgets.{{ cookiecutter.name }}')
+    return Example{{ cookiecutter.widget_name }}App("{{ cookiecutter.formal_name }}", "org.beeware.toga.examples.{{ cookiecutter.name }}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     app = main()
     app.main_loop()

--- a/examples/activityindicator/activityindicator/app.py
+++ b/examples/activityindicator/activityindicator/app.py
@@ -37,7 +37,7 @@ class ExampleActivityIndicatorApp(toga.App):
 
 def main():
     return ExampleActivityIndicatorApp(
-        "Activity Indicator", "org.beeware.widgets.activityindicator"
+        "Activity Indicator", "org.beeware.toga.examples.activityindicator"
     )
 
 

--- a/examples/activityindicator/pyproject.toml
+++ b/examples/activityindicator/pyproject.toml
@@ -47,6 +47,13 @@ requires = [
     "../../android",
 ]
 
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]
+
 # Web deployment
 [tool.briefcase.app.activityindicator.web]
 requires = [

--- a/examples/activityindicator/pyproject.toml
+++ b/examples/activityindicator/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "Activity Indicator"
-bundle = "org.beeware"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
@@ -50,6 +50,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/beeliza/beeliza/app.py
+++ b/examples/beeliza/beeliza/app.py
@@ -93,7 +93,7 @@ class BeelizaApp(toga.App):
 
 
 def main():
-    return BeelizaApp("Beeliza", "org.beeware.beeliza")
+    return BeelizaApp("Beeliza", "org.beeware.toga.examples.beeliza")
 
 
 if __name__ == "__main__":

--- a/examples/beeliza/pyproject.toml
+++ b/examples/beeliza/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "Beeliza"
-bundle = "org.beeware"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
@@ -50,6 +50,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/beeliza/pyproject.toml
+++ b/examples/beeliza/pyproject.toml
@@ -47,6 +47,13 @@ requires = [
     "../../android",
 ]
 
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]
+
 # Web deployment
 [tool.briefcase.app.beeliza.web]
 requires = [

--- a/examples/box/box/app.py
+++ b/examples/box/box/app.py
@@ -82,7 +82,7 @@ class ExampleBoxApp(toga.App):
 def main():
     # Application class
     #   App name and namespace
-    app = ExampleBoxApp("Box", "org.beeware.widgets.boxes")
+    app = ExampleBoxApp("Box", "org.beeware.toga.examples.boxes")
     return app
 
 

--- a/examples/box/pyproject.toml
+++ b/examples/box/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "Box Demo"
-bundle = "org.beeware"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
@@ -50,6 +50,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/box/pyproject.toml
+++ b/examples/box/pyproject.toml
@@ -47,6 +47,13 @@ requires = [
     "../../android",
 ]
 
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]
+
 # Web deployment
 [tool.briefcase.app.box.web]
 requires = [

--- a/examples/button/button/app.py
+++ b/examples/button/button/app.py
@@ -119,7 +119,7 @@ class ExampleButtonApp(toga.App):
 def main():
     # Application class
     #   App name and namespace
-    app = ExampleButtonApp("Button", "org.beeware.widgets.buttons")
+    app = ExampleButtonApp("Button", "org.beeware.toga.examples.buttons")
     return app
 
 

--- a/examples/button/pyproject.toml
+++ b/examples/button/pyproject.toml
@@ -47,6 +47,13 @@ requires = [
     "../../android",
 ]
 
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]
+
 # Web deployment
 [tool.briefcase.app.button.web]
 requires = [

--- a/examples/button/pyproject.toml
+++ b/examples/button/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "Button Demo"
-bundle = "org.beeware"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
@@ -50,6 +50,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/canvas/canvas/app.py
+++ b/examples/canvas/canvas/app.py
@@ -539,7 +539,7 @@ class ExampleCanvasApp(toga.App):
 
 
 def main():
-    return ExampleCanvasApp("Canvas", "org.beeware.widgets.canvas")
+    return ExampleCanvasApp("Canvas", "org.beeware.toga.examples.canvas")
 
 
 if __name__ == "__main__":

--- a/examples/canvas/pyproject.toml
+++ b/examples/canvas/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "Canvas Demo"
-bundle = "org.beeware"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
@@ -50,6 +50,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/canvas/pyproject.toml
+++ b/examples/canvas/pyproject.toml
@@ -47,6 +47,13 @@ requires = [
     "../../android",
 ]
 
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]
+
 # Web deployment
 [tool.briefcase.app.canvas.web]
 requires = [

--- a/examples/colors/colors/app.py
+++ b/examples/colors/colors/app.py
@@ -208,7 +208,7 @@ class ColorsApp(toga.App):
 
 
 def main():
-    return ColorsApp("Colors", "org.beeware.widgets.colors")
+    return ColorsApp("Colors", "org.beeware.toga.examples.colors")
 
 
 if __name__ == "__main__":

--- a/examples/colors/pyproject.toml
+++ b/examples/colors/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "colors"
-bundle = "org.beeware"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
@@ -50,6 +50,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/colors/pyproject.toml
+++ b/examples/colors/pyproject.toml
@@ -47,6 +47,13 @@ requires = [
     "../../android",
 ]
 
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]
+
 # Web deployment
 [tool.briefcase.app.colors.web]
 requires = [

--- a/examples/command/command/app.py
+++ b/examples/command/command/app.py
@@ -169,7 +169,7 @@ class ExampleTestCommandApp(toga.App):
 
 
 def main():
-    return ExampleTestCommandApp("Test Command", "org.beeware.widgets.command")
+    return ExampleTestCommandApp("Test Command", "org.beeware.toga.examples.command")
 
 
 if __name__ == "__main__":

--- a/examples/command/pyproject.toml
+++ b/examples/command/pyproject.toml
@@ -47,6 +47,13 @@ requires = [
     "../../android",
 ]
 
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]
+
 # Web deployment
 [tool.briefcase.app.command.web]
 requires = [

--- a/examples/command/pyproject.toml
+++ b/examples/command/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "Command Example"
-bundle = "org.beeware"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
@@ -50,6 +50,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/date_and_time/date_and_time/app.py
+++ b/examples/date_and_time/date_and_time/app.py
@@ -136,7 +136,7 @@ class DateAndTimeApp(toga.App):
 
 
 def main():
-    return DateAndTimeApp("Dates and Times", "org.beeware.widgets.date_and_time")
+    return DateAndTimeApp("Dates and Times", "org.beeware.toga.examples.date_and_time")
 
 
 if __name__ == "__main__":

--- a/examples/date_and_time/pyproject.toml
+++ b/examples/date_and_time/pyproject.toml
@@ -47,6 +47,13 @@ requires = [
     "../../android",
 ]
 
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]
+
 # Web deployment
 [tool.briefcase.app.date_and_time.web]
 requires = [

--- a/examples/date_and_time/pyproject.toml
+++ b/examples/date_and_time/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "Date And Time"
-bundle = "org.beeware"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
@@ -50,6 +50,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/detailedlist/detailedlist/app.py
+++ b/examples/detailedlist/detailedlist/app.py
@@ -142,7 +142,9 @@ class ExampleDetailedListApp(toga.App):
 
 
 def main():
-    return ExampleDetailedListApp("Detailed List", "org.beeware.widgets.detailedlist")
+    return ExampleDetailedListApp(
+        "Detailed List", "org.beeware.toga.examples.detailedlist"
+    )
 
 
 if __name__ == "__main__":

--- a/examples/detailedlist/pyproject.toml
+++ b/examples/detailedlist/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "DetailedList Demo"
-bundle = "org.beeware"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
@@ -50,6 +50,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/detailedlist/pyproject.toml
+++ b/examples/detailedlist/pyproject.toml
@@ -47,6 +47,13 @@ requires = [
     "../../android",
 ]
 
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]
+
 # Web deployment
 [tool.briefcase.app.detailedlist.web]
 requires = [

--- a/examples/dialogs/dialogs/app.py
+++ b/examples/dialogs/dialogs/app.py
@@ -326,7 +326,7 @@ class ExampleDialogsApp(toga.App):
 
 
 def main():
-    return ExampleDialogsApp("Dialogs", "org.beeware.widgets.dialogs")
+    return ExampleDialogsApp("Dialogs", "org.beeware.toga.examples.dialogs")
 
 
 if __name__ == "__main__":

--- a/examples/dialogs/pyproject.toml
+++ b/examples/dialogs/pyproject.toml
@@ -47,6 +47,13 @@ requires = [
     "../../android",
 ]
 
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]
+
 # Web deployment
 [tool.briefcase.app.dialogs.web]
 requires = [

--- a/examples/dialogs/pyproject.toml
+++ b/examples/dialogs/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "Dialog Demo"
-bundle = "org.beeware"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
@@ -50,6 +50,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/divider/divider/app.py
+++ b/examples/divider/divider/app.py
@@ -37,7 +37,7 @@ class DividerApp(toga.App):
 def main():
     # Application class
     #   App name and namespace
-    app = DividerApp("Dividers", "org.beeware.helloworld")
+    app = DividerApp("Dividers", "org.beeware.toga.examples.divider")
     return app
 
 

--- a/examples/divider/pyproject.toml
+++ b/examples/divider/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "Divider Demo"
-bundle = "org.beeware"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
@@ -50,6 +50,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/divider/pyproject.toml
+++ b/examples/divider/pyproject.toml
@@ -47,6 +47,13 @@ requires = [
     "../../android",
 ]
 
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]
+
 # Web deployment
 [tool.briefcase.app.divider.web]
 requires = [

--- a/examples/documentapp/documentapp/app.py
+++ b/examples/documentapp/documentapp/app.py
@@ -29,7 +29,7 @@ class ExampleDocument(toga.Document):
 def main():
     return toga.DocumentApp(
         "Document App",
-        "org.beeware.widgets.documentapp",
+        "org.beeware.toga.examples.documentapp",
         document_types={
             "exampledoc": ExampleDocument,
         },

--- a/examples/documentapp/pyproject.toml
+++ b/examples/documentapp/pyproject.toml
@@ -47,6 +47,13 @@ requires = [
     "../../android",
 ]
 
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]
+
 # Web deployment
 [tool.briefcase.app.documentapp.web]
 requires = [

--- a/examples/documentapp/pyproject.toml
+++ b/examples/documentapp/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "Document App"
-bundle = "org.beeware"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
@@ -50,6 +50,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/examples_overview/examples_overview/app.py
+++ b/examples/examples_overview/examples_overview/app.py
@@ -121,7 +121,7 @@ class ExampleExamplesOverviewApp(toga.App):
 
 def main():
     return ExampleExamplesOverviewApp(
-        "Examples Overview", "org.beeware.widgets.examples_overview"
+        "Examples Overview", "org.beeware.toga.examples.examples_overview"
     )
 
 

--- a/examples/examples_overview/pyproject.toml
+++ b/examples/examples_overview/pyproject.toml
@@ -47,6 +47,13 @@ requires = [
     "../../android",
 ]
 
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]
+
 # Web deployment
 [tool.briefcase.app.examples_overview.web]
 requires = [

--- a/examples/examples_overview/pyproject.toml
+++ b/examples/examples_overview/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "Examples Overview"
-bundle = "org.beeware"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
@@ -50,6 +50,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/focus/focus/app.py
+++ b/examples/focus/focus/app.py
@@ -145,7 +145,7 @@ class ExampleFocusApp(toga.App):
 def main():
     # Application class
     #   App name and namespace
-    app = ExampleFocusApp("Focus", "org.beeware.widgets.focus")
+    app = ExampleFocusApp("Focus", "org.beeware.toga.examples.focus")
     return app
 
 

--- a/examples/focus/pyproject.toml
+++ b/examples/focus/pyproject.toml
@@ -47,6 +47,13 @@ requires = [
     "../../android",
 ]
 
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]
+
 # Web deployment
 [tool.briefcase.app.focus.web]
 requires = [

--- a/examples/focus/pyproject.toml
+++ b/examples/focus/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "Focus Demo"
-bundle = "org.beeware"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
@@ -50,6 +50,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/font/font/app.py
+++ b/examples/font/font/app.py
@@ -187,7 +187,7 @@ class ExampleFontExampleApp(toga.App):
 
 
 def main():
-    return ExampleFontExampleApp("Font Example", "org.beeware.widgets.font")
+    return ExampleFontExampleApp("Font Example", "org.beeware.toga.examples.font")
 
 
 if __name__ == "__main__":

--- a/examples/font/pyproject.toml
+++ b/examples/font/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "Font Example"
-bundle = "org.beeware"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
@@ -50,6 +50,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/font/pyproject.toml
+++ b/examples/font/pyproject.toml
@@ -47,6 +47,13 @@ requires = [
     "../../android",
 ]
 
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]
+
 # Web deployment
 [tool.briefcase.app.font.web]
 requires = [

--- a/examples/font_size/font_size/app.py
+++ b/examples/font_size/font_size/app.py
@@ -31,4 +31,4 @@ class FontSize(toga.App):
 
 
 def main():
-    return FontSize("Font size", "org.beeware.font_size")
+    return FontSize("Font size", "org.beeware.toga.examples.font_size")

--- a/examples/font_size/pyproject.toml
+++ b/examples/font_size/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "Font size test"
-bundle = "org.beeware"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
@@ -49,6 +49,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/font_size/pyproject.toml
+++ b/examples/font_size/pyproject.toml
@@ -46,6 +46,13 @@ requires = [
     "../../android",
 ]
 
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]
+
 # Web deployment
 [tool.briefcase.app.font_size.web]
 requires = [

--- a/examples/handlers/handlers/app.py
+++ b/examples/handlers/handlers/app.py
@@ -102,7 +102,7 @@ class HandlerApp(toga.App):
 
 
 def main():
-    return HandlerApp("Handlers", "org.beeware.handlers")
+    return HandlerApp("Handlers", "org.beeware.toga.examples.handlers")
 
 
 if __name__ == "__main__":

--- a/examples/handlers/pyproject.toml
+++ b/examples/handlers/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "Handler Demo"
-bundle = "org.beeware"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
@@ -50,6 +50,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/handlers/pyproject.toml
+++ b/examples/handlers/pyproject.toml
@@ -47,6 +47,13 @@ requires = [
     "../../android",
 ]
 
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]
+
 # Web deployment
 [tool.briefcase.app.handlers.web]
 requires = [

--- a/examples/imageview/imageview/app.py
+++ b/examples/imageview/imageview/app.py
@@ -98,7 +98,7 @@ class ImageViewApp(toga.App):
 
 
 def main():
-    return ImageViewApp("ImageView", "org.beeware.widgets.imageview")
+    return ImageViewApp("ImageView", "org.beeware.toga.examples.imageview")
 
 
 if __name__ == "__main__":

--- a/examples/imageview/pyproject.toml
+++ b/examples/imageview/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "ImageView Demo"
-bundle = "org.beeware"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"

--- a/examples/layout/layout/app.py
+++ b/examples/layout/layout/app.py
@@ -130,7 +130,7 @@ class ExampleLayoutApp(toga.App):
 
 
 def main():
-    return ExampleLayoutApp("Layout", "org.beeware.widgets.layout")
+    return ExampleLayoutApp("Layout", "org.beeware.toga.examples.layout")
 
 
 if __name__ == "__main__":

--- a/examples/layout/pyproject.toml
+++ b/examples/layout/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "Layout Test"
-bundle = "org.beeware"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
@@ -50,6 +50,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/layout/pyproject.toml
+++ b/examples/layout/pyproject.toml
@@ -47,6 +47,13 @@ requires = [
     "../../android",
 ]
 
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]
+
 # Web deployment
 [tool.briefcase.app.layout.web]
 requires = [

--- a/examples/multilinetextinput/multilinetextinput/app.py
+++ b/examples/multilinetextinput/multilinetextinput/app.py
@@ -98,7 +98,7 @@ class ExampleMultilineTextInputApp(toga.App):
 
 def main():
     return ExampleMultilineTextInputApp(
-        "Multiline Text Input", "org.beeware.widgets.multilinetextinput"
+        "Multiline Text Input", "org.beeware.toga.examples.multilinetextinput"
     )
 
 

--- a/examples/multilinetextinput/pyproject.toml
+++ b/examples/multilinetextinput/pyproject.toml
@@ -47,6 +47,13 @@ requires = [
     "../../android",
 ]
 
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]
+
 # Web deployment
 [tool.briefcase.app.multilinetextinput.web]
 requires = [

--- a/examples/multilinetextinput/pyproject.toml
+++ b/examples/multilinetextinput/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "MultilineTextInput Demo"
-bundle = "org.beeware"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
@@ -50,6 +50,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/numberinput/numberinput/app.py
+++ b/examples/numberinput/numberinput/app.py
@@ -70,7 +70,9 @@ class ExampleNumberInputApp(toga.App):
 
 
 def main():
-    return ExampleNumberInputApp("Demo NumberInput", "org.beeware.widgets.numberinput")
+    return ExampleNumberInputApp(
+        "Demo NumberInput", "org.beeware.toga.examples.numberinput"
+    )
 
 
 if __name__ == "__main__":

--- a/examples/numberinput/pyproject.toml
+++ b/examples/numberinput/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "Demo NumberInput"
-bundle = "org.beeware"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
@@ -50,6 +50,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/numberinput/pyproject.toml
+++ b/examples/numberinput/pyproject.toml
@@ -47,6 +47,13 @@ requires = [
     "../../android",
 ]
 
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]
+
 # Web deployment
 [tool.briefcase.app.numberinput.web]
 requires = [

--- a/examples/optioncontainer/optioncontainer/app.py
+++ b/examples/optioncontainer/optioncontainer/app.py
@@ -180,7 +180,7 @@ class ExampleOptionContainerApp(toga.App):
 
 def main():
     return ExampleOptionContainerApp(
-        "Option Container Example", "org.beeware.widgets.optioncontainer"
+        "Option Container Example", "org.beeware.toga.examples.optioncontainer"
     )
 
 

--- a/examples/optioncontainer/pyproject.toml
+++ b/examples/optioncontainer/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "Option Container Example"
-bundle = "org.beeware"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
@@ -50,6 +50,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/optioncontainer/pyproject.toml
+++ b/examples/optioncontainer/pyproject.toml
@@ -47,6 +47,13 @@ requires = [
     "../../android",
 ]
 
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]
+
 # Web deployment
 [tool.briefcase.app.optioncontainer.web]
 requires = [

--- a/examples/passwordinput/passwordinput/app.py
+++ b/examples/passwordinput/passwordinput/app.py
@@ -71,7 +71,7 @@ class PasswordInputApp(toga.App):
 
 
 def main():
-    return PasswordInputApp("PasswordInput", "org.beeware.widgets.passwordinput")
+    return PasswordInputApp("PasswordInput", "org.beeware.toga.examples.passwordinput")
 
 
 if __name__ == "__main__":

--- a/examples/passwordinput/pyproject.toml
+++ b/examples/passwordinput/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "Password Input"
-bundle = "org.beeware"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"

--- a/examples/positron-django/pyproject.toml
+++ b/examples/positron-django/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "Positron"
-bundle = "org.beeware"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
@@ -52,6 +52,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/positron-django/pyproject.toml
+++ b/examples/positron-django/pyproject.toml
@@ -49,6 +49,13 @@ requires = [
     "../../android",
 ]
 
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]
+
 # Web deployment
 [tool.briefcase.app.positron.web]
 requires = [

--- a/examples/positron-static/pyproject.toml
+++ b/examples/positron-static/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "Positron"
-bundle = "org.beeware"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
@@ -51,6 +51,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/positron-static/pyproject.toml
+++ b/examples/positron-static/pyproject.toml
@@ -48,6 +48,13 @@ requires = [
     "../../android",
 ]
 
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]
+
 # Web deployment
 [tool.briefcase.app.positron.web]
 requires = [

--- a/examples/progressbar/progressbar/app.py
+++ b/examples/progressbar/progressbar/app.py
@@ -129,7 +129,7 @@ class ProgressBarApp(toga.App):
 
 def main():
     # App name and namespace
-    return ProgressBarApp("ProgressBar", "org.beeware.examples.progressbar")
+    return ProgressBarApp("ProgressBar", "org.beeware.toga.examples.progressbar")
 
 
 if __name__ == "__main__":

--- a/examples/progressbar/pyproject.toml
+++ b/examples/progressbar/pyproject.toml
@@ -47,6 +47,13 @@ requires = [
     "../../android",
 ]
 
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]
+
 # Web deployment
 [tool.briefcase.app.progressbar.web]
 requires = [

--- a/examples/progressbar/pyproject.toml
+++ b/examples/progressbar/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "ProgressBar demo"
-bundle = "org.beeware"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
@@ -50,6 +50,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/resize/pyproject.toml
+++ b/examples/resize/pyproject.toml
@@ -47,6 +47,13 @@ requires = [
     "../../android",
 ]
 
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]
+
 # Web deployment
 [tool.briefcase.app.resize.web]
 requires = [

--- a/examples/resize/pyproject.toml
+++ b/examples/resize/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "Resize Test"
-bundle = "org.beeware"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
@@ -50,6 +50,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/resize/resize/app.py
+++ b/examples/resize/resize/app.py
@@ -112,4 +112,4 @@ def setattr_if_changed(obj, name, value):
 
 
 def main():
-    return Resize("Resize", "org.beeware.resize")
+    return Resize("Resize", "org.beeware.toga.examples.resize")

--- a/examples/screenshot/pyproject.toml
+++ b/examples/screenshot/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "Screenshot Generator"
-bundle = "org.beeware"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
@@ -51,6 +51,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/screenshot/pyproject.toml
+++ b/examples/screenshot/pyproject.toml
@@ -47,3 +47,10 @@ requires = [
 requires = [
     "../../android",
 ]
+
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]

--- a/examples/screenshot/screenshot/app.py
+++ b/examples/screenshot/screenshot/app.py
@@ -479,7 +479,9 @@ class ScreenshotGeneratorApp(toga.App):
 
 
 def main():
-    return ScreenshotGeneratorApp("My Application", "org.beeware.widgets.screenshot")
+    return ScreenshotGeneratorApp(
+        "My Application", "org.beeware.toga.examples.screenshot"
+    )
 
 
 if __name__ == "__main__":

--- a/examples/scrollcontainer/pyproject.toml
+++ b/examples/scrollcontainer/pyproject.toml
@@ -47,6 +47,13 @@ requires = [
     "../../android",
 ]
 
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]
+
 # Web deployment
 [tool.briefcase.app.scrollcontainer.web]
 requires = [

--- a/examples/scrollcontainer/pyproject.toml
+++ b/examples/scrollcontainer/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "ScrollContainer Demo"
-bundle = "org.beeware"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
@@ -50,6 +50,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/scrollcontainer/scrollcontainer/app.py
+++ b/examples/scrollcontainer/scrollcontainer/app.py
@@ -152,7 +152,9 @@ class ScrollContainerApp(toga.App):
 
 
 def main():
-    return ScrollContainerApp("ScrollContainer", "org.beeware.widgets.scrollcontainer")
+    return ScrollContainerApp(
+        "ScrollContainer", "org.beeware.toga.examples.scrollcontainer"
+    )
 
 
 if __name__ == "__main__":

--- a/examples/selection/pyproject.toml
+++ b/examples/selection/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "Selection Demo"
-bundle = "org.beeware"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
@@ -50,6 +50,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/selection/pyproject.toml
+++ b/examples/selection/pyproject.toml
@@ -47,6 +47,13 @@ requires = [
     "../../android",
 ]
 
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]
+
 # Web deployment
 [tool.briefcase.app.selection.web]
 requires = [

--- a/examples/selection/selection/app.py
+++ b/examples/selection/selection/app.py
@@ -146,7 +146,7 @@ class SelectionApp(toga.App):
 
 def main():
     # App name and namespace
-    return SelectionApp("Selection", "org.beeware.selection")
+    return SelectionApp("Selection", "org.beeware.toga.examples.selection")
 
 
 if __name__ == "__main__":

--- a/examples/slider/pyproject.toml
+++ b/examples/slider/pyproject.toml
@@ -47,6 +47,13 @@ requires = [
     "../../android",
 ]
 
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]
+
 # Web deployment
 [tool.briefcase.app.slider.web]
 requires = [

--- a/examples/slider/pyproject.toml
+++ b/examples/slider/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "Slider Demo"
-bundle = "org.beeware"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
@@ -50,6 +50,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/slider/slider/app.py
+++ b/examples/slider/slider/app.py
@@ -105,4 +105,4 @@ class SliderApp(toga.App):
 
 def main():
     # App name and namespace
-    return SliderApp("Slider", "org.beeware.examples.slider")
+    return SliderApp("Slider", "org.beeware.toga.examples.slider")

--- a/examples/splitcontainer/pyproject.toml
+++ b/examples/splitcontainer/pyproject.toml
@@ -47,6 +47,13 @@ requires = [
     "../../android",
 ]
 
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]
+
 # Web deployment
 [tool.briefcase.app.splitcontainer.web]
 requires = [

--- a/examples/splitcontainer/pyproject.toml
+++ b/examples/splitcontainer/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "SplitContainer Demo"
-bundle = "org.beeware"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
@@ -50,6 +50,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/splitcontainer/splitcontainer/app.py
+++ b/examples/splitcontainer/splitcontainer/app.py
@@ -96,7 +96,9 @@ class SplitContainerApp(toga.App):
 
 
 def main():
-    return SplitContainerApp("SplitContainer", "org.beeware.widgets.splitcontainer")
+    return SplitContainerApp(
+        "SplitContainer", "org.beeware.toga.examples.splitcontainer"
+    )
 
 
 if __name__ == "__main__":

--- a/examples/switch_demo/pyproject.toml
+++ b/examples/switch_demo/pyproject.toml
@@ -47,6 +47,13 @@ requires = [
     "../../android",
 ]
 
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]
+
 # Web deployment
 [tool.briefcase.app.switch_demo.web]
 requires = [

--- a/examples/switch_demo/pyproject.toml
+++ b/examples/switch_demo/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "Switch Demo"
-bundle = "org.beeware"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
@@ -50,6 +50,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/switch_demo/switch_demo/app.py
+++ b/examples/switch_demo/switch_demo/app.py
@@ -44,7 +44,7 @@ class SwitchApp(toga.App):
 def main():
     # Application class
     #   App name and namespace
-    app = SwitchApp("Switches", "org.beeware.helloworld")
+    app = SwitchApp("Switches", "org.beeware.toga.examples.switch_demo")
     return app
 
 

--- a/examples/table/pyproject.toml
+++ b/examples/table/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "Table Demo"
-bundle = "org.beeware"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
@@ -49,6 +49,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/table/pyproject.toml
+++ b/examples/table/pyproject.toml
@@ -46,6 +46,13 @@ requires = [
     "../../android",
 ]
 
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]
+
 # Web deployment
 [tool.briefcase.app.table.web]
 requires = [

--- a/examples/table/table/app.py
+++ b/examples/table/table/app.py
@@ -234,7 +234,7 @@ class ExampleTableApp(toga.App):
 
 
 def main():
-    return ExampleTableApp("Table", "org.beeware.widgets.table")
+    return ExampleTableApp("Table", "org.beeware.toga.examples.table")
 
 
 if __name__ == "__main__":

--- a/examples/table_source/pyproject.toml
+++ b/examples/table_source/pyproject.toml
@@ -47,6 +47,13 @@ requires = [
     "../../android",
 ]
 
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]
+
 # Web deployment
 [tool.briefcase.app.table_source.web]
 requires = [

--- a/examples/table_source/pyproject.toml
+++ b/examples/table_source/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "TableSource Demo"
-bundle = "org.beeware"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
@@ -50,6 +50,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/table_source/table_source/app.py
+++ b/examples/table_source/table_source/app.py
@@ -199,7 +199,9 @@ class ExampleTableSourceApp(toga.App):
 
 
 def main():
-    return ExampleTableSourceApp("Table Source", "org.beeware.widgets.table_source")
+    return ExampleTableSourceApp(
+        "Table Source", "org.beeware.toga.examples.table_source"
+    )
 
 
 if __name__ == "__main__":

--- a/examples/textinput/pyproject.toml
+++ b/examples/textinput/pyproject.toml
@@ -47,6 +47,13 @@ requires = [
     "../../android",
 ]
 
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]
+
 # Web deployment
 [tool.briefcase.app.textinput.web]
 requires = [

--- a/examples/textinput/pyproject.toml
+++ b/examples/textinput/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "Text Input Demo"
-bundle = "org.beeware"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
@@ -50,6 +50,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/textinput/textinput/app.py
+++ b/examples/textinput/textinput/app.py
@@ -160,7 +160,7 @@ class TextInputApp(toga.App):
 
 
 def main():
-    return TextInputApp("TextInput", "org.beeware.widgets.textinput")
+    return TextInputApp("TextInput", "org.beeware.toga.examples.textinput")
 
 
 if __name__ == "__main__":

--- a/examples/tree/pyproject.toml
+++ b/examples/tree/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "Tree Demo"
-bundle = "org.beeware"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
@@ -50,6 +50,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/tree/pyproject.toml
+++ b/examples/tree/pyproject.toml
@@ -47,6 +47,13 @@ requires = [
     "../../android",
 ]
 
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]
+
 # Web deployment
 [tool.briefcase.app.tree.web]
 requires = [

--- a/examples/tree/tree/app.py
+++ b/examples/tree/tree/app.py
@@ -152,7 +152,7 @@ class ExampleTreeApp(toga.App):
 
 
 def main():
-    return ExampleTreeApp("Tree", "org.beeware.widgets.tree")
+    return ExampleTreeApp("Tree", "org.beeware.toga.examples.tree")
 
 
 if __name__ == "__main__":

--- a/examples/tree_source/pyproject.toml
+++ b/examples/tree_source/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "TreeSource Demo"
-bundle = "org.beeware"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
@@ -50,6 +50,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/tree_source/pyproject.toml
+++ b/examples/tree_source/pyproject.toml
@@ -47,6 +47,13 @@ requires = [
     "../../android",
 ]
 
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]
+
 # Web deployment
 [tool.briefcase.app.tree_source.web]
 requires = [

--- a/examples/tree_source/tree_source/app.py
+++ b/examples/tree_source/tree_source/app.py
@@ -172,7 +172,7 @@ class ExampleTreeSourceApp(toga.App):
 
 
 def main():
-    return ExampleTreeSourceApp("Tree Source", "org.beeware.widgets.tree_source")
+    return ExampleTreeSourceApp("Tree Source", "org.beeware.toga.examples.tree_source")
 
 
 if __name__ == "__main__":

--- a/examples/tutorial0/pyproject.toml
+++ b/examples/tutorial0/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "Tutorial 0"
-bundle = "org.beeware"
+bundle = "org.beeware.toga"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
@@ -50,6 +50,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/tutorial0/pyproject.toml
+++ b/examples/tutorial0/pyproject.toml
@@ -47,6 +47,13 @@ requires = [
     "../../android",
 ]
 
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]
+
 # Web deployment
 [tool.briefcase.app.tutorial.web]
 requires = [

--- a/examples/tutorial0/tutorial/app.py
+++ b/examples/tutorial0/tutorial/app.py
@@ -17,7 +17,7 @@ def build(app):
 
 
 def main():
-    return toga.App("First App", "org.beeware.helloworld", startup=build)
+    return toga.App("First App", "org.beeware.toga.tutorial", startup=build)
 
 
 if __name__ == "__main__":

--- a/examples/tutorial1/pyproject.toml
+++ b/examples/tutorial1/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "Tutorial 1"
-bundle = "org.beeware"
+bundle = "org.beeware.toga"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
@@ -50,6 +50,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/tutorial1/pyproject.toml
+++ b/examples/tutorial1/pyproject.toml
@@ -47,6 +47,13 @@ requires = [
     "../../android",
 ]
 
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]
+
 # Web deployment
 [tool.briefcase.app.tutorial.web]
 requires = [

--- a/examples/tutorial1/tutorial/app.py
+++ b/examples/tutorial1/tutorial/app.py
@@ -49,7 +49,7 @@ def build(app):
 
 
 def main():
-    return toga.App("Temperature Converter", "org.beeware.f_to_c", startup=build)
+    return toga.App("Temperature Converter", "org.beeware.toga.tutorial", startup=build)
 
 
 if __name__ == "__main__":

--- a/examples/tutorial2/pyproject.toml
+++ b/examples/tutorial2/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "Tutorial 2"
-bundle = "org.beeware"
+bundle = "org.beeware.toga"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
@@ -50,6 +50,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/tutorial2/pyproject.toml
+++ b/examples/tutorial2/pyproject.toml
@@ -47,6 +47,13 @@ requires = [
     "../../android",
 ]
 
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]
+
 # Web deployment
 [tool.briefcase.app.tutorial.web]
 requires = [

--- a/examples/tutorial2/tutorial/app.py
+++ b/examples/tutorial2/tutorial/app.py
@@ -154,7 +154,7 @@ class Tutorial2App(toga.App):
 
 
 def main():
-    return Tutorial2App("Tutorial 2", "org.beeware.helloworld")
+    return Tutorial2App("Tutorial 2", "org.beeware.toga.tutorial")
 
 
 if __name__ == "__main__":

--- a/examples/tutorial3/pyproject.toml
+++ b/examples/tutorial3/pyproject.toml
@@ -47,6 +47,13 @@ requires = [
     "../../android",
 ]
 
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]
+
 # Web deployment
 [tool.briefcase.app.tutorial.web]
 requires = [

--- a/examples/tutorial3/pyproject.toml
+++ b/examples/tutorial3/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "Tutorial 3"
-bundle = "org.beeware"
+bundle = "org.beeware.toga"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
@@ -50,6 +50,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/tutorial3/tutorial/app.py
+++ b/examples/tutorial3/tutorial/app.py
@@ -49,7 +49,7 @@ class Graze(toga.App):
 
 
 def main():
-    return Graze("Graze", "org.beeware.graze")
+    return Graze("Graze", "org.beeware.tutorial")
 
 
 if __name__ == "__main__":

--- a/examples/tutorial4/pyproject.toml
+++ b/examples/tutorial4/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "Tutorial 4"
-bundle = "org.beeware"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
@@ -50,6 +50,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/tutorial4/pyproject.toml
+++ b/examples/tutorial4/pyproject.toml
@@ -47,6 +47,13 @@ requires = [
     "../../android",
 ]
 
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]
+
 # Web deployment
 [tool.briefcase.app.tutorial.web]
 requires = [

--- a/examples/tutorial4/tutorial/app.py
+++ b/examples/tutorial4/tutorial/app.py
@@ -135,7 +135,7 @@ class StartApp(toga.App):
 
 
 def main():
-    return StartApp("Tutorial 4", "org.beeware.helloworld")
+    return StartApp("Tutorial 4", "org.beeware.toga.tutorial")
 
 
 if __name__ == "__main__":

--- a/examples/webview/pyproject.toml
+++ b/examples/webview/pyproject.toml
@@ -46,6 +46,13 @@ requires = [
     "../../android",
 ]
 
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]
+
 # Web deployment
 [tool.briefcase.app.webview.web]
 requires = [

--- a/examples/webview/pyproject.toml
+++ b/examples/webview/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "WebView Demo"
-bundle = "org.beeware"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
@@ -49,6 +49,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/webview/webview/app.py
+++ b/examples/webview/webview/app.py
@@ -103,7 +103,7 @@ class ExampleWebView(toga.App):
 
 
 def main():
-    return ExampleWebView("Toga WebView Demo", "org.beeware.widgets.webview")
+    return ExampleWebView("Toga WebView Demo", "org.beeware.toga.examples.webview")
 
 
 if __name__ == "__main__":

--- a/examples/window/pyproject.toml
+++ b/examples/window/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "Window Demo"
-bundle = "org.beeware"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license = "BSD license"
@@ -50,6 +50,7 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
+    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/window/pyproject.toml
+++ b/examples/window/pyproject.toml
@@ -47,6 +47,13 @@ requires = [
     "../../android",
 ]
 
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+    "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
+]
+
 # Web deployment
 [tool.briefcase.app.window.web]
 requires = [

--- a/examples/window/window/app.py
+++ b/examples/window/window/app.py
@@ -229,7 +229,7 @@ class WindowDemoApp(toga.App):
 
 
 def main():
-    return WindowDemoApp("Window Demo", "org.beeware.widgets.window")
+    return WindowDemoApp("Window Demo", "org.beeware.toga.examples.window")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
With the introduction of beeware/briefcase#1610, the Toga examples need to explicitly list their gradle dependencies to avoid a warning at time of build.

The testbed and hardware app have been updated as part of #2350.

Testing the hardware app revealed that there is a discrepancy between the explicitly declared App ID and the app ID constructed from the bundle and app name; I've used this opportunity to normalise all the examples into an `org.beeware.toga.examples` namespace.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
