### PR TITLE
Implement property for Command.action.

### DIFF
--- a/changes/2433.feature.rst
+++ b/changes/2433.feature.rst
@@ -1,0 +1,1 @@
+It's now easier to change the action for a Toga command to point to a different handler without having to jump through hoops to create the correct ActionHandler.

--- a/changes/2433.feature.rst
+++ b/changes/2433.feature.rst
@@ -1,1 +1,1 @@
-It's now easier to change the action for a Toga command to point to a different handler without having to jump through hoops to create the correct ActionHandler.
+An action for a Toga command can now be easily modified after initial construction.

--- a/core/src/toga/command.py
+++ b/core/src/toga/command.py
@@ -203,7 +203,7 @@ class Command:
         self.section = section
         self.order = order
 
-        self._action = wrapped_handler(self, action)
+        self.action = action
 
         self.factory = get_platform_factory()
         self._impl = self.factory.Command(interface=self)

--- a/core/src/toga/command.py
+++ b/core/src/toga/command.py
@@ -203,7 +203,7 @@ class Command:
         self.section = section
         self.order = order
 
-        self.action = wrapped_handler(self, action)
+        self._action = wrapped_handler(self, action)
 
         self.factory = get_platform_factory()
         self._impl = self.factory.Command(interface=self)
@@ -243,6 +243,19 @@ class Command:
             self._icon = icon_or_name
         else:
             self._icon = Icon(icon_or_name)
+
+    @property
+    def action(self) -> ActionHandler | None:
+        """The Action attached to the command."""
+        return self._action
+
+    @action.setter
+    def action(self, action: ActionHandler | None):
+        """Set the action attached to the command
+
+        Needs to be a valid ActionHandler or ``None``
+        """
+        self._action = wrapped_handler(self, action)
 
     def __lt__(self, other: Any) -> bool:
         if not isinstance(other, (Group, Command)):

--- a/core/tests/command/test_command.py
+++ b/core/tests/command/test_command.py
@@ -63,6 +63,29 @@ def test_create():
     )
 
 
+def test_change_action():
+    def local():
+        assert False
+
+    """A command's action can be changed to another handler"""
+    cmd = toga.Command(local, "Test command")
+
+    assert cmd.text == "Test command"
+    assert cmd.shortcut is None
+    assert cmd.tooltip is None
+    assert cmd.group == toga.Group.COMMANDS
+    assert cmd.section == 0
+    assert cmd.order == 0
+    assert cmd.action._raw is not None
+    cmd.action = None
+    assert cmd.action._raw is None
+
+    assert (
+        repr(cmd)
+        == "<Command text='Test command' group=<Group text='Commands' order=30> section=0 order=0>"
+    )
+
+
 def test_create_explicit(app):
     """A command can be created with explicit arguments"""
     grp = toga.Group("Test group", order=10)

--- a/core/tests/command/test_command.py
+++ b/core/tests/command/test_command.py
@@ -64,11 +64,10 @@ def test_create():
 
 
 def test_change_action():
-    def local():
-        assert False
-
     """A command's action can be changed to another handler"""
-    cmd = toga.Command(local, "Test command")
+    action1 = Mock()
+
+    cmd = toga.Command(action1, "Test command")
 
     assert cmd.text == "Test command"
     assert cmd.shortcut is None
@@ -76,14 +75,17 @@ def test_change_action():
     assert cmd.group == toga.Group.COMMANDS
     assert cmd.section == 0
     assert cmd.order == 0
-    assert cmd.action._raw is not None
+    assert cmd.action._raw == action1
+
+    # Change the action to a something new
+    action2 = Mock()
+    cmd.action = action2
+
+    assert cmd.action._raw == action2
+
+    # Clear the action
     cmd.action = None
     assert cmd.action._raw is None
-
-    assert (
-        repr(cmd)
-        == "<Command text='Test command' group=<Group text='Commands' order=30> section=0 order=0>"
-    )
 
 
 def test_create_explicit(app):

--- a/docs/reference/api/resources/command.rst
+++ b/docs/reference/api/resources/command.rst
@@ -73,6 +73,13 @@ as well. It isn't possible to have functionality exposed on a toolbar that
 isn't also exposed by the app. So, ``cmd2`` will be added to the app, even though
 it wasn't explicitly added to the app commands.
 
+If you want to change the action that a command executes after it's been created, use:
+
+.. code-block:: python
+    ...
+
+    cmd1.action = changed_callback
+
 
 Reference
 ---------

--- a/docs/reference/api/resources/command.rst
+++ b/docs/reference/api/resources/command.rst
@@ -76,6 +76,7 @@ it wasn't explicitly added to the app commands.
 If you want to change the action that a command executes after it's been created, use:
 
 .. code-block:: python
+
     ...
 
     cmd1.action = changed_callback

--- a/docs/reference/api/resources/command.rst
+++ b/docs/reference/api/resources/command.rst
@@ -73,14 +73,6 @@ as well. It isn't possible to have functionality exposed on a toolbar that
 isn't also exposed by the app. So, ``cmd2`` will be added to the app, even though
 it wasn't explicitly added to the app commands.
 
-If you want to change the action that a command executes after it's been created, use:
-
-.. code-block:: python
-
-    ...
-
-    cmd1.action = changed_callback
-
 
 Reference
 ---------


### PR DESCRIPTION
I added a property handler for ``action``, so that it is possible to specify what a Command does after it's been created.

Sometimes, you want to make the action depend on the current state of your application, and having global variables to indicate that state may not always be possible.

With this change, you can change the action to be another closure. But, because the handler needs to be wrapped in a ``wrapped_handler``, doing this from you app looks ugly:

```
self.removepodcast.action = wrapped_handler(self.removepodcast.action, self.showRemovePodcast(main_list_box, podcast_id)
```

After this change, it looks like this:
```
self.removepodcast.action = self.showRemovePodcast(main_list_box, podcast_id)
```

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
