### PR TITLE
Define application lifecycle events by subclassing

### DIFF
--- a/changes/2099.removal.rst
+++ b/changes/2099.removal.rst
@@ -1,0 +1,1 @@
+The ``add_background_task()`` API on ``toga.App`` has been deprecated. Background tasks can be implemented using the new ``on_running`` event handler, or by using :any:`asyncio.create_task` or :any:`asyncio.loop.call_soon_threadsafe`.

--- a/changes/2099.removal.rst
+++ b/changes/2099.removal.rst
@@ -1,1 +1,1 @@
-The ``add_background_task()`` API on ``toga.App`` has been deprecated. Background tasks can be implemented using the new ``on_running`` event handler, or by using :any:`asyncio.create_task` or :any:`asyncio.loop.call_soon_threadsafe`.
+The ``add_background_task()`` API on ``toga.App`` has been deprecated. Background tasks can be implemented using the new ``on_running`` event handler, or by using :any:`asyncio.create_task`.

--- a/changes/2678.feature.1.rst
+++ b/changes/2678.feature.1.rst
@@ -1,0 +1,1 @@
+The ``on_exit`` handler for an app can now be defined by overriding the method on the ``toga.App`` subclass.

--- a/changes/2678.feature.2.rst
+++ b/changes/2678.feature.2.rst
@@ -1,1 +1,1 @@
-An ``on_running`` event handler was added to ``toga.App``. This event will be triggered when the main app loop starts.
+An ``on_running`` event handler was added to ``toga.App``. This event will be triggered when the app's main loop starts.

--- a/changes/2678.feature.2.rst
+++ b/changes/2678.feature.2.rst
@@ -1,0 +1,1 @@
+An ``on_running`` event handler was added to ``toga.App``. This event will be triggered when the main app loop starts.

--- a/cocoa/src/toga_cocoa/app.py
+++ b/cocoa/src/toga_cocoa/app.py
@@ -196,10 +196,10 @@ class App:
                 section=sys.maxsize - 1,
             ),
             # Quit should always be the last item, in a section on its own. Invoke
-            # `on_exit` rather than `exit`, because we want to trigger the "OK to exit?"
-            # logic. It's already a bound handler, so we can use it directly.
+            # `_request_exit` rather than `exit`, because we want to trigger the "OK to
+            # exit?" logic.
             Command(
-                self.interface.on_exit,
+                simple_handler(self.interface._request_exit),
                 f"Quit {self.interface.formal_name}",
                 shortcut=toga.Key.MOD_1 + "q",
                 group=toga.Group.APP,

--- a/core/src/toga/app.py
+++ b/core/src/toga/app.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import importlib.metadata
-import inspect
 import signal
 import sys
 import warnings
@@ -14,7 +13,7 @@ from typing import TYPE_CHECKING, Any, MutableSet, Protocol
 from weakref import WeakValueDictionary
 
 from toga.command import CommandSet
-from toga.handlers import wrapped_handler
+from toga.handlers import simple_handler, wrapped_handler
 from toga.hardware.camera import Camera
 from toga.hardware.location import Location
 from toga.icons import Icon
@@ -43,6 +42,16 @@ class AppStartupMethod(Protocol):
         :param kwargs: Ensures compatibility with additional arguments introduced in
             future versions.
         :returns: The widget to use as the main window content.
+        """
+
+
+class OnRunningHandler(Protocol):
+    def __call__(self, app: App, /, **kwargs: Any) -> None:
+        """A handler to invoke when the app event loop is running.
+
+        :param app: The app instance that is running.
+        :param kwargs: Ensures compatibility with additional arguments introduced in
+            future versions.
         """
 
 
@@ -227,6 +236,7 @@ class App:
         home_page: str | None = None,
         description: str | None = None,
         startup: AppStartupMethod | None = None,
+        on_running: OnRunningHandler | None = None,
         on_exit: OnExitHandler | None = None,
         id: None = None,  # DEPRECATED
         windows: None = None,  # DEPRECATED
@@ -263,6 +273,7 @@ class App:
         :param description: A brief (one line) description of the app. If not provided,
             the metadata key ``Summary`` will be used.
         :param startup: A callable to run before starting the app.
+        :param on_running: The initial :any:`on_running` handler.
         :param on_exit: The initial :any:`on_exit` handler.
         :param id: **DEPRECATED** - This argument will be ignored. If you need a
             machine-friendly identifier, use ``app_id``.
@@ -378,7 +389,19 @@ class App:
         else:
             self.icon = icon
 
-        self.on_exit = on_exit
+        # Install the lifecycle handlers. If passed in as an argument, or assigned using
+        # `app.on_event = my_handler`, the event handler will take the app as the first
+        # argument. If we're using the default value, or we're subclassing app, the app
+        # can be safely implied; so we wrap the method as a simple handler.
+        if on_running:
+            self.on_running = on_running
+        else:
+            self.on_running = simple_handler(self.on_running)
+
+        if on_exit:
+            self.on_exit = on_exit
+        else:
+            self.on_exit = simple_handler(self.on_exit)
 
         # We need the command set to exist so that startup et al. can add commands;
         # but we don't have an impl yet, so we can't set the on_change handler
@@ -484,18 +507,16 @@ class App:
     # App lifecycle
     ######################################################################
 
-    def add_background_task(self, handler: BackgroundTask) -> None:
-        """Schedule a task to run in the background.
+    def _request_exit(self):
+        # Internal method to request an exit. This triggers on_exit handling, and
+        # will only exit if the user agrees.
+        def cleanup(app, should_exit):
+            if should_exit:
+                app.exit()
 
-        Schedules a coroutine or a generator to run in the background. Control
-        will be returned to the event loop during await or yield statements,
-        respectively. Use this to run background tasks without blocking the
-        GUI. If a regular callable is passed, it will be called as is and will
-        block the GUI until the call returns.
-
-        :param handler: A coroutine, generator or callable.
-        """
-        self.loop.call_soon_threadsafe(wrapped_handler(self, handler))
+        # Wrap on_exit to ensure that an async handler is turned into a task,
+        # then immediately invoke.
+        wrapped_handler(self, self.on_exit, cleanup=cleanup)()
 
     def exit(self) -> None:
         """Exit the application gracefully.
@@ -595,15 +616,7 @@ class App:
                 window.toolbar.on_change = window._impl.create_toolbar
 
         # Queue a task to run as soon as the event loop starts.
-        if inspect.iscoroutinefunction(self.running):
-            # running is a co-routine; create a sync wrapper
-            def on_app_running():
-                asyncio.ensure_future(self.running())
-
-        else:
-            on_app_running = self.running
-
-        self.loop.call_soon_threadsafe(on_app_running)
+        self.loop.call_soon_threadsafe(wrapped_handler(self, self.on_running))
 
     def startup(self) -> None:
         """Create and show the main window for the application.
@@ -618,15 +631,6 @@ class App:
             self.main_window.content = self._startup_method(self)
 
         self.main_window.show()
-
-    def running(self) -> None:
-        """Logic to execute as soon as the main event loop is running.
-
-        Override this method to add any logic you want to run as soon as the app's event
-        loop is running.
-
-        If necessary, the overridden method can be defined as as an ``async`` coroutine.
-        """
 
     ######################################################################
     # App resources
@@ -806,18 +810,27 @@ class App:
     # App events
     ######################################################################
 
-    @property
-    def on_exit(self) -> OnExitHandler:
-        """The handler to invoke if the user attempts to exit the app."""
-        return self._on_exit
+    @overridable
+    def on_exit(self) -> bool:
+        """The event handler that will be invoked when the app is about to exit.
 
-    @on_exit.setter
-    def on_exit(self, handler: OnExitHandler | None) -> None:
-        def cleanup(app: App, should_exit: bool) -> None:
-            if should_exit or handler is None:
-                app.exit()
+        The return value of this method controls whether the app is allowed to exit.
+        This can be used to prevent the app exiting with unsaved changes, etc.
 
-        self._on_exit = wrapped_handler(self, handler, cleanup=cleanup)
+        If necessary, the overridden method can be defined as as an ``async`` coroutine.
+
+        :returns: ``True`` if the app is allowed to exit; ``False`` if the app is not
+            allowed to exit.
+        """
+        # Always allow exit
+        return True
+
+    @overridable
+    def on_running(self) -> None:
+        """The event handler that will be invoked when the app's event loop starts running.
+
+        If necessary, the overridden method can be defined as as an ``async`` coroutine.
+        """
 
     ######################################################################
     # 2023-10: Backwards compatibility
@@ -838,6 +851,22 @@ class App:
     def windows(self, windows: WindowSet) -> None:
         if windows is not self._windows:
             raise AttributeError("can't set attribute 'windows'")
+
+    ######################################################################
+    # 2024-06: Backwards compatibility
+    ######################################################################
+
+    def add_background_task(self, handler: BackgroundTask) -> None:
+        """**DEPRECATED** – Use :any:`asyncio.create_task`, or override/assign
+        :meth:`~toga.App.on_running`."""
+        warnings.warn(
+            "App.add_background_task is deprecated. Use asyncio.create_task(), "
+            "or set an App.on_running() handler",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        self.loop.call_soon_threadsafe(wrapped_handler(self, handler))
 
     ######################################################################
     # End backwards compatibility

--- a/core/src/toga/handlers.py
+++ b/core/src/toga/handlers.py
@@ -90,7 +90,7 @@ async def handler_with_cleanup(
         return result
 
 
-def simple_handler(fn):
+def simple_handler(fn, *args, **kwargs):
     """Wrap a function (with args and kwargs) so it can be used as a command handler.
 
     This essentially accepts and ignores the handler-related arguments (i.e., the
@@ -100,18 +100,22 @@ def simple_handler(fn):
     It can accept either a function or a coroutine.
 
     :param fn: The callable to invoke as a handler.
+    :param args: The arguments to pass to the handler when invoked.
+    :param kwargs: The keyword arguments to pass to the handler when invoked.
     :returns: A handler that will invoke the callable.
     """
     if inspect.iscoroutinefunction(fn):
 
-        async def _handler(command, *args, **kwargs):
+        async def _handler(command):
             return await fn(*args, **kwargs)
 
     else:
 
-        def _handler(command, *args, **kwargs):
+        def _handler(command):
             return fn(*args, **kwargs)
 
+    # Preserve a reference to the original function
+    _handler._raw = fn
     return _handler
 
 

--- a/core/src/toga/window.py
+++ b/core/src/toga/window.py
@@ -302,14 +302,13 @@ class Window:
         close_window = True
         if self.app.main_window == self:
             # Closing the window marked as the main window is a request to exit.
-            # Trigger on_exit handling, which may cause the window to close.
-            self.app.on_exit()
+            self.app._request_exit()
             close_window = False
         elif self.app.main_window is None:
             # If this is an app without a main window, this is the last window in the
-            # app, and the platform exits on last window close, trigger an exit.
+            # app, and the platform exits on last window close, request an exit.
             if len(self.app.windows) == 1 and self.app._impl.CLOSE_ON_LAST_WINDOW:
-                self.app.on_exit()
+                self.app._request_exit()
                 close_window = False
 
         if close_window:

--- a/core/tests/app/test_app.py
+++ b/core/tests/app/test_app.py
@@ -235,7 +235,11 @@ def test_create(
     assert app.formal_name == expected_formal_name
     assert app.app_id == expected_app_id
     assert app.app_name == expected_app_name
-    assert app.on_exit._raw is None
+
+    # The default implementations of the on_running and on_exit handlers
+    # have been wrapped as simple handlers
+    assert app.on_running._raw.__func__ == toga.App.on_running
+    assert app.on_exit._raw.__func__ == toga.App.on_exit
 
     metadata_mock.assert_called_once_with(expected_app_name)
 
@@ -316,6 +320,7 @@ def test_explicit_app_metadata(monkeypatch, event_loop):
         ),
     )
 
+    on_running_handler = Mock()
     on_exit_handler = Mock()
 
     app = toga.App(
@@ -325,6 +330,7 @@ def test_explicit_app_metadata(monkeypatch, event_loop):
         version="1.2.3",
         home_page="https://example.com/test-app",
         description="A test app",
+        on_running=on_running_handler,
         on_exit=on_exit_handler,
     )
 
@@ -333,7 +339,11 @@ def test_explicit_app_metadata(monkeypatch, event_loop):
     assert app.home_page == "https://example.com/test-app"
     assert app.description == "A test app"
 
-    assert app.on_exit._raw == on_exit_handler
+    # App handlers have been installed; they have not been wrapped.
+    # Wrapping will occur when they are invoked, to allow for late
+    # assignment of a new handler.
+    assert app.on_running == on_running_handler
+    assert app.on_exit == on_exit_handler
 
 
 @pytest.mark.parametrize("construct", [True, False])
@@ -658,6 +668,30 @@ def test_exit_no_handler(app):
     assert_action_performed(app, "exit")
 
 
+def test_exit_subclassed_handler(app):
+    """An app can implement on_exit by subclassing."""
+    exit = {}
+
+    class SubclassedApp(toga.App):
+        def startup(self):
+            self.main_window = toga.MainWindow()
+
+        def on_exit(self):
+            exit["called"] = True
+            return True
+
+    app = SubclassedApp(formal_name="Test App", app_id="org.example.test")
+
+    # Close the app
+    app._impl.simulate_exit()
+
+    # The exit method was invoked
+    assert exit["called"]
+
+    # App has been exited
+    assert_action_performed(app, "exit")
+
+
 def test_exit_successful_handler(app):
     """An app with a successful exit handler can be exited."""
     on_exit_handler = Mock(return_value=True)
@@ -720,25 +754,6 @@ def test_loop(app, event_loop):
     assert app.loop is event_loop
 
 
-def test_background_task(app):
-    """A background task can be queued."""
-    canary = Mock()
-
-    async def background(app, **kwargs):
-        canary()
-
-    app.add_background_task(background)
-
-    # Create an async task that we can use to start the event loop for a short time.
-    async def waiter():
-        await asyncio.sleep(0.1)
-
-    app.loop.run_until_complete(waiter())
-
-    # Once the loop has executed, the background task should have executed as well.
-    canary.assert_called_once()
-
-
 def test_running(event_loop):
     """The running() method is invoked when the main loop starts"""
     running = {}
@@ -747,7 +762,7 @@ def test_running(event_loop):
         def startup(self):
             self.main_window = toga.MainWindow()
 
-        def running(self):
+        def on_running(self):
             running["called"] = True
 
     app = SubclassedApp(formal_name="Test App", app_id="org.example.test")
@@ -767,7 +782,7 @@ def test_async_running_method(event_loop):
         def startup(self):
             self.main_window = toga.MainWindow()
 
-        async def running(self):
+        async def on_running(self):
             running["called"] = True
 
     app = SubclassedApp(formal_name="Test App", app_id="org.example.test")
@@ -799,3 +814,25 @@ def test_deprecated_name(event_loop):
     assert app.formal_name == "Test App"
     with pytest.warns(DeprecationWarning, match=name_warning):
         assert app.name == "Test App"
+
+
+def test_deprecated_background_task(app):
+    """A background task can be queued using the deprecated API."""
+    canary = Mock()
+
+    async def background(app, **kwargs):
+        canary()
+
+    with pytest.warns(
+        DeprecationWarning, match="App.add_background_task is deprecated"
+    ):
+        app.add_background_task(background)
+
+    # Create an async task that we can use to start the event loop for a short time.
+    async def waiter():
+        await asyncio.sleep(0.1)
+
+    app.loop.run_until_complete(waiter())
+
+    # Once the loop has executed, the background task should have executed as well.
+    canary.assert_called_once()

--- a/core/tests/app/test_customized_app.py
+++ b/core/tests/app/test_customized_app.py
@@ -41,7 +41,11 @@ def test_create(event_loop, AppClass):
     assert custom_app.formal_name == "Custom App"
     assert custom_app.app_id == "org.beeware.customized-app"
     assert custom_app.app_name == "customized-app"
-    assert custom_app.on_exit._raw is None
+
+    # The default implementations of the on_running and on_exit handlers
+    # have been wrapped as simple handlers
+    assert custom_app.on_running._raw.__func__ == toga.App.on_running
+    assert custom_app.on_exit._raw.__func__ == toga.App.on_exit
 
     # About menu item exists and is disabled
     assert toga.Command.ABOUT in custom_app.commands

--- a/core/tests/test_handlers.py
+++ b/core/tests/test_handlers.py
@@ -586,11 +586,12 @@ def test_simple_handler_function():
         handler_call["kwargs"] = kwargs
         return 42
 
-    wrapped = simple_handler(handler)
+    wrapped = simple_handler(handler, "arg1", "arg2", kwarg1=3, kwarg2=4)
 
     # Invoke the handler as if it were a method handler (i.e., with the extra "widget"
     # argument)
-    assert wrapped("obj", "arg1", "arg2", kwarg1=3, kwarg2=4) == 42
+    assert wrapped("obj") == 42
+    assert wrapped._raw == handler
 
     # The "widget" bound argument has been dropped
     assert handler_call == {
@@ -608,16 +609,12 @@ def test_simple_handler_coroutine(event_loop):
         handler_call["kwargs"] = kwargs
         return 42
 
-    wrapped = simple_handler(handler)
+    wrapped = simple_handler(handler, "arg1", "arg2", kwarg1=3, kwarg2=4)
 
     # Invoke the handler as if it were a coroutine method handler (i.e., with the extra
     # "widget" argument)
-    assert (
-        event_loop.run_until_complete(
-            wrapped("obj", "arg1", "arg2", kwarg1=3, kwarg2=4)
-        )
-        == 42
-    )
+    assert event_loop.run_until_complete(wrapped("obj")) == 42
+    assert wrapped._raw == handler
 
     # The "widget" bound argument has been dropped
     assert handler_call == {

--- a/docs/reference/api/app.rst
+++ b/docs/reference/api/app.rst
@@ -174,4 +174,5 @@ Reference
 
 .. autoprotocol:: toga.app.AppStartupMethod
 .. autoprotocol:: toga.app.BackgroundTask
+.. autoprotocol:: toga.app.OnRunningHandler
 .. autoprotocol:: toga.app.OnExitHandler

--- a/docs/reference/api/app.rst
+++ b/docs/reference/api/app.rst
@@ -141,7 +141,7 @@ All other events in the life cycle of the app can be managed with event handlers
 * :meth:`~toga.App.on_running` occurs as soon as the app's event loop has started.
 
 * :meth:`~toga.App.on_exit` occurs when the app wishes to exit. The handler for this
-  event must return a boolean value: ``True`` if the app is allowed to exit; ``False``
+  event must return a Boolean value: ``True`` if the app is allowed to exit; ``False``
   otherwise. This allows an app to abort the exit process (for example, to prevent exit
   if there are unsaved changes).
 

--- a/docs/reference/api/app.rst
+++ b/docs/reference/api/app.rst
@@ -140,7 +140,7 @@ All other events in the life cycle of the app can be managed with event handlers
 
 * :meth:`~toga.App.on_running` occurs as soon as the app's event loop has started.
 
-* :meth:`~toga.App.on_exit` occurs when the app wishes to exit. The handler for this
+* :meth:`~toga.App.on_exit` occurs when the user tries to exit. The handler for this
   event must return a Boolean value: ``True`` if the app is allowed to exit; ``False``
   otherwise. This allows an app to abort the exit process (for example, to prevent exit
   if there are unsaved changes).

--- a/docs/reference/api/app.rst
+++ b/docs/reference/api/app.rst
@@ -125,6 +125,34 @@ icon from your taskbar.
 
 Background apps are not supported on mobile, web and console platforms.
 
+Life cycle of an app
+--------------------
+
+Regardless of what an application does, every application goes through the same
+life cycle of starting, running, and shutting down.
+
+Application startup is handled by the :meth:`~toga.App.startup` method described above.
+:meth:`~toga.App.startup` *cannot* be an asynchronous method, as it runs *before* the
+App's event loop is started.
+
+All other events in the life cycle of the app can be managed with event handlers.
+:class:`toga.App` defines the following event handlers:
+
+* :meth:`~toga.App.on_running` occurs as soon as the app's event loop has started.
+
+* :meth:`~toga.App.on_exit` occurs when the app wishes to exit. The handler for this
+  event must return a boolean value: ``True`` if the app is allowed to exit; ``False``
+  otherwise. This allows an app to abort the exit process (for example, to prevent exit
+  if there are unsaved changes).
+
+Event handlers can be defined by subclassing :class:`toga.App` and overriding the event
+handler method, by assigning a value to the event handler when the app instance is
+constructed, or by assigning the event handler attribute on an existing app instance.
+When the event handler is set by assigning a value to the event handler, the handler
+method must accept an ``app`` argument. This argument is not required when subclassing,
+as the app instance can be implied. Regardless of how they are defined, event handlers
+*can* be defined as ``async`` methods.
+
 Notes
 -----
 

--- a/dummy/src/toga_dummy/app.py
+++ b/dummy/src/toga_dummy/app.py
@@ -34,10 +34,10 @@ class App(LoggedObject):
     def create_app_commands(self):
         self._action("create App commands")
         self.interface.commands.add(
-            # Invoke `on_exit` rather than `exit`, because we want to trigger the "OK to
-            # exit?" logic. It's already a bound handler, so we can use it directly.
+            # Invoke `_request_exit` rather than `exit`, because we want to trigger the
+            # "OK to exit?" logic.
             Command(
-                self.interface.on_exit,
+                simple_handler(self.interface._request_exit),
                 "Exit",
                 group=Group.APP,
                 section=sys.maxsize,
@@ -181,7 +181,7 @@ class App(LoggedObject):
     ######################################################################
 
     def simulate_exit(self):
-        self.interface.on_exit()
+        self.interface._request_exit()
 
 
 class DocumentApp(App):

--- a/examples/statusiconapp/statusiconapp/app.py
+++ b/examples/statusiconapp/statusiconapp/app.py
@@ -13,7 +13,7 @@ class ExampleStatusIconApp(toga.App):
         #
         # Support for defining status icons is coming soon (See #97)
 
-    async def running(self):
+    async def on_running(self):
         # Once the app is running, start a heartbeat
         while True:
             await asyncio.sleep(1)

--- a/examples/window/window/app.py
+++ b/examples/window/window/app.py
@@ -136,7 +136,7 @@ class WindowDemoApp(toga.App):
     def do_beep(self, widget):
         self.app.beep()
 
-    async def exit_handler(self, app, **kwargs):
+    async def on_exit(self):
         self.close_count += 1
         if self.close_count % 2 == 1:
             await self.main_window.dialog(
@@ -160,7 +160,6 @@ class WindowDemoApp(toga.App):
 
         # Set up main window
         self.main_window = toga.MainWindow()
-        self.on_exit = self.exit_handler
 
         # Label to show responses.
         self.label = toga.Label("Ready.")

--- a/gtk/src/toga_gtk/app.py
+++ b/gtk/src/toga_gtk/app.py
@@ -64,10 +64,10 @@ class App:
         self.interface.commands.add(
             # ---- App menu -----------------------------------
             # Quit should always be the last item, in a section on its own. Invoke
-            # `on_exit` rather than `exit`, because we want to trigger the "OK to exit?"
-            # logic. It's already a bound handler, so we can use it directly.
+            # `_request_exit` rather than `exit`, because we want to trigger the "OK to
+            # exit?" logic.
             Command(
-                self.interface.on_exit,
+                simple_handler(self.interface._request_exit),
                 "Quit " + self.interface.formal_name,
                 shortcut=toga.Key.MOD_1 + "q",
                 group=toga.Group.APP,

--- a/testbed/tests/app/test_desktop.py
+++ b/testbed/tests/app/test_desktop.py
@@ -16,6 +16,7 @@ if toga.platform.current_platform not in {"macOS", "windows", "linux"}:
 
 
 async def test_exit_on_close_main_window(
+    monkeypatch,
     app,
     main_window,
     main_window_probe,
@@ -28,7 +29,7 @@ async def test_exit_on_close_main_window(
 
     # Set an on_exit for the app handler, initially rejecting exit.
     on_exit_handler = Mock(return_value=False)
-    app.on_exit = on_exit_handler
+    monkeypatch.setattr(app, "on_exit", on_exit_handler)
 
     # Try to close the main window; rejected by window
     main_window_probe.close()
@@ -326,7 +327,6 @@ async def test_current_window(app, app_probe, main_window):
 
     try:
         window1.content = toga.Box(style=Pack(background_color=REBECCAPURPLE))
-        window2 = toga.Window("Test Window 2", position=(400, 150), size=(200, 200))
         window2.content = toga.Box(style=Pack(background_color=CORNFLOWERBLUE))
         window3.content = toga.Box(style=Pack(background_color=FIREBRICK))
 
@@ -358,6 +358,7 @@ async def test_current_window(app, app_probe, main_window):
 
 
 async def test_session_based_app(
+    monkeypatch,
     app,
     app_probe,
     main_window,
@@ -367,7 +368,7 @@ async def test_session_based_app(
     """A desktop app can be converted into a session-based app."""
     # Set an on_exit for the app handler, allowing exit.
     on_exit_handler = Mock(return_value=True)
-    app.on_exit = on_exit_handler
+    monkeypatch.setattr(app, "on_exit", on_exit_handler)
 
     # Create and show a secondary window
     secondary_window = toga.Window()
@@ -431,6 +432,7 @@ async def test_session_based_app(
 
 
 async def test_background_app(
+    monkeypatch,
     app,
     app_probe,
     main_window,
@@ -440,7 +442,7 @@ async def test_background_app(
     """A desktop app can be turned into a background app."""
     # Set an on_exit for the app handler, allowing exit.
     on_exit_handler = Mock(return_value=True)
-    app.on_exit = on_exit_handler
+    monkeypatch.setattr(app, "on_exit", on_exit_handler)
 
     # Create and show a secondary window
     secondary_window = toga.Window()

--- a/testbed/tests/app/test_desktop.py
+++ b/testbed/tests/app/test_desktop.py
@@ -78,8 +78,7 @@ async def test_menu_exit(monkeypatch, app, app_probe, mock_app_exit):
     """An app can be exited by using the menu item"""
     # Rebind the exit command to the on_exit handler.
     on_exit_handler = Mock(return_value=False)
-    app.on_exit = on_exit_handler
-    monkeypatch.setattr(app.commands[toga.Command.EXIT], "_action", app.on_exit)
+    monkeypatch.setattr(app, "on_exit", on_exit_handler)
 
     # Close the main window
     app_probe.activate_menu_exit()
@@ -327,6 +326,7 @@ async def test_current_window(app, app_probe, main_window):
 
     try:
         window1.content = toga.Box(style=Pack(background_color=REBECCAPURPLE))
+        window2 = toga.Window("Test Window 2", position=(400, 150), size=(200, 200))
         window2.content = toga.Box(style=Pack(background_color=CORNFLOWERBLUE))
         window3.content = toga.Box(style=Pack(background_color=FIREBRICK))
 

--- a/testbed/tests/testbed.py
+++ b/testbed/tests/testbed.py
@@ -174,7 +174,7 @@ if __name__ == "__main__":
     # Queue a background task to run that will start the main thread. We do this,
     # instead of just starting the thread directly, so that we can make sure the App has
     # been fully initialized, and the event loop is running.
-    app.on_running = lambda app, **kwargs: thread.start()
+    app.loop.call_soon_threadsafe(thread.start)
 
     # Start the test app.
     app.main_loop()

--- a/testbed/tests/testbed.py
+++ b/testbed/tests/testbed.py
@@ -174,7 +174,7 @@ if __name__ == "__main__":
     # Queue a background task to run that will start the main thread. We do this,
     # instead of just starting the thread directly, so that we can make sure the App has
     # been fully initialized, and the event loop is running.
-    app.add_background_task(lambda app, **kwargs: thread.start())
+    app.on_running = lambda app, **kwargs: thread.start()
 
     # Start the test app.
     app.main_loop()

--- a/testbed/tests/testbed.py
+++ b/testbed/tests/testbed.py
@@ -88,7 +88,7 @@ def run_tests(app, cov, args, report_coverage, run_slow, running_in_ci):
         print(f">>>>>>>>>> EXIT {app.returncode} <<<<<<<<<<")
         # Add a short pause to make sure any log tailing gets a chance to flush
         time.sleep(0.5)
-        app.add_background_task(lambda app, **kwargs: app.exit())
+        app.loop.call_soon_threadsafe(app.exit)
 
 
 if __name__ == "__main__":

--- a/winforms/src/toga_winforms/app.py
+++ b/winforms/src/toga_winforms/app.py
@@ -136,11 +136,11 @@ class App:
     def create_app_commands(self):
         self.interface.commands.add(
             # ---- File menu -----------------------------------
-            # Exit should always be the last item, in a section on its own. Invoke
-            # `on_exit` rather than `exit`, because we want to trigger the "OK to exit?"
-            # logic. It's already a bound handler, so we can use it directly.
+            # Quit should always be the last item, in a section on its own. Invoke
+            # `_request_exit` rather than `exit`, because we want to trigger the "OK to
+            # exit?" logic.
             Command(
-                self.interface.on_exit,
+                simple_handler(self.interface._request_exit),
                 "Exit",
                 shortcut=toga.Key.MOD_1 + "q",
                 group=Group.FILE,


### PR DESCRIPTION
* Modifies the handling of `on_exit` so that it can be defined by subclassing, in addition to assigning an `on_exit` attribute
* Modifies the `running` entry point added by #2651 to be named `on_running` (reflecting it's status as a lifecycle event), following the same pattern as `on_exit`.
* Deprecates `app.add_background_task()`.

Fixes #2099.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
