### PR TITLE
Speculative workaround for macOS test reporting issue.

### DIFF
--- a/changes/2689.misc.rst
+++ b/changes/2689.misc.rst
@@ -1,0 +1,1 @@
+A potential workaround for macOS CI result reporting was added.

--- a/testbed/tests/testbed.py
+++ b/testbed/tests/testbed.py
@@ -102,9 +102,12 @@ def run_tests(app, cov, args, report_coverage, run_slow, running_in_ci):
         traceback.print_exc()
         app.returncode = 1
     finally:
-        print(f">>>>>>>>>> EXIT {app.returncode} <<<<<<<<<<")
-        # Add a short pause to make sure any log tailing gets a chance to flush
-        time.sleep(0.5)
+        # Add a short pause to make sure any log tailing gets a chance to flush. Run a
+        # couple of times to make sure any log streaming dropouts don't prevent
+        # Briefcase from seeing the output.
+        for i in range(0, 6):
+            print(f">>>>>>>>>> EXIT {app.returncode} <<<<<<<<<<")
+            time.sleep(0.5)
         app.loop.call_soon_threadsafe(app.exit)
 
 


### PR DESCRIPTION
I *believe* the issue reported by #2689 is that the log line that outputs the test termination condition is being dropped by log streaming. The long term fix is to make sure that Briefcase either doesn't lose the log stream, or remove the need for log streaming entirely; but in the meantime, this approach has proven reliable (so far) in #2666.

This approach outputs the log termination condition 6 times, 0.5s apart. This gives multiple opportunities for the log message to be caught by the stream; Briefcase will stop the stream as soon as it sees one of them. The process will still stop - it will just take a couple more seconds to do so - which isn't a big problem when the test is already taking 3 minutes to run.

Fixes #2689.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
