### PR TITLE
Update syntax for ObjC constraint API usage to avoid long lines.

### DIFF
--- a/changes/2682.misc.rst
+++ b/changes/2682.misc.rst
@@ -1,0 +1,1 @@
+An intermittent failure in macOS CI was corrected, and usage of Rubicon syntax was upgraded.

--- a/cocoa/pyproject.toml
+++ b/cocoa/pyproject.toml
@@ -63,7 +63,7 @@ root = ".."
 [tool.setuptools_dynamic_dependencies]
 dependencies = [
     "fonttools >= 4.42.1, < 5.0.0",
-    "rubicon-objc >= 0.4.7, < 0.5.0",
+    "rubicon-objc >= 0.4.9, < 0.5.0",
     "toga-core == {version}",
 ]
 

--- a/cocoa/src/toga_cocoa/constraints.py
+++ b/cocoa/src/toga_cocoa/constraints.py
@@ -62,47 +62,47 @@ class Constraints:
         self._container = value
         if value is not None:
             # print(f"Add constraints for {self.widget} in {self.container} {self.widget.interface.layout})
-            self.left_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # noqa: E501
+            self.left_constraint = NSLayoutConstraint.constraintWithItem(
                 self.widget.native,
-                NSLayoutAttributeLeft,
-                NSLayoutRelationEqual,
-                self.container.native,
-                NSLayoutAttributeLeft,
-                1.0,
-                10,  # Use a dummy, non-zero value for now
+                attribute__1=NSLayoutAttributeLeft,
+                relatedBy=NSLayoutRelationEqual,
+                toItem=self.container.native,
+                attribute__2=NSLayoutAttributeLeft,
+                multiplier=1.0,
+                constant=10,  # Use a dummy, non-zero value for now
             ).retain()
             self.container.native.addConstraint(self.left_constraint)
 
-            self.top_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # noqa: E501
+            self.top_constraint = NSLayoutConstraint.constraintWithItem(
                 self.widget.native,
-                NSLayoutAttributeTop,
-                NSLayoutRelationEqual,
-                self.container.native,
-                NSLayoutAttributeTop,
-                1.0,
-                5,  # Use a dummy, non-zero value for now
+                attribute__1=NSLayoutAttributeTop,
+                relatedBy=NSLayoutRelationEqual,
+                toItem=self.container.native,
+                attribute__2=NSLayoutAttributeTop,
+                multiplier=1.0,
+                constant=5,  # Use a dummy, non-zero value for now
             ).retain()
             self.container.native.addConstraint(self.top_constraint)
 
-            self.width_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # noqa: E501
+            self.width_constraint = NSLayoutConstraint.constraintWithItem(
                 self.widget.native,
-                NSLayoutAttributeRight,
-                NSLayoutRelationEqual,
-                self.widget.native,
-                NSLayoutAttributeLeft,
-                1.0,
-                50,  # Use a dummy, non-zero value for now
+                attribute__1=NSLayoutAttributeRight,
+                relatedBy=NSLayoutRelationEqual,
+                toItem=self.widget.native,
+                attribute__2=NSLayoutAttributeLeft,
+                multiplier=1.0,
+                constant=50,  # Use a dummy, non-zero value for now
             ).retain()
             self.container.native.addConstraint(self.width_constraint)
 
-            self.height_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # noqa: E501
+            self.height_constraint = NSLayoutConstraint.constraintWithItem(
                 self.widget.native,
-                NSLayoutAttributeBottom,
-                NSLayoutRelationEqual,
-                self.widget.native,
-                NSLayoutAttributeTop,
-                1.0,
-                30,  # Use a dummy, non-zero value for now
+                attribute__1=NSLayoutAttributeBottom,
+                relatedBy=NSLayoutRelationEqual,
+                toItem=self.widget.native,
+                attribute__2=NSLayoutAttributeTop,
+                multiplier=1.0,
+                constant=30,  # Use a dummy, non-zero value for now
             ).retain()
             self.container.native.addConstraint(self.height_constraint)
 

--- a/cocoa/src/toga_cocoa/container.py
+++ b/cocoa/src/toga_cocoa/container.py
@@ -59,25 +59,25 @@ class Container:
         # bigger. If the window is resizable, using >= allows the window to
         # be dragged larger; if not resizable, it enforces the smallest
         # size that can be programmatically set on the window.
-        self._min_width_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # noqa: E501
+        self._min_width_constraint = NSLayoutConstraint.constraintWithItem(
             self.native,
-            NSLayoutAttributeRight,
-            NSLayoutRelationGreaterThanOrEqual,
-            self.native,
-            NSLayoutAttributeLeft,
-            1.0,
-            min_width,
+            attribute__1=NSLayoutAttributeRight,
+            relatedBy=NSLayoutRelationGreaterThanOrEqual,
+            toItem=self.native,
+            attribute__2=NSLayoutAttributeLeft,
+            multiplier=1.0,
+            constant=min_width,
         ).retain()
         self.native.addConstraint(self._min_width_constraint)
 
-        self._min_height_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # noqa: E501
+        self._min_height_constraint = NSLayoutConstraint.constraintWithItem(
             self.native,
-            NSLayoutAttributeBottom,
-            NSLayoutRelationGreaterThanOrEqual,
-            self.native,
-            NSLayoutAttributeTop,
-            1.0,
-            min_height,
+            attribute__1=NSLayoutAttributeBottom,
+            relatedBy=NSLayoutRelationGreaterThanOrEqual,
+            toItem=self.native,
+            attribute__2=NSLayoutAttributeTop,
+            multiplier=1.0,
+            constant=min_height,
         ).retain()
         self.native.addConstraint(self._min_height_constraint)
 

--- a/cocoa/src/toga_cocoa/widgets/internal/cells.py
+++ b/cocoa/src/toga_cocoa/widgets/internal/cells.py
@@ -50,64 +50,64 @@ class TogaIconView(NSTableCellView):
         self.textField.translatesAutoresizingMaskIntoConstraints = False
 
         # center icon vertically in cell
-        self.iv_vertical_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # NOQA:E501
+        self.iv_vertical_constraint = NSLayoutConstraint.constraintWithItem(
             self.imageView,
-            NSLayoutAttributeCenterY,
-            NSLayoutRelationEqual,
-            self,
-            NSLayoutAttributeCenterY,
-            1,
-            0,
+            attribute__1=NSLayoutAttributeCenterY,
+            relatedBy=NSLayoutRelationEqual,
+            toItem=self,
+            attribute__2=NSLayoutAttributeCenterY,
+            multiplier=1,
+            constant=0,
         )
         # align left edge of icon with left edge of cell
-        self.iv_left_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # NOQA:E501
+        self.iv_left_constraint = NSLayoutConstraint.constraintWithItem(
             self.imageView,
-            NSLayoutAttributeLeft,
-            NSLayoutRelationEqual,
-            self,
-            NSLayoutAttributeLeft,
-            1,
-            0,
+            attribute__1=NSLayoutAttributeLeft,
+            relatedBy=NSLayoutRelationEqual,
+            toItem=self,
+            attribute__2=NSLayoutAttributeLeft,
+            multiplier=1,
+            constant=0,
         )
         # set fixed width of icon
-        self.iv_width_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # NOQA:E501
+        self.iv_width_constraint = NSLayoutConstraint.constraintWithItem(
             self.imageView,
-            NSLayoutAttributeWidth,
-            NSLayoutRelationEqual,
-            None,
-            NSLayoutAttributeNotAnAttribute,
-            1,
-            16,
+            attribute__1=NSLayoutAttributeWidth,
+            relatedBy=NSLayoutRelationEqual,
+            toItem=None,
+            attribute__2=NSLayoutAttributeNotAnAttribute,
+            multiplier=1,
+            constant=6,
         )
         # align text vertically in cell
-        self.tv_vertical_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # NOQA:E501
+        self.tv_vertical_constraint = NSLayoutConstraint.constraintWithItem(
             self.textField,
-            NSLayoutAttributeCenterY,
-            NSLayoutRelationEqual,
-            self,
-            NSLayoutAttributeCenterY,
-            1,
-            0,
+            attribute__1=NSLayoutAttributeCenterY,
+            relatedBy=NSLayoutRelationEqual,
+            toItem=self,
+            attribute__2=NSLayoutAttributeCenterY,
+            multiplier=1,
+            constant=0,
         )
         # align left edge of text with right edge of icon
-        self.tv_left_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # NOQA:E501
+        self.tv_left_constraint = NSLayoutConstraint.constraintWithItem(
             self.textField,
-            NSLayoutAttributeLeft,
-            NSLayoutRelationEqual,
-            self.imageView,
-            NSLayoutAttributeRight,
-            1,
-            5,  # 5 pixels padding between icon and text
+            attribute__1=NSLayoutAttributeLeft,
+            relatedBy=NSLayoutRelationEqual,
+            toItem=self.imageView,
+            attribute__2=NSLayoutAttributeRight,
+            multiplier=1,
+            constant=5,  # 5 pixels padding between icon and text
         )
         # align right edge of text with right edge of cell
-        self.tv_right_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # NOQA:E501
+        self.tv_right_constraint = NSLayoutConstraint.constraintWithItem(
             self.textField,
-            NSLayoutAttributeRight,
-            NSLayoutRelationEqual,
-            self,
-            NSLayoutAttributeRight,
-            1,
-            -5,
+            attribute__1=NSLayoutAttributeRight,
+            relatedBy=NSLayoutRelationEqual,
+            toItem=self,
+            attribute__2=NSLayoutAttributeRight,
+            multiplier=1,
+            constant=-5,
         )
 
         self.addConstraint(self.iv_vertical_constraint)

--- a/cocoa/src/toga_cocoa/widgets/internal/refresh.py
+++ b/cocoa/src/toga_cocoa/widgets/internal/refresh.py
@@ -193,58 +193,58 @@ class RefreshableScrollView(NSScrollView):
         self.contentView.addSubview(self.refresh_view)
 
         # set layout constraints
-        indicatorHCenter = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # noqa: E501
+        indicatorHCenter = NSLayoutConstraint.constraintWithItem(
             self.refresh_indicator,
-            NSLayoutAttributeCenterX,
-            NSLayoutRelationEqual,
-            self.refresh_view,
-            NSLayoutAttributeCenterX,
-            1.0,
-            0,
+            attribute__1=NSLayoutAttributeCenterX,
+            relatedBy=NSLayoutRelationEqual,
+            toItem=self.refresh_view,
+            attribute__2=NSLayoutAttributeCenterX,
+            multiplier=1.0,
+            constant=0,
         )
         self.refresh_view.addConstraint(indicatorHCenter)
 
-        indicatorVCenter = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # noqa: E501
+        indicatorVCenter = NSLayoutConstraint.constraintWithItem(
             self.refresh_indicator,
-            NSLayoutAttributeCenterY,
-            NSLayoutRelationEqual,
-            self.refresh_view,
-            NSLayoutAttributeCenterY,
-            1.0,
-            0,
+            attribute__1=NSLayoutAttributeCenterY,
+            relatedBy=NSLayoutRelationEqual,
+            toItem=self.refresh_view,
+            attribute__2=NSLayoutAttributeCenterY,
+            multiplier=1.0,
+            constant=0,
         )
         self.refresh_view.addConstraint(indicatorVCenter)
 
-        refreshWidth = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # noqa: E501
+        refreshWidth = NSLayoutConstraint.constraintWithItem(
             self.refresh_view,
-            NSLayoutAttributeWidth,
-            NSLayoutRelationEqual,
-            self.contentView,
-            NSLayoutAttributeWidth,
-            1.0,
-            0,
+            attribute__1=NSLayoutAttributeWidth,
+            relatedBy=NSLayoutRelationEqual,
+            toItem=self.contentView,
+            attribute__2=NSLayoutAttributeWidth,
+            multiplier=1.0,
+            constant=0,
         )
         self.contentView.addConstraint(refreshWidth)
 
-        refreshHeight = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # noqa: E501
+        refreshHeight = NSLayoutConstraint.constraintWithItem(
             self.refresh_view,
-            NSLayoutAttributeHeight,
-            NSLayoutRelationEqual,
-            None,
-            NSLayoutAttributeNotAnAttribute,
-            1.0,
-            HEADER_HEIGHT,
+            attribute__1=NSLayoutAttributeHeight,
+            relatedBy=NSLayoutRelationEqual,
+            toItem=None,
+            attribute__2=NSLayoutAttributeNotAnAttribute,
+            multiplier=1.0,
+            constant=HEADER_HEIGHT,
         )
         self.contentView.addConstraint(refreshHeight)
 
-        refreshHeight = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # noqa: E501
+        refreshHeight = NSLayoutConstraint.constraintWithItem(
             self.refresh_view,
-            NSLayoutAttributeTop,
-            NSLayoutRelationEqual,
-            self.contentView,
-            NSLayoutAttributeTop,
-            1.0,
-            -HEADER_HEIGHT,
+            attribute__1=NSLayoutAttributeTop,
+            relatedBy=NSLayoutRelationEqual,
+            toItem=self.contentView,
+            attribute__2=NSLayoutAttributeTop,
+            multiplier=1.0,
+            constant=-HEADER_HEIGHT,
         )
         self.contentView.addConstraint(refreshHeight)
 

--- a/cocoa/src/toga_cocoa/widgets/textinput.py
+++ b/cocoa/src/toga_cocoa/widgets/textinput.py
@@ -124,32 +124,32 @@ class TextInput(Widget):
         self.error_label.textColor = NSColor.systemRedColor
         self.native.addSubview(self.error_label)
 
-        leading_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # noqa: E501
+        leading_constraint = NSLayoutConstraint.constraintWithItem(
             self.native,
-            NSLayoutAttributeLeading,
-            NSLayoutRelationEqual,
-            self.error_label,
-            NSLayoutAttributeLeading,
-            1.0,
-            4.0,
+            attribute__1=NSLayoutAttributeLeading,
+            relatedBy=NSLayoutRelationEqual,
+            toItem=self.error_label,
+            attribute__2=NSLayoutAttributeLeading,
+            multiplier=1.0,
+            constant=4.0,
         )
-        trailing_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # noqa: E501
+        trailing_constraint = NSLayoutConstraint.constraintWithItem(
             self.native,
-            NSLayoutAttributeTrailing,
-            NSLayoutRelationEqual,
-            self.error_label,
-            NSLayoutAttributeTrailing,
-            1.0,
-            4.0,
+            attribute__1=NSLayoutAttributeTrailing,
+            relatedBy=NSLayoutRelationEqual,
+            toItem=self.error_label,
+            attribute__2=NSLayoutAttributeTrailing,
+            multiplier=1.0,
+            constant=4.0,
         )
-        center_y_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # noqa: E501
+        center_y_constraint = NSLayoutConstraint.constraintWithItem(
             self.error_label,
-            NSLayoutAttributeCenterY,
-            NSLayoutRelationEqual,
-            self.native,
-            NSLayoutAttributeCenterY,
-            1.0,
-            0.0,
+            attribute__1=NSLayoutAttributeCenterY,
+            relatedBy=NSLayoutRelationEqual,
+            toItem=self.native,
+            attribute__2=NSLayoutAttributeCenterY,
+            multiplier=1.0,
+            constant=0.0,
         )
         self.native.addConstraints(
             [

--- a/iOS/pyproject.toml
+++ b/iOS/pyproject.toml
@@ -62,7 +62,7 @@ root = ".."
 [tool.setuptools_dynamic_dependencies]
 dependencies = [
     "fonttools >= 4.42.1, < 5.0.0",
-    "rubicon-objc >= 0.4.7, < 0.5.0",
+    "rubicon-objc >= 0.4.9, < 0.5.0",
     "toga-core == {version}",
 ]
 

--- a/iOS/src/toga_iOS/constraints.py
+++ b/iOS/src/toga_iOS/constraints.py
@@ -57,47 +57,47 @@ class Constraints:
         self._container = value
         if value is not None:
             # print(f"Add constraints for {self.widget} in {self.container} {self.widget.interface.layout}")
-            self.left_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # noqa: E501
+            self.left_constraint = NSLayoutConstraint.constraintWithItem(
                 self.widget.native,
-                NSLayoutAttributeLeft,
-                NSLayoutRelationEqual,
-                self.container.native,
-                NSLayoutAttributeLeft,
-                1.0,
-                10,  # Use a dummy, non-zero value for now
+                attribute__1=NSLayoutAttributeLeft,
+                relatedBy=NSLayoutRelationEqual,
+                toItem=self.container.native,
+                attribute__2=NSLayoutAttributeLeft,
+                multiplier=1.0,
+                constant=10,  # Use a dummy, non-zero value for now
             ).retain()
             self.container.native.addConstraint(self.left_constraint)
 
-            self.top_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # noqa: E501
+            self.top_constraint = NSLayoutConstraint.constraintWithItem(
                 self.widget.native,
-                NSLayoutAttributeTop,
-                NSLayoutRelationEqual,
-                self.container.native,
-                NSLayoutAttributeTop,
-                1.0,
-                5,  # Use a dummy, non-zero value for now
+                attribute__1=NSLayoutAttributeTop,
+                relatedBy=NSLayoutRelationEqual,
+                toItem=self.container.native,
+                attribute__2=NSLayoutAttributeTop,
+                multiplier=1.0,
+                constant=5,  # Use a dummy, non-zero value for now
             ).retain()
             self.container.native.addConstraint(self.top_constraint)
 
-            self.width_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # noqa: E501
+            self.width_constraint = NSLayoutConstraint.constraintWithItem(
                 self.widget.native,
-                NSLayoutAttributeRight,
-                NSLayoutRelationEqual,
-                self.widget.native,
-                NSLayoutAttributeLeft,
-                1.0,
-                50,  # Use a dummy, non-zero value for now
+                attribute__1=NSLayoutAttributeRight,
+                relatedBy=NSLayoutRelationEqual,
+                toItem=self.widget.native,
+                attribute__2=NSLayoutAttributeLeft,
+                multiplier=1.0,
+                constant=50,  # Use a dummy, non-zero value for now
             ).retain()
             self.container.native.addConstraint(self.width_constraint)
 
-            self.height_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # noqa: E501
+            self.height_constraint = NSLayoutConstraint.constraintWithItem(
                 self.widget.native,
-                NSLayoutAttributeBottom,
-                NSLayoutRelationEqual,
-                self.widget.native,
-                NSLayoutAttributeTop,
-                1.0,
-                30,  # Use a dummy, non-zero value for now
+                attribute__1=NSLayoutAttributeBottom,
+                relatedBy=NSLayoutRelationEqual,
+                toItem=self.widget.native,
+                attribute__2=NSLayoutAttributeTop,
+                multiplier=1.0,
+                constant=30,  # Use a dummy, non-zero value for now
             ).retain()
             self.container.native.addConstraint(self.height_constraint)
 

--- a/iOS/src/toga_iOS/widgets/multilinetextinput.py
+++ b/iOS/src/toga_iOS/widgets/multilinetextinput.py
@@ -76,41 +76,41 @@ class MultilineTextInput(Widget):
         self.add_constraints()
 
     def constrain_placeholder_label(self):
-        leading_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # noqa: E501
+        leading_constraint = NSLayoutConstraint.constraintWithItem(
             self.placeholder_label,
-            NSLayoutAttributeLeading,
-            NSLayoutRelationEqual,
-            self.native,
-            NSLayoutAttributeLeading,
-            1.0,
-            4.0,
+            attribute__1=NSLayoutAttributeLeading,
+            relatedBy=NSLayoutRelationEqual,
+            toItem=self.native,
+            attribute__2=NSLayoutAttributeLeading,
+            multiplier=1.0,
+            constant=4.0,
         )
-        trailing_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # noqa: E501
+        trailing_constraint = NSLayoutConstraint.constraintWithItem(
             self.placeholder_label,
-            NSLayoutAttributeTrailing,
-            NSLayoutRelationEqual,
-            self.native,
-            NSLayoutAttributeTrailing,
-            1.0,
-            0,
+            attribute__1=NSLayoutAttributeTrailing,
+            relatedBy=NSLayoutRelationEqual,
+            toItem=self.native,
+            attribute__2=NSLayoutAttributeTrailing,
+            multiplier=1.0,
+            constant=0,
         )
-        top_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # noqa: E501
+        top_constraint = NSLayoutConstraint.constraintWithItem(
             self.placeholder_label,
-            NSLayoutAttributeTop,
-            NSLayoutRelationEqual,
-            self.native,
-            NSLayoutAttributeTop,
-            1.0,
-            8.0,
+            attribute__1=NSLayoutAttributeTop,
+            relatedBy=NSLayoutRelationEqual,
+            toItem=self.native,
+            attribute__2=NSLayoutAttributeTop,
+            multiplier=1.0,
+            constant=8.0,
         )
-        bottom_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # noqa: E501
+        bottom_constraint = NSLayoutConstraint.constraintWithItem(
             self.placeholder_label,
-            NSLayoutAttributeBottom,
-            NSLayoutRelationEqual,
-            self.native,
-            NSLayoutAttributeBottom,
-            1.0,
-            0,
+            attribute__1=NSLayoutAttributeBottom,
+            relatedBy=NSLayoutRelationEqual,
+            toItem=self.native,
+            attribute__2=NSLayoutAttributeBottom,
+            multiplier=1.0,
+            constant=0,
         )
         self.native.addConstraints(
             [leading_constraint, trailing_constraint, top_constraint, bottom_constraint]

--- a/iOS/src/toga_iOS/widgets/textinput.py
+++ b/iOS/src/toga_iOS/widgets/textinput.py
@@ -73,32 +73,32 @@ class TextInput(Widget):
         self.error_label.textColor = UIColor.redColor
         self.native.addSubview(self.error_label)
 
-        leading_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # noqa: E501
+        leading_constraint = NSLayoutConstraint.constraintWithItem(
             self.native,
-            NSLayoutAttributeLeading,
-            NSLayoutRelationEqual,
-            self.error_label,
-            NSLayoutAttributeLeading,
-            1.0,
-            8.0,
+            attribute__1=NSLayoutAttributeLeading,
+            relatedBy=NSLayoutRelationEqual,
+            toItem=self.error_label,
+            attribute__2=NSLayoutAttributeLeading,
+            multiplier=1.0,
+            constant=8.0,
         )
-        trailing_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # noqa: E501
+        trailing_constraint = NSLayoutConstraint.constraintWithItem(
             self.native,
-            NSLayoutAttributeTrailing,
-            NSLayoutRelationEqual,
-            self.error_label,
-            NSLayoutAttributeTrailing,
-            1.0,
-            8.0,
+            attribute__1=NSLayoutAttributeTrailing,
+            relatedBy=NSLayoutRelationEqual,
+            toItem=self.error_label,
+            attribute__2=NSLayoutAttributeTrailing,
+            multiplier=1.0,
+            constant=8.0,
         )
-        center_y_constraint = NSLayoutConstraint.constraintWithItem_attribute_relatedBy_toItem_attribute_multiplier_constant_(  # noqa: E501
+        center_y_constraint = NSLayoutConstraint.constraintWithItem(
             self.error_label,
-            NSLayoutAttributeCenterY,
-            NSLayoutRelationEqual,
-            self.native,
-            NSLayoutAttributeCenterY,
-            1.0,
-            0.0,
+            attribute__1=NSLayoutAttributeCenterY,
+            relatedBy=NSLayoutRelationEqual,
+            toItem=self.native,
+            attribute__2=NSLayoutAttributeCenterY,
+            multiplier=1.0,
+            constant=0.0,
         )
         self.native.addConstraints(
             [

--- a/testbed/tests/conftest.py
+++ b/testbed/tests/conftest.py
@@ -1,4 +1,5 @@
 import asyncio
+import gc
 import inspect
 from dataclasses import dataclass
 from importlib import import_module
@@ -46,10 +47,35 @@ async def app_probe(app):
         print("\nConstructing app probe")
     yield probe
 
+    # Force a GC pass on the main thread. This isn't perfect, but it helps
+    # minimize garbage collection on the test thread.
+    gc.collect()
+
 
 @fixture(scope="session")
 def main_window(app):
     return app.main_window
+
+
+@fixture(autouse=True)
+async def window_cleanup(app, main_window):
+    # Ensure that at the end of every test, all windows that aren't the
+    # main window have been closed and deleted. This needs to be done in
+    # 2 passes because we can't modify the list while iterating over it.
+    kill_list = []
+    for window in app.windows:
+        if window != main_window:
+            kill_list.append(window)
+
+    # Then purge everything on the kill list.
+    while kill_list:
+        window = kill_list.pop()
+        window.close()
+        del window
+
+    # Force a GC pass on the main thread. This isn't perfect, but it helps
+    # minimize garbage collection on the test thread.
+    gc.collect()
 
 
 @fixture(scope="session")

--- a/testbed/tests/testbed.py
+++ b/testbed/tests/testbed.py
@@ -16,13 +16,26 @@ from testbed.app import main
 def run_tests(app, cov, args, report_coverage, run_slow, running_in_ci):
     try:
         # Wait for the app's main window to be visible. Retrieving the actual main window
-        # will raise an exception until the app is actually initialized, so we check the
-        # underlying variable.
+        # will raise an exception until the app is actually initialized.
         print("Waiting for app to be ready for testing... ", end="", flush=True)
-        while app._main_window is app._UNDEFINED:
+        i = 0
+        ready = False
+        while i < 100 and not ready:
+            try:
+                main_window = app.main_window
+                if main_window.visible:
+                    ready = True
+            except ValueError:
+                pass
+
             time.sleep(0.05)
-        while not app.main_window.visible:
-            time.sleep(0.05)
+            i += 1
+
+        if not ready:
+            print("\nApp didn't display a main window.")
+            app.returncode = 1
+            return
+
         print("ready.")
         # Control the run speed of the test app.
         app.run_slow = run_slow

--- a/testbed/tests/testbed.py
+++ b/testbed/tests/testbed.py
@@ -15,9 +15,13 @@ from testbed.app import main
 
 def run_tests(app, cov, args, report_coverage, run_slow, running_in_ci):
     try:
-        # Wait for the app's main window to be visible.
+        # Wait for the app's main window to be visible. Retrieving the actual main window
+        # will raise an exception until the app is actually initialized, so we check the
+        # underlying variable.
         print("Waiting for app to be ready for testing... ", end="", flush=True)
-        while app.main_window is None or not app.main_window.visible:
+        while app._main_window is app._UNDEFINED:
+            time.sleep(0.05)
+        while not app.main_window.visible:
             time.sleep(0.05)
         print("ready.")
         # Control the run speed of the test app.


### PR DESCRIPTION
With the fix for beeware/rubicon-objc#148 being introduced in Rubicon 0.4.9, we can now remove the unwieldy long lines when creating NSLayoutConstraint objects.

This was fixed in the process of trying to narrow down an intermittent segfault I was seeing in the testing for #2666. The underlying fix for that issue is included here (a window cleanup autouse fixture, with explicit GC passes in the app and window cleanup fixtures). That segfault was caused by garbage collection of NSWindow (and related) objects in the pytest thread; we previously added a GC pass in the *Window* tests to allow for this class of issue, but we've recently added app tests that also create windows; and the main window is also (sometimes) prone to this issue.

Updating the constraint syntax is mostly incidental to the test stability fix - but I spent a lot of time poking around constraints, so I did some housekeeping while I was in the area.

This also corrects an edge case around testbed startup that I've now seen a couple of times on iOS. If the pytest thread starts quickly, the main window may not have been assigned yet, resulting in an exception being raised in testbed startup.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
