### PR TITLE
Defer firing on_select event in GTK OptionContainer

### DIFF
--- a/changes/2703.bugfix.rst
+++ b/changes/2703.bugfix.rst
@@ -1,0 +1,1 @@
+On GTK, the currently selected tab index on an ``OptionContainer`` can now be retrieved inside an ``on_select`` handler.

--- a/gtk/src/toga_gtk/widgets/optioncontainer.py
+++ b/gtk/src/toga_gtk/widgets/optioncontainer.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from ..container import TogaContainer
 from ..libs import Gtk
 from .base import Widget
@@ -12,7 +14,14 @@ class OptionContainer(Widget):
         self.sub_containers = []
 
     def gtk_on_switch_page(self, widget, page, page_num):
-        self.interface.on_select()
+        # Inside the switch-page event handler, the page_num argument gives the
+        # correct value for the page that has just been selected, but
+        # self.native.current_page() does not. It won't return the correct value
+        # until the switch-page event has completed. Since `on_select()` will
+        # likely need to retrieve the current tab, we need to defer triggering
+        # on_select() until we know current_page will return the correct value.
+        # We do this by deferring the callback to execute on the event loop.
+        asyncio.get_event_loop().call_soon_threadsafe(self.interface.on_select)
 
     def add_option(self, index, text, widget, icon):
         sub_container = TogaContainer()

--- a/gtk/src/toga_gtk/widgets/optioncontainer.py
+++ b/gtk/src/toga_gtk/widgets/optioncontainer.py
@@ -21,7 +21,7 @@ class OptionContainer(Widget):
         # likely need to retrieve the current tab, we need to defer triggering
         # on_select() until we know current_page will return the correct value.
         # We do this by deferring the callback to execute on the event loop.
-        asyncio.get_event_loop().call_soon_threadsafe(self.interface.on_select)
+        asyncio.get_event_loop().call_soon(self.interface.on_select)
 
     def add_option(self, index, text, widget, icon):
         sub_container = TogaContainer()

--- a/testbed/tests/widgets/test_optioncontainer.py
+++ b/testbed/tests/widgets/test_optioncontainer.py
@@ -105,6 +105,14 @@ async def test_select_tab(
     on_select_handler.assert_called_once_with(widget)
     on_select_handler.reset_mock()
 
+    handler_current_index = -1
+
+    def on_select(widget, **kwargs):
+        nonlocal handler_current_index
+        handler_current_index = widget.current_tab.index
+
+    on_select_handler.side_effect = on_select
+
     # Select item 2 in the GUI
     probe.select_tab(2)
     await probe.redraw("Tab 3 should be selected")
@@ -115,6 +123,8 @@ async def test_select_tab(
     # on_select has been invoked
     on_select_handler.assert_called_once_with(widget)
     on_select_handler.reset_mock()
+    # The current index as evaluated in the handler agrees
+    assert handler_current_index == 2
 
 
 async def test_select_tab_overflow(widget, probe, on_select_handler):


### PR DESCRIPTION
Fixes #2703.

Under GTK, the `current_page()` API doesn't return the current value while still in the `on_select` handler; as a result, a user-space event handler trying to retrieve the current tab will get the wrong result.

This change defers the execution of the `on_select` handler so that `current_page()` is guaranteed to return the correct result.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
