### PR TITLE
Increased the delay when waiting for map rendering updates.

### DIFF
--- a/changes/2509.misc.rst
+++ b/changes/2509.misc.rst
@@ -1,0 +1,1 @@
+The delay used when waiting for web-backed map rendering to complete was increased, to accommodate server-side slowdowns.

--- a/gtk/tests_backend/widgets/mapview.py
+++ b/gtk/tests_backend/widgets/mapview.py
@@ -44,11 +44,11 @@ class MapViewProbe(SimpleProbe):
         previous = initial
         panning = True
 
-        # Iterate until 2 successive reads of the region, 0.1s apart, return the same
+        # Iterate until 2 successive reads of the region, 0.2s apart, return the same
         # value; or we've been waiting max_delay seconds. If confirm_pan is True, also
         # confirm that the value has actually changed from the initial value.
         tick_count = 0
-        delta = 0.1
+        delta = 0.2
         while panning and tick_count < (max_delay / delta):
             await asyncio.sleep(delta)
             current = await self._map_region()

--- a/winforms/tests_backend/widgets/mapview.py
+++ b/winforms/tests_backend/widgets/mapview.py
@@ -39,11 +39,11 @@ class MapViewProbe(SimpleProbe):
         previous = initial
         panning = True
 
-        # Iterate until 2 successive reads of the region, 0.1s apart, return the same
+        # Iterate until 2 successive reads of the region, 0.2s apart, return the same
         # value; or we've been waiting max_delay seconds. If confirm_pan is True, also
         # confirm that the value has actually changed from the initial value.
         tick_count = 0
-        delta = 0.1
+        delta = 0.2
         while panning and tick_count < (max_delay / delta):
             await asyncio.sleep(delta)
             current = await self._map_region()


### PR DESCRIPTION
Fixes #2509 

Increases the delay when waiting for map rendering updates. 

The test case passes consistently when run in slow mode; when running in fast mode, there's an appreciable "stutter" in rendering, which, depending on exact testing conditions, can result in a test failure. Increasing the delay gives the web view a little more time to complete rendering, which seems to avoid the problem. 

Not sure why this suddenly started being a problem 2 days ago - my guess would be a change in how leaflet is deployed, but that's difficult to verify.

I've speculatively made the same change to the Winforms implementation, since it's using same underlying implementation.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
