### PR TITLE
Update/clarify Linux system requirements

### DIFF
--- a/changes/2549.doc.rst
+++ b/changes/2549.doc.rst
@@ -1,0 +1,1 @@
+The system requirements were updated to be more explicit and now include details for OpenSUSE Tumbleweed.

--- a/docs/how-to/contribute/code.rst
+++ b/docs/how-to/contribute/code.rst
@@ -86,31 +86,7 @@ Next, install any additional dependencies for your operating system:
 
   .. group-tab:: Linux
 
-    Ubuntu 18.04+, Debian 10+
-
-    .. code-block:: console
-
-      (venv) $ sudo apt update
-      (venv) $ sudo apt install pkg-config python3-dev libgirepository1.0-dev libcairo2-dev gir1.2-webkit2-4.0 libcanberra-gtk3-module
-
-    Fedora
-
-    .. code-block:: console
-
-      (venv) $ sudo dnf install pkg-config python3-devel gobject-introspection-devel cairo-gobject-devel webkit2gtk3 libcanberra-gtk3
-
-    Arch / Manjaro
-
-    .. code-block:: console
-
-      (venv) $ sudo pacman -Syu git pkgconf gobject-introspection cairo webkit2gtk libcanberra
-
-    FreeBSD
-
-    .. code-block:: console
-
-      (venv) $ sudo pkg update
-      (venv) $ sudo pkg install gobject-introspection cairo webkit2-gtk3
+    .. include:: /reference/platforms/unix-prerequisites.rst
 
   .. group-tab:: Windows
 

--- a/docs/how-to/contribute/docs.rst
+++ b/docs/how-to/contribute/docs.rst
@@ -40,7 +40,7 @@ You'll also need to install the Enchant spell checking library.
 
     Enchant can be installed as a system package:
 
-    **Ubuntu 20.04+ / Debian 10+**
+    **Ubuntu / Debian**
 
     .. code-block:: console
 
@@ -53,11 +53,17 @@ You'll also need to install the Enchant spell checking library.
 
       $ sudo dnf install enchant
 
-    **Arch, Manjaro**
+    **Arch / Manjaro**
 
     .. code-block:: console
 
       $ sudo pacman -Syu enchant
+
+    **OpenSUSE Tumbleweed**
+
+    .. code-block:: console
+
+      $ sudo zypper install enchant
 
   .. group-tab:: Windows
 

--- a/docs/reference/api/widgets/mapview.rst
+++ b/docs/reference/api/widgets/mapview.rst
@@ -109,10 +109,11 @@ System requirements
   for WebKit2, plus the GObject Introspection bindings for WebKit2. The name of
   the system package required is distribution dependent:
 
-  - Ubuntu 18.04, 20.04; Debian 11: ``gir1.2-webkit2-4.0``
+  - Ubuntu 20.04; Debian 11: ``gir1.2-webkit2-4.0``
   - Ubuntu 22.04+; Debian 12+: ``gir1.2-webkit2-4.1``
   - Fedora: ``webkit2gtk4.1``
   - Arch/Manjaro: ``webkit2gtk-4.1``
+  - OpenSUSE Tumbleweed: ``libwebkit2gtk3 typelib(WebKit2)``
   - FreeBSD: ``webkit2-gtk3``
 
 * Using MapView on Android requires the OSMDroid package in your project's Gradle

--- a/docs/reference/api/widgets/webview.rst
+++ b/docs/reference/api/widgets/webview.rst
@@ -76,10 +76,11 @@ System requirements
   for WebKit2, plus the GObject Introspection bindings for WebKit2. The name of
   the system package required is distribution dependent:
 
-  - Ubuntu 18.04, 20.04; Debian 11: ``gir1.2-webkit2-4.0``
+  - Ubuntu 20.04; Debian 11: ``gir1.2-webkit2-4.0``
   - Ubuntu 22.04+; Debian 12+: ``gir1.2-webkit2-4.1``
   - Fedora: ``webkit2gtk4.1``
   - Arch/Manjaro: ``webkit2gtk-4.1``
+  - OpenSUSE Tumbleweed: ``libwebkit2gtk3 typelib(WebKit2)``
   - FreeBSD: ``webkit2-gtk3``
 
 Notes

--- a/docs/reference/platforms/linux.rst
+++ b/docs/reference/platforms/linux.rst
@@ -27,11 +27,9 @@ The Toga backend for Linux (and other Unix-like operating systems) is `toga-gtk
 Prerequisites
 -------------
 
-``toga-gtk`` requires GTK 3.22 or newer. This requirement can be met with with all
-versions of Ubuntu since 18.04, and all versions of Fedora since Fedora 26.
-
-Toga receives the most testing with GTK 3.24. This is the version that has shipped with
-all versions of Ubuntu since Ubuntu 20.04, and all versions of Fedora since Fedora 29.
+``toga-gtk`` requires GTK 3.22 or newer. Most testing occurs with GTK 3.24 as this is
+the version that has shipped with all versions of Ubuntu since Ubuntu 20.04, and all
+versions of Fedora since Fedora 29.
 
 The system packages that provide GTK must be installed manually:
 

--- a/docs/reference/platforms/unix-prerequisites.rst
+++ b/docs/reference/platforms/unix-prerequisites.rst
@@ -5,31 +5,37 @@ some of the common alternatives:
     The package list should be the same as in ci.yml, and the BeeWare tutorial
     (CI will also have WebView requirements)
 
-**Ubuntu 18.04+ / Debian 11+**
+**Ubuntu / Debian**
 
 .. code-block:: console
 
     (venv) $ sudo apt update
-    (venv) $ sudo apt install pkg-config python3-dev libgirepository1.0-dev libcairo2-dev libcanberra-gtk3-module
+    (venv) $ sudo apt install gcc git pkg-config python3-dev gir1.2-gtk-3.0 libgirepository1.0-dev libcairo2-dev libcanberra-gtk3-module
 
 **Fedora**
 
 .. code-block:: console
 
-    (venv) $ sudo dnf install pkg-config python3-devel gobject-introspection-devel cairo-gobject-devel libcanberra-gtk3
+    (venv) $ sudo dnf install gcc git pkg-config python3-devel gtk3 gobject-introspection-devel cairo-gobject-devel libcanberra-gtk3
 
 **Arch / Manjaro**
 
 .. code-block:: console
 
-    (venv) $ sudo pacman -Syu git pkgconf gobject-introspection cairo libcanberra
+    (venv) $ sudo pacman -Syu gcc git pkgconf python3 gtk3 gobject-introspection cairo libcanberra
+
+**OpenSUSE Tumbleweed**
+
+.. code-block:: console
+
+    (venv) $ sudo zypper install gcc git pkgconf-pkg-config python3-devel gtk3 'typelib(Gtk)=3.0' gobject-introspection-devel cairo-devel libcanberra-gtk3-0
 
 **FreeBSD**
 
 .. code-block:: console
 
     (venv) $ sudo pkg update
-    (venv) $ sudo pkg install gobject-introspection cairo libcanberra-gtk3
+    (venv) $ sudo pkg install gcc cmake git python3 pkgconf gtk3 gobject-introspection cairo libcanberra-gtk3
 
 If you're not using one of these, you'll need to work out how to install the developer
 libraries for ``python3``, ``cairo``, and ``gobject-introspection`` (and please let us

--- a/docs/reference/platforms/unix-prerequisites.rst
+++ b/docs/reference/platforms/unix-prerequisites.rst
@@ -10,32 +10,32 @@ some of the common alternatives:
 .. code-block:: console
 
     (venv) $ sudo apt update
-    (venv) $ sudo apt install gcc git pkg-config python3-dev gir1.2-gtk-3.0 libgirepository1.0-dev libcairo2-dev libcanberra-gtk3-module
+    (venv) $ sudo apt install git build-essential pkg-config python3-dev libgirepository1.0-dev libcairo2-dev gir1.2-gtk-3.0 libcanberra-gtk3-module
 
 **Fedora**
 
 .. code-block:: console
 
-    (venv) $ sudo dnf install gcc git pkg-config python3-devel gtk3 gobject-introspection-devel cairo-gobject-devel libcanberra-gtk3
+    (venv) $ sudo dnf install git gcc make pkg-config python3-devel gobject-introspection-devel cairo-gobject-devel gtk3 libcanberra-gtk3
 
 **Arch / Manjaro**
 
 .. code-block:: console
 
-    (venv) $ sudo pacman -Syu gcc git pkgconf python3 gtk3 gobject-introspection cairo libcanberra
+    (venv) $ sudo pacman -Syu git base-devel pkgconf python3 gobject-introspection cairo gtk3 libcanberra
 
 **OpenSUSE Tumbleweed**
 
 .. code-block:: console
 
-    (venv) $ sudo zypper install gcc git pkgconf-pkg-config python3-devel gtk3 'typelib(Gtk)=3.0' gobject-introspection-devel cairo-devel libcanberra-gtk3-0
+    (venv) $ sudo zypper install git patterns-devel-base-devel_basis pkgconf-pkg-config python3-devel gobject-introspection-devel cairo-devel gtk3 'typelib(Gtk)=3.0' libcanberra-gtk3-module
 
 **FreeBSD**
 
 .. code-block:: console
 
     (venv) $ sudo pkg update
-    (venv) $ sudo pkg install gcc cmake git python3 pkgconf gtk3 gobject-introspection cairo libcanberra-gtk3
+    (venv) $ sudo pkg install git gcc cmake pkgconf python3 gobject-introspection cairo gtk3 libcanberra-gtk3
 
 If you're not using one of these, you'll need to work out how to install the developer
 libraries for ``python3``, ``cairo``, and ``gobject-introspection`` (and please let us


### PR DESCRIPTION
## Changes
- Add _all_ requirements for each distro
  - `gcc` since it's a requirement to build `PyGObject`
  - `git` since `pip` is going to need it....at a minimum
  - `gtk3`....most distros are already going to have this installed but useful to explicitly list it for docker images
  - `cmake` for FreeBSD since it needs to build `ninja` as PyPI doesn't have a FreeBSD wheel
- Add requirements for OpenSUSE Tumbleweed
- Drop documentation for Ubuntu 18.04 since it is no longer supported by recent versions of PyGObject
  - 18.04 doesn't work: `Dependency gobject-introspection-1.0 found: NO found 1.56.1 but need: '>= 1.64.0'`

## Notes
- If we agree, I should probably update the BeeWare Tutorial as well

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct