### PR TITLE
Update WebKit2 dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,7 @@ jobs:
           pre-command: |
             sudo apt update -y
             sudo apt install -y --no-install-recommends \
-              blackbox pkg-config python3-dev libgirepository1.0-dev libcairo2-dev gir1.2-webkit2-4.0
+              blackbox pkg-config python3-dev libgirepository1.0-dev libcairo2-dev gir1.2-webkit2-4.1
 
             # Start Virtual X server
             echo "Start X server..."

--- a/changes/2544.doc.rst
+++ b/changes/2544.doc.rst
@@ -1,0 +1,1 @@
+An explicit system requirements section was added to the documentation for widgets that require the installation of additional system components.

--- a/docs/reference/api/containers/optioncontainer.rst
+++ b/docs/reference/api/containers/optioncontainer.rst
@@ -132,6 +132,13 @@ item, you can specify an item using:
       # Delete the pasta tab
       del container.content[pasta_tab]
 
+System requirements
+-------------------
+
+* Using OptionContainer on Android requires the Material package in your project's
+  Gradle dependencies. Ensure your app declares a dependency on
+  ``com.google.android.material:material:1.11.0`` or later.
+
 Notes
 -----
 

--- a/docs/reference/api/widgets/mapview.rst
+++ b/docs/reference/api/widgets/mapview.rst
@@ -95,6 +95,8 @@ updated and removed at runtime:
 Pins can respond to being pressed. When a pin is pressed, the map generates an
 ``on_select`` event, which receives the pin as an argument.
 
+.. _mapview-system-requires:
+
 System requirements
 -------------------
 
@@ -111,6 +113,7 @@ System requirements
   - Ubuntu 22.04+; Debian 11+: ``gir1.2-webkit2-4.1``
   - Fedora: ``webkit2gtk3``
   - Arch/Manjaro: ``webkit2gtk-4.1``
+  - FreeBSD: ``webkit2-gtk3``
 
 * Using MapView on Android requires the OSMDroid package in your project's Gradle
   dependencies. Ensure your app declares a dependency on

--- a/docs/reference/api/widgets/mapview.rst
+++ b/docs/reference/api/widgets/mapview.rst
@@ -95,6 +95,27 @@ updated and removed at runtime:
 Pins can respond to being pressed. When a pin is pressed, the map generates an
 ``on_select`` event, which receives the pin as an argument.
 
+System requirements
+-------------------
+
+* Using MapView on Windows 10 requires that your users have installed the `Edge
+  WebView2 Evergreen Runtime
+  <https://developer.microsoft.com/en-us/microsoft-edge/webview2/#download>`__.
+  This is installed by default on Windows 11.
+
+* Using MapView on Linux requires that the user has installed the system packages
+  for WebKit2, plus the GObject Introspection bindings for WebKit2. The name of
+  the system package required is distribution dependent:
+
+  - Ubuntu 18.04, 20.04; Debian 10: ``gir1.2-webkit2-4.0``
+  - Ubuntu 22.04+; Debian 11+: ``gir1.2-webkit2-4.1``
+  - Fedora: ``webkit2gtk3``
+  - Arch/Manjaro: ``webkit2gtk-4.1``
+
+* Using MapView on Android requires the OSMDroid package in your project's Gradle
+  dependencies. Ensure your app declares a dependency on
+  ``org.osmdroid:osmdroid-android:6.1.0`` or later.
+
 Notes
 -----
 
@@ -106,18 +127,6 @@ Notes
   terms. In addition, we strongly encourage you to financially support the
   `OpenStreetMap Foundation <https://osmfoundation.org>`__, as their work is what allows
   Toga to provide map content on these platforms.
-
-* Using MapView on Android requires the OSMDroid package to be added your project's
-  Gradle dependencies. Ensure your app declares a dependency on
-  ``org.osmdroid:osmdroid-android:6.1.0`` or later.
-
-* Using MapView on Windows 10 requires that your users have installed the `Edge
-  WebView2 Evergreen Runtime
-  <https://developer.microsoft.com/en-us/microsoft-edge/webview2/#download>`__.
-  This is installed by default on Windows 11.
-
-* Using MapView on Linux requires that the user has installed the system packages
-  for WebKit2, plus the GObject Introspection bindings for WebKit2.
 
 * On macOS and iOS, MapView will not repeat map tiles if the viewable area at the given
   zoom level is bigger than the entire world. A zoom to a very low level will be clipped

--- a/docs/reference/api/widgets/mapview.rst
+++ b/docs/reference/api/widgets/mapview.rst
@@ -109,9 +109,9 @@ System requirements
   for WebKit2, plus the GObject Introspection bindings for WebKit2. The name of
   the system package required is distribution dependent:
 
-  - Ubuntu 18.04, 20.04; Debian 10: ``gir1.2-webkit2-4.0``
-  - Ubuntu 22.04+; Debian 11+: ``gir1.2-webkit2-4.1``
-  - Fedora: ``webkit2gtk3``
+  - Ubuntu 18.04, 20.04; Debian 11: ``gir1.2-webkit2-4.0``
+  - Ubuntu 22.04+; Debian 12+: ``gir1.2-webkit2-4.1``
+  - Fedora: ``webkit2gtk4.1``
   - Arch/Manjaro: ``webkit2gtk-4.1``
   - FreeBSD: ``webkit2-gtk3``
 

--- a/docs/reference/api/widgets/webview.rst
+++ b/docs/reference/api/widgets/webview.rst
@@ -76,9 +76,9 @@ System requirements
   for WebKit2, plus the GObject Introspection bindings for WebKit2. The name of
   the system package required is distribution dependent:
 
-  - Ubuntu 18.04, 20.04; Debian 10: ``gir1.2-webkit2-4.0``
-  - Ubuntu 22.04+; Debian 11+: ``gir1.2-webkit2-4.1``
-  - Fedora: ``webkit2gtk3``
+  - Ubuntu 18.04, 20.04; Debian 11: ``gir1.2-webkit2-4.0``
+  - Ubuntu 22.04+; Debian 12+: ``gir1.2-webkit2-4.1``
+  - Fedora: ``webkit2gtk4.1``
   - Arch/Manjaro: ``webkit2gtk-4.1``
   - FreeBSD: ``webkit2-gtk3``
 

--- a/docs/reference/api/widgets/webview.rst
+++ b/docs/reference/api/widgets/webview.rst
@@ -61,6 +61,9 @@ Usage
     # Load static HTML content into the wevbiew.
     webview.set_content("https://example.com", "<html>...</html>")
 
+
+.. _webview-system-requires:
+
 System requirements
 -------------------
 
@@ -77,6 +80,7 @@ System requirements
   - Ubuntu 22.04+; Debian 11+: ``gir1.2-webkit2-4.1``
   - Fedora: ``webkit2gtk3``
   - Arch/Manjaro: ``webkit2gtk-4.1``
+  - FreeBSD: ``webkit2-gtk3``
 
 Notes
 -----

--- a/docs/reference/api/widgets/webview.rst
+++ b/docs/reference/api/widgets/webview.rst
@@ -61,12 +61,8 @@ Usage
     # Load static HTML content into the wevbiew.
     webview.set_content("https://example.com", "<html>...</html>")
 
-Notes
------
-
-* Due to app security restrictions, WebView can only display ``http://`` and
-  ``https://`` URLs, not ``file://`` URLs. To serve local file content, run a
-  web server on ``localhost`` using a background thread.
+System requirements
+-------------------
 
 * Using WebView on Windows 10 requires that your users have installed the `Edge
   WebView2 Evergreen Runtime
@@ -74,7 +70,20 @@ Notes
   This is installed by default on Windows 11.
 
 * Using WebView on Linux requires that the user has installed the system packages
-  for WebKit2, plus the GObject Introspection bindings for WebKit2.
+  for WebKit2, plus the GObject Introspection bindings for WebKit2. The name of
+  the system package required is distribution dependent:
+
+  - Ubuntu 18.04, 20.04; Debian 10: ``gir1.2-webkit2-4.0``
+  - Ubuntu 22.04+; Debian 11+: ``gir1.2-webkit2-4.1``
+  - Fedora: ``webkit2gtk3``
+  - Arch/Manjaro: ``webkit2gtk-4.1``
+
+Notes
+-----
+
+* Due to app security restrictions, WebView can only display ``http://`` and
+  ``https://`` URLs, not ``file://`` URLs. To serve local file content, run a
+  web server on ``localhost`` using a background thread.
 
 * On macOS 13.3 (Ventura) and later, the content inspector for your app can be opened by
   running Safari, `enabling the developer tools

--- a/docs/reference/platforms/unix-prerequisites.rst
+++ b/docs/reference/platforms/unix-prerequisites.rst
@@ -3,41 +3,45 @@ some of the common alternatives:
 
 ..
     The package list should be the same as in ci.yml, and the BeeWare tutorial
-    (except for the webkit2 parts, which aren't included in the tutorial)
+    (CI will also have WebView requirements)
 
 **Ubuntu 18.04, 20.04 / Debian 10**
 
 .. code-block:: console
 
     (venv) $ sudo apt update
-    (venv) $ sudo apt install pkg-config python3-dev libgirepository1.0-dev libcairo2-dev gir1.2-webkit2-4.0 libcanberra-gtk3-module
+    (venv) $ sudo apt install pkg-config python3-dev libgirepository1.0-dev libcairo2-dev libcanberra-gtk3-module
 
 **Ubuntu 22.04+ / Debian 11+**
 
 .. code-block:: console
 
     (venv) $ sudo apt update
-    (venv) $ sudo apt install pkg-config python3-dev libgirepository1.0-dev libcairo2-dev gir1.2-webkit2-4.1 libcanberra-gtk3-module
+    (venv) $ sudo apt install pkg-config python3-dev libgirepository1.0-dev libcairo2-dev libcanberra-gtk3-module
 
 **Fedora**
 
 .. code-block:: console
 
-    (venv) $ sudo dnf install pkg-config python3-devel gobject-introspection-devel cairo-gobject-devel webkit2gtk3 libcanberra-gtk3
+    (venv) $ sudo dnf install pkg-config python3-devel gobject-introspection-devel cairo-gobject-devel libcanberra-gtk3
 
 **Arch / Manjaro**
 
 .. code-block:: console
 
-    (venv) $ sudo pacman -Syu git pkgconf gobject-introspection cairo webkit2gtk libcanberra
+    (venv) $ sudo pacman -Syu git pkgconf gobject-introspection cairo libcanberra
 
 **FreeBSD**
 
 .. code-block:: console
 
     (venv) $ sudo pkg update
-    (venv) $ sudo pkg install gobject-introspection cairo webkit2-gtk3 libcanberra-gtk3
+    (venv) $ sudo pkg install gobject-introspection cairo libcanberra-gtk3
 
 If you're not using one of these, you'll need to work out how to install the developer
 libraries for ``python3``, ``cairo``, and ``gobject-introspection`` (and please let us
 know so we can improve this documentation!)
+
+Some widgets (most notably, the :ref:`WebView <webview-system-requires>` and
+:ref:`MapView <mapview-system-requires>` widgets) have additional system requirements.
+See the documentation of those widgets for details.

--- a/docs/reference/platforms/unix-prerequisites.rst
+++ b/docs/reference/platforms/unix-prerequisites.rst
@@ -2,14 +2,22 @@ These instructions are different on almost every version of Linux and Unix; here
 some of the common alternatives:
 
 ..
-    The package list should be the same as in ci.yml, and the BeeWare tutorial.
+    The package list should be the same as in ci.yml, and the BeeWare tutorial
+    (except for the webkit2 parts, which aren't included in the tutorial)
 
-**Ubuntu 18.04+ / Debian 10+**
+**Ubuntu 18.04, 20.04 / Debian 10**
 
 .. code-block:: console
 
     (venv) $ sudo apt update
     (venv) $ sudo apt install pkg-config python3-dev libgirepository1.0-dev libcairo2-dev gir1.2-webkit2-4.0 libcanberra-gtk3-module
+
+**Ubuntu 22.04+ / Debian 11+**
+
+.. code-block:: console
+
+    (venv) $ sudo apt update
+    (venv) $ sudo apt install pkg-config python3-dev libgirepository1.0-dev libcairo2-dev gir1.2-webkit2-4.1 libcanberra-gtk3-module
 
 **Fedora**
 

--- a/docs/reference/platforms/unix-prerequisites.rst
+++ b/docs/reference/platforms/unix-prerequisites.rst
@@ -5,14 +5,7 @@ some of the common alternatives:
     The package list should be the same as in ci.yml, and the BeeWare tutorial
     (CI will also have WebView requirements)
 
-**Ubuntu 18.04, 20.04 / Debian 10**
-
-.. code-block:: console
-
-    (venv) $ sudo apt update
-    (venv) $ sudo apt install pkg-config python3-dev libgirepository1.0-dev libcairo2-dev libcanberra-gtk3-module
-
-**Ubuntu 22.04+ / Debian 11+**
+**Ubuntu 18.04+ / Debian 11+**
 
 .. code-block:: console
 

--- a/gtk/src/toga_gtk/libs/gtk.py
+++ b/gtk/src/toga_gtk/libs/gtk.py
@@ -16,8 +16,8 @@ if Gdk.Screen.get_default() is None:  # pragma: no cover
 try:
     try:
         gi.require_version("WebKit2", "4.1")
-    except ValueError:
-        gi.require_version("WebKit2", "4.0")  # pragma: no cover
+    except ValueError:  # pragma: no cover
+        gi.require_version("WebKit2", "4.0")
     from gi.repository import WebKit2  # noqa: F401
 except (ImportError, ValueError):  # pragma: no cover
     WebKit2 = None

--- a/gtk/src/toga_gtk/libs/gtk.py
+++ b/gtk/src/toga_gtk/libs/gtk.py
@@ -17,7 +17,7 @@ try:
     try:
         gi.require_version("WebKit2", "4.1")
     except ValueError:
-        gi.require_version("WebKit2", "4.0")
+        gi.require_version("WebKit2", "4.0")  # pragma: no cover
     from gi.repository import WebKit2  # noqa: F401
 except (ImportError, ValueError):  # pragma: no cover
     WebKit2 = None

--- a/gtk/src/toga_gtk/widgets/mapview.py
+++ b/gtk/src/toga_gtk/widgets/mapview.py
@@ -71,7 +71,9 @@ class MapView(Widget):
         if WebKit2 is None:  # pragma: no cover
             raise RuntimeError(
                 "Unable to import WebKit2. Ensure that the system package "
-                "providing Webkit2 and its GTK bindings have been installed."
+                "providing WebKit2 and its GTK bindings have been installed. "
+                "See https://toga.readthedocs.io/en/stable/reference/api/widgets/mapview.html#system-requirements "
+                "for details."
             )
 
         self.native = WebKit2.WebView()

--- a/gtk/src/toga_gtk/widgets/webview.py
+++ b/gtk/src/toga_gtk/widgets/webview.py
@@ -13,7 +13,9 @@ class WebView(Widget):
         if WebKit2 is None:  # pragma: no cover
             raise RuntimeError(
                 "Unable to import WebKit2. Ensure that the system package "
-                "providing Webkit2 and its GTK bindings have been installed."
+                "providing WebKit2 and its GTK bindings have been installed. "
+                "See https://toga.readthedocs.io/en/stable/reference/api/widgets/webview.html#system-requirements "
+                "for details."
             )
 
         self.native = WebKit2.WebView()


### PR DESCRIPTION
Updates the unix pre-requisites to accomodate the WebKit2 package changes, primarily for the benefit of Ubuntu 24.04.

WebKit2 has been removed from the general Linux requirements list, in favor of a base set of packages plus an explicit list of system requirements on widgets that require it. The error message raised when those system requirements can't be found now explicitly references the system requirements in the docs (although the anchor on the link won't be valid until a stable release is cut). 

Fixes #2544.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
