### PR TITLE
Fix memory leak for toga.Icon and toga.Image on Cocoa

### DIFF
--- a/changes/2472.bugfix.rst
+++ b/changes/2472.bugfix.rst
@@ -1,0 +1,1 @@
+Fix memory leaks for toga.Icon and toga.Image in the Cocoa backend.

--- a/cocoa/src/toga_cocoa/icons.py
+++ b/cocoa/src/toga_cocoa/icons.py
@@ -26,11 +26,12 @@ class Icon:
             if self.native is None:
                 raise ValueError(f"Unable to load icon from {path}")
         finally:
+            # Calling `release` here disabled Rubicon's "release on delete" automation.
+            # We therefore add an explicit `release` call in __del__ if the NSImage was
+            # initialized successfully.
             image.release()
 
     def __del__(self):
-        # Calling `release` during init disabled Rubicon's "release on delete"
-        # automation. We therefore need to release manually here.
         if self.native:
             self.native.release()
 

--- a/cocoa/src/toga_cocoa/icons.py
+++ b/cocoa/src/toga_cocoa/icons.py
@@ -13,13 +13,14 @@ class Icon:
         self.path = path
         try:
             # We *should* be able to do a direct NSImage.alloc.init...(), but if the
-            # image file is invalid, the init fails, and returns NULL - but we've
-            # created an ObjC instance, so when the object passes out of scope, Rubicon
-            # tries to free it, which segfaults. To avoid this, we retain result of the
-            # alloc() (overriding the default Rubicon behavior of alloc), then release
-            # that reference once we're done. If the image was created successfully, we
-            # temporarily have a reference count that is 1 higher than it needs to be;
-            # if it fails, we don't end up with a stray release.
+            # image file is invalid, the init fails, returns NULL, and releases the
+            # Objective-C object. Since we've created an ObjC instance, when the object
+            # passes out of scope, Rubicon tries to free it, which segfaults.
+            # To avoid this, we retain result of the alloc() (overriding the default
+            # Rubicon behavior of alloc), then release that reference once we're done.
+            # If the image was created successfully, we temporarily have a reference
+            # count that is 1 higher than it needs to be; if it fails, we don't end up
+            # with a stray release.
             image = NSImage.alloc().retain()
             self.native = image.initWithContentsOfFile(str(path))
             if self.native is None:
@@ -27,11 +28,9 @@ class Icon:
         finally:
             image.release()
 
-        # Multiple icon interface instances can end up referencing the same native
-        # instance, so make sure we retain a reference count at the impl level.
-        self.native.retain()
-
     def __del__(self):
+        # Calling `release` during init disabled Rubicon's "release on delete"
+        # automation. We therefore need to release manually here.
         if self.native:
             self.native.release()
 

--- a/cocoa/src/toga_cocoa/images.py
+++ b/cocoa/src/toga_cocoa/images.py
@@ -52,11 +52,12 @@ class Image:
             else:
                 self.native = raw
         finally:
+            # Calling `release` here disabled Rubicon's "release on delete" automation.
+            # We therefore add an explicit `release` call in __del__ if the NSImage was
+            # initialized successfully.
             image.release()
 
     def __del__(self):
-        # Calling `release` during init disabled Rubicon's "release on delete"
-        # automation. We therefore need to release manually here.
         if self._needs_release:
             self.native.release()
 

--- a/cocoa/src/toga_cocoa/images.py
+++ b/cocoa/src/toga_cocoa/images.py
@@ -23,30 +23,42 @@ class Image:
 
     def __init__(self, interface, path=None, data=None, raw=None):
         self.interface = interface
+        self._needs_release = False
 
         try:
             # We *should* be able to do a direct NSImage.alloc.init...(), but if the
-            # image file is invalid, the init fails, and returns NULL - but we've
-            # created an ObjC instance, so when the object passes out of scope, Rubicon
-            # tries to free it, which segfaults. To avoid this, we retain result of the
-            # alloc() (overriding the default Rubicon behavior of alloc), then release
-            # that reference once we're done. If the image was created successfully, we
-            # temporarily have a reference count that is 1 higher than it needs to be;
-            # if it fails, we don't end up with a stray release.
+            # image file is invalid, the init fails, returns NULL, and releases the
+            # Objective-C object. Since we've created an ObjC instance, when the object
+            # passes out of scope, Rubicon tries to free it, which segfaults.
+            # To avoid this, we retain result of the alloc() (overriding the default
+            # Rubicon behavior of alloc), then release that reference once we're done.
+            # If the image was created successfully, we temporarily have a reference
+            # count that is 1 higher than it needs to be; if it fails, we don't end up
+            # with a stray release.
             image = NSImage.alloc().retain()
             if path:
                 self.native = image.initWithContentsOfFile(str(path))
                 if self.native is None:
                     raise ValueError(f"Unable to load image from {path}")
+                else:
+                    self._needs_release = True
             elif data:
                 nsdata = NSData.dataWithBytes(data, length=len(data))
                 self.native = image.initWithData(nsdata)
                 if self.native is None:
                     raise ValueError("Unable to load image from data")
+                else:
+                    self._needs_release = True
             else:
                 self.native = raw
         finally:
             image.release()
+
+    def __del__(self):
+        # Calling `release` during init disabled Rubicon's "release on delete"
+        # automation. We therefore need to release manually here.
+        if self._needs_release:
+            self.native.release()
 
     def get_width(self):
         return self.native.size.width


### PR DESCRIPTION
Fixes #2468 by explicitly releasing any successfully create NSImage on __del__.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
