### PR TITLE
Update PyPI project links

### DIFF
--- a/android/README.rst
+++ b/android/README.rst
@@ -6,7 +6,7 @@ An Android backend for the `Toga widget toolkit`_.
 This package isn't much use by itself; it needs to be combined with `the core Toga library`_,
 
 For platform requirements, see the `Android platform documentation
-<https://toga.readthedocs.io/en/stable/reference/platforms/android.html#prerequisites>`__.
+<https://toga.readthedocs.io/en/latest/reference/platforms/android.html#prerequisites>`__.
 
 For more details, see the `Toga project on Github`_.
 

--- a/android/pyproject.toml
+++ b/android/pyproject.toml
@@ -48,9 +48,10 @@ classifiers = [
 [project.urls]
 Homepage = "https://beeware.org/project/projects/libraries/toga/"
 Funding = "https://beeware.org/contributing/membership/"
-Documentation = "https://toga.readthedocs.io/en/latest/"
+Documentation = "https://toga.readthedocs.io/"
 Tracker = "https://github.com/beeware/toga/issues"
 Source = "https://github.com/beeware/toga"
+Changelog = "https://toga.readthedocs.io/en/stable/background/project/releases.html"
 
 [project.entry-points."toga.backends"]
 android = "toga_android"

--- a/changes/2510.doc.rst
+++ b/changes/2510.doc.rst
@@ -1,0 +1,1 @@
+The links to ReadTheDocs were updated to better arbitrate between linking to the stable version or the latest version.

--- a/cocoa/README.rst
+++ b/cocoa/README.rst
@@ -6,7 +6,7 @@ A Cocoa backend for the `Toga widget toolkit`_.
 This package isn't much use by itself; it needs to be combined with `the core Toga library`_.
 
 For platform requirements, see the `macOS platform documentation
-<https://toga.readthedocs.io/en/stable/reference/platforms/macOS.html#prerequisites>`__.
+<https://toga.readthedocs.io/en/latest/reference/platforms/macOS.html#prerequisites>`__.
 
 For more details, see the `Toga project on Github`_.
 

--- a/cocoa/pyproject.toml
+++ b/cocoa/pyproject.toml
@@ -49,9 +49,10 @@ classifiers = [
 [project.urls]
 Homepage = "https://beeware.org/project/projects/libraries/toga/"
 Funding = "https://beeware.org/contributing/membership/"
-Documentation = "https://toga.readthedocs.io/en/latest/"
+Documentation = "https://toga.readthedocs.io/"
 Tracker = "https://github.com/beeware/toga/issues"
 Source = "https://github.com/beeware/toga"
+Changelog = "https://toga.readthedocs.io/en/stable/background/project/releases.html"
 
 [project.entry-points."toga.backends"]
 macOS = "toga_cocoa"

--- a/core/README.rst
+++ b/core/README.rst
@@ -19,7 +19,7 @@ Minimum requirements
 Toga requires **Python 3.8** or newer. Python 2 is not supported.
 
 Each backend also has specific requirements and pre-requisites. See the `platform
-documentation <https://toga.readthedocs.io/en/stable/reference/platforms.html>`__ for
+documentation <https://toga.readthedocs.io/en/latest/reference/platforms.html>`__ for
 details.
 
 Quickstart

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -102,9 +102,10 @@ docs = [
 [project.urls]
 Homepage = "https://beeware.org/project/projects/libraries/toga/"
 Funding = "https://beeware.org/contributing/membership/"
-Documentation = "https://toga.readthedocs.io/en/latest/"
+Documentation = "https://toga.readthedocs.io/"
 Tracker = "https://github.com/beeware/toga/issues"
 Source = "https://github.com/beeware/toga"
+Changelog = "https://toga.readthedocs.io/en/stable/background/project/releases.html"
 
 [project.entry-points."toga.image_formats"]
 pil = "toga.plugins.image_formats.PILConverter"

--- a/demo/pyproject.toml
+++ b/demo/pyproject.toml
@@ -55,9 +55,10 @@ classifiers = [
 [project.urls]
 Homepage = "https://beeware.org/project/projects/libraries/toga/"
 Funding = "https://beeware.org/contributing/membership/"
-Documentation = "https://toga.readthedocs.io/en/latest/"
+Documentation = "https://toga.readthedocs.io/"
 Tracker = "https://github.com/beeware/toga/issues"
 Source = "https://github.com/beeware/toga"
+Changelog = "https://toga.readthedocs.io/en/stable/background/project/releases.html"
 
 [project.scripts]
 toga-demo = "toga_demo.__main__:run"

--- a/dummy/README.rst
+++ b/dummy/README.rst
@@ -7,7 +7,7 @@ anything; it exists purely as a testing environment.
 This package isn't much use by itself; it needs to be combined with `the core Toga library`_,
 
 For platform requirements, see the `testing platform documentation
-<https://toga.readthedocs.io/en/stable/reference/platforms/testing.html#prerequisites>`__.
+<https://toga.readthedocs.io/en/latest/reference/platforms/testing.html#prerequisites>`__.
 
 For more details, see the `Toga project on Github`_.
 

--- a/dummy/pyproject.toml
+++ b/dummy/pyproject.toml
@@ -47,9 +47,10 @@ classifiers = [
 [project.urls]
 Homepage = "https://beeware.org/project/projects/libraries/toga/"
 Funding = "https://beeware.org/contributing/membership/"
-Documentation = "https://toga.readthedocs.io/en/latest/"
+Documentation = "https://toga.readthedocs.io/"
 Tracker = "https://github.com/beeware/toga/issues"
 Source = "https://github.com/beeware/toga"
+Changelog = "https://toga.readthedocs.io/en/stable/background/project/releases.html"
 
 [project.entry-points."toga.backends"]
 dummy = "toga_dummy"

--- a/gtk/README.rst
+++ b/gtk/README.rst
@@ -6,7 +6,7 @@ A GTK backend for the `Toga widget toolkit`_.
 This package isn't much use by itself; it needs to be combined with `the core Toga library`_.
 
 For platform requirements, see the `Linux platform documentation
-<https://toga.readthedocs.io/en/stable/reference/platforms/linux.html#prerequisites>`__.
+<https://toga.readthedocs.io/en/latest/reference/platforms/linux.html#prerequisites>`__.
 
 For more details, see the `Toga project on Github`_.
 

--- a/gtk/pyproject.toml
+++ b/gtk/pyproject.toml
@@ -50,9 +50,10 @@ classifiers = [
 [project.urls]
 Homepage = "https://beeware.org/project/projects/libraries/toga/"
 Funding = "https://beeware.org/contributing/membership/"
-Documentation = "https://toga.readthedocs.io/en/latest/"
+Documentation = "https://toga.readthedocs.io/"
 Tracker = "https://github.com/beeware/toga/issues"
 Source = "https://github.com/beeware/toga"
+Changelog = "https://toga.readthedocs.io/en/stable/background/project/releases.html"
 
 [project.entry-points."toga.backends"]
 linux = "toga_gtk"

--- a/iOS/README.rst
+++ b/iOS/README.rst
@@ -6,7 +6,7 @@ An iOS backend for the `Toga widget toolkit`_.
 This package isn't much use by itself; it needs to be combined with `the core Toga library`_.
 
 For platform requirements, see the `iOS platform documentation
-<https://toga.readthedocs.io/en/stable/reference/platforms/iOS.html#prerequisites>`__.
+<https://toga.readthedocs.io/en/latest/reference/platforms/iOS.html#prerequisites>`__.
 
 For more details, see the `Toga project on Github`_.
 

--- a/iOS/pyproject.toml
+++ b/iOS/pyproject.toml
@@ -48,9 +48,10 @@ classifiers = [
 [project.urls]
 Homepage = "https://beeware.org/project/projects/libraries/toga/"
 Funding = "https://beeware.org/contributing/membership/"
-Documentation = "https://toga.readthedocs.io/en/latest/"
+Documentation = "https://toga.readthedocs.io/"
 Tracker = "https://github.com/beeware/toga/issues"
 Source = "https://github.com/beeware/toga"
+Changelog = "https://toga.readthedocs.io/en/stable/background/project/releases.html"
 
 [project.entry-points."toga.backends"]
 iOS = "toga_iOS"

--- a/nursery/curses/pyproject.toml
+++ b/nursery/curses/pyproject.toml
@@ -49,9 +49,10 @@ classifiers = [
 [project.urls]
 Homepage = "https://beeware.org/project/projects/libraries/toga/"
 Funding = "https://beeware.org/contributing/membership/"
-Documentation = "https://toga.readthedocs.io/en/latest/"
+Documentation = "https://toga.readthedocs.io/"
 Tracker = "https://github.com/beeware/toga/issues"
 Source = "https://github.com/beeware/toga"
+Changelog = "https://toga.readthedocs.io/en/stable/background/project/releases.html"
 
 [project.entry-points."toga.backends"]
 linux = "toga_curses"

--- a/nursery/qt/pyproject.toml
+++ b/nursery/qt/pyproject.toml
@@ -48,9 +48,10 @@ classifiers = [
 [project.urls]
 Homepage = "https://beeware.org/project/projects/libraries/toga/"
 Funding = "https://beeware.org/contributing/membership/"
-Documentation = "https://toga.readthedocs.io/en/latest/"
+Documentation = "https://toga.readthedocs.io/"
 Tracker = "https://github.com/beeware/toga/issues"
 Source = "https://github.com/beeware/toga"
+Changelog = "https://toga.readthedocs.io/en/stable/background/project/releases.html"
 
 [project.entry-points."toga.backends"]
 linux = "toga_curses"

--- a/nursery/tvOS/pyproject.toml
+++ b/nursery/tvOS/pyproject.toml
@@ -49,9 +49,10 @@ classifiers = [
 [project.urls]
 Homepage = "https://beeware.org/project/projects/libraries/toga/"
 Funding = "https://beeware.org/contributing/membership/"
-Documentation = "https://toga.readthedocs.io/en/latest/"
+Documentation = "https://toga.readthedocs.io/"
 Tracker = "https://github.com/beeware/toga/issues"
 Source = "https://github.com/beeware/toga"
+Changelog = "https://toga.readthedocs.io/en/stable/background/project/releases.html"
 
 [project.entry-points."toga.backends"]
 tvOS = "toga_tvOS"

--- a/nursery/uwp/pyproject.toml
+++ b/nursery/uwp/pyproject.toml
@@ -49,9 +49,10 @@ classifiers = [
 [project.urls]
 Homepage = "https://beeware.org/project/projects/libraries/toga/"
 Funding = "https://beeware.org/contributing/membership/"
-Documentation = "https://toga.readthedocs.io/en/latest/"
+Documentation = "https://toga.readthedocs.io/"
 Tracker = "https://github.com/beeware/toga/issues"
 Source = "https://github.com/beeware/toga"
+Changelog = "https://toga.readthedocs.io/en/stable/background/project/releases.html"
 
 [project.entry-points."toga.backends"]
 windows = "toga_uwp"

--- a/nursery/watchOS/pyproject.toml
+++ b/nursery/watchOS/pyproject.toml
@@ -49,9 +49,10 @@ classifiers = [
 [project.urls]
 Homepage = "https://beeware.org/project/projects/libraries/toga/"
 Funding = "https://beeware.org/contributing/membership/"
-Documentation = "https://toga.readthedocs.io/en/latest/"
+Documentation = "https://toga.readthedocs.io/"
 Tracker = "https://github.com/beeware/toga/issues"
 Source = "https://github.com/beeware/toga"
+Changelog = "https://toga.readthedocs.io/en/stable/background/project/releases.html"
 
 [project.entry-points."toga.backends"]
 watchOS = "toga_watchOS"

--- a/textual/README.rst
+++ b/textual/README.rst
@@ -6,7 +6,7 @@ A Textual backend for the `Toga widget toolkit`_.
 This package isn't much use by itself; it needs to be combined with `the core Toga library`_.
 
 For platform requirements, see the `Terminal platform documentation
-<https://toga.readthedocs.io/en/stable/reference/platforms/terminal.html#prerequisites>`__.
+<https://toga.readthedocs.io/en/latest/reference/platforms/terminal.html#prerequisites>`__.
 
 For more details, see the `Toga project on Github`_.
 

--- a/textual/pyproject.toml
+++ b/textual/pyproject.toml
@@ -49,9 +49,10 @@ classifiers = [
 [project.urls]
 Homepage = "https://beeware.org/project/projects/libraries/toga/"
 Funding = "https://beeware.org/contributing/membership/"
-Documentation = "https://toga.readthedocs.io/en/latest/"
+Documentation = "https://toga.readthedocs.io/"
 Tracker = "https://github.com/beeware/toga/issues"
 Source = "https://github.com/beeware/toga"
+Changelog = "https://toga.readthedocs.io/en/stable/background/project/releases.html"
 
 [project.entry-points."toga.backends"]
 linux = "toga_textual"

--- a/toga/README.rst
+++ b/toga/README.rst
@@ -17,7 +17,7 @@ Backends are also available for `Android <https://pypi.org/project/toga-android>
 
 Toga requires **Python 3.8** or newer. It does not support Python 2. Some platforms have
 additional prerequisites; see the `Toga platform guide
-<https://toga.readthedocs.io/en/stable/reference/platforms/index.html>`__ for details.
+<https://toga.readthedocs.io/en/latest/reference/platforms/index.html>`__ for details.
 
 For more details, see the `Toga project on Github`_.
 

--- a/toga/pyproject.toml
+++ b/toga/pyproject.toml
@@ -60,9 +60,10 @@ classifiers = [
 [project.urls]
 Homepage = "https://beeware.org/project/projects/libraries/toga/"
 Funding = "https://beeware.org/contributing/membership/"
-Documentation = "https://toga.readthedocs.io/en/latest/"
+Documentation = "https://toga.readthedocs.io/"
 Tracker = "https://github.com/beeware/toga/issues"
 Source = "https://github.com/beeware/toga"
+Changelog = "https://toga.readthedocs.io/en/stable/background/project/releases.html"
 
 [tool.setuptools_scm]
 root = ".."

--- a/web/README.rst
+++ b/web/README.rst
@@ -6,7 +6,7 @@ A backend for the `Toga widget toolkit`_ on web platforms.
 This package isn't much use by itself; it needs to be combined with `the core Toga library`_.
 
 For platform requirements, see the `Web platform documentation
-<https://toga.readthedocs.io/en/stable/reference/platforms/web.html#prerequisites>`__.
+<https://toga.readthedocs.io/en/latest/reference/platforms/web.html#prerequisites>`__.
 
 For more details, see the `Toga project on Github`_.
 

--- a/web/pyproject.toml
+++ b/web/pyproject.toml
@@ -50,9 +50,10 @@ classifiers = [
 [project.urls]
 Homepage = "https://beeware.org/project/projects/libraries/toga/"
 Funding = "https://beeware.org/contributing/membership/"
-Documentation = "https://toga.readthedocs.io/en/latest/"
+Documentation = "https://toga.readthedocs.io/"
 Tracker = "https://github.com/beeware/toga/issues"
 Source = "https://github.com/beeware/toga"
+Changelog = "https://toga.readthedocs.io/en/stable/background/project/releases.html"
 
 [project.entry-points."toga.backends"]
 web = "toga_web"

--- a/winforms/README.rst
+++ b/winforms/README.rst
@@ -6,7 +6,7 @@ A Microsoft .NET backend for the `Toga widget toolkit`_ utilizing the WinForms A
 This package isn't much use by itself; it needs to be combined with `the core Toga library`_.
 
 For platform requirements, see the `Windows platform documentation
-<https://toga.readthedocs.io/en/stable/reference/platforms/windows.html#prerequisites>`__.
+<https://toga.readthedocs.io/en/latest/reference/platforms/windows.html#prerequisites>`__.
 
 For more details, see the `Toga project on Github`_.
 

--- a/winforms/pyproject.toml
+++ b/winforms/pyproject.toml
@@ -49,9 +49,10 @@ classifiers = [
 [project.urls]
 Homepage = "https://beeware.org/project/projects/libraries/toga/"
 Funding = "https://beeware.org/contributing/membership/"
-Documentation = "https://toga.readthedocs.io/en/latest/"
+Documentation = "https://toga.readthedocs.io/"
 Tracker = "https://github.com/beeware/toga/issues"
 Source = "https://github.com/beeware/toga"
+Changelog = "https://toga.readthedocs.io/en/stable/background/project/releases.html"
 
 [project.entry-points."toga.backends"]
 windows = "toga_winforms"


### PR DESCRIPTION
## Changes
- The Documentation link is updated to the default landing page configured in RTD...which is currently `stable`
  - Previously, this was `latest` but that seems strange given these links only really show up on PyPI...and the code on PyPI usually isn't the "latest"
- Add a new "Changelog" link on PyPI for Toga's release history
  - I had previously mentioned linking to the GitHub release page to advertise new releases but it was said that PyPI is the official source of releases
  - That makes sense to me but I've been a little bothered that the release history isn't prominently made available to users on PyPI; this resolves that with a dedicated link
  - The name "Changelog" for the link probably has room for debate...
- Update RTD link in READMEs to `latest` instead of `stable`
  - If you're reading a README, you are probably more interested in the latest documentation than the last release

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct