### PR TITLE
Ensure menu creation sequence is consistent.

### DIFF
--- a/android/src/toga_android/app.py
+++ b/android/src/toga_android/app.py
@@ -195,9 +195,9 @@ class App:
         # The `_listener` listens for activity event callbacks. For simplicity,
         # the app's `.native` is the listener's native Java class.
         self._listener = TogaApp(self)
+
         # Call user code to populate the main window
         self.interface._startup()
-        self.create_app_commands()
 
     ######################################################################
     # Commands and menus

--- a/changes/2619.bugfix.rst
+++ b/changes/2619.bugfix.rst
@@ -1,0 +1,1 @@
+The order of creation of system-level commands is now consistent between platforms, and menu creation is deferred until the user's startup method has been invoked.

--- a/cocoa/src/toga_cocoa/app.py
+++ b/cocoa/src/toga_cocoa/app.py
@@ -151,16 +151,12 @@ class App:
         self.appDelegate.native = self.native
         self.native.setDelegate_(self.appDelegate)
 
-        self.create_app_commands()
+        # Create the lookup table for menu items
+        self._menu_groups = {}
+        self._menu_items = {}
 
         # Call user code to populate the main window
         self.interface._startup()
-
-        # Create the lookup table of menu items,
-        # then force the creation of the menus.
-        self._menu_groups = {}
-        self._menu_items = {}
-        self.create_menus()
 
     ######################################################################
     # Commands and menus

--- a/core/src/toga/app.py
+++ b/core/src/toga/app.py
@@ -492,10 +492,8 @@ class App:
 
         self._full_screen_windows = None
 
+        # Create the implementation. This will trigger any startup logic.
         self._create_impl()
-
-        # Now that we have an impl, set the on_change handler for commands
-        self.commands.on_change = self._impl.create_menus
 
     def _create_impl(self):
         return self.factory.App(interface=self)
@@ -644,10 +642,20 @@ class App:
             )
 
     def _startup(self):
+        # App commands are created before the startup method so that the user's
+        # code has the opportunity to remove/change the default commands.
+        self._impl.create_app_commands()
+
         # This is a wrapper around the user's startup method that performs any
         # post-setup validation.
         self.startup()
         self._verify_startup()
+
+        # Manifest the initial state of the menus.
+        self._impl.create_menus()
+
+        # Now that we have a finalized impl, set the on_change handler for commands
+        self.commands.on_change = self._impl.create_menus
 
     def startup(self) -> None:
         """Create and show the main window for the application.

--- a/core/tests/command/test_commandset.py
+++ b/core/tests/command/test_commandset.py
@@ -27,6 +27,9 @@ def test_create_with_values():
 @pytest.mark.parametrize("change_handler", [(None), (Mock())])
 def test_add_clear(app, change_handler):
     """Commands can be added and removed from a commandset."""
+    # Make sure the app commands are clear to start with.
+    app.commands.clear()
+
     # Put some commands into the app
     cmd_a = toga.Command(None, text="App command a")
     cmd_b = toga.Command(None, text="App command b", order=10)
@@ -68,6 +71,9 @@ def test_add_clear(app, change_handler):
 @pytest.mark.parametrize("change_handler", [(None), (Mock())])
 def test_add_clear_with_app(app, change_handler):
     """Commands can be added and removed from a commandset that is linked to an app."""
+    # Make sure the app commands are clear to start with.
+    app.commands.clear()
+
     # Put some commands into the app
     cmd_a = toga.Command(None, text="App command a")
     cmd_b = toga.Command(None, text="App command b", order=10)

--- a/core/tests/window/test_window.py
+++ b/core/tests/window/test_window.py
@@ -136,26 +136,30 @@ def test_title(window, value, expected):
 
 def test_toolbar_implicit_add(window, app):
     """Adding an item to a toolbar implicitly adds it to the app."""
+    # Clear the app commands to start with
+    app.commands.clear()
+    assert list(window.toolbar) == []
+    assert list(app.commands) == []
+
     cmd1 = toga.Command(None, "Command 1")
     cmd2 = toga.Command(None, "Command 2")
 
-    toolbar = window.toolbar
-    assert list(toolbar) == []
+    assert list(window.toolbar) == []
     assert list(app.commands) == []
 
     # Adding a command to the toolbar automatically adds it to the app
-    toolbar.add(cmd1)
-    assert list(toolbar) == [cmd1]
+    window.toolbar.add(cmd1)
+    assert list(window.toolbar) == [cmd1]
     assert list(app.commands) == [cmd1]
 
     # But not vice versa
     app.commands.add(cmd2)
-    assert list(toolbar) == [cmd1]
+    assert list(window.toolbar) == [cmd1]
     assert list(app.commands) == [cmd1, cmd2]
 
     # Adding a command to both places does not cause a duplicate
     app.commands.add(cmd1)
-    assert list(toolbar) == [cmd1]
+    assert list(window.toolbar) == [cmd1]
     assert list(app.commands) == [cmd1, cmd2]
 
 

--- a/dummy/src/toga_dummy/app.py
+++ b/dummy/src/toga_dummy/app.py
@@ -2,6 +2,8 @@ import asyncio
 import sys
 from pathlib import Path
 
+from toga.command import Command
+
 from .screens import Screen as ScreenImpl
 from .utils import LoggedObject
 from .window import Window
@@ -24,8 +26,18 @@ class App(LoggedObject):
         self._action("create App")
         self.interface._startup()
 
+    def create_app_commands(self):
+        self._action("create App commands")
+        self.interface.commands.add(
+            Command(
+                None,
+                f"About {self.interface.formal_name}",
+            ),
+        )
+
     def create_menus(self):
         self._action("create App menus")
+        self.n_menu_items = len(self.interface.commands)
 
     def main_loop(self):
         print("Starting app using Dummy backend.")

--- a/gtk/src/toga_gtk/app.py
+++ b/gtk/src/toga_gtk/app.py
@@ -61,14 +61,7 @@ class App:
         pass
 
     def gtk_startup(self, data=None):
-        # Set up the default commands for the interface.
-        self.create_app_commands()
-
         self.interface._startup()
-
-        # Create the lookup table of menu items,
-        # then force the creation of the menus.
-        self.create_menus()
 
         # Now that we have menus, make the app take responsibility for
         # showing the menubar.

--- a/iOS/src/toga_iOS/app.py
+++ b/iOS/src/toga_iOS/app.py
@@ -73,6 +73,10 @@ class App:
     # Commands and menus
     ######################################################################
 
+    def create_app_commands(self):
+        # No menus on an iOS app (for now)
+        pass
+
     def create_menus(self):
         # No menus on an iOS app (for now)
         pass

--- a/textual/src/toga_textual/app.py
+++ b/textual/src/toga_textual/app.py
@@ -37,6 +37,9 @@ class App:
     # Commands and menus
     ######################################################################
 
+    def create_app_commands(self):
+        pass
+
     def create_menus(self):
         pass
 

--- a/web/src/toga_web/app.py
+++ b/web/src/toga_web/app.py
@@ -20,6 +20,14 @@ class App:
         # self.resource_path = os.path.dirname(os.path.dirname(NSBundle.mainBundle.bundlePath))
         self.native = js.document.getElementById("app-placeholder")
 
+        # Call user code to populate the main window
+        self.interface._startup()
+
+    ######################################################################
+    # Commands and menus
+    ######################################################################
+
+    def create_app_commands(self):
         formal_name = self.interface.formal_name
 
         self.interface.commands.add(
@@ -35,18 +43,6 @@ class App:
                 group=toga.Group.HELP,
             ),
         )
-
-        # Create the menus. This is done before main window content to ensure
-        # the <header> for the menubar is inserted before the <main> for the
-        # main window.
-        self.create_menus()
-
-        # Call user code to populate the main window
-        self.interface._startup()
-
-    ######################################################################
-    # Commands and menus
-    ######################################################################
 
     def _create_submenu(self, group, items):
         submenu = create_element(
@@ -140,7 +136,7 @@ class App:
         if old_menubar:
             old_menubar.replaceWith(self.menubar)
         else:
-            self.native.append(self.menubar)
+            self.native.prepend(self.menubar)
 
     ######################################################################
     # App lifecycle

--- a/winforms/src/toga_winforms/app.py
+++ b/winforms/src/toga_winforms/app.py
@@ -204,11 +204,6 @@ class App:
         return submenu
 
     def create_menus(self):
-        if self.interface.main_window is None:  # pragma: no branch
-            # The startup method may create commands before creating the window, so
-            # we'll call create_menus again after it returns.
-            return
-
         window = self.interface.main_window._impl
         menubar = window.native.MainMenuStrip
         if menubar:

--- a/winforms/src/toga_winforms/app.py
+++ b/winforms/src/toga_winforms/app.py
@@ -146,8 +146,7 @@ class App:
 
         # Call user code to populate the main window
         self.interface._startup()
-        self.create_app_commands()
-        self.create_menus()
+
         self.interface.main_window._impl.set_app(self)
 
     ######################################################################


### PR DESCRIPTION
The existing app startup sequence is inconsistent between platforms, as it doesn't guarantee:

1. That system-installed app commands are installed before `startup()` is invoked
2. That the change listener is added to the command list *after* commands have been fully created
3. That menus are created *after* the initial menu state has been established.

Derived from #2244.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
