### PR TITLE
Allow ``sphinx-autobuild`` time to shutdown http server in tox

### DIFF
--- a/changes/2647.misc.rst
+++ b/changes/2647.misc.rst
@@ -1,0 +1,1 @@
+The "live docs" tox environments were updated to allow a grace period for ``sphinx-autobuild`` to shutdown the HTTP server. Without waiting, the HTTP server may have been left running when tox exited.

--- a/tox.ini
+++ b/tox.ini
@@ -93,6 +93,8 @@ sphinx_args = -T -W --keep-going --jobs auto
 
 [testenv:docs{,-lint,-all,-live,-live-src}]
 skip_install = True
+# give sphinx-autobuild time to shutdown http server
+suicide_timeout = 1
 deps =
     # editable install so docstrings can be updated for 'all' and 'live'
     -e {tox_root}{/}core[docs]


### PR DESCRIPTION
## Changes
- Tox is apparently a bit aggressive in shutting down processes when it receives a CTRL+C; this can ultimately result in tox exiting and leaving the HTTP server still running requiring manual process kills.
- I think this results from ``sphinx-autobuild`` receiving the SIGINT and starting its shutdown...but tox then sends it [_another_](https://tox.wiki/en/4.15.1/config.html#execute) SIGINT that seems to abort the shutdown procedure for ``sphinx-autobuild``.
- So, this gives ``sphinx-autobuild`` a window of time to shutdown before tox starts trying to help.

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct