### PR TITLE
Remove Napoleon from the documentation configuration.

### DIFF
--- a/changes/2629.misc.rst
+++ b/changes/2629.misc.rst
@@ -1,0 +1,1 @@
+Support for Napoleon format was removed from the docs configuration.

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -90,7 +90,6 @@ docs = [
     # Sphinx 2024.2.4 deprecated support for Python 3.8
     "sphinx-autobuild == 2021.3.14 ; python_version < '3.9'",
     "sphinx-autobuild == 2024.4.16 ; python_version >= '3.9'",
-    "sphinx-autodoc-typehints == 2.1.0",
     "sphinx-csv-filter == 0.4.1",
     "sphinx-copybutton == 0.5.2",
     "sphinx-toolbox == 3.5.0",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,6 @@ from importlib.metadata import version as metadata_version
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
     "sphinx.ext.autodoc",
-    "sphinx.ext.napoleon",
     "sphinx.ext.todo",
     "sphinx_tabs.tabs",
     "crate.sphinx.csv",


### PR DESCRIPTION
A historical hangover - we no longer support NumPy/Google docstring format, so we can remove the Napoleon configuration.

We can also remove the sphinx-autodoc-typehints package as a dependency, as we're not using it any more.

Stemmed from [this discussion](https://github.com/beeware/toga/pull/2628#issuecomment-2156785292)

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
