### PR TITLE
Add Python3.13 and iOS/macOS ARM64 testing to CI 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ defaults:
 
 # Cancel active CI runs for a PR before starting another run
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow}}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -60,17 +60,33 @@ jobs:
         - "winforms"
 
   core:
-    runs-on: ${{ matrix.platform }}-latest
+    runs-on: ${{ matrix.platform }}
     needs: [pre-commit, towncrier, package]
     continue-on-error: ${{ matrix.experimental }}
     strategy:
+      fail-fast: false
       matrix:
-        platform: [ "macos", "ubuntu", "windows" ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        platform: [ "macos-12", "macos-14", "ubuntu-latest", "windows-latest" ]
+        python-version: [ "3.8", "3.12", "3.13-dev" ]
         include:
           - experimental: false
-          # - python-version: "3.13-dev"
-          #   experimental: true
+          # Test Python 3.9-3.11 on Ubuntu only
+          - platform: "ubuntu-latest"
+            python-version: "3.9"
+            experimental: false
+          - platform: "ubuntu-latest"
+            python-version: "3.10"
+            experimental: false
+          - platform: "ubuntu-latest"
+            python-version: "3.11"
+            experimental: false
+          # Allow development Python to fail without failing entire job.
+          - python-version: "3.13-dev"
+            experimental: true
+        exclude:
+          # macos-14 (i.e. arm64) does not support Python 3.8
+          - platform: "macos-14"
+            python-version: "3.8"
     steps:
     - uses: actions/checkout@v4.1.1
     - name: Set up Python ${{ matrix.python-version }}
@@ -143,15 +159,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        backend: [ "macOS", "windows", "linux", "android", "iOS" ]
+        backend: [ "macOS-x86_64", "macOS-arm64", "windows", "linux", "android", "iOS" ]
         include:
-          - pre-command:
+          - platform: ${{ matrix.backend }}
+            pre-command:
             briefcase-run-prefix:
             briefcase-run-args:
             setup-python: true
 
-          - backend: macOS
-            runs-on: macos-12
+          - backend: "macOS-x86_64"
+            runs-on: "macos-12"
+            platform: "macOS"
+            app-user-data-path: $HOME/Library/Application Support/org.beeware.toga.testbed
+
+          - backend: "macOS-arm64"
+            runs-on: "macos-14"
+            platform: "macOS"
             app-user-data-path: $HOME/Library/Application Support/org.beeware.toga.testbed
 
           # We use a fixed Ubuntu version rather than `-latest` because at some point,
@@ -189,7 +212,7 @@ jobs:
             app-user-data-path: $HOME\AppData\Local\Tiberius Yak\Toga Testbed\Data
 
           - backend: iOS
-            runs-on: macos-12
+            runs-on: macos-14
             briefcase-run-args: ' -d "iPhone SE (3rd generation)"'
             app-user-data-path: $(xcrun simctl get_app_container booted org.beeware.toga.testbed data)/Documents
 

--- a/android/pyproject.toml
+++ b/android/pyproject.toml
@@ -38,6 +38,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development",
     "Topic :: Software Development :: User Interfaces",

--- a/changes/2404.feature.1.rst
+++ b/changes/2404.feature.1.rst
@@ -1,0 +1,1 @@
+Support for Python 3.13 was added.

--- a/changes/2404.feature.2.rst
+++ b/changes/2404.feature.2.rst
@@ -1,0 +1,1 @@
+Toga's release processes now include automated testing on ARM64.

--- a/cocoa/pyproject.toml
+++ b/cocoa/pyproject.toml
@@ -39,6 +39,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development",
     "Topic :: Software Development :: User Interfaces",

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -50,6 +50,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development",
     "Topic :: Software Development :: User Interfaces",

--- a/demo/pyproject.toml
+++ b/demo/pyproject.toml
@@ -45,6 +45,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development",
     "Topic :: Software Development :: User Interfaces",

--- a/dummy/pyproject.toml
+++ b/dummy/pyproject.toml
@@ -37,6 +37,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development",
     "Topic :: Software Development :: User Interfaces",

--- a/gtk/pyproject.toml
+++ b/gtk/pyproject.toml
@@ -40,6 +40,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development",
     "Topic :: Software Development :: User Interfaces",

--- a/iOS/pyproject.toml
+++ b/iOS/pyproject.toml
@@ -38,6 +38,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development",
     "Topic :: Software Development :: User Interfaces",

--- a/nursery/curses/pyproject.toml
+++ b/nursery/curses/pyproject.toml
@@ -39,6 +39,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development",
     "Topic :: Software Development :: User Interfaces",

--- a/nursery/qt/pyproject.toml
+++ b/nursery/qt/pyproject.toml
@@ -38,6 +38,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development",
     "Topic :: Software Development :: User Interfaces",

--- a/nursery/tvOS/pyproject.toml
+++ b/nursery/tvOS/pyproject.toml
@@ -39,6 +39,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development",
     "Topic :: Software Development :: User Interfaces",

--- a/nursery/uwp/pyproject.toml
+++ b/nursery/uwp/pyproject.toml
@@ -39,6 +39,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development",
     "Topic :: Software Development :: User Interfaces",

--- a/nursery/watchOS/pyproject.toml
+++ b/nursery/watchOS/pyproject.toml
@@ -39,6 +39,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development",
     "Topic :: Software Development :: User Interfaces",

--- a/textual/pyproject.toml
+++ b/textual/pyproject.toml
@@ -39,6 +39,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development",
     "Topic :: Software Development :: User Interfaces",

--- a/toga/pyproject.toml
+++ b/toga/pyproject.toml
@@ -50,6 +50,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development",
     "Topic :: Software Development :: User Interfaces",

--- a/web/pyproject.toml
+++ b/web/pyproject.toml
@@ -40,6 +40,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development",
     "Topic :: Software Development :: User Interfaces",

--- a/winforms/pyproject.toml
+++ b/winforms/pyproject.toml
@@ -39,6 +39,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development",
     "Topic :: Software Development :: User Interfaces",


### PR DESCRIPTION
Adds Python3.13 to the CI matrix.

Also adds ARM64 testing by way of the new macOS-14 runners. iOS tests are now run on macOS-14, as it's a more realistic hardware platform (and, evidence suggests, faster as well)

As 4 platforms x 6 Python versions is a whole lot of CI to test, only "min python" (3.8), "max python" (3.12) and "dev python" (3.13-dev) are tested on every operating system, with 3.9-3.11 tested on Linux to ensure there aren't any standard library or language discrepancies.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
