### PR TITLE
Revert iOS CI testing to use Xcode 14.3.1/iOS 16.4.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,7 +231,14 @@ jobs:
         - backend: "iOS"
           platform: "iOS"
           runs-on: "macos-14"
-          briefcase-run-args: "--device 'iPhone SE (3rd generation)'"
+          # As of early April 2024, the XCode 15/iOS 17 simulator had a performance
+          # issue that rendered Github Actions testing impossible. The issue didn't
+          # impact iOS 16.4, but that required the use of Xcode 14.3.1.
+          #
+          # Refs #2476, actions/runner-images#9591.
+          pre-command: "sudo xcode-select -s /Applications/Xcode_14.3.1.app"
+          briefcase-run-args: "--device 'iPhone SE (3rd generation)::iOS 16.4'"
+          # briefcase-run-args: "--device 'iPhone SE (3rd generation)'"
           app-user-data-path: "$(xcrun simctl get_app_container booted org.beeware.toga.testbed data)/Documents"
 
         - backend: "android"

--- a/changes/2476.misc.rst
+++ b/changes/2476.misc.rst
@@ -1,0 +1,1 @@
+iOS CI testing was reverted to use XCode 14.3.1 and iOS 16.4, due to a performance issue with Github Actions.


### PR DESCRIPTION
actions/runner-images#9591 has identified a problem with Xcode 15 and/or the iOS 17 simulators running under Github Actions. Reverting to Xcode 14.3.1 and iOS 16.4 is a workaround for this problem.

Refs #2476.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
