### PR TITLE
Use GTK WebKit2 4.1; else fallback to 4.0

### DIFF
--- a/changes/2527.bugfix.rst
+++ b/changes/2527.bugfix.rst
@@ -1,0 +1,1 @@
+:class:`~toga.WebView` is now compatible with Linux GTK environments only providing WebKit2 version 4.1 without version 4.0.

--- a/gtk/src/toga_gtk/libs/gtk.py
+++ b/gtk/src/toga_gtk/libs/gtk.py
@@ -14,7 +14,10 @@ if Gdk.Screen.get_default() is None:  # pragma: no cover
 # wrappers aren't installed; handle failure gracefully (see
 # https://github.com/beeware/toga/issues/26)
 try:
-    gi.require_version("WebKit2", "4.0")
+    try:
+        gi.require_version("WebKit2", "4.1")
+    except ValueError:
+        gi.require_version("WebKit2", "4.0")
     from gi.repository import WebKit2  # noqa: F401
 except (ImportError, ValueError):  # pragma: no cover
     WebKit2 = None


### PR DESCRIPTION
## Changes
- With Ubuntu Noble 24.04 dropping support for GTK WebKit2 4.0, Toga now supports detecting 4.1
- If 4.1 is not available, Toga falls back to the previous behavior of detecting 4.0

```pycon
>>> import gi
>>> gi.require_version("WebKit2", "4.0")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/tmp/venv/lib/python3.12/site-packages/gi/__init__.py", line 125, in require_version
    raise ValueError('Namespace %s not available for version %s' %
ValueError: Namespace WebKit2 not available for version 4.0
>>> gi.require_version("WebKit2", "4.1")
>>> 
```

## Notes
- RE: https://github.com/beeware/toga/discussions/2528 (Thanks @eichin!)
- RE: https://github.com/beeware/beeware/issues/333
- RE: https://github.com/beeware/briefcase/pull/1748

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct