### PR TITLE
Simplifying static getattr calls

### DIFF
--- a/changes/2396.misc.rst
+++ b/changes/2396.misc.rst
@@ -1,0 +1,1 @@
+getattr calls with string literals for attr have been collapsed to dot lookup.

--- a/testbed/tests/conftest.py
+++ b/testbed/tests/conftest.py
@@ -40,7 +40,7 @@ def app():
 @fixture
 async def app_probe(app):
     module = import_module("tests_backend.app")
-    probe = getattr(module, "AppProbe")(app)
+    probe = module.AppProbe(app)
 
     if app.run_slow:
         print("\nConstructing app probe")
@@ -62,7 +62,7 @@ async def main_window_probe(app, main_window):
     module = import_module("tests_backend.window")
     if app.run_slow:
         print("\nConstructing Window probe")
-    yield getattr(module, "WindowProbe")(app, main_window)
+    yield module.WindowProbe(app, main_window)
 
     main_window.content = old_content
 

--- a/testbed/tests/test_fonts.py
+++ b/testbed/tests/test_fonts.py
@@ -28,7 +28,7 @@ async def font_probe(main_window, widget):
     main_window.content = box
 
     module = import_module("tests_backend.widgets.label")
-    probe = getattr(module, "LabelProbe")(widget)
+    probe = module.LabelProbe(widget)
     await probe.redraw("\nConstructing Font probe")
     probe.assert_container(box)
 

--- a/testbed/tests/test_icons.py
+++ b/testbed/tests/test_icons.py
@@ -8,7 +8,7 @@ import toga
 
 def icon_probe(app, image):
     module = import_module("tests_backend.icons")
-    return getattr(module, "IconProbe")(app, image)
+    return module.IconProbe(app, image)
 
 
 async def test_icon(app):

--- a/testbed/tests/test_images.py
+++ b/testbed/tests/test_images.py
@@ -12,7 +12,7 @@ import toga
 
 def image_probe(app, image):
     module = import_module("tests_backend.images")
-    return getattr(module, "ImageProbe")(app, image)
+    return module.ImageProbe(app, image)
 
 
 async def test_local_image(app):

--- a/testbed/tests/test_window.py
+++ b/testbed/tests/test_window.py
@@ -17,7 +17,7 @@ from toga.style.pack import COLUMN, Pack
 
 def window_probe(app, window):
     module = import_module("tests_backend.window")
-    return getattr(module, "WindowProbe")(app, window)
+    return module.WindowProbe(app, window)
 
 
 @pytest.fixture


### PR DESCRIPTION
This is another kind-of-frivolous-but-why-not PR. Due to the magic of copy & paste, there are a few places where `getattr` is used even thought the attribute isn't dynamic or a reserved word / other syntax error. I've switched them to normal attribute access.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
