### PR TITLE
Fix GC on iOS Camera

### DIFF
--- a/changes/2381.bugfix.rst
+++ b/changes/2381.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed taking photos on iOS using camera.

--- a/changes/2381.bugfix.rst
+++ b/changes/2381.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed taking photos on iOS using camera.
+A crash observed on iOS devices when taking photographs has been resolved.

--- a/changes/2381.docs.rst
+++ b/changes/2381.docs.rst
@@ -1,0 +1,1 @@
+The camera permission requirements on macOS apps were clarified.

--- a/docs/reference/api/hardware/camera.rst
+++ b/docs/reference/api/hardware/camera.rst
@@ -56,7 +56,8 @@ Notes
   The permissions required are platform specific:
 
   * iOS: ``NSCameraUsageDescription`` must be defined in the app's ``Info.plist`` file.
-  * macOS: The ``com.apple.security.device.camera`` entitlement must be enabled.
+  * macOS: The ``com.apple.security.device.camera`` entitlement must be enabled, and
+    ``NSCameraUsageDescription`` must be defined in the app's ``Info.plist`` file.
   * Android: The ``android.permission.CAMERA`` permission must be declared.
 
 * The iOS simulator implements the iOS Camera APIs, but is not able to take photographs.

--- a/iOS/src/toga_iOS/hardware/camera.py
+++ b/iOS/src/toga_iOS/hardware/camera.py
@@ -74,7 +74,8 @@ class Camera:
             ):
                 self.native = iOS.UIImagePickerController.new()
                 self.native.sourceType = UIImagePickerControllerSourceTypeCamera
-                self.native.delegate = TogaImagePickerDelegate.new()
+                self.delegate_link = TogaImagePickerDelegate.new()
+                self.native.delegate = self.delegate_link
             else:
                 self.native = None
         else:  # pragma: no cover


### PR DESCRIPTION
See #2381 - where GC seems to collect self.native.delegate instantly.

Keep a reference to avoid GC until class destroyed.

- Fixes #2381 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
