### PR TITLE
Fixed divider widget on WinForms

### DIFF
--- a/changes/2667.bugfix.rst
+++ b/changes/2667.bugfix.rst
@@ -1,0 +1,1 @@
+On WinForms, the Divider widget now behaves correctly and allows changing its background_color and dimensions.

--- a/winforms/src/toga_winforms/widgets/divider.py
+++ b/winforms/src/toga_winforms/widgets/divider.py
@@ -1,6 +1,7 @@
 from decimal import ROUND_UP
 
 import System.Windows.Forms as WinForms
+from System.Drawing import SystemColors
 from travertino.size import at_least
 
 from .base import Widget
@@ -8,10 +9,9 @@ from .base import Widget
 
 class Divider(Widget):
     def create(self):
-        self.native = WinForms.Label()
-        self.native.BorderStyle = WinForms.BorderStyle.Fixed3D
+        self.native = WinForms.Panel()
         self.native.AutoSize = False
-
+        self._default_background = SystemColors.ControlDark
         self._direction = self.interface.HORIZONTAL
 
     def get_direction(self):
@@ -20,11 +20,11 @@ class Divider(Widget):
     def set_direction(self, value):
         self._direction = value
         if value == self.interface.HORIZONTAL:
-            self.native.Height = 2
+            self.native.Height = 1
             self.native.Width = 0
         else:
             self.native.Height = 0
-            self.native.Width = 2
+            self.native.Width = 1
 
     def rehint(self):
         if self.get_direction() == self.interface.HORIZONTAL:

--- a/winforms/tests_backend/widgets/divider.py
+++ b/winforms/tests_backend/widgets/divider.py
@@ -4,4 +4,4 @@ from .base import SimpleProbe
 
 
 class DividerProbe(SimpleProbe):
-    native_class = System.Windows.Forms.Label
+    native_class = System.Windows.Forms.Panel


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Derived from #2484:

> I have corrected the WinForms Divider implementation to use a `WinForms.Panel` instead of a `WinForms.Label`, as `WinForms.Panel` is more suitable for a Divider widget and allows setting a background color.
> 
> The previous implementation did not produce any visual results when background color was set. This is because it was producing the Divider widget by squeezing the borders of the WinForms.Label and setting its height to 2 px, which hid its background, resulting in just the borders being visible.
> 
> The reason why it was passing tests was because it was setting the background color of the `WinForms.Label`. However, the probe only checks through the native APIs, which returned the set background color. Since its background was hidden, there were no visual results.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
