### PR TITLE
fix: Copy/paste typos in Menu status icon docs

### DIFF
--- a/changes/2792.doc.rst
+++ b/changes/2792.doc.rst
@@ -1,1 +1,0 @@
-Fixed runtime error due to misnamed variables in status icon docs.

--- a/changes/2792.doc.rst
+++ b/changes/2792.doc.rst
@@ -1,0 +1,1 @@
+Fixed runtime error due to misnamed variables in status icon docs.

--- a/changes/2792.misc.rst
+++ b/changes/2792.misc.rst
@@ -1,0 +1,1 @@
+Typos in the status icon examples were corrected.

--- a/docs/reference/api/resources/command.rst
+++ b/docs/reference/api/resources/command.rst
@@ -43,7 +43,7 @@ For example:
     def callback(sender, **kwargs):
         print("Command activated")
 
-    stuff_group = Group('Stuff', order=40)
+    stuff_group = toga.Group('Stuff', order=40)
 
     cmd1 = toga.Command(
         callback,

--- a/docs/reference/api/resources/statusicons.rst
+++ b/docs/reference/api/resources/statusicons.rst
@@ -132,7 +132,7 @@ a sub-menu that itself has a single menu item:
     )
 
     # Create a sub-group of the status icon. This will appear as a submenu.
-    stuff_group = Group('Stuff', parent=status_icon)
+    stuff_group = toga.Group('Stuff', parent=status_icon)
 
     cmd2 = toga.Command(
         callback,
@@ -141,7 +141,7 @@ a sub-menu that itself has a single menu item:
     )
 
     # Add the status icon to the app
-    app.status_icons.add(status_icon_1, status_icon_2)
+    app.status_icons.add(status_icon)
 
     # Add the commands to the status icons command set
     app.status_icons.commands.add(cmd1, cmd2)


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Just a small doc fix to fix runtime errors in the Status Icon code example
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

As an aside, the docs also refer to "icons/green" and "icons/blue"; are these expected to exist in the source somewhere?

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
