### PR TITLE
Correct the display of the stack trace dialog on winforms

### DIFF
--- a/changes/2474.bugfix.rst
+++ b/changes/2474.bugfix.rst
@@ -1,0 +1,1 @@
+The stack trace dialog no longer raises an async timeout error when displayed.

--- a/winforms/src/toga_winforms/dialogs.py
+++ b/winforms/src/toga_winforms/dialogs.py
@@ -165,7 +165,10 @@ class StackTraceDialog(BaseDialog):
 
             self.native.Controls.Add(accept)
 
-        self.start_inner_loop(self.native.ShowDialog)
+        def show():
+            self.native.ShowDialog()
+
+        self.start_inner_loop(show)
 
     def winforms_FormClosing(self, sender, event):
         # If the close button is pressed, there won't be a future yet.


### PR DESCRIPTION
Fixes #2474 

The mechanism used to display the stack trace dialog wasn't correctly invoking the `ShowDialog()` method; it should be a blocking method, but it was completing and returning. I can't completely work out why, but my guess is that it's related to `ShowDialog` being a bound method on a Python.net object, rather than pure Python function. Wrapping the Python.net method in a Python callable results in the dialog being shown as expected. 

Testbed didn't catch this because showing dialogs always involves a bit of an end-run around the dialog display process.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
