### PR TITLE
Fix visibility and display support in Pack()

### DIFF
--- a/changes/2428.bugfix.rst
+++ b/changes/2428.bugfix.rst
@@ -1,0 +1,1 @@
+Issue with `visibility` on GTK and `display` on all platform.

--- a/core/src/toga/style/pack.py
+++ b/core/src/toga/style/pack.py
@@ -86,7 +86,7 @@ class Pack(BaseStyle):
     @property
     def _hidden(self):
         "Does this style declaration define a object that should be hidden"
-        return self.visibility == HIDDEN
+        return self.visibility == HIDDEN or self.display == NONE
 
     def apply(self, prop, value):
         if self._applicator:
@@ -104,8 +104,8 @@ class Pack(BaseStyle):
                 self._applicator.set_color(value)
             elif prop == "background_color":
                 self._applicator.set_background_color(value)
-            elif prop == "visibility":
-                self._applicator.set_hidden(value == HIDDEN)
+            elif prop == "visibility" or prop == "display":
+                self._applicator.set_hidden(self._hidden)
             elif prop in (
                 "font_family",
                 "font_size",
@@ -275,6 +275,9 @@ class Pack(BaseStyle):
         min_width = 0
         remaining_width = available_width
         for child in node.children:
+            # Skip calculation if widget is not displayed
+            if child.style.display == NONE:
+                continue
             # self._debug(f"PASS 1 {child}")
             if child.style.width != NONE:
                 # self._debug(f"- fixed width {child.style.width}")
@@ -404,6 +407,9 @@ class Pack(BaseStyle):
         # Pass 2: Lay out children with an intrinsic flexible width,
         # or no width specification at all.
         for child in node.children:
+            # Skip calculation if widget is not displayed
+            if child.style.display == NONE:
+                continue
             # self._debug(f"PASS 2 {child}")
             if child.style.width != NONE:
                 # self._debug("- already laid out (explicit width)")
@@ -489,6 +495,9 @@ class Pack(BaseStyle):
         height = 0
         min_height = 0
         for child in node.children:
+            # Skip calculation if widget is not displayed
+            if child.style.display == NONE:
+                continue
             # self._debug(f"PASS 3: {child} AT HORIZONTAL {offset=}")
             if node.style.text_direction is RTL:
                 # self._debug("- RTL")
@@ -522,6 +531,9 @@ class Pack(BaseStyle):
 
         # Pass 4: set vertical position of each child.
         for child in node.children:
+            # Skip calculation if widget is not displayed
+            if child.style.display == NONE:
+                continue
             # self._debug(f"PASS 4: {child}")
             extra = height - (
                 child.layout.content_height
@@ -559,6 +571,9 @@ class Pack(BaseStyle):
         min_height = 0
         remaining_height = available_height
         for child in node.children:
+            # Skip calculation if widget is not displayed
+            if child.style.display == NONE:
+                continue
             # self._debug(f"PASS 1 {child}")
             if child.style.height != NONE:
                 # self._debug(f"- fixed height {child.style.height}")
@@ -689,6 +704,9 @@ class Pack(BaseStyle):
         # Pass 2: Lay out children with an intrinsic flexible height,
         # or no height specification at all.
         for child in node.children:
+            # Skip calculation if widget is not displayed
+            if child.style.display == NONE:
+                continue
             # self._debug(f"PASS 2 {child}")
             if child.style.height != NONE:
                 # self._debug("- already laid out (explicit height)")
@@ -775,6 +793,9 @@ class Pack(BaseStyle):
         width = 0
         min_width = 0
         for child in node.children:
+            # Skip calculation if widget is not displayed
+            if child.style.display == NONE:
+                continue
             # self._debug(f"PASS 3: {child} AT VERTICAL OFFSET {offset}")
             offset += child.style.padding_top
             child.layout.content_top = offset
@@ -800,6 +821,9 @@ class Pack(BaseStyle):
 
         # Pass 4: set horizontal position of each child.
         for child in node.children:
+            # Skip calculation if widget is not displayed
+            if child.style.display == NONE:
+                continue
             # self._debug(f"PASS 4: {child}")
             extra = width - (
                 child.layout.content_width

--- a/gtk/src/toga_gtk/widgets/activityindicator.py
+++ b/gtk/src/toga_gtk/widgets/activityindicator.py
@@ -16,9 +16,6 @@ class ActivityIndicator(Widget):
         self.native.stop()
 
     def rehint(self):
-        # print("REHINT", self, self.native.get_preferred_width(), self.native.get_preferred_height())
-        width = self.native.get_preferred_width()
-        height = self.native.get_preferred_height()
-
+        width, height = self._get_preferred_size(self.native)
         self.interface.intrinsic.width = width[0]
         self.interface.intrinsic.height = height[0]

--- a/gtk/src/toga_gtk/widgets/base.py
+++ b/gtk/src/toga_gtk/widgets/base.py
@@ -57,7 +57,6 @@ class Widget:
             # setting container, adding self to container.native
             self._container = container
             self._container.add(self.native)
-            self.native.show_all()
 
         for child in self.interface.children:
             child._impl.container = container
@@ -83,6 +82,18 @@ class Widget:
 
     def set_tab_index(self, tab_index):
         self.interface.factory.not_implemented("Widget.set_tab_index()")
+
+    def _get_preferred_size(self, native):
+        # Utility function to get the preferred size of widget regardless of it's visibility.
+        visible = native.get_visible()
+        if not visible:
+            native.set_visible(True)
+        # print("REHINT", self, native.get_preferred_width(), native.get_preferred_height())
+        width = native.get_preferred_width()
+        height = native.get_preferred_height()
+        if not visible:
+            native.set_visible(visible)
+        return width, height
 
     ######################################################################
     # CSS tools
@@ -185,9 +196,6 @@ class Widget:
 
     def rehint(self):
         # Perform the actual GTK rehint.
-        # print("REHINT", self, self.native.get_preferred_width(), self.native.get_preferred_height())
-        width = self.native.get_preferred_width()
-        height = self.native.get_preferred_height()
-
+        width, height = self._get_preferred_size(self.native)
         self.interface.intrinsic.width = at_least(width[0])
         self.interface.intrinsic.height = at_least(height[0])

--- a/gtk/src/toga_gtk/widgets/button.py
+++ b/gtk/src/toga_gtk/widgets/button.py
@@ -41,10 +41,7 @@ class Button(Widget):
         super().set_background_color(color)
 
     def rehint(self):
-        # print("REHINT", self, self.native.get_preferred_width(), self.native.get_preferred_height())
-        width = self.native.get_preferred_width()
-        height = self.native.get_preferred_height()
-
+        width, height = self._get_preferred_size(self.native)
         self.interface.intrinsic.width = at_least(width[0])
         self.interface.intrinsic.height = height[1]
 

--- a/gtk/src/toga_gtk/widgets/canvas.py
+++ b/gtk/src/toga_gtk/widgets/canvas.py
@@ -299,7 +299,6 @@ class Canvas(Widget):
 
     # Rehint
     def rehint(self):
-        # print("REHINT", self, self.native.get_preferred_width(), self.native.get_preferred_height())
         # width = self.native.get_allocation().width
         # height = self.native.get_allocation().height
         width = self.interface._MIN_WIDTH

--- a/gtk/src/toga_gtk/widgets/divider.py
+++ b/gtk/src/toga_gtk/widgets/divider.py
@@ -9,9 +9,7 @@ class Divider(Widget):
         self.native = Gtk.Separator()
 
     def rehint(self):
-        width = self.native.get_preferred_width()
-        height = self.native.get_preferred_height()
-
+        width, height = self._get_preferred_size(self.native)
         if self.get_direction() == self.interface.VERTICAL:
             self.interface.intrinsic.width = width[0]
             self.interface.intrinsic.height = at_least(height[1])

--- a/gtk/src/toga_gtk/widgets/label.py
+++ b/gtk/src/toga_gtk/widgets/label.py
@@ -24,12 +24,6 @@ class Label(Widget):
         self.native.set_text(value)
 
     def rehint(self):
-        # print("REHINT", self,
-        #     self.native.get_preferred_width(), self.native.get_preferred_height(),
-        #     getattr(self, '_fixed_height', False), getattr(self, '_fixed_width', False)
-        # )
-        width = self.native.get_preferred_width()
-        height = self.native.get_preferred_height()
-
+        width, height = self._get_preferred_size(self.native)
         self.interface.intrinsic.width = at_least(width[0])
         self.interface.intrinsic.height = height[1]

--- a/gtk/src/toga_gtk/widgets/numberinput.py
+++ b/gtk/src/toga_gtk/widgets/numberinput.py
@@ -64,9 +64,7 @@ class NumberInput(Widget):
         self.native.set_alignment(xalign)
 
     def rehint(self):
-        width = self.native.get_preferred_width()
-        height = self.native.get_preferred_height()
-
+        width, height = self._get_preferred_size(self.native)
         self.interface.intrinsic.width = at_least(
             max(self.interface._MIN_WIDTH, width[1])
         )

--- a/gtk/src/toga_gtk/widgets/progressbar.py
+++ b/gtk/src/toga_gtk/widgets/progressbar.py
@@ -91,9 +91,6 @@ class ProgressBar(Widget):
         self._stop_indeterminate()
 
     def rehint(self):
-        # print("REHINT", self, self.native.get_preferred_width(), self.native.get_preferred_height())
-        width = self.native.get_preferred_width()
-        height = self.native.get_preferred_height()
-
+        width, height = self._get_preferred_size(self.native)
         self.interface.intrinsic.width = at_least(width[0])
         self.interface.intrinsic.height = height[0]

--- a/gtk/src/toga_gtk/widgets/selection.py
+++ b/gtk/src/toga_gtk/widgets/selection.py
@@ -89,8 +89,7 @@ class Selection(Widget):
         return index
 
     def rehint(self):
-        width = self.native.get_preferred_width()
-        height = self.native.get_preferred_height()
+        width, height = self._get_preferred_size(self.native)
 
         # FIXME: 2023-05-31 This will always provide a size that is big enough,
         # but sometimes it will be *too* big. For example, if you set the font size

--- a/gtk/src/toga_gtk/widgets/slider.py
+++ b/gtk/src/toga_gtk/widgets/slider.py
@@ -82,8 +82,7 @@ class Slider(Widget, toga.widgets.slider.SliderImpl):
         return self.tick_count
 
     def rehint(self):
-        # print("REHINT", self, self.native.get_preferred_width(), self.native.get_preferred_height())
-        height = self.native.get_preferred_height()
+        width, height = self._get_preferred_size(self.native)
 
         # Set intrinsic width to at least the minimum width
         self.interface.intrinsic.width = at_least(self.interface._MIN_WIDTH)

--- a/gtk/src/toga_gtk/widgets/switch.py
+++ b/gtk/src/toga_gtk/widgets/switch.py
@@ -52,12 +52,8 @@ class Switch(Widget):
         self.apply_css("font", get_font_css(font), native=self.native_label)
 
     def rehint(self):
-        # print("REHINT", self, self.native.get_preferred_width(), self.native.get_preferred_height())
-        label_width = self.native_label.get_preferred_width()
-        label_height = self.native_label.get_preferred_height()
-
-        switch_width = self.native_switch.get_preferred_width()
-        switch_height = self.native_switch.get_preferred_height()
+        label_width, label_height = self._get_preferred_size(native=self.native_label)
+        switch_width, switch_height = self._get_preferred_size(native=self.native_label)
 
         # Set intrinsic width to at least the minimum width
         self.interface.intrinsic.width = at_least(

--- a/gtk/src/toga_gtk/widgets/textinput.py
+++ b/gtk/src/toga_gtk/widgets/textinput.py
@@ -55,13 +55,7 @@ class TextInput(Widget):
         self.native.set_text(value)
 
     def rehint(self):
-        # print("REHINT", self,
-        #     self._impl.get_preferred_width(), self._impl.get_preferred_height(),
-        #     getattr(self, '_fixed_height', False), getattr(self, '_fixed_width', False)
-        # )
-        width = self.native.get_preferred_width()
-        height = self.native.get_preferred_height()
-
+        width, height = self._get_preferred_size(self.native)
         self.interface.intrinsic.width = at_least(
             max(self.interface._MIN_WIDTH, width[1])
         )

--- a/gtk/src/toga_gtk/window.py
+++ b/gtk/src/toga_gtk/window.py
@@ -144,7 +144,10 @@ class Window:
         app.native.add_window(self.native)
 
     def show(self):
-        self.native.show_all()
+        # Avoid calling show_all() as it change the visibility of all children.
+        self.native.show()
+        self.layout.show()
+        self.container.show()
 
     ######################################################################
     # Window content and resources


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

This is a first attempt to resolve two issues within the Pack() implementation.
1. On GTK, the visibility=HIDDEN is not working
2. On all platform except Web, display=NONE is not working

The the visibility problem on GTK. It seams to be related to the fact we are making call to `show_all()` which effectively make all children of the container visible. There are a couple of way to get this fixed. I decide to manually call `show()` on every widget to fine tune when to show or hide it.

To match the behavior of other platform and reserve enough space for the widget in the interface, when getting the preferred size, we need to make the widget visible. Otherwise, the return values are zero (0).

For display=NONE, the problem is mush simpler, I simply skip all the calculation in Pack() for every children with display==NONE. This exclude them from the layout.

* Fixes #2447 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested : On GTK & Windows only.
- [ ] All new features have been documented : Already documented.
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
