### PR TITLE
Bump codespell from v2.2.6 to v2.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.6
+    rev: v2.3.0
     hooks:
     - id: codespell
       # remove toml extra once Python 3.10 is no longer supported

--- a/changes/2602.misc.rst
+++ b/changes/2602.misc.rst
@@ -1,0 +1,1 @@
+The ``pre-commit`` hook for ``codespell`` was updated to its latest version.

--- a/gtk/src/toga_gtk/widgets/multilinetextinput.py
+++ b/gtk/src/toga_gtk/widgets/multilinetextinput.py
@@ -122,7 +122,7 @@ class MultilineTextInput(Widget):
 
     def gtk_on_changed(self, *args):
         # buffer.set_text("foo") generates 2 change signals; one clearing the
-        # buffer, and one setting the new value. We only propegate the second
+        # buffer, and one setting the new value. We only propagate the second
         # signal. To ensure that we also get a signal when the value is
         # deliberately cleared, we add an explicit signal handler to set_value()
         # for the empty value case.

--- a/gtk/tests_backend/widgets/base.py
+++ b/gtk/tests_backend/widgets/base.py
@@ -166,7 +166,7 @@ class SimpleProbe(BaseProbe, FontMixin):
         self._keypress_target.disconnect(handler_id)
 
         # GTK has an intermittent failure because on_change handler
-        # caused by typing a character doesn't fully propegate. A
+        # caused by typing a character doesn't fully propagate. A
         # short delay fixes this.
         await asyncio.sleep(0.04)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 skip = ".git,*.pdf,*.svg"
 # the way to make case sensitive skips of words etc
 ignore-regex = "\bNd\b"
-ignore-words-list = "te,crate,re-use"
+ignore-words-list = "te,crate,re-use,MapPin"
 
 # The coverage settings in this file only control `coverage report`. `coverage run` and
 # `coverage combine` are controlled by the pyproject.toml files in each package's

--- a/testbed/tests/widgets/test_webview.py
+++ b/testbed/tests/widgets/test_webview.py
@@ -257,7 +257,7 @@ def javascript_error_context(probe):
 
 
 async def test_evaluate_javascript_error(widget, probe):
-    "If JavaScript content raises an error, the error is propegated"
+    "If JavaScript content raises an error, the error is propagated"
     on_result_handler = Mock()
 
     with javascript_error_context(probe):
@@ -285,7 +285,7 @@ async def test_evaluate_javascript_error(widget, probe):
 
 
 async def test_evaluate_javascript_error_without_handler(widget, probe):
-    "A handler isn't needed to propegate a JavaScript error"
+    "A handler isn't needed to propagate a JavaScript error"
     with javascript_error_context(probe):
         result = await wait_for(
             widget.evaluate_javascript("not valid js"),


### PR DESCRIPTION
Bumps `pre-commit` hook for `codespell` from v2.2.6 to v2.3.0 and ran the update against the repo.