### PR TITLE
Add warning error when camera permission missing

### DIFF
--- a/changes/2589.bugfix.rst
+++ b/changes/2589.bugfix.rst
@@ -1,0 +1,1 @@
+App now warns / errors if camera permission is requested but required metadata is not added to pyproject.toml.

--- a/cocoa/src/toga_cocoa/hardware/camera.py
+++ b/cocoa/src/toga_cocoa/hardware/camera.py
@@ -256,7 +256,11 @@ class Camera:
             # The app doesn't have the NSCameraUsageDescription key (e.g., via
             # `permission.camera` in Briefcase). No-cover because we can't manufacture
             # this condition in testing.
-            msg = "Application metadata does not declare that the app will use the camera."
+            msg = (
+                "Application metadata does not declare that the app will use "
+                "the camera. See "
+                "https://toga.readthedocs.io/en/stable/reference/api/hardware/camera.html"
+            )
             if self.interface.app.is_bundled:
                 raise RuntimeError(msg)
             warnings.warn(msg)

--- a/cocoa/src/toga_cocoa/hardware/camera.py
+++ b/cocoa/src/toga_cocoa/hardware/camera.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import warnings
 
 from threading import Thread
 
@@ -22,6 +23,7 @@ from toga_cocoa.libs import (
     AVCaptureVideoPreviewLayer,
     AVLayerVideoGravityResizeAspectFill,
     AVMediaTypeVideo,
+    NSBundle,
 )
 
 
@@ -247,6 +249,18 @@ class TogaCameraWindow(toga.Window):
 class Camera:
     def __init__(self, interface):
         self.interface = interface
+
+        if not NSBundle.mainBundle.objectForInfoDictionaryKey(
+            "NSCameraUsageDescription"
+        ):  # pragma: no cover
+            # The app doesn't have the NSCameraUsageDescription key (e.g., via
+            # `permission.camera` in Briefcase). No-cover because we can't manufacture
+            # this condition in testing.
+            msg = "Application metadata does not declare that the app will use the camera."
+            if not self.interface.app.is_bundled:
+                raise RuntimeError(msg)
+            warnings.warn(msg)
+
         self.preview_windows = []
 
     def has_permission(self, allow_unknown=False):

--- a/cocoa/src/toga_cocoa/hardware/camera.py
+++ b/cocoa/src/toga_cocoa/hardware/camera.py
@@ -257,7 +257,7 @@ class Camera:
             # `permission.camera` in Briefcase). No-cover because we can't manufacture
             # this condition in testing.
             msg = "Application metadata does not declare that the app will use the camera."
-            if not self.interface.app.is_bundled:
+            if self.interface.app.is_bundled:
                 raise RuntimeError(msg)
             warnings.warn(msg)
 

--- a/cocoa/src/toga_cocoa/hardware/camera.py
+++ b/cocoa/src/toga_cocoa/hardware/camera.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
-import warnings
 
+import warnings
 from threading import Thread
 
 from rubicon.objc import Block, objc_method

--- a/core/src/toga/app.py
+++ b/core/src/toga/app.py
@@ -674,7 +674,6 @@ class App:
             # This will raise an exception if the platform doesn't implement
             # the Camera API.
             self._camera = Camera(self)
-
         return self._camera
 
     @property

--- a/core/src/toga/app.py
+++ b/core/src/toga/app.py
@@ -674,6 +674,7 @@ class App:
             # This will raise an exception if the platform doesn't implement
             # the Camera API.
             self._camera = Camera(self)
+
         return self._camera
 
     @property

--- a/core/src/toga/app.py
+++ b/core/src/toga/app.py
@@ -16,6 +16,7 @@ from collections.abc import (
     ValuesView,
 )
 from email.message import Message
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol
 from warnings import warn
 from weakref import WeakValueDictionary
@@ -569,6 +570,15 @@ class App:
     def version(self) -> str | None:
         """The version number of the app (read-only)."""
         return self._version
+
+    @property
+    def is_bundled(self) -> bool:
+        """Has the app been bundled, or running in dev?"""
+        return Path(sys.executable).stem not in {
+            "python",
+            f"python{sys.version_info.major}",
+            f"python{sys.version_info.major}.{sys.version_info.minor}",
+        }
 
     ######################################################################
     # App lifecycle

--- a/core/src/toga/icons.py
+++ b/core/src/toga/icons.py
@@ -136,11 +136,7 @@ class Icon:
             # icon, and this isn't running as a script, fall back to the application
             # binary
             if path is _APP_ICON:
-                if Path(sys.executable).stem not in {
-                    "python",
-                    f"python{sys.version_info.major}",
-                    f"python{sys.version_info.major}.{sys.version_info.minor}",
-                }:
+                if toga.App.app.is_bundled:
                     try:
                         # Use the application binary's icon
                         self._impl = self.factory.Icon(interface=self, path=None)

--- a/core/tests/app/test_app.py
+++ b/core/tests/app/test_app.py
@@ -289,6 +289,7 @@ def test_app_metadata(monkeypatch, event_loop):
     assert app.version == "1.2.3"
     assert app.home_page == "https://example.com/test-app"
     assert app.description == "A test app"
+    assert app.is_bundled == False
 
 
 def test_explicit_app_metadata(monkeypatch, event_loop):


### PR DESCRIPTION
- `toga_cocoa` `Camera` now checks if `NSCameraUsageDescription` has been set in `pyproject.toml`, and warns if running with `dev`, and raises a `RuntimeError` otherwise
- Also added an `is_bundled` property to the `core` `App` in order to determine whether a warning / error is appropriate
- Refactored code in `icons.py` to use this `is_bundled` helper property
- Added an assertion for `is_bundled` to `test_app_metadata` 


Closes #2589 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
