### PR TITLE
Prevent garbage collection of WebView during testbed testing

### DIFF
--- a/changes/2648.misc.rst
+++ b/changes/2648.misc.rst
@@ -1,0 +1,1 @@
+The testbed testing strategy for MapView and WebView were updated to avoid Python crashes from WebKit.

--- a/testbed/src/testbed/app.py
+++ b/testbed/src/testbed/app.py
@@ -4,6 +4,10 @@ import toga
 
 
 class Testbed(toga.App):
+    # Objects can be added to this list to avoid them being garbage collected in the
+    # middle of the tests running. This is problematic, at least, for WebView (#2648).
+    _gc_protector = []
+
     def startup(self):
         # Set a default return code for the app, so that a value is
         # available if the app exits for a reason other than the test


### PR DESCRIPTION
## Changes
- As outlined in the references below, allowing WebKit-based WebViews to be garbage collected on GTK while the tests are running risks crashing the tests from WebKit raising a SIGABRT
- This mitigates that crash occurring by maintaining a reference to the Toga WebView until testing has completed, thereby meaning the testing thread has joined, and subsequent garbage collection can _only_ run in the main Python thread

## References
- Fixes https://github.com/beeware/toga/issues/2648
- RE: https://github.com/beeware/toga/pull/2655

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct