### PR TITLE
Avoid Testbed failures for `test_save_as_document`

### DIFF
--- a/changes/2807.misc.rst
+++ b/changes/2807.misc.rst
@@ -1,0 +1,1 @@
+The tests for Testbed no longer error for Document save as testing.

--- a/testbed/tests/app/test_document_app.py
+++ b/testbed/tests/app/test_document_app.py
@@ -26,7 +26,7 @@ async def test_new_document(app, app_probe):
 
     # Document has not been read
     app.documents[0]._content.read.assert_not_called()
-    app.documents[0].title == "Example document: Untitled"
+    assert app.documents[0].title == "Example Document: Untitled"
 
 
 async def test_open_document(app, app_probe):
@@ -35,7 +35,7 @@ async def test_open_document(app, app_probe):
     document_path = Path(__file__).parent / "docs/example.testbed"
     app.documents.open(document_path)
 
-    await app_probe.redraw("Document has been opened")
+    await app_probe.redraw("Document has been opened", delay=0.1)
 
     assert len(app.documents) == 1
     assert len(app.windows) == 2
@@ -109,7 +109,7 @@ async def test_save_document(app, app_probe):
     document_path = Path(__file__).parent / "docs/example.testbed"
     app.documents.open(document_path)
 
-    await app_probe.redraw("Document has been opened")
+    await app_probe.redraw("Document has been opened", delay=0.1)
 
     assert len(app.documents) == 1
     assert len(app.windows) == 2
@@ -138,7 +138,7 @@ async def test_save_as_document(monkeypatch, app, app_probe, tmp_path):
 
     monkeypatch.setattr(document.main_window, "dialog", mock_save_as_dialog)
 
-    await app_probe.redraw("Document has been opened")
+    await app_probe.redraw("Document has been opened", delay=0.1)
 
     assert len(app.documents) == 1
     assert len(app.windows) == 2
@@ -162,7 +162,7 @@ async def test_save_all_documents(app, app_probe):
     document_path = Path(__file__).parent / "docs/example.testbed"
     app.documents.open(document_path)
 
-    await app_probe.redraw("Document has been opened")
+    await app_probe.redraw("Document has been opened", delay=0.1)
 
     assert len(app.documents) == 1
     assert len(app.windows) == 2


### PR DESCRIPTION
## Changes
- Closes #2807

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
