### PR TITLE
Remove some over-enthusiastic memory retention.

### DIFF
--- a/changes/2472.bugfix.rst
+++ b/changes/2472.bugfix.rst
@@ -1,1 +1,1 @@
-Fix memory leaks for toga.Icon and toga.Image in the Cocoa backend.
+Some memory leaks associated with macOS Icon and Image storage were resolved.

--- a/changes/2482.bugfix.rst
+++ b/changes/2482.bugfix.rst
@@ -1,0 +1,1 @@
+Some memory leaks associated with the macOS Table, Tree and DetailedList widgets were resolved.

--- a/cocoa/src/toga_cocoa/widgets/detailedlist.py
+++ b/cocoa/src/toga_cocoa/widgets/detailedlist.py
@@ -83,7 +83,6 @@ class TogaList(NSTableView):
             data = value._impl
         except AttributeError:
             data = TogaData.alloc().init()
-            data.retain()
             value._impl = data
 
         try:

--- a/cocoa/src/toga_cocoa/widgets/table.py
+++ b/cocoa/src/toga_cocoa/widgets/table.py
@@ -73,7 +73,6 @@ class TogaTable(NSTableView):
 
             # Prevent tcv from being deallocated prematurely when no Python references
             # are left
-            tcv.retain()
             tcv.autorelease()
 
         tcv.setText(str(value))

--- a/cocoa/src/toga_cocoa/widgets/tree.py
+++ b/cocoa/src/toga_cocoa/widgets/tree.py
@@ -101,7 +101,6 @@ class TogaTree(NSOutlineView):
 
             # Prevent tcv from being deallocated prematurely when no Python references
             # are left
-            tcv.retain()
             tcv.autorelease()
 
         tcv.setText(str(value))


### PR DESCRIPTION
In the process of exploring beeware/rubicon-objc#256, I found a couple of over-enthusiastic memory retentions. These will be causing memory leaks over time.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
