### PR TITLE
Show error dialog if WebView fails to load

### DIFF
--- a/changes/2779.bugfix.rst
+++ b/changes/2779.bugfix.rst
@@ -1,0 +1,1 @@
+The WebView and MapView widgets now log an error if initialization fails.

--- a/winforms/src/toga_winforms/widgets/mapview.py
+++ b/winforms/src/toga_winforms/widgets/mapview.py
@@ -81,7 +81,7 @@ class MapView(Widget):
     def create(self):
         self.native = WebView2()
         # WebView has a 2 phase startup; the widget needs to be initialized,
-        # the the content needs to be loaded. We can't actually use the widget
+        # the content needs to be loaded. We can't actually use the widget
         # until the content is fully loaded.
         self.native.CoreWebView2InitializationCompleted += WeakrefCallable(
             self.winforms_initialization_completed
@@ -141,11 +141,18 @@ class MapView(Widget):
                     WinForms.MessageBoxIcon.Error,
                 )
                 webbrowser.open(
-                    "https://developer.microsoft.com/en-us/microsoft-edge/webview2/#download-section"
+                    "https://developer.microsoft.com/en-us/microsoft-edge/webview2/#download"
                 )
 
         else:  # pragma: nocover
-            raise RuntimeError(args.InitializationException)
+            WinForms.MessageBox.Show(
+                "A critical error has occurred and functionality may be impaired.\n\n"
+                "The WebView2 initialization failed with an exception:\n\n"
+                f"{args.InitializationException}",
+                "Error",
+                WinForms.MessageBoxButtons.OK,
+                WinForms.MessageBoxIcon.Error,
+            )
 
     def winforms_navigation_completed(self, sender, args):
         # The Toga API allows you to invoke methods on the MapView as soon

--- a/winforms/src/toga_winforms/widgets/slider.py
+++ b/winforms/src/toga_winforms/widgets/slider.py
@@ -27,11 +27,11 @@ class Slider(Widget, IntSliderImpl):
 
         # Unlike Scroll, ValueChanged also fires when the value is changed
         # programmatically, such as via the testbed probe.
-        self.native.ValueChanged += WeakrefCallable(self.winforms_value_chaned)
+        self.native.ValueChanged += WeakrefCallable(self.winforms_value_changed)
         self.native.MouseDown += WeakrefCallable(self.winforms_mouse_down)
         self.native.MouseUp += WeakrefCallable(self.winforms_mouse_up)
 
-    def winforms_value_chaned(self, sender, event):
+    def winforms_value_changed(self, sender, event):
         self.on_change()
 
     def winforms_mouse_down(self, sender, event):

--- a/winforms/src/toga_winforms/widgets/webview.py
+++ b/winforms/src/toga_winforms/widgets/webview.py
@@ -76,6 +76,7 @@ class WebView(Widget):
             self.default_user_agent = settings.UserAgent
 
             debug = True
+            settings.AreBrowserAcceleratorKeysEnabled = debug
             settings.AreDefaultContextMenusEnabled = debug
             settings.AreDefaultScriptDialogsEnabled = True
             settings.AreDevToolsEnabled = debug
@@ -83,6 +84,7 @@ class WebView(Widget):
             settings.IsScriptEnabled = True
             settings.IsWebMessageEnabled = True
             settings.IsStatusBarEnabled = debug
+            settings.IsSwipeNavigationEnabled = False
             settings.IsZoomControlEnabled = True
 
             for task in self.pending_tasks:
@@ -108,11 +110,18 @@ class WebView(Widget):
                     WinForms.MessageBoxIcon.Error,
                 )
                 webbrowser.open(
-                    "https://developer.microsoft.com/en-us/microsoft-edge/webview2/#download-section"
+                    "https://developer.microsoft.com/en-us/microsoft-edge/webview2/#download"
                 )
 
         else:  # pragma: nocover
-            raise RuntimeError(args.InitializationException)
+            WinForms.MessageBox.Show(
+                "A critical error has occurred and functionality may be impaired.\n\n"
+                "The WebView2 initialization failed with an exception:\n\n"
+                f"{args.InitializationException}",
+                "Error",
+                WinForms.MessageBoxButtons.OK,
+                WinForms.MessageBoxIcon.Error,
+            )
 
     def winforms_navigation_completed(self, sender, args):
         self.interface.on_webview_load()


### PR DESCRIPTION
## Changes
- When the WebView fails to initialize, an error dialog is now presented to the user
- Closes #2779

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
