### PR TITLE
modified invokation order of TextInput on_change and validation withi…

### DIFF
--- a/android/src/toga_android/widgets/textinput.py
+++ b/android/src/toga_android/widgets/textinput.py
@@ -1,10 +1,10 @@
 from decimal import ROUND_UP
 
+from java import dynamic_proxy
+
 from android.text import InputType, TextWatcher
 from android.view import Gravity, View
 from android.widget import EditText
-from java import dynamic_proxy
-
 from toga_android.keys import toga_key
 
 from .label import TextViewWidget
@@ -111,8 +111,7 @@ class TextInput(TextViewWidget):
         return self.native.getError() is None
 
     def _on_change(self):
-        self.interface.on_change()
-        self.interface._validate()
+        self.interface._value_changed()
 
     def _on_confirm(self):
         self.interface.on_confirm()

--- a/cocoa/src/toga_cocoa/widgets/textinput.py
+++ b/cocoa/src/toga_cocoa/widgets/textinput.py
@@ -213,8 +213,7 @@ class TextInput(Widget):
 
     def set_value(self, value):
         self.native.stringValue = value
-        self.interface.on_change()
-        self.interface._validate()
+        self.interface._value_changed()
 
     def rehint(self):
         # Height of a text input is known and fixed.

--- a/core/src/toga/widgets/textinput.py
+++ b/core/src/toga/widgets/textinput.py
@@ -181,6 +181,12 @@ class TextInput(Widget):
         else:
             self._impl.clear_error()
 
+    def _value_changed(self):
+        """Validate the current value of the widget and invoke the on_change handler."""
+        self._validate()
+        self.on_change()
+
+
     @property
     def on_confirm(self) -> callable:
         """The handler to invoke when the user accepts the value of the widget,

--- a/core/tests/widgets/test_textinput.py
+++ b/core/tests/widgets/test_textinput.py
@@ -1,8 +1,6 @@
 from unittest.mock import Mock
 
 import pytest
-
-import toga
 from toga_dummy.utils import (
     EventLog,
     assert_action_not_performed,
@@ -10,6 +8,8 @@ from toga_dummy.utils import (
     assert_action_performed_with,
     attribute_value,
 )
+
+import toga
 
 
 @pytest.fixture
@@ -111,6 +111,13 @@ def test_value(widget, value, expected, validator):
 
     # change handler was invoked
     on_change_handler.assert_called_once_with(widget)
+
+    # Change the widget value to confirm the on_change handler is invoked
+    widget.value.upper()
+    assert widget._value_changed
+
+    widget.value.lower()
+    assert widget._value_changed
 
 
 @pytest.mark.parametrize(

--- a/dummy/src/toga_dummy/widgets/textinput.py
+++ b/dummy/src/toga_dummy/widgets/textinput.py
@@ -36,8 +36,7 @@ class TextInput(Widget):
         return self._get_value("valid")
 
     def simulate_change(self):
-        self.interface.on_change()
-        self.interface._validate()
+        self.interface._value_changed()
 
     def simulate_confirm(self):
         self.interface.on_confirm()

--- a/gtk/src/toga_gtk/widgets/textinput.py
+++ b/gtk/src/toga_gtk/widgets/textinput.py
@@ -16,8 +16,7 @@ class TextInput(Widget):
         self.native.connect("key-press-event", self.gtk_key_press_event)
 
     def gtk_on_change(self, entry):
-        self.interface.on_change()
-        self.interface._validate()
+        self.interface._value_changed()
 
     def gtk_focus_in_event(self, entry, user_data):
         self.interface.on_gain_focus()

--- a/iOS/src/toga_iOS/widgets/textinput.py
+++ b/iOS/src/toga_iOS/widgets/textinput.py
@@ -29,8 +29,7 @@ class TogaTextField(UITextField):
 
     @objc_method
     def textFieldDidChange_(self, textField) -> None:
-        self.interface.on_change()
-        self.interface._validate()
+        self.interface._value_changed()
 
     @objc_method
     def textFieldDidEndEditing_(self, textField) -> None:
@@ -127,8 +126,7 @@ class TextInput(Widget):
 
     def set_value(self, value):
         self.native.text = value
-        self.interface.on_change()
-        self.interface._validate()
+        self.interface._value_changed()
 
     def set_alignment(self, value):
         self.native.textAlignment = NSTextAlignment(value)

--- a/winforms/src/toga_winforms/widgets/textinput.py
+++ b/winforms/src/toga_winforms/widgets/textinput.py
@@ -76,8 +76,7 @@ class TextInput(Widget):
         )
 
     def winforms_text_changed(self, sender, event):
-        self.interface.on_change()
-        self.interface._validate()
+        self.interface._value_changed()
 
     def winforms_key_press(self, sender, event):
         if ord(event.KeyChar) == int(WinForms.Keys.Enter):


### PR DESCRIPTION
…n a new private method in toga core, then updated the backends to call the new core method

<!--- Describe your changes in detail -->
I updated the invocation order of _validate() and on_change() in toga core and the appropriate backends where on_change() is validated for TextInputs. I did this by creating a new private method within the TextInput class named `_value_changed` and switched the call order between _validate and on_change. Then I attempted to add to existing test code to validate the _value_changed method. But I was not able to update any documentation reflecting the change.

<!--- What problem does this change solve? -->
fixes issue where validation was called before a text change was recognized, thus preventing certain fields from being properly updated.

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
#2325 2325
## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
