### PR TITLE
Update README's supported Ubuntu/Fedora versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,20 +38,20 @@ A Python native, OS native GUI toolkit.
 Minimum requirements
 --------------------
 
-* Toga requires **Python 3.8 or higher**. Python 2 is not supported.
+* Toga requires **Python 3.8 or higher**.
 
 * If you're on macOS, you need to be on 11 (Big Sur) or newer.
 
 * If you're on Windows, you'll need Windows 10 or newer. If you are using
   Windows 10 and want to use a WebView to display web content, you will also
-  need to install the `Edge WebView2 Evergreen
-  Runtime. <https://developer.microsoft.com/en-us/microsoft-edge/webview2/#download-section>`__
+  need to install the `Edge WebView2 Evergreen Runtime
+  <https://developer.microsoft.com/en-us/microsoft-edge/webview2/#download-section>`__.
   Windows 11 has this runtime installed by default.
 
 * If you're on Linux (or another Unix-based operating system), you need to have
-  GTK+ 3.10 or newer. This is the version that ships starting with Ubuntu 14.04
-  and Fedora 20. You also need to install the system packages listed
-  in `Tutorial 0 <docs/tutorial/tutorial-0.rst>`__.
+  GTK+ >= 3.24 and glib >= 2.64. These are available starting with Ubuntu 20.04 and
+  Fedora 32. You also need to install the system packages listed in `Linux platform
+  documentation <https://toga.readthedocs.io/en/latest/reference/platforms/linux.html#prerequisites>`__.
 
 Quickstart
 ----------

--- a/changes/2566.doc.rst
+++ b/changes/2566.doc.rst
@@ -1,0 +1,1 @@
+The minimum supported Linux release requirements were updated to Ubuntu 20.04 or Fedora 32.

--- a/docs/reference/platforms/linux.rst
+++ b/docs/reference/platforms/linux.rst
@@ -29,7 +29,7 @@ Prerequisites
 
 ``toga-gtk`` requires GTK 3.22 or newer. Most testing occurs with GTK 3.24 as this is
 the version that has shipped with all versions of Ubuntu since Ubuntu 20.04, and all
-versions of Fedora since Fedora 29.
+versions of Fedora since Fedora 32.
 
 The system packages that provide GTK must be installed manually:
 


### PR DESCRIPTION
## Changes
- Yet more updates to Linux requirements....specifically that Ubuntu 20.04+ and Fedora 32+ is required

## Notes
- The requirements for Toga on Linux are more complex now than GTK>=3.22
- The primary driver of Toga's base requirements for Linux is the oldest supported version of PyGObject: 3.46.0
- PyGObject 3.46.0 [requires](https://gitlab.gnome.org/GNOME/pygobject/-/blob/3.46.0/meson.build?ref_type=tags):
  - glib >= 2.64.0
  - GObject Introspection >= 1.64.0
  - pycairo >=1.16.0
    - pycairo 1.17.0 (i.e. Toga's minimum version) [requires](https://github.com/pygobject/pycairo/blob/v1.17.0/setup.py) cairo >= 1.13.1
    - but more recent pycairo 1.26.0 [requires](https://github.com/pygobject/pycairo/blob/main/meson.build) cairo >= 1.15.10
- While experimenting with different distro releases, I hit issues for each one of these being too old...
- Of these, though, the most likely issue will probably be glib2 being too old
- I would add these specific versions to the Toga docs....but it just seems they will become inevitably out of date while also being of little value because most people use modern distro releases

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
