### PR TITLE
Change Command attribute to `text` instead label

### DIFF
--- a/changes/2605.misc.rst
+++ b/changes/2605.misc.rst
@@ -1,0 +1,1 @@
+An error in an example argument was corrected.

--- a/docs/reference/api/resources/command.rst
+++ b/docs/reference/api/resources/command.rst
@@ -44,7 +44,7 @@ For example:
 
     cmd1 = toga.Command(
         callback,
-        label='Example command',
+        text='Example command',
         tooltip='Tells you when it has been activated',
         shortcut=toga.Key.MOD_1 + 'k',
         icon='icons/pretty.png',


### PR DESCRIPTION
Probably something was left behind after the change

## PR Checklist:
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
