### PR TITLE
Update briefcase configurations in demo and examples to use new license format

### DIFF
--- a/changes/2621.misc.rst
+++ b/changes/2621.misc.rst
@@ -1,0 +1,1 @@
+Briefcase configurations were updated to use new license format.

--- a/demo/pyproject.toml
+++ b/demo/pyproject.toml
@@ -76,7 +76,7 @@ project_name = "Toga Demo"
 bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/demo/pyproject.toml
+++ b/demo/pyproject.toml
@@ -115,7 +115,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/.template/{{ cookiecutter.name }}/pyproject.toml
+++ b/examples/.template/{{ cookiecutter.name }}/pyproject.toml
@@ -50,7 +50,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/.template/{{ cookiecutter.name }}/pyproject.toml
+++ b/examples/.template/{{ cookiecutter.name }}/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "{{ cookiecutter.formal_name }}"
 bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = 'Tiberius Yak'
 author_email = "tiberius@beeware.org"
 

--- a/examples/activityindicator/pyproject.toml
+++ b/examples/activityindicator/pyproject.toml
@@ -50,7 +50,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
 ]
 

--- a/examples/activityindicator/pyproject.toml
+++ b/examples/activityindicator/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "Activity Indicator"
 bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/examples/beeliza/pyproject.toml
+++ b/examples/beeliza/pyproject.toml
@@ -50,7 +50,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/beeliza/pyproject.toml
+++ b/examples/beeliza/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "Beeliza"
 bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/examples/box/pyproject.toml
+++ b/examples/box/pyproject.toml
@@ -50,7 +50,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
 ]
 

--- a/examples/box/pyproject.toml
+++ b/examples/box/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "Box Demo"
 bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/examples/button/pyproject.toml
+++ b/examples/button/pyproject.toml
@@ -50,7 +50,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
 ]
 

--- a/examples/button/pyproject.toml
+++ b/examples/button/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "Button Demo"
 bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/examples/canvas/pyproject.toml
+++ b/examples/canvas/pyproject.toml
@@ -50,7 +50,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
 ]
 

--- a/examples/canvas/pyproject.toml
+++ b/examples/canvas/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "Canvas Demo"
 bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/examples/colors/pyproject.toml
+++ b/examples/colors/pyproject.toml
@@ -50,7 +50,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
 ]
 

--- a/examples/colors/pyproject.toml
+++ b/examples/colors/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "colors"
 bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/examples/command/pyproject.toml
+++ b/examples/command/pyproject.toml
@@ -50,7 +50,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
 ]
 

--- a/examples/command/pyproject.toml
+++ b/examples/command/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "Command Example"
 bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/examples/date_and_time/pyproject.toml
+++ b/examples/date_and_time/pyproject.toml
@@ -50,7 +50,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
 ]
 

--- a/examples/date_and_time/pyproject.toml
+++ b/examples/date_and_time/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "Date And Time"
 bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/examples/detailedlist/pyproject.toml
+++ b/examples/detailedlist/pyproject.toml
@@ -50,7 +50,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
 ]

--- a/examples/detailedlist/pyproject.toml
+++ b/examples/detailedlist/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "DetailedList Demo"
 bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/examples/dialogs/pyproject.toml
+++ b/examples/dialogs/pyproject.toml
@@ -50,7 +50,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
 ]
 

--- a/examples/dialogs/pyproject.toml
+++ b/examples/dialogs/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "Dialog Demo"
 bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/examples/divider/pyproject.toml
+++ b/examples/divider/pyproject.toml
@@ -50,7 +50,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
 ]
 

--- a/examples/divider/pyproject.toml
+++ b/examples/divider/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "Divider Demo"
 bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/examples/documentapp/pyproject.toml
+++ b/examples/documentapp/pyproject.toml
@@ -50,7 +50,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
 ]
 

--- a/examples/documentapp/pyproject.toml
+++ b/examples/documentapp/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "Document App"
 bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/examples/examples_overview/pyproject.toml
+++ b/examples/examples_overview/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "Examples Overview"
 bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/examples/examples_overview/pyproject.toml
+++ b/examples/examples_overview/pyproject.toml
@@ -50,7 +50,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
 ]
 

--- a/examples/focus/pyproject.toml
+++ b/examples/focus/pyproject.toml
@@ -50,7 +50,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
 ]
 

--- a/examples/focus/pyproject.toml
+++ b/examples/focus/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "Focus Demo"
 bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/examples/font/pyproject.toml
+++ b/examples/font/pyproject.toml
@@ -50,7 +50,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
 ]
 

--- a/examples/font/pyproject.toml
+++ b/examples/font/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "Font Example"
 bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/examples/font_size/pyproject.toml
+++ b/examples/font_size/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "Font size test"
 bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/examples/font_size/pyproject.toml
+++ b/examples/font_size/pyproject.toml
@@ -49,7 +49,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
 ]
 

--- a/examples/handlers/pyproject.toml
+++ b/examples/handlers/pyproject.toml
@@ -50,7 +50,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
 ]
 

--- a/examples/handlers/pyproject.toml
+++ b/examples/handlers/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "Handler Demo"
 bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/examples/hardware/pyproject.toml
+++ b/examples/hardware/pyproject.toml
@@ -54,7 +54,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "org.osmdroid:osmdroid-android:6.1.0",
 ]

--- a/examples/hardware/pyproject.toml
+++ b/examples/hardware/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "Hardware"
 bundle = "org.beeware.examples"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = 'Tiberius Yak'
 author_email = "tiberius@beeware.org"
 

--- a/examples/imageview/pyproject.toml
+++ b/examples/imageview/pyproject.toml
@@ -53,6 +53,12 @@ requires = [
     "Pillow==8.4.0; python_version=='3.8'",
 ]
 
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+]
+
 # Web deployment
 [tool.briefcase.app.imageview.web]
 requires = [

--- a/examples/imageview/pyproject.toml
+++ b/examples/imageview/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "ImageView Demo"
 bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/examples/layout/pyproject.toml
+++ b/examples/layout/pyproject.toml
@@ -50,7 +50,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
 ]
 

--- a/examples/layout/pyproject.toml
+++ b/examples/layout/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "Layout Test"
 bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/examples/mapview/pyproject.toml
+++ b/examples/mapview/pyproject.toml
@@ -50,7 +50,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "org.osmdroid:osmdroid-android:6.1.0",
 ]

--- a/examples/mapview/pyproject.toml
+++ b/examples/mapview/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "Map View"
 bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = 'Tiberius Yak'
 author_email = "tiberius@beeware.org"
 

--- a/examples/multilinetextinput/pyproject.toml
+++ b/examples/multilinetextinput/pyproject.toml
@@ -50,7 +50,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
 ]
 

--- a/examples/multilinetextinput/pyproject.toml
+++ b/examples/multilinetextinput/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "MultilineTextInput Demo"
 bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/examples/numberinput/pyproject.toml
+++ b/examples/numberinput/pyproject.toml
@@ -50,7 +50,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
 ]
 

--- a/examples/numberinput/pyproject.toml
+++ b/examples/numberinput/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "Demo NumberInput"
 bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/examples/optioncontainer/pyproject.toml
+++ b/examples/optioncontainer/pyproject.toml
@@ -50,7 +50,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
 ]
 

--- a/examples/optioncontainer/pyproject.toml
+++ b/examples/optioncontainer/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "Option Container Example"
 bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/examples/passwordinput/pyproject.toml
+++ b/examples/passwordinput/pyproject.toml
@@ -47,6 +47,12 @@ requires = [
     '../../android',
 ]
 
+base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
+
+build_gradle_dependencies = [
+    "com.google.android.material:material:1.11.0",
+]
+
 # Web deployment
 [tool.briefcase.app.passwordinput.web]
 requires = [

--- a/examples/passwordinput/pyproject.toml
+++ b/examples/passwordinput/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "Password Input"
 bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = 'Tiberius Yak'
 author_email = "tiberius@beeware.org"
 

--- a/examples/positron-django/pyproject.toml
+++ b/examples/positron-django/pyproject.toml
@@ -52,7 +52,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
 ]
 

--- a/examples/positron-django/pyproject.toml
+++ b/examples/positron-django/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "Positron"
 bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/examples/positron-static/pyproject.toml
+++ b/examples/positron-static/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "Positron"
 bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/examples/positron-static/pyproject.toml
+++ b/examples/positron-static/pyproject.toml
@@ -51,7 +51,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
 ]
 

--- a/examples/progressbar/pyproject.toml
+++ b/examples/progressbar/pyproject.toml
@@ -50,7 +50,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
 ]
 

--- a/examples/progressbar/pyproject.toml
+++ b/examples/progressbar/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "ProgressBar demo"
 bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/examples/resize/pyproject.toml
+++ b/examples/resize/pyproject.toml
@@ -50,7 +50,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
 ]
 

--- a/examples/resize/pyproject.toml
+++ b/examples/resize/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "Resize Test"
 bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/examples/screenshot/pyproject.toml
+++ b/examples/screenshot/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "Screenshot Generator"
 bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/examples/screenshot/pyproject.toml
+++ b/examples/screenshot/pyproject.toml
@@ -51,7 +51,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "org.osmdroid:osmdroid-android:6.1.0",
 ]

--- a/examples/scrollcontainer/pyproject.toml
+++ b/examples/scrollcontainer/pyproject.toml
@@ -50,7 +50,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
 ]
 

--- a/examples/scrollcontainer/pyproject.toml
+++ b/examples/scrollcontainer/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "ScrollContainer Demo"
 bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/examples/selection/pyproject.toml
+++ b/examples/selection/pyproject.toml
@@ -50,7 +50,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
 ]
 

--- a/examples/selection/pyproject.toml
+++ b/examples/selection/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "Selection Demo"
 bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/examples/slider/pyproject.toml
+++ b/examples/slider/pyproject.toml
@@ -50,7 +50,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
 ]
 

--- a/examples/slider/pyproject.toml
+++ b/examples/slider/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "Slider Demo"
 bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/examples/splitcontainer/pyproject.toml
+++ b/examples/splitcontainer/pyproject.toml
@@ -50,7 +50,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
 ]
 

--- a/examples/splitcontainer/pyproject.toml
+++ b/examples/splitcontainer/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "SplitContainer Demo"
 bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/examples/switch_demo/pyproject.toml
+++ b/examples/switch_demo/pyproject.toml
@@ -50,7 +50,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
 ]
 

--- a/examples/switch_demo/pyproject.toml
+++ b/examples/switch_demo/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "Switch Demo"
 bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/examples/table/pyproject.toml
+++ b/examples/table/pyproject.toml
@@ -49,7 +49,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
 ]
 

--- a/examples/table/pyproject.toml
+++ b/examples/table/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "Table Demo"
 bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/examples/table_source/pyproject.toml
+++ b/examples/table_source/pyproject.toml
@@ -50,7 +50,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
 ]
 

--- a/examples/table_source/pyproject.toml
+++ b/examples/table_source/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "TableSource Demo"
 bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/examples/textinput/pyproject.toml
+++ b/examples/textinput/pyproject.toml
@@ -50,7 +50,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
 ]
 

--- a/examples/textinput/pyproject.toml
+++ b/examples/textinput/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "Text Input Demo"
 bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/examples/tree/pyproject.toml
+++ b/examples/tree/pyproject.toml
@@ -50,7 +50,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
 ]
 

--- a/examples/tree/pyproject.toml
+++ b/examples/tree/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "Tree Demo"
 bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/examples/tree_source/pyproject.toml
+++ b/examples/tree_source/pyproject.toml
@@ -50,7 +50,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
 ]
 

--- a/examples/tree_source/pyproject.toml
+++ b/examples/tree_source/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "TreeSource Demo"
 bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/examples/tutorial0/pyproject.toml
+++ b/examples/tutorial0/pyproject.toml
@@ -50,7 +50,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
 ]
 

--- a/examples/tutorial0/pyproject.toml
+++ b/examples/tutorial0/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "Tutorial 0"
 bundle = "org.beeware.toga"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/examples/tutorial1/pyproject.toml
+++ b/examples/tutorial1/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "Tutorial 1"
 bundle = "org.beeware.toga"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/examples/tutorial1/pyproject.toml
+++ b/examples/tutorial1/pyproject.toml
@@ -50,7 +50,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
 ]
 

--- a/examples/tutorial2/pyproject.toml
+++ b/examples/tutorial2/pyproject.toml
@@ -50,7 +50,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
 ]
 

--- a/examples/tutorial2/pyproject.toml
+++ b/examples/tutorial2/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "Tutorial 2"
 bundle = "org.beeware.toga"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/examples/tutorial3/pyproject.toml
+++ b/examples/tutorial3/pyproject.toml
@@ -50,7 +50,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
 ]
 

--- a/examples/tutorial3/pyproject.toml
+++ b/examples/tutorial3/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "Tutorial 3"
 bundle = "org.beeware.toga"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/examples/tutorial4/pyproject.toml
+++ b/examples/tutorial4/pyproject.toml
@@ -50,7 +50,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
 ]
 

--- a/examples/tutorial4/pyproject.toml
+++ b/examples/tutorial4/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "Tutorial 4"
 bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/examples/webview/pyproject.toml
+++ b/examples/webview/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "WebView Demo"
 bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/examples/webview/pyproject.toml
+++ b/examples/webview/pyproject.toml
@@ -49,7 +49,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
 ]
 

--- a/examples/window/pyproject.toml
+++ b/examples/window/pyproject.toml
@@ -50,7 +50,6 @@ requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
 ]
 

--- a/examples/window/pyproject.toml
+++ b/examples/window/pyproject.toml
@@ -6,7 +6,7 @@ project_name = "Window Demo"
 bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
-license = "BSD license"
+license.file = "LICENSE"
 author = "Tiberius Yak"
 author_email = "tiberius@beeware.org"
 

--- a/testbed/pyproject.toml
+++ b/testbed/pyproject.toml
@@ -83,7 +83,6 @@ test_requires = [
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 
 build_gradle_dependencies = [
-    "androidx.appcompat:appcompat:1.6.1",
     "com.google.android.material:material:1.11.0",
     "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
     "org.osmdroid:osmdroid-android:6.1.0",


### PR DESCRIPTION
Corrects the usage of `license` in the demo and examples to use PEP 621 format.

`license` was previously an optional field that was only used by the Linux backends with a fallback if it wasn't defined, so this change is backwards compatible with Briefcase 0.3.18.

We can also drop the explicit reference to appcompat (Refs beeware/briefcase#1845).

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
