### PR TITLE
Fixed widget IDs to be reusable after window closes

### DIFF
--- a/changes/2514.bugfix.rst
+++ b/changes/2514.bugfix.rst
@@ -1,0 +1,1 @@
+Widget IDs can now be reused after the associated widget's window is closed.

--- a/core/src/toga/window.py
+++ b/core/src/toga/window.py
@@ -272,6 +272,9 @@ class Window:
         undefined, except for :attr:`closed` which can be used to check if the window
         was closed.
         """
+        if getattr(self, "content", None) is not None:
+            self.content.clear()
+            self.content.window = None
         self.app.windows.discard(self)
         self._impl.close()
         self._closed = True

--- a/core/src/toga/window.py
+++ b/core/src/toga/window.py
@@ -272,8 +272,7 @@ class Window:
         undefined, except for :attr:`closed` which can be used to check if the window
         was closed.
         """
-        if getattr(self, "content", None) is not None:
-            self.content.clear()
+        if self.content:
             self.content.window = None
         self.app.windows.discard(self)
         self._impl.close()

--- a/core/tests/test_window.py
+++ b/core/tests/test_window.py
@@ -381,6 +381,49 @@ def test_screen_position(window, app):
     assert window.screen_position == (100, 100)
 
 
+def test_widget_id_reusable_after_window_closes(window, app):
+    """Widget IDs can be reused after the associated widget's window is closed."""
+
+    # Common widget IDs
+    common_widget_ids = {"content": "window_content", "label": "sample_label"}
+
+    # Create a second window and create its content and children & specify their IDs.
+    second_window = toga.Window()
+    second_window.content = toga.Box(
+        id=common_widget_ids["content"],
+        children=[toga.Label(text="Sample Label", id=common_widget_ids["label"])],
+    )
+    # Show the second window and check that it is in the app's windows registry.
+    second_window.show()
+    assert second_window.app == app
+    assert second_window in app.windows
+    assert_action_performed(second_window, "show")
+
+    # Close the second window and check that it is *not* in the app's windows registry.
+    second_window.close()
+    assert second_window.closed
+    assert second_window not in app.windows
+    assert_action_performed(second_window, "close")
+
+    # Again create a third window and create its content and children using the same IDs.
+    third_window = toga.Window()
+    third_window.content = toga.Box(
+        id=common_widget_ids["content"],
+        children=[toga.Label(text="sample_label", id=common_widget_ids["label"])],
+    )
+    # Show the third window and check that it is in the app's windows registry.
+    third_window.show()
+    assert third_window.app == app
+    assert third_window in app.windows
+    assert_action_performed(third_window, "show")
+
+    # Close the third window and check that it is *not* in the app's windows registry.
+    third_window.close()
+    assert third_window.closed
+    assert third_window not in app.windows
+    assert_action_performed(third_window, "close")
+
+
 def test_info_dialog(window, app):
     """An info dialog can be shown."""
     on_result_handler = Mock()

--- a/core/tests/test_window.py
+++ b/core/tests/test_window.py
@@ -395,7 +395,7 @@ def test_widget_id_reusablity(window, app):
     try:
         third_window_content = toga.Box(id=CONTENT_WIDGET_ID)
     except KeyError:
-        raise AssertionError(
+        pytest.fail(
             "Reusing same ID to create another widget when not assigned to a window"
             "should not have raised KeyError."
         )
@@ -411,33 +411,21 @@ def test_widget_id_reusablity(window, app):
     assert CONTENT_WIDGET_ID in app.widgets
     assert LABEL_WIDGET_ID in app.widgets
     # Assigning widget with same widget ID to be a window's content should raise a KeyError
-    try:
+    with pytest.raises(KeyError):
         third_window.content = third_window_content
-    except KeyError:
-        assert True
-    else:
-        raise AssertionError(
-            "Assigning a widget with same ID to be a window's content should have raised KeyError."
-        )
     assert CONTENT_WIDGET_ID not in third_window.widgets
 
     # Creating a new widget with same widget ID should not raise KeyError
     try:
         new_label_widget = toga.Label(text="Sample Label", id=LABEL_WIDGET_ID)
     except KeyError:
-        raise AssertionError(
+        pytest.fail(
             "Reusing same ID to create another widget when not assigned to a window "
             "should not have raised KeyError."
         )
     # But adding the widget to another window's content should raise KeyError
-    try:
+    with pytest.raises(KeyError):
         third_window.content = toga.Box(children=[new_label_widget])
-    except KeyError:
-        assert True
-    else:
-        raise AssertionError(
-            "Adding a widget with same ID to a window's content should have raised KeyError."
-        )
     assert CONTENT_WIDGET_ID not in third_window.widgets
 
     # Close the windows

--- a/core/tests/test_window.py
+++ b/core/tests/test_window.py
@@ -385,43 +385,40 @@ def test_widget_id_reusable_after_window_closes(window, app):
     """Widget IDs can be reused after the associated widget's window is closed."""
 
     # Common widget IDs
-    common_widget_ids = {"content": "window_content", "label": "sample_label"}
+    CONTENT_WIDGET_ID = "window_content"
+    LABEL_WIDGET_ID = "sample_label"
 
     # Create a second window and create its content and children & specify their IDs.
     second_window = toga.Window()
     second_window.content = toga.Box(
-        id=common_widget_ids["content"],
-        children=[toga.Label(text="Sample Label", id=common_widget_ids["label"])],
+        id=CONTENT_WIDGET_ID,
+        children=[toga.Label(text="Sample Label", id=LABEL_WIDGET_ID)],
     )
-    # Show the second window and check that it is in the app's windows registry.
+    # Show the second window and check that the widgets are in the app's widget registry.
     second_window.show()
-    assert second_window.app == app
-    assert second_window in app.windows
-    assert_action_performed(second_window, "show")
+    assert CONTENT_WIDGET_ID in app.widgets
+    assert LABEL_WIDGET_ID in app.widgets
 
-    # Close the second window and check that it is *not* in the app's windows registry.
+    # Close the second window and check that the widgets are *not* in the app's widget registry.
     second_window.close()
-    assert second_window.closed
-    assert second_window not in app.windows
-    assert_action_performed(second_window, "close")
+    assert CONTENT_WIDGET_ID not in app.widgets
+    assert LABEL_WIDGET_ID not in app.widgets
 
     # Again create a third window and create its content and children using the same IDs.
     third_window = toga.Window()
     third_window.content = toga.Box(
-        id=common_widget_ids["content"],
-        children=[toga.Label(text="sample_label", id=common_widget_ids["label"])],
+        id=CONTENT_WIDGET_ID,
+        children=[toga.Label(text="sample_label", id=LABEL_WIDGET_ID)],
     )
-    # Show the third window and check that it is in the app's windows registry.
+    # Show the third window and check that the widgets are in the app's widget registry.
     third_window.show()
-    assert third_window.app == app
-    assert third_window in app.windows
-    assert_action_performed(third_window, "show")
+    assert CONTENT_WIDGET_ID in app.widgets
+    assert LABEL_WIDGET_ID in app.widgets
 
-    # Close the third window and check that it is *not* in the app's windows registry.
+    # Close the third window and check that the widgets are *not* in the app's widget registry.
     third_window.close()
-    assert third_window.closed
-    assert third_window not in app.windows
-    assert_action_performed(third_window, "close")
+    assert CONTENT_WIDGET_ID not in app.widgets
+    assert LABEL_WIDGET_ID not in app.widgets
 
 
 def test_info_dialog(window, app):

--- a/core/tests/window/test_window.py
+++ b/core/tests/window/test_window.py
@@ -383,26 +383,26 @@ def test_screen_position(window, app):
 
 def test_widget_id_reusablity(window, app):
     """Widget IDs can be reused after the associated widget's window is closed."""
-
     # Common IDs
     CONTENT_WIDGET_ID = "sample_window_content"
     LABEL_WIDGET_ID = "sample_label"
 
     label_widget = toga.Label(text="Sample Label", id=LABEL_WIDGET_ID)
     second_window_content = toga.Box(id=CONTENT_WIDGET_ID, children=[label_widget])
-    # Creating widgets with same ID is allowed but it should
-    # raise KeyError only when assigned to a window.
-    try:
-        third_window_content = toga.Box(id=CONTENT_WIDGET_ID)
-    except KeyError:
-        pytest.fail(
-            "Reusing same ID to create another widget when not assigned to a window"
-            "should not have raised KeyError."
-        )
 
-    # Create extra windows and show them
+    third_window_content = toga.Box(children=[])
+
+    # A widget ID is only "used" when it is part of a visible layout;
+    # creating a widget and *not* putting it in a layout isn't an problem.
+    try:
+        new_label_widget = toga.Label(text="New Label", id=LABEL_WIDGET_ID)
+    except KeyError:
+        pytest.fail("Widget IDs that aren't part of a layout can be re-used.")
+
+    # Create 2 new visible windows
     second_window = toga.Window()
     second_window.show()
+
     third_window = toga.Window()
     third_window.show()
 
@@ -410,28 +410,58 @@ def test_widget_id_reusablity(window, app):
     second_window.content = second_window_content
     assert CONTENT_WIDGET_ID in app.widgets
     assert LABEL_WIDGET_ID in app.widgets
-    # Assigning widget with same widget ID to be a window's content should raise a KeyError
-    with pytest.raises(KeyError):
-        third_window.content = third_window_content
+
+    # CONTENT_WIDGET_ID is in use, so a widget with that ID can't be assigned to a window.
+    with pytest.raises(
+        KeyError,
+        match=r"There is already a widget with the id 'sample_label'",
+    ):
+        third_window.content = new_label_widget
     assert CONTENT_WIDGET_ID not in third_window.widgets
+    assert LABEL_WIDGET_ID not in third_window.widgets
+
+    # Adding content that has a child with a re-used ID should raise an error
+    with pytest.raises(
+        KeyError,
+        match=r"There is already a widget with the id 'sample_label'",
+    ):
+        third_window.content = toga.Box(children=[new_label_widget])
+    assert CONTENT_WIDGET_ID not in third_window.widgets
+    assert LABEL_WIDGET_ID not in third_window.widgets
+
+    # Adding a child with a re-used ID should raise an error.
+    third_window.content = third_window_content
+    with pytest.raises(
+        KeyError,
+        match=r"There is already a widget with the id 'sample_label'",
+    ):
+        third_window_content.add(new_label_widget)
+    assert CONTENT_WIDGET_ID not in third_window.widgets
+    assert LABEL_WIDGET_ID not in third_window.widgets
 
     # Creating a new widget with same widget ID should not raise KeyError
     try:
-        new_label_widget = toga.Label(text="Sample Label", id=LABEL_WIDGET_ID)
+        another_label_widget = toga.Label(text="Another Label", id=LABEL_WIDGET_ID)
     except KeyError:
-        pytest.fail(
-            "Reusing same ID to create another widget when not assigned to a window "
-            "should not have raised KeyError."
-        )
-    # But adding the widget to another window's content should raise KeyError
-    with pytest.raises(KeyError):
-        third_window.content = toga.Box(children=[new_label_widget])
-    assert CONTENT_WIDGET_ID not in third_window.widgets
+        pytest.fail("Widget IDs that aren't part of a layout can be re-used.")
 
-    # Close the windows
+    # If a widget using an ID is being *replaced*, the ID can be re-used.
+    try:
+        second_window.content = another_label_widget
+    except KeyError:
+        pytest.fail("Widget IDs that are replaced can be re-used.")
+
+    # Close Window 2
     second_window.close()
     assert CONTENT_WIDGET_ID not in app.widgets
     assert LABEL_WIDGET_ID not in app.widgets
+
+    # Now that second_window has been closed, the duplicate ID can be used
+    try:
+        third_window_content.add(new_label_widget)
+    except KeyError:
+        pytest.fail("Widget IDs that are replaced can be re-used.")
+
     third_window.close()
 
 


### PR DESCRIPTION
Fixes #2514 
<!--- Describe your changes in detail -->
Fixed widget IDs to be reusable after window closes. Also added a new test to check the behavior.
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
