### PR TITLE
Update testbed project to use new license format.

### DIFF
--- a/changes/2606.misc.rst
+++ b/changes/2606.misc.rst
@@ -1,0 +1,1 @@
+The testbed project was updated to use PEP621 format for the license field.

--- a/testbed/pyproject.toml
+++ b/testbed/pyproject.toml
@@ -4,7 +4,7 @@ project_name = "Toga Testbed"
 bundle = "org.beeware.toga"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 


### PR DESCRIPTION
With the introduction of beeware/briefcase#1812 and PEP 621 license handling, the testbed project now uses a deprecated format for the `license` field. This updates the project to use the new form, avoiding the build warning associated with the old format.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
