### PR TITLE
Resolve pytest-asyncio deprecation warning

### DIFF
--- a/changes/2799.misc.rst
+++ b/changes/2799.misc.rst
@@ -1,0 +1,1 @@
+A deprecation warning from pytest-asyncio was resolved.

--- a/testbed/tests/testbed.py
+++ b/testbed/tests/testbed.py
@@ -57,8 +57,10 @@ def run_tests(app, cov, args, report_coverage, run_slow, running_in_ci):
                 "-Wignore::toga.NotImplementedWarning",
                 # Run all async tests and fixtures using pytest-asyncio.
                 "--asyncio-mode=auto",
+                "--override-ini",
+                "asyncio_default_fixture_loop_scope=session",
                 # Override the cache directory to be somewhere known writable
-                "-o",
+                "--override-ini",
                 f"cache_dir={tempfile.gettempdir()}/.pytest_cache",
             ]
             + args


### PR DESCRIPTION
## Changes
- Prevent pytest-asyncio [complaining](https://github.com/beeware/toga/actions/runs/10636771863/job/29489543747#step:6:165) when [`asyncio_default_fixture_loop_scope`](https://pytest-asyncio.readthedocs.io/en/stable/reference/configuration.html) is not set

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct