### PR TITLE
Add content argument to MainWindow instantiation & Add Tests

### DIFF
--- a/core/src/toga/app.py
+++ b/core/src/toga/app.py
@@ -205,6 +205,7 @@ class MainWindow(Window):
         self,
         id: str | None = None,
         title: str | None = None,
+        content: Widget | None = None,
         position: tuple[int, int] = (100, 100),
         size: tuple[int, int] = (640, 480),
         resizable: bool = True,
@@ -217,6 +218,8 @@ class MainWindow(Window):
         :param id: A unique identifier for the window. If not provided, one will be
             automatically generated.
         :param title: Title for the window. Defaults to the formal name of the app.
+        :param content: Content of the window. On setting, the content is added to the same app as
+            the window.
         :param position: Position of the window, as a tuple of ``(x, y)`` coordinates,
             in :ref:`CSS pixels <css-units>`.
         :param size: Size of the window, as a tuple of ``(width, height)``, in :ref:`CSS
@@ -229,6 +232,7 @@ class MainWindow(Window):
         super().__init__(
             id=id,
             title=title,
+            content=content,
             position=position,
             size=size,
             resizable=resizable,

--- a/core/src/toga/window.py
+++ b/core/src/toga/window.py
@@ -121,6 +121,7 @@ class Window:
         self,
         id: str | None = None,
         title: str | None = None,
+        content: Widget | None = None,
         position: tuple[int, int] = (100, 100),
         size: tuple[int, int] = (640, 480),
         resizable: bool = True,
@@ -135,6 +136,8 @@ class Window:
         :param id: A unique identifier for the window. If not provided, one will be
             automatically generated.
         :param title: Title for the window. Defaults to "Toga".
+        :param content: Content of the window. On setting, the content is added to the same app as
+            the window.
         :param position: Position of the window, as a tuple of ``(x, y)`` coordinates,
             in :ref:`CSS pixels <css-units>`.
         :param size: Size of the window, as a tuple of ``(width, height)``, in :ref:`CSS
@@ -197,6 +200,9 @@ class Window:
         self._toolbar = CommandSet(on_change=self._impl.create_toolbar, app=self._app)
 
         self.on_close = on_close
+
+        if content is not None:
+            self.content = content
 
     def __lt__(self, other) -> bool:
         return self.id < other.id

--- a/core/tests/window/test_window.py
+++ b/core/tests/window/test_window.py
@@ -98,6 +98,12 @@ def test_set_app_with_content(window, app):
     window.content = content
     assert content.app == app
 
+def test_set_app_with_content_at_instantiation(app):
+    """A window can be created with content"""
+    content = toga.Box()
+    window = toga.Window(content=content)
+
+    assert window.content == content
 
 @pytest.mark.parametrize(
     "value, expected",

--- a/testbed/tests/test_window.py
+++ b/testbed/tests/test_window.py
@@ -740,6 +740,11 @@ async def test_open_file_dialog(
     )
     await assert_dialog_result(main_window, dialog_result, on_result_handler, result)
 
+async def test_instantiate_window_with_content(app):
+    content = toga.Box()
+    window = toga.Window(content=content)
+
+    assert window.content == content
 
 @pytest.mark.parametrize(
     "initial_directory, multiple_select, result",


### PR DESCRIPTION
Add content argument to MainWindow instantiation & Add Tests (made by cosmatech in PR #2314)

I've added a 'context' parameter to the __init___ method of the Window and MainWindow classes, a doc string for each of those parameters, and added testing functions for this.

This simplifies the configuration of the context of the MainWindow.

Fixes #2307.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
