### PR TITLE
Always create Briefcase log for testbed app for upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,7 +299,7 @@ jobs:
       timeout-minutes: 15
       run: |
         ${{ matrix.briefcase-run-prefix }} \
-          briefcase run ${{ matrix.platform }} --test ${{ matrix.briefcase-run-args }}
+          briefcase run ${{ matrix.platform }} --log --test ${{ matrix.briefcase-run-args }}
 
     - name: Upload Logs
       uses: actions/upload-artifact@v4.3.3

--- a/changes/2635.misc.rst
+++ b/changes/2635.misc.rst
@@ -1,0 +1,1 @@
+The testbed app always creates a Briefcase logfile in CI now.


### PR DESCRIPTION
## Changes
- The app can fail without Briefcase creating a log....so, always create the log so it can be uploaded as an artifact
- Example run: https://github.com/beeware/toga/actions/runs/9457851473/attempts/3

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
