### PR TITLE
Correct flakiness in macOS CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,7 +275,7 @@ jobs:
     # Github runners seem to have intermittent connectivity issues.
     # See https://github.com/beeware/toga/issues/2632
     - name: Tune GitHub-hosted runner network
-      uses: smorimoto/tune-github-hosted-runner-network@v1
+      uses: smorimoto/tune-github-hosted-runner-network@v1.0.0
 
     - name: Checkout
       uses: actions/checkout@v4.1.6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,6 +272,11 @@ jobs:
             sudo udevadm control --reload-rules
             sudo udevadm trigger --name-match=kvm
     steps:
+    # Github runners seem to have intermittent connectivity issues.
+    # See https://github.com/beeware/toga/issues/2632
+    - name: Tune GitHub-hosted runner network
+      uses: smorimoto/tune-github-hosted-runner-network@v1
+
     - name: Checkout
       uses: actions/checkout@v4.1.6
       with:

--- a/changes/2631.misc.rst
+++ b/changes/2631.misc.rst
@@ -1,0 +1,1 @@
+An intermittent failure in macOS CI was corrected.

--- a/changes/2632.misc.rst
+++ b/changes/2632.misc.rst
@@ -1,0 +1,1 @@
+An step has been added to the Github actions configuration to fix an issue with Github's network configuration.

--- a/testbed/tests/test_window.py
+++ b/testbed/tests/test_window.py
@@ -243,6 +243,9 @@ else:
             assert window_with_content.content == content
         finally:
             window_with_content.close()
+            await window_with_content_probe.redraw("Secondary window has been closed")
+            del window_with_content
+            gc.collect()
 
     async def test_secondary_window_cleanup(app_probe):
         """Memory for windows is cleaned up when windows are deleted."""


### PR DESCRIPTION
Corrects the intermittent failure seen in macOS CI with the `test_secondary_window_with_content` test.

The underlying cause of the crash appears to be an issue with removal of constraints; since the test involves the addition of content in a window and then rapidly deleting that window, it's at least conceptually consistent that the issue is related to ObjC reference counting on the very-short-lived window.

The problem can't be reproduced with 100% reliability, so it's difficult to confirm with 100% reliability that the problem has been resolved; but I've re-run the macOS x86-64 test [multiple times](https://github.com/beeware/toga/actions/runs/9459283216/job/26056572628?pr=2637) with this fix in place, and it doesn't seem to be occurring any more. 

This isn't a very satisfying fix - this sort of cleanup shouldn't be required; but until beeware/rubicon-objc#256 is addressed, I think it's about as good as we're going to get.

Also includes the "network fix" suggested in the discussion for #2632.

Fixes #2631.
Fixes #2632.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
