### PR TITLE
Fixed cocoa window content visibilty in app full screen

### DIFF
--- a/changes/2796.bugfix.rst
+++ b/changes/2796.bugfix.rst
@@ -1,1 +1,1 @@
-The children of a window with a ``toga.Box()`` as its content are now visible in app full-screen mode.
+A macOS app in full-screen mode now correctly displays the contents of windows that use a ``toga.Box()`` as the top-level content.

--- a/changes/2796.bugfix.rst
+++ b/changes/2796.bugfix.rst
@@ -1,0 +1,1 @@
+The children of a window with a ``toga.Box()`` as its content are now visible in app full-screen mode.

--- a/cocoa/src/toga_cocoa/app.py
+++ b/cocoa/src/toga_cocoa/app.py
@@ -381,18 +381,14 @@ class App:
         for window, screen in zip(windows, NSScreen.screens):
             # The widgets are actually added to window._impl.container.native, instead of
             # window.content._impl.native. And window._impl.native.contentView is
-            # window._impl.container.native. But, directly using window._impl.container.native
-            # would be more implementation specific and likely to break with any future
-            # implementation changes. Hence, use  window._impl.native.contentView, which is
-            # guaranteed to be present and assigned on a NSWindow.
-            #
-            # Hence, we need to go fullscreen on window._impl.native.contentView instead.
-            window._impl.content_view.enterFullScreenMode(screen, withOptions=opts)
+            # window._impl.container.native. Hence, we need to go fullscreen on
+            # window._impl.container.native instead.
+            window._impl.container.native.enterFullScreenMode(screen, withOptions=opts)
             # Going full screen causes the window content to be re-homed
             # in a NSFullScreenWindow; teach the new parent window
             # about its Toga representations.
-            window._impl.content_view.window._impl = window._impl
-            window._impl.content_view.window.interface = window
+            window._impl.container.native.window._impl = window._impl
+            window._impl.container.native.window.interface = window
             window.content.refresh()
 
     def exit_full_screen(self, windows):
@@ -402,5 +398,5 @@ class App:
         )
 
         for window in windows:
-            window._impl.content_view.exitFullScreenModeWithOptions(opts)
+            window._impl.container.native.exitFullScreenModeWithOptions(opts)
             window.content.refresh()

--- a/cocoa/src/toga_cocoa/app.py
+++ b/cocoa/src/toga_cocoa/app.py
@@ -379,12 +379,20 @@ class App:
         )
 
         for window, screen in zip(windows, NSScreen.screens):
-            window.content._impl.native.enterFullScreenMode(screen, withOptions=opts)
+            # The widgets are actually added to window._impl.container.native, instead of
+            # window.content._impl.native. And window._impl.native.contentView is
+            # window._impl.container.native. But, directly using window._impl.container.native
+            # would be more implementation specific and likely to break with any future
+            # implementation changes. Hence, use  window._impl.native.contentView, which is
+            # guaranteed to be present and assigned on a NSWindow.
+            #
+            # Hence, we need to go fullscreen on window._impl.native.contentView instead.
+            window._impl.content_view.enterFullScreenMode(screen, withOptions=opts)
             # Going full screen causes the window content to be re-homed
             # in a NSFullScreenWindow; teach the new parent window
             # about its Toga representations.
-            window.content._impl.native.window._impl = window._impl
-            window.content._impl.native.window.interface = window
+            window._impl.content_view.window._impl = window._impl
+            window._impl.content_view.window.interface = window
             window.content.refresh()
 
     def exit_full_screen(self, windows):
@@ -394,5 +402,5 @@ class App:
         )
 
         for window in windows:
-            window.content._impl.native.exitFullScreenModeWithOptions(opts)
+            window._impl.content_view.exitFullScreenModeWithOptions(opts)
             window.content.refresh()

--- a/cocoa/src/toga_cocoa/window.py
+++ b/cocoa/src/toga_cocoa/window.py
@@ -175,11 +175,6 @@ class Window:
         self.container = Container(on_refresh=self.content_refreshed)
         self.native.contentView = self.container.native
 
-        # In app full-screen mode, window._impl.native.contentView is moved to a
-        # _NSFullScreenWindow, making NSWindow.contentView as None. Hence, retain a
-        # reference to the view before going full-screen.
-        self.content_view = self.native.contentView
-
         # Ensure that the container renders it's background in the same color as the window.
         self.native.wantsLayer = True
         self.container.native.backgroundColor = self.native.backgroundColor

--- a/cocoa/src/toga_cocoa/window.py
+++ b/cocoa/src/toga_cocoa/window.py
@@ -175,6 +175,11 @@ class Window:
         self.container = Container(on_refresh=self.content_refreshed)
         self.native.contentView = self.container.native
 
+        # In app full-screen mode, window._impl.native.contentView is moved to a
+        # _NSFullScreenWindow, making NSWindow.contentView as None. Hence, retain a
+        # reference to the view before going full-screen.
+        self.content_view = self.native.contentView
+
         # Ensure that the container renders it's background in the same color as the window.
         self.native.wantsLayer = True
         self.container.native.backgroundColor = self.native.backgroundColor

--- a/cocoa/tests_backend/app.py
+++ b/cocoa/tests_backend/app.py
@@ -56,7 +56,7 @@ class AppProbe(BaseProbe, DialogsMixin):
         return self.app._impl._cursor_visible
 
     def is_full_screen(self, window):
-        return window._impl.content_view.isInFullScreenMode()
+        return window._impl.container.native.isInFullScreenMode()
 
     def content_size(self, window):
         return (

--- a/cocoa/tests_backend/app.py
+++ b/cocoa/tests_backend/app.py
@@ -56,7 +56,7 @@ class AppProbe(BaseProbe, DialogsMixin):
         return self.app._impl._cursor_visible
 
     def is_full_screen(self, window):
-        return window.content._impl.native.isInFullScreenMode()
+        return window._impl.content_view.isInFullScreenMode()
 
     def content_size(self, window):
         return (

--- a/testbed/tests/app/test_desktop.py
+++ b/testbed/tests/app/test_desktop.py
@@ -6,6 +6,7 @@ import toga
 from toga.colors import CORNFLOWERBLUE, FIREBRICK, REBECCAPURPLE
 from toga.style.pack import Pack
 
+from ..widgets.probe import get_probe
 from ..window.test_window import window_probe
 
 ####################################################################################
@@ -172,8 +173,17 @@ async def test_full_screen(app, app_probe):
     window1 = toga.Window("Test Window 1", position=(150, 150), size=(200, 200))
     window2 = toga.Window("Test Window 2", position=(400, 150), size=(200, 200))
 
-    window1.content = toga.Box(style=Pack(background_color=REBECCAPURPLE))
-    window2.content = toga.Box(style=Pack(background_color=CORNFLOWERBLUE))
+    window1_widget = toga.Box(style=Pack(flex=1))
+    window2_widget = toga.Box(style=Pack(flex=1))
+    window1_widget_probe = get_probe(window1_widget)
+    window2_widget_probe = get_probe(window2_widget)
+
+    window1.content = toga.Box(
+        children=[window1_widget], style=Pack(background_color=REBECCAPURPLE)
+    )
+    window2.content = toga.Box(
+        children=[window2_widget], style=Pack(background_color=CORNFLOWERBLUE)
+    )
     window1_probe = window_probe(app, window1)
     window2_probe = window_probe(app, window2)
 
@@ -187,6 +197,15 @@ async def test_full_screen(app, app_probe):
     initial_content1_size = app_probe.content_size(window1)
     initial_content2_size = app_probe.content_size(window2)
 
+    initial_window1_widget_size = (
+        window1_widget_probe.width,
+        window1_widget_probe.height,
+    )
+    initial_window2_widget_size = (
+        window2_widget_probe.width,
+        window2_widget_probe.height,
+    )
+
     # Make window 2 full screen via the app
     app.set_full_screen(window2)
     await window2_probe.wait_for_window(
@@ -197,10 +216,18 @@ async def test_full_screen(app, app_probe):
 
     assert not app_probe.is_full_screen(window1)
     assert app_probe.content_size(window1) == initial_content1_size
+    assert (
+        window1_widget_probe.width == initial_window1_widget_size[0]
+        and window1_widget_probe.height == initial_window1_widget_size[1]
+    )
 
     assert app_probe.is_full_screen(window2)
     assert app_probe.content_size(window2)[0] > 1000
     assert app_probe.content_size(window2)[1] > 700
+    assert (
+        window2_widget_probe.width > initial_window2_widget_size[0]
+        and window2_widget_probe.height > initial_window2_widget_size[1]
+    )
 
     # Make window 1 full screen via the app, window 2 no longer full screen
     app.set_full_screen(window1)
@@ -213,9 +240,17 @@ async def test_full_screen(app, app_probe):
     assert app_probe.is_full_screen(window1)
     assert app_probe.content_size(window1)[0] > 1000
     assert app_probe.content_size(window1)[1] > 700
+    assert (
+        window1_widget_probe.width > initial_window1_widget_size[0]
+        and window1_widget_probe.height > initial_window1_widget_size[1]
+    )
 
     assert not app_probe.is_full_screen(window2)
     assert app_probe.content_size(window2) == initial_content2_size
+    assert (
+        window2_widget_probe.width == initial_window2_widget_size[0]
+        and window2_widget_probe.height == initial_window2_widget_size[1]
+    )
 
     # Exit full screen
     app.exit_full_screen()
@@ -228,9 +263,17 @@ async def test_full_screen(app, app_probe):
 
     assert not app_probe.is_full_screen(window1)
     assert app_probe.content_size(window1) == initial_content1_size
+    assert (
+        window1_widget_probe.width == initial_window1_widget_size[0]
+        and window1_widget_probe.height == initial_window1_widget_size[1]
+    )
 
     assert not app_probe.is_full_screen(window2)
     assert app_probe.content_size(window2) == initial_content2_size
+    assert (
+        window2_widget_probe.width == initial_window2_widget_size[0]
+        and window2_widget_probe.height == initial_window2_widget_size[1]
+    )
 
     # Go full screen again on window 1
     app.set_full_screen(window1)
@@ -244,9 +287,17 @@ async def test_full_screen(app, app_probe):
     assert app_probe.is_full_screen(window1)
     assert app_probe.content_size(window1)[0] > 1000
     assert app_probe.content_size(window1)[1] > 700
+    assert (
+        window1_widget_probe.width > initial_window1_widget_size[0]
+        and window1_widget_probe.height > initial_window1_widget_size[1]
+    )
 
     assert not app_probe.is_full_screen(window2)
     assert app_probe.content_size(window2) == initial_content2_size
+    assert (
+        window2_widget_probe.width == initial_window2_widget_size[0]
+        and window2_widget_probe.height == initial_window2_widget_size[1]
+    )
 
     # Exit full screen by passing no windows
     app.set_full_screen()
@@ -259,9 +310,17 @@ async def test_full_screen(app, app_probe):
 
     assert not app_probe.is_full_screen(window1)
     assert app_probe.content_size(window1) == initial_content1_size
+    assert (
+        window1_widget_probe.width == initial_window1_widget_size[0]
+        and window1_widget_probe.height == initial_window1_widget_size[1]
+    )
 
     assert not app_probe.is_full_screen(window2)
     assert app_probe.content_size(window2) == initial_content2_size
+    assert (
+        window2_widget_probe.width == initial_window2_widget_size[0]
+        and window2_widget_probe.height == initial_window2_widget_size[1]
+    )
 
 
 async def test_show_hide_cursor(app, app_probe):


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Fixed cocoa window content visibilty in app full screen. 

The bug was caused since in cocoa, widgets are not added to `window.content._impl.native`, but rather to `window._impl.container.native`. However, this PR uses `NSWindow.contentView` to remain internal-implementation independent and less likely to break with any future changes.
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
#2796 

#### With `window.content` as `toga.Box()`:
```python
"""
My first application
"""

import toga


class HelloWorld(toga.App):
    def handle_exit(self, widget, **kwargs):
        self.exit_full_screen()

    def handle_press(self, widget, **kwargs):
        self.set_full_screen(self.main_window)
        self.main_window.content.add(toga.Label(text="We are in App Full Screen mode"))

    def startup(self):
        """Construct and show the Toga application.

        Usually, you would add your application to a main content box.
        We then create a main window (with a name matching the app), and
        show the main window.
        """

        self.main_window = toga.MainWindow(title=self.formal_name)
        self.main_window.content = toga.Box(
            children=[
                toga.Button(
                    text="Enter App Full Screen Mode", on_press=self.handle_press
                ),
                toga.Button(
                    text="Exit App Full Screen Mode", on_press=self.handle_exit
                ),
                toga.Label(
                    text=""" Lorem ipsum dolor sit amet, consectetur adipiscing elit.\n"""
                    """ Maecenas vitae felis non est vehicula pulvinar id eu augue.\n"""
                    """ Maecenas et lectus tellus. Sed et lacinia erat, at pharetra quam.\n"""
                ),
            ]
        )

        self.main_window.show()


def main():
    return HelloWorld()
```

|Before Entering FullScreen|After Entering FullScreen|
|--|--|
|![Screenshot 2024-09-01 at 1 15 19 PM](https://github.com/user-attachments/assets/fd0e7295-53dc-4af4-b816-8e8124c30484)|![Screenshot 2024-09-01 at 1 16 47 PM](https://github.com/user-attachments/assets/377fdf98-1009-417c-80e6-48bb5c15ffd8)|

#### With `window.content` as `toga.ScrollContainer()`:
```python
"""
My first application
"""

import toga


class HelloWorld(toga.App):
    def handle_exit(self, widget, **kwargs):
        self.exit_full_screen()

    def handle_press(self, widget, **kwargs):
        self.set_full_screen(self.main_window)
        self.main_window.content.content.add(
            toga.Label(text="We are in App Full Screen mode")
        )

    def startup(self):
        """Construct and show the Toga application.

        Usually, you would add your application to a main content box.
        We then create a main window (with a name matching the app), and
        show the main window.
        """

        self.main_window = toga.MainWindow(title=self.formal_name)
        self.main_window.content = toga.ScrollContainer(
            content=toga.Box(
                children=[
                    toga.Button(
                        text="Enter App Full Screen Mode", on_press=self.handle_press
                    ),
                    toga.Button(
                        text="Exit App Full Screen Mode", on_press=self.handle_exit
                    ),
                    toga.Label(
                        text=""" Lorem ipsum dolor sit amet, consectetur adipiscing elit.\n"""
                        """ Maecenas vitae felis non est vehicula pulvinar id eu augue.\n"""
                        """ Maecenas et lectus tellus. Sed et lacinia erat, at pharetra quam.\n"""
                    ),
                ]
            )
        )

        self.main_window.show()


def main():
    return HelloWorld()

```
|Before Entering FullScreen|After Entering FullScreen|
|--|--|
|![Screenshot 2024-09-01 at 1 08 32 PM](https://github.com/user-attachments/assets/2bf65126-0ee8-4c2d-a9d3-4bc4bc17d572)|![Screenshot 2024-09-01 at 1 12 52 PM](https://github.com/user-attachments/assets/8b19f287-8537-468e-8cfb-ae4a2995faf9)|
## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
