### PR TITLE
Correct the fallback handling when an icon cannot be loaded.

### DIFF
--- a/changes/2558.bugfix.rst
+++ b/changes/2558.bugfix.rst
@@ -1,0 +1,1 @@
+If an icon file exists but cannot be loaded, or an application icon cannot be found, Toga will fall back to a default icon.

--- a/changes/2558.bugfix.rst
+++ b/changes/2558.bugfix.rst
@@ -1,1 +1,1 @@
-If an icon file exists but cannot be loaded, or an application icon cannot be found, Toga will fall back to a default icon.
+If an application icon cannot be found, Toga will now fall back to a default icon.

--- a/cocoa/src/toga_cocoa/icons.py
+++ b/cocoa/src/toga_cocoa/icons.py
@@ -16,16 +16,19 @@ class Icon:
         if path is None:
             # Look to the app bundle, and get the icon. Set self.path as None
             # as an indicator that this is the app's default icon.
+            # This bundle icon file definition might not contain an extension,
+            # even thought the actual file will; so force the .icns extension.
             bundle_icon = Path(
                 NSBundle.mainBundle.objectForInfoDictionaryKey("CFBundleIconFile")
             )
             path = NSBundle.mainBundle.pathForResource(
                 bundle_icon.stem,
-                ofType=bundle_icon.suffix,
+                ofType=".icns",
             )
             # If the icon file doesn't exist, raise the problem as FileNotFoundError
+            # This can't be tested, as the app will always have an icon.
             if not Path(path).is_file():
-                raise FileNotFoundError()
+                raise FileNotFoundError()  # pragma: no cover
 
             self.path = None
         else:

--- a/cocoa/src/toga_cocoa/icons.py
+++ b/cocoa/src/toga_cocoa/icons.py
@@ -23,6 +23,10 @@ class Icon:
                 bundle_icon.stem,
                 ofType=bundle_icon.suffix,
             )
+            # If the icon file doesn't exist, raise the problem as FileNotFoundError
+            if not Path(path).is_file():
+                raise FileNotFoundError()
+
             self.path = None
         else:
             self.path = path

--- a/core/src/toga/icons.py
+++ b/core/src/toga/icons.py
@@ -129,8 +129,8 @@ class Icon:
                 )
 
             self._impl = self.factory.Icon(interface=self, path=full_path)
-        except (FileNotFoundError, ValueError):
-            # Icon path couldn't be loaded. If the path is the sentinel for the app
+        except FileNotFoundError:
+            # Icon path couldn't be found. If the path is the sentinel for the app
             # icon, and this isn't running as a script, fall back to the application
             # binary
             if path is _APP_ICON:
@@ -142,7 +142,7 @@ class Icon:
                     try:
                         # Use the application binary's icon
                         self._impl = self.factory.Icon(interface=self, path=None)
-                    except (FileNotFoundError, ValueError):
+                    except FileNotFoundError:
                         # Can't find the application binary's icon.
                         print(
                             "WARNING: Can't find app icon; falling back to default icon"

--- a/core/src/toga/icons.py
+++ b/core/src/toga/icons.py
@@ -95,7 +95,6 @@ class Icon:
         :param system: **For internal use only**
         """
         self.factory = get_platform_factory()
-
         try:
             # Try to load the icon with the given path snippet. If the request is for the
             # app icon, use ``resources/<app name>`` as the path.
@@ -130,7 +129,7 @@ class Icon:
                 )
 
             self._impl = self.factory.Icon(interface=self, path=full_path)
-        except FileNotFoundError:
+        except (FileNotFoundError, ValueError):
             # Icon path couldn't be loaded. If the path is the sentinel for the app
             # icon, and this isn't running as a script, fall back to the application
             # binary
@@ -143,7 +142,7 @@ class Icon:
                     try:
                         # Use the application binary's icon
                         self._impl = self.factory.Icon(interface=self, path=None)
-                    except FileNotFoundError:
+                    except (FileNotFoundError, ValueError):
                         # Can't find the application binary's icon.
                         print(
                             "WARNING: Can't find app icon; falling back to default icon"

--- a/core/src/toga/icons.py
+++ b/core/src/toga/icons.py
@@ -91,7 +91,9 @@ class Icon:
             path, or a path relative to the module that defines your Toga application
             class. This base filename should *not* contain an extension. If an extension
             is specified, it will be ignored. If the icon cannot be found, the default
-            icon will be :attr:`~toga.Icon.DEFAULT_ICON`.
+            icon will be :attr:`~toga.Icon.DEFAULT_ICON`. If an icon file is found, but
+            it cannot be loaded (due to a file format or permission error), an exception
+            will be raised.
         :param system: **For internal use only**
         """
         self.factory = get_platform_factory()

--- a/docs/reference/api/resources/icons.rst
+++ b/docs/reference/api/resources/icons.rst
@@ -71,9 +71,11 @@ icon variants that are not available from the highest resolution provided (e.g.,
 128px variant can be found, one will be created by scaling the highest resolution
 variant that *is* available).
 
-An icon is **guaranteed** to have an implementation, regardless of the path
-specified. If you specify a path and no matching icon can be found, Toga will
-output a warning to the console, and return :attr:`~toga.Icon.DEFAULT_ICON`.
+An icon is **guaranteed** to have an implementation, regardless of the path specified.
+If you specify a path and no matching icon can be found, Toga will output a warning to
+the console, and return :attr:`~toga.Icon.DEFAULT_ICON`. The only exception to this is
+if an icon file is *found*, but it cannot be loaded (e.g., due to a file format or
+permission error). In this case, an error will be raised.
 
 Reference
 ---------

--- a/dummy/src/toga_dummy/icons.py
+++ b/dummy/src/toga_dummy/icons.py
@@ -2,18 +2,19 @@ from .utils import LoggedObject
 
 
 class Icon(LoggedObject):
-    ICON_EXISTS = True
+    ICON_FAILURE = None
     EXTENSIONS = [".png", ".ico"]
     SIZES = None
 
     def __init__(self, interface, path):
         super().__init__()
         self.interface = interface
-        if not self.ICON_EXISTS:
-            raise FileNotFoundError("Couldn't find icon")
-        elif path is None:
-            self.path = "<APP ICON>"
-        elif path == {}:
-            raise FileNotFoundError("No image variants found")
+        if self.ICON_FAILURE:
+            raise self.ICON_FAILURE
         else:
-            self.path = path
+            if path is None:
+                self.path = "<APP ICON>"
+            elif path == {}:
+                raise FileNotFoundError("No image variants found")
+            else:
+                self.path = path


### PR DESCRIPTION
If the macOS backend can't find the icon file, it is currently raised as a ValueError. This should be a FileNotFound error, so that fallback logic is activated.

It also modifies the icon lookup logic to ask specifically for a `.icns` resource, rather than relying on CFBundleIconFile to provide the extension.

Fixes #2558.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
