### PR TITLE
Correct handling of menu sections in GTK

### DIFF
--- a/android/tests_backend/app.py
+++ b/android/tests_backend/app.py
@@ -78,6 +78,20 @@ class AppProbe(BaseProbe):
     def assert_menu_item(self, path, *, enabled=True):
         assert self._menu_item(path).isEnabled() == enabled
 
+    def assert_menu_order(self, path, expected):
+        item = self._menu_item(path)
+        menu = item.getSubMenu()
+
+        # Android doesn't include separators, so we need to exclude separators from the
+        # length check, and add an offset when a separator is expected.
+        separator_offset = 0
+        assert menu.size() == len([item for item in expected if item != "---"])
+        for i, title in enumerate(expected):
+            if title == "---":
+                separator_offset += 1
+            else:
+                assert menu.getItem(i - separator_offset).getTitle() == title
+
     def assert_system_menus(self):
         self.assert_menu_item(["About Toga Testbed"])
 

--- a/changes/2418.bugfix.rst
+++ b/changes/2418.bugfix.rst
@@ -1,0 +1,1 @@
+The placement of menu items relative to submenus was corrected on GTK.

--- a/cocoa/tests_backend/app.py
+++ b/cocoa/tests_backend/app.py
@@ -151,11 +151,11 @@ class AppProbe(BaseProbe):
         menu = self._menu_item(path).submenu
 
         assert menu.numberOfItems == len(expected)
-        for item, expected in zip(menu.itemArray, expected):
-            if expected == "---":
-                assert item.title == ""
+        for item, title in zip(menu.itemArray, expected):
+            if title == "---":
+                assert item.isSeparatorItem
             else:
-                assert item.title == expected
+                assert item.title == title
 
     def keystroke(self, combination):
         key, modifiers = cocoa_key(combination)

--- a/cocoa/tests_backend/app.py
+++ b/cocoa/tests_backend/app.py
@@ -147,6 +147,16 @@ class AppProbe(BaseProbe):
         item = self._menu_item(path)
         assert item.isEnabled() == enabled
 
+    def assert_menu_order(self, path, expected):
+        menu = self._menu_item(path).submenu
+
+        assert menu.numberOfItems == len(expected)
+        for item, expected in zip(menu.itemArray, expected):
+            if expected == "---":
+                assert item.title == ""
+            else:
+                assert item.title == expected
+
     def keystroke(self, combination):
         key, modifiers = cocoa_key(combination)
         key_code = {

--- a/iOS/tests_backend/app.py
+++ b/iOS/tests_backend/app.py
@@ -56,6 +56,9 @@ class AppProbe(BaseProbe):
     def assert_menu_item(self, path, enabled):
         pytest.skip("Menus not implemented on iOS")
 
+    def assert_menu_order(self, path, expected):
+        pytest.skip("Menus not implemented on iOS")
+
     def enter_background(self):
         self.native.delegate.applicationWillResignActive(self.native)
         self.native.delegate.applicationDidEnterBackground(self.native)

--- a/testbed/src/testbed/app.py
+++ b/testbed/src/testbed/app.py
@@ -70,6 +70,9 @@ class Testbed(toga.App):
         # Items on submenu2
         self.cmd5 = toga.Command(self.cmd_action, "Jiggle", group=subgroup2)
 
+        # Items on the main group after a submenu
+        self.cmd6 = toga.Command(self.cmd_action, "Wiggle", group=group, section=2)
+
         # Add all the commands
         self.commands.add(
             self.cmd1,
@@ -80,6 +83,7 @@ class Testbed(toga.App):
             self.no_action_cmd,
             self.deep_cmd,
             self.cmd5,
+            self.cmd6,
         )
 
         self.main_window = toga.MainWindow(title=self.formal_name)

--- a/testbed/tests/app/test_app.py
+++ b/testbed/tests/app/test_app.py
@@ -500,6 +500,10 @@ async def test_menu_items(app, app_probe):
         ["Other", "Submenu1", "Submenu1 menu1", "Deep"],
         enabled=True,
     )
+    app_probe.assert_menu_item(
+        ["Other", "Wiggle"],
+        enabled=True,
+    )
 
     app_probe.assert_menu_item(
         ["Commands", "No Tooltip"],

--- a/testbed/tests/app/test_app.py
+++ b/testbed/tests/app/test_app.py
@@ -505,6 +505,23 @@ async def test_menu_items(app, app_probe):
         enabled=True,
     )
 
+    app_probe.assert_menu_order(
+        ["Other"],
+        ["Full command", "---", "Submenu1", "Submenu2", "Wiggle"],
+    )
+    app_probe.assert_menu_order(
+        ["Other", "Submenu1"],
+        ["Disabled", "No Action", "Submenu1 menu1"],
+    )
+    app_probe.assert_menu_order(
+        ["Other", "Submenu1", "Submenu1 menu1"],
+        ["Deep"],
+    )
+    app_probe.assert_menu_order(
+        ["Other", "Submenu2"],
+        ["Jiggle"],
+    )
+
     app_probe.assert_menu_item(
         ["Commands", "No Tooltip"],
         enabled=True,

--- a/winforms/tests_backend/app.py
+++ b/winforms/tests_backend/app.py
@@ -150,6 +150,16 @@ class AppProbe(BaseProbe):
         else:
             assert item.ShortcutKeyDisplayString == shortcut
 
+    def assert_menu_order(self, path, expected):
+        menu = self._menu_item(path)
+
+        assert len(menu.DropDownItems) == len(expected)
+        for item, expected in zip(menu.DropDownItems, expected):
+            if expected == "---":
+                assert item.Text == ""
+            else:
+                assert item.Text == expected
+
     def assert_system_menus(self):
         self.assert_menu_item(["File", "Preferences"], enabled=False)
         self.assert_menu_item(["File", "Exit"])

--- a/winforms/tests_backend/app.py
+++ b/winforms/tests_backend/app.py
@@ -5,7 +5,7 @@ from time import sleep
 import pytest
 from System import EventArgs
 from System.Drawing import Point
-from System.Windows.Forms import Application, Cursor
+from System.Windows.Forms import Application, Cursor, ToolStripSeparator
 
 from toga_winforms.keys import toga_to_winforms_key, winforms_to_toga_key
 
@@ -154,11 +154,11 @@ class AppProbe(BaseProbe):
         menu = self._menu_item(path)
 
         assert len(menu.DropDownItems) == len(expected)
-        for item, expected in zip(menu.DropDownItems, expected):
-            if expected == "---":
-                assert item.Text == ""
+        for item, title in zip(menu.DropDownItems, expected):
+            if title == "---":
+                assert isinstance(item, ToolStripSeparator)
             else:
-                assert item.Text == expected
+                assert item.Text == title
 
     def assert_system_menus(self):
         self.assert_menu_item(["File", "Preferences"], enabled=False)


### PR DESCRIPTION
Modifies the handling of sections in menus under GTK.

In the old code, the "current section" was tracked, and section/submenu breaks caused the creation of a new section. However. this caused problems when a menu contained a submenu followed by a regular item, as the "current section" would be the section of the submenu.

This modifies the approach so that a menu section is created at the same time as a menu, and stored in the cache as part of the group->submenu mapping. The current submenu and section is looked up on every item insertion, so when the item is added after the submenu is added, it finds the section that *was* active when the submenu was added, rather than the section active inside the submenu. When an explicit section break is added, the group cache is updated to reflect the new section. 

This also corrects an issue where GTK submenus would float to the bottom of their parent menu, because they were being added to the *menu*, not the current section of the menu.

Fixes #2418.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
