### PR TITLE
Fixed `OptionContainer` example app

### DIFF
--- a/changes/2532.bugfix.rst
+++ b/changes/2532.bugfix.rst
@@ -1,0 +1,1 @@
+The error raised by the OptionContainer example app when the current tab is changed from commands has been resolved.

--- a/changes/2532.bugfix.rst
+++ b/changes/2532.bugfix.rst
@@ -1,1 +1,1 @@
-The error raised by the OptionContainer example app when the current tab is changed from commands has been resolved.
+The error raised by the OptionContainer example app when the current tab is changed from commands is now resolved.

--- a/changes/2532.bugfix.rst
+++ b/changes/2532.bugfix.rst
@@ -1,1 +1,0 @@
-The error raised by the OptionContainer example app when the current tab is changed from commands is now resolved.

--- a/changes/2532.misc.rst
+++ b/changes/2532.misc.rst
@@ -1,0 +1,1 @@
+The Next/Previous Tab commands in the OptionContainer example were updated to remove the use of a backwards incompatible API.

--- a/examples/optioncontainer/optioncontainer/app.py
+++ b/examples/optioncontainer/optioncontainer/app.py
@@ -69,11 +69,15 @@ class ExampleOptionContainerApp(toga.App):
             self.optioncontainer.current_tab.index
             < len(self.optioncontainer.content) - 1
         ):
-            self.optioncontainer.current_tab += 1
+            self.optioncontainer.current_tab = (
+                self.optioncontainer.current_tab.index + 1
+            )
 
     def set_previous_tab(self, widget):
         if self.optioncontainer.current_tab.index > 0:
-            self.optioncontainer.current_tab -= 1
+            self.optioncontainer.current_tab = (
+                self.optioncontainer.current_tab.index - 1
+            )
 
     def on_select_tab(self, widget, **kwargs):
         self.selected_label.text = (


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Fixes the `OptionContainer` example app. 

Currently when the `OptionContainer` example app is run and `Commands`=>`Next Tab` is pressed, the following TypeError is raised:
```
File "D:\optioncontainer_example_fix\examples\optioncontainer\optioncontainer\app.py", line 72, in set_next_tab
    self.optioncontainer.current_tab += 1
TypeError: unsupported operand type(s) for +=: 'OptionItem' and 'int'
Error in handler: unsupported operand type(s) for +=: 'OptionItem' and 'int'
```
This PR fixes the above error.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
