### PR TITLE
Temporarily use the stable version of Briefcase.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,7 +323,9 @@ jobs:
         ${{ matrix.pre-command }}
         # Use the development version of Briefcase
         python -m pip install -U pip
-        python -m pip install git+https://github.com/beeware/briefcase.git
+        # python -m pip install git+https://github.com/beeware/briefcase.git
+        # TODO: Use the stable release of Briefcase so that binary packages are available.
+        python -m pip install briefcase==0.3.19
 
     - name: Test App
       working-directory: testbed

--- a/changes/2771.misc.rst
+++ b/changes/2771.misc.rst
@@ -1,0 +1,1 @@
+Testbed CI was temporarily reverted to use briefcase 0.3.19.


### PR DESCRIPTION
With beeware/briefcase#1934 being merged, we're now using the official iOS package tags. However, we haven't published wheels for Pillow with the new tags, which prevents testbed CI from running successfully on iOS.

This temporarily reverts testbed to use the 0.3.19 *stable* release, which uses the older support packages, and thus has a Pillow binary wheel available on iOS.

This can be reverted as soon as binary wheels for the new tag format have been published.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
