### PR TITLE
Remove the customization of run_in_executor for Android.

### DIFF
--- a/android/src/toga_android/libs/events.py
+++ b/android/src/toga_android/libs/events.py
@@ -49,12 +49,6 @@ class AndroidEventLoop(asyncio.SelectorEventLoop):
         # Create placeholders for lazily-created objects.
         self.android_interop = AndroidInterop()
 
-    # Override parent `run_in_executor()` to run all code synchronously. This disables the
-    # `executor` thread that typically exists in event loops. The event loop itself relies
-    # on `run_in_executor()` for DNS lookups. In the future, we can restore `run_in_executor()`.
-    async def run_in_executor(self, executor, func, *args):
-        return func(*args)  # pragma: no cover
-
     # Override parent `_call_soon()` to ensure Android wakes us up to do the delayed task.
     def _call_soon(self, callback, args, context):
         ret = super()._call_soon(callback, args, context)

--- a/changes/2479.bugfix.rst
+++ b/changes/2479.bugfix.rst
@@ -1,0 +1,1 @@
+The integration of the ``asyncio`` event loop was simplified on Android. As a result, ``asyncio.loop.run_in_executor()`` now works as expected.


### PR DESCRIPTION
The Android event loop integration uses a stub implementation for `run_in_executor` that effectively disables the ability to run blocking code in a thread. This override doesn't appear to be necessary any more; this PR removes the override, restoring the default executor behavior.

The previous implementation was marked no-cover, so deleting that code increases code coverage. I used the example code from #2479 to verify that the default implementation worked as expected.

Fixes #2479.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
