### PR TITLE
Add API to replace children #2301

### DIFF
--- a/changes/2301.feature.rst
+++ b/changes/2301.feature.rst
@@ -1,0 +1,1 @@
+Added a method to replace a child widget with another widget.

--- a/changes/2301.feature.rst
+++ b/changes/2301.feature.rst
@@ -1,1 +1,1 @@
-Added a method to replace a child widget with another widget.
+APIs were added for replacing a widget in an existing layout, and for obtaining the index of a widget in a list of children.

--- a/core/src/toga/widgets/base.py
+++ b/core/src/toga/widgets/base.py
@@ -141,7 +141,7 @@ class Widget(Node):
         self.refresh()
 
     def index(self, child: Widget) -> int:
-        """Get the index of a child widget.
+        """Get the index of a widget in the list of children of this widget.
 
         :param child: The child widget of interest.
         :raises ValueError: If the specified child widget is not found in the

--- a/core/src/toga/widgets/base.py
+++ b/core/src/toga/widgets/base.py
@@ -141,14 +141,22 @@ class Widget(Node):
         self.refresh()
 
     def index(self, child: Widget) -> int:
-        """Get the index of a child widget."""
+        """Get the index of a child widget.
+
+        :param child: The child widget of interest.
+        :raises ValueError: If this widget is not a child widget.
+        """
         for _ind, _child in enumerate(self._children):
             if child == _child:
                 return _ind
         raise ValueError(f"{type(child).__name__} not found")
 
     def replace(self, old_child: Widget, new_child: Widget) -> None:
-        """Replace an existing child with a new child."""
+        """Replace an existing child widget with a new child widget.
+
+        :param old_child: The existing child widget to be replaced.
+        :param new_child: The new child widget to be included.
+        """
         old_child_index = self.index(old_child)
         self.remove(old_child)
         self.insert(old_child_index, new_child)

--- a/core/src/toga/widgets/base.py
+++ b/core/src/toga/widgets/base.py
@@ -140,6 +140,13 @@ class Widget(Node):
         # Whatever layout we're a part of needs to be refreshed
         self.refresh()
 
+    def index(self, child: Widget) -> int:
+        """Get the index of a child widget."""
+        for _ind, _child in enumerate(self._children):
+            if child == _child:
+                return _ind
+        raise ValueError(f"{type(child).__name__} not found")
+
     def remove(self, *children: Widget) -> None:
         """Remove the provided widgets as children of this node.
 

--- a/core/src/toga/widgets/base.py
+++ b/core/src/toga/widgets/base.py
@@ -144,7 +144,10 @@ class Widget(Node):
         """Get the index of a child widget.
 
         :param child: The child widget of interest.
-        :raises ValueError: If this widget is not a child widget.
+        :raises ValueError: If the specified child widget is not found in the
+            list of children.
+
+        :returns: Index of specified child widget in children list.
         """
         for _ind, _child in enumerate(self._children):
             if child == _child:

--- a/core/src/toga/widgets/base.py
+++ b/core/src/toga/widgets/base.py
@@ -147,6 +147,12 @@ class Widget(Node):
                 return _ind
         raise ValueError(f"{type(child).__name__} not found")
 
+    def replace(self, old_child: Widget, new_child: Widget) -> None:
+        """Replace an existing child with a new child."""
+        old_child_index = self.index(old_child)
+        self.remove(old_child)
+        self.insert(old_child_index, new_child)
+
     def remove(self, *children: Widget) -> None:
         """Remove the provided widgets as children of this node.
 

--- a/core/tests/widgets/test_base.py
+++ b/core/tests/widgets/test_base.py
@@ -163,6 +163,24 @@ def test_add_child(app, widget):
     assert app.widgets["child_id"] == child
 
 
+def test_child_square_bracket_access(widget):
+    """Assign and get individual children via square bracket notation."""
+    child1 = ExampleLeafWidget(id="child1_id")
+    child2 = ExampleLeafWidget(id="child2_id")
+
+    # Add child to widget
+    widget.add(child1)
+
+    # Verify child has been added
+    assert widget.children == [child1]
+
+    # Assign child via __setitem__
+    widget.children[0] = child2
+
+    # Verify new child is in children via __getitem__
+    assert widget.children[0] == child2
+
+
 def test_get_index_of_children(widget):
     """Populate a widget with children and check the index method."""
     child1 = ExampleLeafWidget(id="child1_id")

--- a/core/tests/widgets/test_base.py
+++ b/core/tests/widgets/test_base.py
@@ -163,6 +163,28 @@ def test_add_child(app, widget):
     assert app.widgets["child_id"] == child
 
 
+def test_get_index_of_children(widget):
+    """Populate a widget with children and check the index method."""
+    child1 = ExampleLeafWidget(id="child1_id")
+    child2 = ExampleLeafWidget(id="child2_id")
+    child3 = ExampleLeafWidget(id="child3_id")
+
+    # Add only two children to widget
+    widget.add(child1)
+    widget.add(child2)
+
+    # Verify children have been added
+    assert widget.children == [child1, child2]
+
+    # Get indices of valid children
+    assert widget.index(child1) == 0
+    assert widget.index(child2) == 1
+
+    # Raise error when child not found in children
+    with pytest.raises(ValueError, match=r"ExampleLeafWidget not found"):
+        widget.index(child3)
+
+
 def test_add_multiple_children(app, widget):
     """Multiple children can be added in one call."""
     # Set the app and window for the widget.

--- a/core/tests/widgets/test_base.py
+++ b/core/tests/widgets/test_base.py
@@ -185,6 +185,25 @@ def test_get_index_of_children(widget):
         widget.index(child3)
 
 
+def test_replace_child_with_non_child(widget):
+    """Remove a child and add new widget in its place."""
+    child1 = ExampleLeafWidget(id="child1_id")
+    child2 = ExampleLeafWidget(id="child2_id")
+    child3 = ExampleLeafWidget(id="child3_id")
+
+    # Add only two children to widget
+    widget.add(child1)
+    widget.add(child2)
+
+    # Verify children have been added
+    assert widget.children == [child1, child2]
+
+    widget.replace(child1, child3)
+
+    # Verify child1 has been removed and child3 has been added
+    assert widget.children == [child3, child2]
+
+
 def test_add_multiple_children(app, widget):
     """Multiple children can be added in one call."""
     # Set the app and window for the widget.


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Added ``replace`` and ``index`` methods to base widget class and minimal test cases.
Added another test case to verify the functionality of children access/assignment via square bracket notation ``__setitem__``/ ``__getitem__``.

<!--- What problem does this change solve? -->
This allows users to replace a child widget with another with a single method, instead of needing to remove the old one, keep track of the index, and insert a new one.

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Fixes #2301 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
