### PR TITLE
Correct the typing of SplitContainer content to be list/Sequence

### DIFF
--- a/changes/2638.bugfix.rst
+++ b/changes/2638.bugfix.rst
@@ -1,0 +1,1 @@
+The type of SplitContainer's content was modified to be a list, rather than a tuple.

--- a/core/src/toga/widgets/splitcontainer.py
+++ b/core/src/toga/widgets/splitcontainer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Sequence
 
 from toga.app import App
 from toga.constants import Direction
@@ -27,7 +27,7 @@ class SplitContainer(Widget):
         id: str | None = None,
         style: StyleT | None = None,
         direction: Direction = Direction.VERTICAL,
-        content: tuple[SplitContainerContentT, SplitContainerContentT] = (None, None),
+        content: Sequence[SplitContainerContentT] = [None, None],
     ):
         """Create a new SplitContainer.
 
@@ -42,10 +42,10 @@ class SplitContainer(Widget):
             of the container. Defaults to both panels being empty.
         """
         super().__init__(id=id, style=style)
-        self._content: tuple[SplitContainerContentT, SplitContainerContentT] = (
+        self._content: Sequence[SplitContainerContentT] = [
             None,
             None,
-        )
+        ]
 
         # Create a platform specific implementation of a SplitContainer
         self._impl = self.factory.SplitContainer(interface=self)
@@ -71,7 +71,7 @@ class SplitContainer(Widget):
         pass
 
     @property
-    def content(self) -> tuple[SplitContainerContentT, SplitContainerContentT]:
+    def content(self) -> Sequence[SplitContainerContentT]:
         """The widgets displayed in the SplitContainer.
 
         This property accepts a sequence of exactly 2 elements, each of which can be
@@ -89,9 +89,7 @@ class SplitContainer(Widget):
         return self._content
 
     @content.setter
-    def content(
-        self, content: tuple[SplitContainerContentT, SplitContainerContentT]
-    ) -> None:
+    def content(self, content: Sequence[SplitContainerContentT]) -> None:
         try:
             if len(content) != 2:
                 raise TypeError()
@@ -128,10 +126,10 @@ class SplitContainer(Widget):
                 widget.window = self.window
 
         self._impl.set_content(
-            tuple(w._impl if w is not None else None for w in _content),
+            list(w._impl if w is not None else None for w in _content),
             flex,
         )
-        self._content = tuple(_content)
+        self._content = list(_content)
         self.refresh()
 
     @Widget.app.setter

--- a/core/src/toga/widgets/splitcontainer.py
+++ b/core/src/toga/widgets/splitcontainer.py
@@ -27,7 +27,7 @@ class SplitContainer(Widget):
         id: str | None = None,
         style: StyleT | None = None,
         direction: Direction = Direction.VERTICAL,
-        content: Sequence[SplitContainerContentT] = [None, None],
+        content: Sequence[SplitContainerContentT] | None = None,
     ):
         """Create a new SplitContainer.
 
@@ -50,7 +50,8 @@ class SplitContainer(Widget):
         # Create a platform specific implementation of a SplitContainer
         self._impl = self.factory.SplitContainer(interface=self)
 
-        self.content = content
+        if content:
+            self.content = content
         self.direction = direction
 
     @property

--- a/core/src/toga/widgets/splitcontainer.py
+++ b/core/src/toga/widgets/splitcontainer.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING, Sequence
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 from toga.app import App
 from toga.constants import Direction
@@ -42,10 +43,7 @@ class SplitContainer(Widget):
             of the container. Defaults to both panels being empty.
         """
         super().__init__(id=id, style=style)
-        self._content: Sequence[SplitContainerContentT] = [
-            None,
-            None,
-        ]
+        self._content: list[SplitContainerContentT] = [None, None]
 
         # Create a platform specific implementation of a SplitContainer
         self._impl = self.factory.SplitContainer(interface=self)
@@ -72,7 +70,7 @@ class SplitContainer(Widget):
         pass
 
     @property
-    def content(self) -> Sequence[SplitContainerContentT]:
+    def content(self) -> list[SplitContainerContentT]:
         """The widgets displayed in the SplitContainer.
 
         This property accepts a sequence of exactly 2 elements, each of which can be

--- a/core/tests/widgets/test_splitcontainer.py
+++ b/core/tests/widgets/test_splitcontainer.py
@@ -39,7 +39,7 @@ def test_widget_created():
     assert splitcontainer._impl.interface == splitcontainer
     assert_action_performed(splitcontainer, "create SplitContainer")
 
-    assert splitcontainer.content == (None, None)
+    assert splitcontainer.content == [None, None]
     assert splitcontainer.direction == toga.SplitContainer.VERTICAL
 
 
@@ -52,14 +52,14 @@ def test_widget_created_with_values(content1, content2):
     assert splitcontainer._impl.interface == splitcontainer
     assert_action_performed(splitcontainer, "create SplitContainer")
 
-    assert splitcontainer.content == (content1, content2)
+    assert splitcontainer.content == [content1, content2]
     assert splitcontainer.direction == toga.SplitContainer.HORIZONTAL
 
     # The content has been assigned to the widget
     assert_action_performed_with(
         splitcontainer,
         "set content",
-        content=(content1._impl, content2._impl),
+        content=[content1._impl, content2._impl],
         flex=[1, 1],
     )
 
@@ -212,10 +212,10 @@ def test_set_content_widgets(
     assert_action_performed_with(
         splitcontainer,
         "set content",
-        content=(
+        content=[
             content2._impl if include_left else None,
             content3._impl if include_right else None,
-        ),
+        ],
         flex=[1, 1],
     )
 
@@ -248,10 +248,10 @@ def test_set_content_flex(
     assert_action_performed_with(
         splitcontainer,
         "set content",
-        content=(
+        content=[
             content2._impl if include_left else None,
             content3._impl if include_right else None,
-        ),
+        ],
         flex=[2, 3],
     )
 
@@ -284,10 +284,10 @@ def test_set_content_flex_mixed(
     assert_action_performed_with(
         splitcontainer,
         "set content",
-        content=(
+        content=[
             content2._impl if include_left else None,
             content3._impl if include_right else None,
-        ),
+        ],
         flex=[1, 3],
     )
 

--- a/docs/reference/api/containers/splitcontainer.rst
+++ b/docs/reference/api/containers/splitcontainer.rst
@@ -49,7 +49,7 @@ Usage
     left_container = toga.Box()
     right_container = toga.ScrollContainer()
 
-    split = toga.SplitContainer(content=(left_container, right_container))
+    split = toga.SplitContainer(content=[left_container, right_container])
 
 Content can be specified when creating the widget, or after creation by assigning
 the ``content`` attribute. The direction of the split can also be configured, either
@@ -65,7 +65,7 @@ at time of creation, or by setting the ``direction`` attribute:
     left_container = toga.Box()
     right_container = toga.ScrollContainer()
 
-    split.content = (left_container, right_container)
+    split.content = [left_container, right_container]
 
 By default, the space of the SplitContainer will be evenly divided between the
 two panels. To specify an uneven split, you can provide a flex value when specifying
@@ -80,7 +80,7 @@ and right panels.
     left_container = toga.Box()
     right_container = toga.ScrollContainer()
 
-    split.content = ((left_container, 3), (right_container, 2))
+    split.content = [(left_container, 3), (right_container, 2)]
 
 This only specifies the initial split; the split can be modified by the user
 once it is displayed.


### PR DESCRIPTION
Discovered in the review of #2252. 

SplitContainer's `content` attribute was typed as a `tuple`. Correct usage of tuple vs list is a hill I will die on :-) - and while there's a possible interpretation where SplitContainer content is considered to be N-position-sensitive content items (which *would* be consistent with a tuple), IMHO it's more natural to think of a list of content. Each item in the list has the same type, and the only unusual restriction is the content *must* have a length of 2. 

As further supporting evidence - the existing documentation refers to "A sequence of 2 elements".

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
