### PR TITLE
Make releases resilient to failures.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,10 +10,9 @@ jobs:
     permissions:
       # This permission is required for trusted publishing.
       id-token: write
-    # Let all the publication steps run to completion. This prevents one bad publish
-    # due to a transient error from stalling the publication of other packages.
-    continue-on-error: true
     strategy:
+      # One element of this matrix failing should not terminate the others mid-run.
+      # This prevents one bad platform from stalling the publication of others.
       fail-fast: false
       matrix:
         package:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,11 @@ jobs:
     permissions:
       # This permission is required for trusted publishing.
       id-token: write
+    # Let all the publication steps run to completion. This prevents one bad publish
+    # due to a transient error from stalling the publication of other packages.
+    continue-on-error: true
     strategy:
+      fail-fast: false
       matrix:
         package:
         - "toga"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,10 +49,10 @@ jobs:
     permissions:
       # This permission is required for trusted publishing.
       id-token: write
-    # Let all the publication steps run to completion. This prevents one bad publish
-    # due to a transient error from stalling the publication of other packages.
     continue-on-error: true
     strategy:
+      # One element of this matrix failing should not terminate the others mid-run.
+      # This prevents one bad platform from stalling the publication of others.
       fail-fast: false
       matrix:
         package:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,11 @@ jobs:
     permissions:
       # This permission is required for trusted publishing.
       id-token: write
+    # Let all the publication steps run to completion. This prevents one bad publish
+    # due to a transient error from stalling the publication of other packages.
+    continue-on-error: true
     strategy:
+      fail-fast: false
       matrix:
         package:
         - "toga"


### PR DESCRIPTION
The release of v0.4.3 required 2 passes, because the use of a pre-release freezegun version wasn't picked up as a problem until the toga-core package was pushed to PyPI. However, by this point, toga-android had been successfully published.

As a result of this, any attempt to re-publish toga-android will fail, because the wheel already exists; but there's no way to make any other 0.4.3 artefact complete upload. 

This PR modifies the matrix tasks to *not* fail fast, and continue on error; this would allow a recovery from the 0.4.3 test release. 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
