### PR TITLE
Ensure that winforms doesn't beep when confirming content.

### DIFF
--- a/changes/2374.bugfix.rst
+++ b/changes/2374.bugfix.rst
@@ -1,0 +1,1 @@
+Winforms no longer generates a system beep when pressing Enter in a TextInput.

--- a/winforms/src/toga_winforms/widgets/textinput.py
+++ b/winforms/src/toga_winforms/widgets/textinput.py
@@ -82,6 +82,9 @@ class TextInput(Widget):
     def winforms_key_press(self, sender, event):
         if ord(event.KeyChar) == int(WinForms.Keys.Enter):
             self.interface.on_confirm()
+            # Mark the event as handled; otherwise the Enter event will
+            # propegate upstream, and generate a system beep.
+            event.Handled = True
 
     def winforms_got_focus(self, sender, event):
         self.interface.on_gain_focus()

--- a/winforms/src/toga_winforms/widgets/textinput.py
+++ b/winforms/src/toga_winforms/widgets/textinput.py
@@ -83,7 +83,7 @@ class TextInput(Widget):
         if ord(event.KeyChar) == int(WinForms.Keys.Enter):
             self.interface.on_confirm()
             # Mark the event as handled; otherwise the Enter event will
-            # propegate upstream, and generate a system beep.
+            # propagate upstream, and generate a system beep.
             event.Handled = True
 
     def winforms_got_focus(self, sender, event):


### PR DESCRIPTION
Reported via @ethindp on Discord.

Pressing enter in a TextInput under Winforms generates a system beep. This is the default behaviour for an Enter keypress in  a TextInput; however, in Toga's case, it's undesirable. 

This PR marks the event as processed when Enter is pressed, so that the event doesn't propagate any further, preventing the beep.

I can't think of any reliable way to test this, as we can't monitor for the existence of a system beep, and we don't have visibility on the processing of system events.

It wasn't detected previously (at least, in my case) because the VM I use to test Windows didn't have a speaker connected, so I didn't hear system beeps.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
