### PR TITLE
Use latest dependencies for Testbed testing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -72,3 +72,14 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "20:00"
+
+  - package-ecosystem: "pip"
+    directory: "/testbed"
+    ignore:
+      # pin PIL for Android and iOS
+      - dependency-name: "pillow"
+    schedule:
+      # Check for updates on Sunday, 8PM UTC
+      interval: "weekly"
+      day: "sunday"
+      time: "20:00"

--- a/changes/2382.misc.rst
+++ b/changes/2382.misc.rst
@@ -1,0 +1,1 @@
+The Testbed tests were updated to use the latest testing dependencies.

--- a/testbed/pyproject.toml
+++ b/testbed/pyproject.toml
@@ -22,9 +22,9 @@ requires = [
     "../core",
 ]
 test_requires = [
-    "coverage==7.2.0",
-    "pytest==7.2.0",
-    "pytest-asyncio==0.20.3",
+    "coverage==7.5.3",
+    "pytest==8.2.2",
+    "pytest-asyncio==0.23.7",
     "pillow==9.2.0",
 ]
 

--- a/testbed/pyproject.toml
+++ b/testbed/pyproject.toml
@@ -6,9 +6,9 @@ dependencies = ["../core"]
 [project.optional-dependencies]
 test = [
     "coverage==7.5.3",
-    # fonttools is only needed by Android, but we need to use 
+    # fonttools is only needed by Android, but we need to use
     # sys.platform == 'linux' as there's no dependency identifier
-    # that can target Android exclusively until 3.13 lands. 
+    # that can target Android exclusively until 3.13 lands.
     "fonttools==4.53.0 ; sys.platform == 'linux'",
     "pillow==9.2.0",
     "pytest==8.2.2",

--- a/testbed/pyproject.toml
+++ b/testbed/pyproject.toml
@@ -1,8 +1,20 @@
-# This project was generated using template: https://github.com/beeware/briefcase-template and branch: v0.3.12
+[project]
+name = "testbed"
+version = "0.0.1"
+dependencies = ["../core"]
+
+[project.optional-dependencies]
+test = [
+    "coverage==7.5.3",
+    "fonttools==4.53.0",
+    "pillow==9.2.0",
+    "pytest==8.2.2",
+    "pytest-asyncio==0.23.7",
+]
+
 [tool.briefcase]
 project_name = "Toga Testbed"
 bundle = "org.beeware.toga"
-version = "0.0.1"
 url = "https://beeware.org"
 license.file = "LICENSE"
 author = "Tiberius Yak"
@@ -17,15 +29,6 @@ sources = [
 ]
 test_sources = [
     "tests",
-]
-requires = [
-    "../core",
-]
-test_requires = [
-    "coverage==7.5.3",
-    "pytest==8.2.2",
-    "pytest-asyncio==0.23.7",
-    "pillow==9.2.0",
 ]
 
 permission.camera = "The testbed needs to exercise Camera APIs"
@@ -75,9 +78,6 @@ test_sources = [
 ]
 requires = [
     "../android",
-]
-test_requires = [
-    "fonttools==4.42.1",
 ]
 
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"

--- a/testbed/pyproject.toml
+++ b/testbed/pyproject.toml
@@ -6,7 +6,10 @@ dependencies = ["../core"]
 [project.optional-dependencies]
 test = [
     "coverage==7.5.3",
-    "fonttools==4.53.0",
+    # fonttools is only needed by Android, but we need to use 
+    # sys.platform == 'linux' as there's no dependency identifier
+    # that can target Android exclusively until 3.13 lands. 
+    "fonttools==4.53.0 ; sys.platform == 'linux'",
     "pillow==9.2.0",
     "pytest==8.2.2",
     "pytest-asyncio==0.23.7",


### PR DESCRIPTION
## Changes
- Recent versions of pytest-asyncio introduced a lot of breaking changes. Notably, a session-wide event loop can no longer be specified via the ``event_loop()`` fixture. However, an event loop policy can be specified via the ``event_loop_policy()`` fixture.
- As such, this introduces a simple event loop policy that defers to the existing event loop proxy
- Closes #2382
- Also, allows Dependabot to manage the testbed's dependencies

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
