### PR TITLE
Catch an error that is reported, but silently ignored during CI testing

### DIFF
--- a/changes/2665.misc.rst
+++ b/changes/2665.misc.rst
@@ -1,0 +1,1 @@
+An error raised and ignored during testbed testing on Winforms was silenced.

--- a/winforms/src/toga_winforms/widgets/table.py
+++ b/winforms/src/toga_winforms/widgets/table.py
@@ -171,14 +171,11 @@ class Table(Widget):
             [text(attr) for attr in self._accessors],
         )
 
-        # TODO: ListView only has built-in support for one icon per row. One possible
-        # workaround is in https://stackoverflow.com/a/46128593.
-        try:
+        # If the table has accessors, populate the icons for the table.
+        if self._accessors:
+            # TODO: ListView only has built-in support for one icon per row. One possible
+            # workaround is in https://stackoverflow.com/a/46128593.
             icon = icon(self._accessors[0])
-        except IndexError:
-            # There's no _accessors, so there's no icon.
-            pass
-        else:
             if icon is not None:
                 lvi.ImageIndex = self._image_index(icon)
 

--- a/winforms/src/toga_winforms/widgets/table.py
+++ b/winforms/src/toga_winforms/widgets/table.py
@@ -173,9 +173,14 @@ class Table(Widget):
 
         # TODO: ListView only has built-in support for one icon per row. One possible
         # workaround is in https://stackoverflow.com/a/46128593.
-        icon = icon(self._accessors[0])
-        if icon is not None:
-            lvi.ImageIndex = self._image_index(icon)
+        try:
+            icon = icon(self._accessors[0])
+        except IndexError:
+            # There's no _accessors, so there's no icon.
+            pass
+        else:
+            if icon is not None:
+                lvi.ImageIndex = self._image_index(icon)
 
         return lvi
 


### PR DESCRIPTION
Close inspection of a [CI run for the Winforms testbed](https://github.com/beeware/toga/actions/runs/9542502328/job/26297482563) shows the following:
```
tests\widgets\test_table.py::test_headerless_column_changes PASSED       [ 75%]
tests\widgets\test_table.py::test_remove_all_columns Traceback (most recent call last):
  File "D:\a\toga\toga\testbed\build\testbed\windows\app\src\app_packages\toga_winforms\widgets\table.py", line 176, in _new_item
    icon = icon(self._accessors[0])
  File "D:\a\toga\toga\testbed\build\testbed\windows\app\src\app_packages\toga_winforms\widgets\table.py", line 90, in winforms_retrieve_virtual_item
    e.Item = self._new_item(e.ItemIndex)
  File "D:\a\toga\toga\testbed\build\testbed\windows\app\src\app_packages\toga_winforms\libs\wrapper.py", line 22, in __call__
    return function(*args, **kwargs)
   at Python.Runtime.PythonException.ThrowLastAsClrException() in /tmp/build-via-sdist-h3j67_wc/pythonnet-3.0.3/src/runtime/PythonException.cs:line 53

   at Python.Runtime.Dispatcher.TrueDispatch(Object[] args) in /tmp/build-via-sdist-h3j67_wc/pythonnet-3.0.3/src/runtime/DelegateManager.cs:line 341

   at Python.Runtime.Dispatcher.Dispatch(Object[] args) in /tmp/build-via-sdist-h3j67_wc/pythonnet-3.0.3/src/runtime/DelegateManager.cs:line 208

   at __System_Windows_Forms_RetrieveVirtualItemEventHandlerDispatcher.Invoke(Object , RetrieveVirtualItemEventArgs )

   at System.Windows.Forms.ListView.OnRetrieveVirtualItem(RetrieveVirtualItemEventArgs e)

   at System.Windows.Forms.ListView.WmReflectNotify(Message& m)

   at System.Windows.Forms.ListView.WndProc(Message& m)

   at System.Windows.Forms.NativeWindow.Callback(IntPtr hWnd, Int32 msg, IntPtr wparam, IntPtr lparam)
list index out of range
PASSED              [ 75%]
tests\widgets\test_table.py::test_cell_icon PASSED                       [ 76%]
```

`tests\widgets\test_table.py::test_remove_all_columns` is *passing* but raising an exception that is being ignored. The error is caused when the all columns are removed from the table, it no longer has accessors, so looking up column 0 to render the table's icon fails. However, because this exception occurs in a callback, it doesn't surface as a full error.

This PR catches and ignores the error.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
