### PR TITLE
Add support for conditional coverage rules during unit testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
         merge-multiple: true
 
     - name: Generate Coverage Report
-      run: tox -e coverage-html-fail
+      run: tox -e coverage-html-fail-platform
 
     - name: Upload HTML Coverage Report
       uses: actions/upload-artifact@v4.3.3

--- a/changes/2640.misc.rst
+++ b/changes/2640.misc.rst
@@ -1,0 +1,1 @@
+Support for conditional coverage based on the Python version was added for unit testing.

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -67,6 +67,7 @@ dependencies = [
 # ensure environment consistency.
 dev = [
     "coverage[toml] == 7.5.3",
+    "coverage-conditional-plugin == 0.9.0",
     "Pillow == 10.3.0",
     # Pre-commit 3.6.0 deprecated support for Python 3.8
     "pre-commit == 3.5.0 ; python_version < '3.9'",

--- a/core/src/toga/__init__.py
+++ b/core/src/toga/__init__.py
@@ -128,7 +128,10 @@ def _package_version(file: Path | str | None, name: str) -> str:
         # Excluded from coverage because a pure test environment (such as the one
         # used by tox in CI) won't have setuptools_scm
         return get_version(root="../../..", relative_to=file)  # pragma: no cover
-    except (ModuleNotFoundError, LookupError):
+    except (
+        ModuleNotFoundError,
+        LookupError,
+    ):  # pragma: no-cover-if-missing-setuptools_scm
         # If setuptools_scm isn't in the environment, the call to import will fail.
         # If it *is* in the environment, but the code isn't a git checkout (e.g.,
         # it's been pip installed non-editable) the call to get_version() will fail.

--- a/core/src/toga/images.py
+++ b/core/src/toga/images.py
@@ -12,9 +12,9 @@ from warnings import warn
 import toga
 from toga.platform import get_platform_factory
 
-if sys.version_info >= (3, 10):
+if sys.version_info >= (3, 10):  # pragma: no-cover-if-lt-py310
     from importlib.metadata import entry_points
-else:
+else:  # pragma: no-cover-if-gte-py310
     # Before Python 3.10, entry_points did not support the group argument;
     # so, the backport package must be used on older versions.
     from importlib_metadata import entry_points

--- a/core/src/toga/platform.py
+++ b/core/src/toga/platform.py
@@ -6,9 +6,9 @@ import sys
 from functools import lru_cache
 from types import ModuleType
 
-if sys.version_info >= (3, 10):  # pragma: no cover
+if sys.version_info >= (3, 10):  # pragma: no-cover-if-lt-py310
     from importlib.metadata import entry_points
-else:  # pragma: no cover
+else:  # pragma: no-cover-if-gte-py310
     # Before Python 3.10, entry_points did not support the group argument;
     # so, the backport package must be used on older versions.
     from importlib_metadata import entry_points

--- a/core/src/toga/plugins/image_formats.py
+++ b/core/src/toga/plugins/image_formats.py
@@ -12,9 +12,9 @@ if TYPE_CHECKING:
 try:
     import PIL.Image
 
-    PIL_imported = True
+    PIL_imported = True  # pragma: no-cover-if-missing-PIL
 
-except ImportError:  # pragma: no cover
+except ImportError:  # pragma: no-cover-if-PIL-installed
     PIL_imported = False
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ ignore-words-list = "te,crate,re-use,MapPin"
 # with `coverage combine`.
 
 [tool.coverage.run]
+plugins = ["coverage_conditional_plugin"]
 relative_files = true
 
 [tool.coverage.report]
@@ -32,6 +33,14 @@ exclude_lines = [
     "class .+?\\(Protocol.*\\):",
     "@overload",
 ]
+
+[tool.coverage.coverage_conditional_plugin.rules]
+no-cover-if-missing-setuptools_scm = "not is_installed('setuptools_scm')"
+no-cover-if-missing-PIL = "not is_installed('PIL')"
+no-cover-if-PIL-installed = "is_installed('PIL')"
+no-cover-if-lt-py310 = "sys_version_info < (3, 10) and os_environ.get('COVERAGE_EXCLUDE_PYTHON_VERSION') != 'disable'"
+no-cover-if-gte-py310 = "sys_version_info > (3, 10) and os_environ.get('COVERAGE_EXCLUDE_PYTHON_VERSION') != 'disable'"
+
 
 [tool.isort]
 profile = "black"

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ labels =
     test311 = py311-cov,coverage311
     test312 = py312-cov,coverage312
     test313 = py313-cov,coverage313
-    ci = towncrier-check,docs-lint,pre-commit,py{38,39,310,311,312}-cov,coverage
+    ci = towncrier-check,docs-lint,pre-commit,py{38,39,310,311,312}-cov,coverage-fail-platform
 skip_missing_interpreters = True
 
 [testenv:pre-commit]
@@ -42,7 +42,7 @@ commands =
     !cov: python -m pytest {posargs:-vv --color yes}
     cov : python -m coverage run -m pytest {posargs:-vv --color yes}
 
-[testenv:coverage{,38,39,310,311,312,313}{,-html}{,-keep}{,-fail}]
+[testenv:coverage{,38,39,310,311,312,313}{,-html}{,-keep}{,-fail}{,-platform}]
 depends = pre-commit,py{,38,39,310,311,312,313}{,-cov}
 changedir = core
 skip_install = True
@@ -62,6 +62,8 @@ setenv =
     fail: REPORT_FAIL_COND = --fail-under=100
     CORE_RCFILE = --rcfile {tox_root}{/}core{/}pyproject.toml
     PROJECT_RCFILE = --rcfile {tox_root}{/}pyproject.toml
+    # disable conditional coverage exclusions for Python version
+    {platform}: COVERAGE_EXCLUDE_PYTHON_VERSION=disable
 commands_pre = python --version
 commands =
     -python -m coverage combine {env:CORE_RCFILE} {env:COMBINE_KEEP}


### PR DESCRIPTION
## Changes
- As was done for Briefcase in https://github.com/beeware/briefcase/pull/1262, Toga unit testing now supports conditional coverage for the Python version
- Closes #2640.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct