### PR TITLE
Use a pre-release freezegun on Python 3.13.

### DIFF
--- a/changes/2498.misc.rst
+++ b/changes/2498.misc.rst
@@ -1,0 +1,1 @@
+The version of Freezegun used on Python 3.13 has been pinned to a prerelease to avoid an incompatibility with Python 3.13.0a6.

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -77,7 +77,9 @@ dev = [
     "setuptools-scm == 8.0.4",
     "tox == 4.14.2",
     # typing-extensions needed for TypeAlias added in Py 3.10
-    "typing-extensions == 4.9.0 ; python_version < '3.10'"
+    "typing-extensions == 4.9.0 ; python_version < '3.10'",
+    # FIXME: Freezegun 1.4.0 is incompatible with Python 3.13.0a6; use a pre-release
+    "freezegun @ git+https://github.com/spulec/freezegun#c65f4db6ef4824538061978be30954c1c739d380b ; python_version >= '3.13'",
 ]
 docs = [
     "furo == 2024.1.29",


### PR DESCRIPTION
Freezegun 1.4.0 has an incompatibility with 3.13.0a6; the issue [has been fixed upstream](https://github.com/spulec/freezegun/commit/d75458f3f691d0c2c35559872716d0ebab738817), but it isn't in a format release yet.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
