### PR TITLE
tests: Add a test that a dialog is modal

### DIFF
--- a/android/tests_backend/window.py
+++ b/android/tests_backend/window.py
@@ -87,3 +87,6 @@ class WindowProbe(BaseProbe):
 
     def press_toolbar_button(self, index):
         self.native.onOptionsItemSelected(self._toolbar_items()[index])
+
+    def is_dialog_modal(self, dialog):
+        return True

--- a/android/tests_backend/window.py
+++ b/android/tests_backend/window.py
@@ -88,5 +88,5 @@ class WindowProbe(BaseProbe):
     def press_toolbar_button(self, index):
         self.native.onOptionsItemSelected(self._toolbar_items()[index])
 
-    def is_dialog_modal(self, dialog):
+    def is_modal_dialog(self, dialog):
         return True

--- a/changes/2446.bugfix.rst
+++ b/changes/2446.bugfix.rst
@@ -1,0 +1,1 @@
+Dialog windows are now properly modal when using the Gtk+ backend.

--- a/cocoa/tests_backend/window.py
+++ b/cocoa/tests_backend/window.py
@@ -261,3 +261,6 @@ class WindowProbe(BaseProbe):
             restype=None,
             argtypes=[objc_id],
         )
+
+    def is_dialog_modal(self, dialog):
+        return True

--- a/cocoa/tests_backend/window.py
+++ b/cocoa/tests_backend/window.py
@@ -262,5 +262,5 @@ class WindowProbe(BaseProbe):
             argtypes=[objc_id],
         )
 
-    def is_dialog_modal(self, dialog):
+    def is_modal_dialog(self, dialog):
         return True

--- a/gtk/src/toga_gtk/dialogs.py
+++ b/gtk/src/toga_gtk/dialogs.py
@@ -30,6 +30,7 @@ class MessageDialog(BaseDialog):
             buttons=buttons,
             text=title,
         )
+        self.native.set_modal(True)
         self.build_dialog(**kwargs)
 
         self.native.connect("response", self.gtk_response)

--- a/gtk/tests_backend/window.py
+++ b/gtk/tests_backend/window.py
@@ -251,3 +251,6 @@ class WindowProbe(BaseProbe):
     def press_toolbar_button(self, index):
         item = self.impl.native_toolbar.get_nth_item(index)
         item.emit("clicked")
+
+    def is_modal_dialog(self, dialog):
+        return dialog.native.get_modal()

--- a/iOS/tests_backend/window.py
+++ b/iOS/tests_backend/window.py
@@ -78,5 +78,5 @@ class WindowProbe(BaseProbe):
     def has_toolbar(self):
         pytest.skip("Toolbars not implemented on iOS")
 
-    def is_dialog_modal(self, dialog):
+    def is_modal_dialog(self, dialog):
         return True

--- a/iOS/tests_backend/window.py
+++ b/iOS/tests_backend/window.py
@@ -77,3 +77,6 @@ class WindowProbe(BaseProbe):
 
     def has_toolbar(self):
         pytest.skip("Toolbars not implemented on iOS")
+
+    def is_dialog_modal(self, dialog):
+        return True

--- a/testbed/tests/test_window.py
+++ b/testbed/tests/test_window.py
@@ -560,6 +560,7 @@ async def test_info_dialog(main_window, main_window_probe):
             "Info", "Some info", on_result=on_result_handler
         )
     await main_window_probe.redraw("Info dialog displayed")
+    assert main_window_probe.is_modal_dialog(dialog_result._impl)
     await main_window_probe.close_info_dialog(dialog_result._impl)
     await assert_dialog_result(main_window, dialog_result, on_result_handler, None)
 

--- a/winforms/tests_backend/window.py
+++ b/winforms/tests_backend/window.py
@@ -149,5 +149,5 @@ class WindowProbe(BaseProbe):
     def press_toolbar_button(self, index):
         self._native_toolbar_item(index).OnClick(EventArgs.Empty)
 
-    def is_dialog_modal(self, dialog):
+    def is_modal_dialog(self, dialog):
         return True

--- a/winforms/tests_backend/window.py
+++ b/winforms/tests_backend/window.py
@@ -148,3 +148,6 @@ class WindowProbe(BaseProbe):
 
     def press_toolbar_button(self, index):
         self._native_toolbar_item(index).OnClick(EventArgs.Empty)
+
+    def is_dialog_modal(self, dialog):
+        return True


### PR DESCRIPTION
In Gtk it's necessary to explicitly make dialog boxes modal. Do this & add a test.

This was also manually tested at PyConUS 2024 on Debian.

Closes #2446 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
