### PR TITLE
Replace gbulb with a direct GTK main loop integration.

### DIFF
--- a/changes/2458.feature.rst
+++ b/changes/2458.feature.rst
@@ -1,0 +1,1 @@
+The GTK backend was modified to integrate the GTK event loop directly into the asyncio event loop, rather than using GBulb.

--- a/examples/handlers/handlers/app.py
+++ b/examples/handlers/handlers/app.py
@@ -1,6 +1,8 @@
 import asyncio
 import random
 
+import httpx
+
 import toga
 from toga.constants import COLUMN
 from toga.style import Pack
@@ -52,6 +54,16 @@ class HandlerApp(toga.App):
             self.label.text = f"Background: Iteration {self.counter}"
             await asyncio.sleep(1)
 
+    async def do_web_get(self, widget, **kwargs):
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                f"https://jsonplaceholder.typicode.com/posts/{random.randint(0, 100)}"
+            )
+
+        payload = response.json()
+
+        self.web_label.text = payload["title"]
+
     def startup(self):
         # Set up main window
         self.main_window = toga.MainWindow()
@@ -61,6 +73,7 @@ class HandlerApp(toga.App):
         self.function_label = toga.Label("Ready.", style=Pack(padding=10))
         self.generator_label = toga.Label("Ready.", style=Pack(padding=10))
         self.async_label = toga.Label("Ready.", style=Pack(padding=10))
+        self.web_label = toga.Label("Ready.", style=Pack(padding=10))
 
         # Add a background task.
         self.counter = 0
@@ -78,6 +91,9 @@ class HandlerApp(toga.App):
             "Async callback", on_press=self.do_async, style=btn_style
         )
         btn_clear = toga.Button("Clear", on_press=self.do_clear, style=btn_style)
+        btn_web = toga.Button(
+            "Get web content", on_press=self.do_web_get, style=btn_style
+        )
 
         # Outermost box
         box = toga.Box(
@@ -89,6 +105,8 @@ class HandlerApp(toga.App):
                 self.generator_label,
                 btn_async,
                 self.async_label,
+                btn_web,
+                self.web_label,
                 btn_clear,
             ],
             style=Pack(flex=1, direction=COLUMN, padding=10),

--- a/examples/handlers/pyproject.toml
+++ b/examples/handlers/pyproject.toml
@@ -16,6 +16,7 @@ description = "A testing app"
 sources = ["handlers"]
 requires = [
     "../../core",
+    "httpx",
 ]
 
 

--- a/gtk/pyproject.toml
+++ b/gtk/pyproject.toml
@@ -64,7 +64,6 @@ root = ".."
 
 [tool.setuptools_dynamic_dependencies]
 dependencies = [
-    "gbulb >= 0.5.3",
     "pycairo >= 1.17.0",
     "pygobject >= 3.46.0",
     "toga-core == {version}",

--- a/gtk/src/toga_gtk/libs/events.py
+++ b/gtk/src/toga_gtk/libs/events.py
@@ -1,0 +1,138 @@
+##########################################################################
+# This code is derived from asyncio-glib:
+#
+#     https://github.com/jhenstridge/asyncio-glib
+#
+# Copyright (C) James Henstridge
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
+##########################################################################
+
+import asyncio
+import selectors
+
+from .gtk import GLib
+
+try:
+    g_main_loop_run = super(GLib.MainLoop, GLib.MainLoop).run
+except AttributeError:
+    g_main_loop_run = GLib.MainLoop.run
+
+
+class _SelectorSource(GLib.Source):
+    """A GLib source that gathers selectors."""
+
+    def __init__(self, main_loop):
+        super().__init__()
+        self._fd_to_tag = {}
+        self._fd_to_events = {}
+        self._main_loop = main_loop
+
+    def prepare(self):
+        return False, -1
+
+    def check(self):
+        return False
+
+    def dispatch(self, callback, args):
+        for fd, tag in self._fd_to_tag.items():
+            condition = self.query_unix_fd(tag)
+            events = self._fd_to_events.setdefault(fd, 0)
+            if condition & GLib.IOCondition.IN:
+                events |= selectors.EVENT_READ
+            if condition & GLib.IOCondition.OUT:
+                events |= selectors.EVENT_WRITE
+            self._fd_to_events[fd] = events
+        self._main_loop.quit()
+        return GLib.SOURCE_CONTINUE
+
+    def register(self, fd, events):
+        assert fd not in self._fd_to_tag
+
+        condition = GLib.IOCondition(0)
+        if events & selectors.EVENT_READ:
+            condition |= GLib.IOCondition.IN
+        if events & selectors.EVENT_WRITE:
+            condition |= GLib.IOCondition.OUT
+        self._fd_to_tag[fd] = self.add_unix_fd(fd, condition)
+
+    def unregister(self, fd):
+        tag = self._fd_to_tag.pop(fd)
+        self.remove_unix_fd(tag)
+
+    def get_events(self, fd):
+        return self._fd_to_events.get(fd, 0)
+
+    def clear(self):
+        self._fd_to_events.clear()
+
+
+class GLibSelector(selectors._BaseSelectorImpl):
+
+    def __init__(self, context):
+        super().__init__()
+        self._context = context
+        self._main_loop = GLib.MainLoop.new(self._context, False)
+        self._source = _SelectorSource(self._main_loop)
+        self._source.attach(self._context)
+
+    def close(self):
+        self._source.destroy()
+        super().close()
+
+    def register(self, fileobj, events, data=None):
+        key = super().register(fileobj, events, data)
+        self._source.register(key.fd, events)
+        return key
+
+    def unregister(self, fileobj):
+        key = super().unregister(fileobj)
+        self._source.unregister(key.fd)
+        return key
+
+    def select(self, timeout=None):
+        may_block = True
+        self._source.set_ready_time(-1)
+        if timeout is not None:
+            if timeout > 0:
+                self._source.set_ready_time(
+                    GLib.get_monotonic_time() + int(timeout * 1000000)
+                )
+            else:
+                may_block = False
+
+        self._source.clear()
+        if may_block:
+            g_main_loop_run(self._main_loop)
+        else:
+            self._context.iteration(False)
+
+        ready = []
+        for key in self.get_map().values():
+            events = self._source.get_events(key.fd) & key.events
+            if events != 0:
+                ready.append((key, events))
+        return ready
+
+
+class GtkEventLoop(asyncio.SelectorEventLoop):
+    def __init__(self):
+        selector = GLibSelector(GLib.MainContext.default())
+        super().__init__(selector)
+
+
+class GtkEventLoopPolicy(asyncio.DefaultEventLoopPolicy):
+    _loop_factory = GtkEventLoop

--- a/gtk/src/toga_gtk/libs/events.py
+++ b/gtk/src/toga_gtk/libs/events.py
@@ -3,22 +3,27 @@
 #
 #     https://github.com/jhenstridge/asyncio-glib
 #
+# It includes patches from pull requests against that project:
+#
+#   * #9, contributed by Benjamin Berg
+#   * #6, contributed by Niels Avonds
+#
+# ------------------------------------------------------------------------
 # Copyright (C) James Henstridge
 #
-# This library is free software; you can redistribute it and/or
-# modify it under the terms of the GNU Lesser General Public
-# License as published by the Free Software Foundation; either
-# version 2.1 of the License, or (at your option) any later version.
+# This library is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
 #
-# This library is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# Lesser General Public License for more details.
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
 #
-# You should have received a copy of the GNU Lesser General Public
-# License along with this library; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
-#
+# You should have received a copy of the GNU Lesser General Public License along
+# with this library; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 ##########################################################################
 
 import asyncio
@@ -26,23 +31,18 @@ import selectors
 
 from .gtk import GLib
 
-try:
-    g_main_loop_run = super(GLib.MainLoop, GLib.MainLoop).run
-except AttributeError:
-    g_main_loop_run = GLib.MainLoop.run
-
 
 class _SelectorSource(GLib.Source):
     """A GLib source that gathers selectors."""
 
-    def __init__(self, main_loop):
+    def __init__(self):
         super().__init__()
         self._fd_to_tag = {}
         self._fd_to_events = {}
-        self._main_loop = main_loop
+        self._iteration_timeout = 0
 
     def prepare(self):
-        return False, -1
+        return False, self._iteration_timeout
 
     def check(self):
         return False
@@ -53,10 +53,11 @@ class _SelectorSource(GLib.Source):
             events = self._fd_to_events.setdefault(fd, 0)
             if condition & GLib.IOCondition.IN:
                 events |= selectors.EVENT_READ
+            if condition & GLib.IOCondition.HUP:
+                events |= selectors.EVENT_READ
             if condition & GLib.IOCondition.OUT:
                 events |= selectors.EVENT_WRITE
             self._fd_to_events[fd] = events
-        self._main_loop.quit()
         return GLib.SOURCE_CONTINUE
 
     def register(self, fd, events):
@@ -65,6 +66,7 @@ class _SelectorSource(GLib.Source):
         condition = GLib.IOCondition(0)
         if events & selectors.EVENT_READ:
             condition |= GLib.IOCondition.IN
+            condition |= GLib.IOCondition.HUP
         if events & selectors.EVENT_WRITE:
             condition |= GLib.IOCondition.OUT
         self._fd_to_tag[fd] = self.add_unix_fd(fd, condition)
@@ -85,8 +87,7 @@ class GLibSelector(selectors._BaseSelectorImpl):
     def __init__(self, context):
         super().__init__()
         self._context = context
-        self._main_loop = GLib.MainLoop.new(self._context, False)
-        self._source = _SelectorSource(self._main_loop)
+        self._source = _SelectorSource()
         self._source.attach(self._context)
 
     def close(self):
@@ -104,21 +105,15 @@ class GLibSelector(selectors._BaseSelectorImpl):
         return key
 
     def select(self, timeout=None):
-        may_block = True
-        self._source.set_ready_time(-1)
+        # Calling .set_ready_time() always causes a mainloop iteration to finish.
         if timeout is not None:
-            if timeout > 0:
-                self._source.set_ready_time(
-                    GLib.get_monotonic_time() + int(timeout * 1000000)
-                )
-            else:
-                may_block = False
+            # Negative timeout implies immediate dispatch
+            self._source._iteration_timeout = int(max(0, timeout) * 1000)
+        else:
+            self._source._iteration_timeout = -1
 
         self._source.clear()
-        if may_block:
-            g_main_loop_run(self._main_loop)
-        else:
-            self._context.iteration(False)
+        self._context.iteration(False)
 
         ready = []
         for key in self.get_map().values():
@@ -132,6 +127,7 @@ class GtkEventLoop(asyncio.SelectorEventLoop):
     def __init__(self):
         selector = GLibSelector(GLib.MainContext.default())
         super().__init__(selector)
+        self._clock_resolution = 1e-3
 
 
 class GtkEventLoopPolicy(asyncio.DefaultEventLoopPolicy):

--- a/testbed/tests/widgets/test_webview.py
+++ b/testbed/tests/widgets/test_webview.py
@@ -84,6 +84,8 @@ async def widget(on_load):
         # This prevents a segfault at GC time likely coming from the test suite running
         # in a thread and Gtk WebViews sharing resources between instances. We perform
         # the GC run here since pytest fixtures make earlier cleanup difficult.
+        # Do 2 GC passes to ensure loops are resolved.
+        gc.collect()
         gc.collect()
 
     widget = toga.WebView(style=Pack(flex=1), on_webview_load=on_load)
@@ -117,7 +119,9 @@ async def widget(on_load):
         # On Gtk, ensure that the WebView is garbage collection before the next test
         # case. This prevents a segfault at GC time likely coming from the test suite
         # running in a thread and Gtk WebViews sharing resources between instances.
+        # Do 2 GC passes to ensure loops are resolved.
         del widget
+        gc.collect()
         gc.collect()
 
 


### PR DESCRIPTION
GBulb has a number of bugs logged against it; new versions of Python are particularly affected, due to changes in the underlying CPython asyncio libraries.

Gbulb is based on the idea of making the GTK event loop the main loop, and then trying to re-implement asyncio functionality using Glib primitives. This that the bulk of GBulb is a re-implementation of basic socket handling that ascynio has out-of-the-box.

This PR takes the other approach; try to integrate GTK into the asyncio event loop. GTKApplication.run() has a fairly simple implementation, so this seems like it could be a lot more reliable (and avoid any future issues of asyncio updates).

The one notable downside to this approach is that there is a `sleep()` involved; this means there is an inherent "delay" in responding to events. Reducing this delay causes the event loop to thrash, so there's a balance between the length of the delay and the responsiveness of the app. 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
