### PR TITLE
Hold strong references to asyncio Tasks until they complete

### DIFF
--- a/android/src/toga_android/app.py
+++ b/android/src/toga_android/app.py
@@ -284,7 +284,7 @@ class App:
 
         # Create and show an info dialog as the about dialog.
         # We don't care about the response.
-        asyncio.create_task(
+        self.interface._create_task(
             self.interface.dialog(
                 InfoDialog(
                     f"About {self.interface.formal_name}",

--- a/changes/2809.bugfix.rst
+++ b/changes/2809.bugfix.rst
@@ -1,1 +1,1 @@
-When Toga creates asyncio Tasks for widget and app handlers, the garbage collector will no longer prematurely destroy these tasks in the unlikely occasions it would occur previously.
+Asynchronous tasks created by Toga are now protected from garbage collection while they are running. This could lead to asynchronous tasks terminating unexpectedly with an error under some conditions.

--- a/changes/2809.bugfix.rst
+++ b/changes/2809.bugfix.rst
@@ -1,0 +1,1 @@
+When Toga creates asyncio Tasks for widget and app handlers, the garbage collector will no longer prematurely destroy these tasks in the unlikely occasions it would occur previously.

--- a/cocoa/src/toga_cocoa/app.py
+++ b/cocoa/src/toga_cocoa/app.py
@@ -49,7 +49,7 @@ class AppDelegate(NSObject):
 
     @objc_method
     def applicationOpenUntitledFile_(self, sender) -> bool:
-        asyncio.create_task(self.interface.documents.request_open())
+        self.interface._create_task(self.interface.documents.request_open())
         return True
 
     @objc_method

--- a/cocoa/src/toga_cocoa/dialogs.py
+++ b/cocoa/src/toga_cocoa/dialogs.py
@@ -94,7 +94,7 @@ class NSAlertDialog(BaseDialog):
             self.native.window.orderOut(None)
 
         # This needs to be queued as a background task
-        asyncio.create_task(_run_app_modal())
+        toga.App._create_task(_run_app_modal())
 
 
 class InfoDialog(NSAlertDialog):

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -126,6 +126,7 @@ source = [
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 filterwarnings = [
     "error",
 ]

--- a/core/src/toga/app.py
+++ b/core/src/toga/app.py
@@ -14,7 +14,7 @@ from weakref import WeakValueDictionary
 
 from toga.command import Command, CommandSet
 from toga.documents import Document, DocumentSet
-from toga.handlers import simple_handler, wrapped_handler
+from toga.handlers import create_task, simple_handler, wrapped_handler
 from toga.hardware.camera import Camera
 from toga.hardware.location import Location
 from toga.icons import Icon
@@ -146,6 +146,8 @@ class App:
     BACKGROUND: str = "background app"
 
     _UNDEFINED: str = "<main window not assigned>"
+
+    _create_task = staticmethod(create_task)
 
     def __init__(
         self,
@@ -578,7 +580,7 @@ class App:
 
     def _create_initial_windows(self):
         """Internal utility method for creating initial windows based on command line
-        arguments. This method is used when the platform doesn't provide it's own
+        arguments. This method is used when the platform doesn't provide its own
         command-line handling interface.
 
         If document types are defined, try to open every argument on the command line as
@@ -607,7 +609,7 @@ class App:
 
     def _startup(self) -> None:
         # Install the standard commands. This is done *before* startup so the user's
-        # code has the opporuntity to remove/change the default commands.
+        # code has the opportunity to remove/change the default commands.
         self._create_standard_commands()
         self._impl.create_standard_commands()
 
@@ -843,7 +845,7 @@ class App:
         The return value of this method controls whether the app is allowed to exit.
         This can be used to prevent the app exiting with unsaved changes, etc.
 
-        If necessary, the overridden method can be defined as as an ``async`` coroutine.
+        If necessary, the overridden method can be defined as an ``async`` coroutine.
 
         :returns: ``True`` if the app is allowed to exit; ``False`` if the app is not
             allowed to exit.
@@ -883,10 +885,16 @@ class App:
 
     def add_background_task(self, handler: BackgroundTask) -> None:
         """**DEPRECATED** – Use :any:`asyncio.create_task`, or override/assign
-        :meth:`~toga.App.on_running`."""
+        :meth:`~toga.App.on_running`.
+
+        Please review the Python docs for :any:`asyncio.create_task` and follow the
+        advice to save a reference to the returned task in your app.
+        """
         warnings.warn(
-            "App.add_background_task is deprecated. Use asyncio.create_task(), "
-            "or set an App.on_running() handler",
+            "App.add_background_task() is deprecated. Use asyncio.create_task(), "
+            "or set an App.on_running() handler. Notice the important note for "
+            "asyncio.create_task() at https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task "
+            "to save a reference to the returned task.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/core/src/toga/app.py
+++ b/core/src/toga/app.py
@@ -854,7 +854,7 @@ class App:
     def on_running(self) -> None:
         """The event handler that will be invoked when the app's event loop starts running.
 
-        If necessary, the overridden method can be defined as as an ``async`` coroutine.
+        If necessary, the overridden method can be defined as an ``async`` coroutine.
         """
 
     ######################################################################

--- a/core/src/toga/handlers.py
+++ b/core/src/toga/handlers.py
@@ -11,12 +11,15 @@ from typing import (
     Any,
     Awaitable,
     Callable,
+    Coroutine,
     Generator,
     NoReturn,
     Protocol,
     TypeVar,
     Union,
 )
+
+T = TypeVar("T")
 
 if TYPE_CHECKING:
     if sys.version_info < (3, 10):
@@ -35,20 +38,40 @@ if TYPE_CHECKING:
     HandlerT: TypeAlias = Union[HandlerSyncT, HandlerAsyncT, HandlerGeneratorT]
     WrappedHandlerT: TypeAlias = Callable[..., object]
 
+# Holds references to asyncio.Tasks created by Toga; see create_task().
+running_tasks = set()
 
-def overridable(method):
+
+def overridable(method: T) -> T:
     """Decorate the method as being user-overridable"""
     method._overridden = True
     return method
 
 
-def overridden(coroutine_or_method):
+def overridden(coroutine_or_method: Callable) -> bool:
     """Has the user overridden this method?
 
     This is based on the method *not* having a ``_overridden`` attribute. Overridable
     default methods have this attribute; user-defined method will not.
     """
     return not hasattr(coroutine_or_method, "_overridden")
+
+
+def create_task(coro_or_future: Coroutine | Awaitable[object]) -> asyncio.Task:
+    """Add a task for a handler to the event loop.
+
+    When Tasks are created, a strong reference should be maintained for it while it is
+    running. The event loop only keeps weak references for the task; so, tracking each
+    Task here ensures the garbage collector will not destroy it mid-execution.
+    Upstream issue tracking at python/cpython#91887.
+
+    :param coro_or_future: Coroutine or Future for the Task to run
+    :returns: the created Task
+    """
+    task = asyncio.ensure_future(coro_or_future)
+    running_tasks.add(task)
+    task.add_done_callback(running_tasks.discard)
+    return task
 
 
 class NativeHandler:
@@ -60,7 +83,7 @@ async def long_running_task(
     interface: object,
     generator: HandlerGeneratorReturnT[object],
     cleanup: HandlerSyncT | None,
-) -> None:
+) -> object | None:
     """Run a generator as an asynchronous coroutine."""
     try:
         try:
@@ -89,7 +112,7 @@ async def handler_with_cleanup(
     interface: object,
     *args: object,
     **kwargs: object,
-) -> None:
+) -> object | None:
     try:
         result = await handler(interface, *args, **kwargs)
     except Exception as e:
@@ -105,7 +128,7 @@ async def handler_with_cleanup(
         return result
 
 
-def simple_handler(fn, *args, **kwargs):
+def simple_handler(fn: T, *args: object, **kwargs: object) -> T:
     """Wrap a function (with args and kwargs) so it can be used as a command handler.
 
     This essentially accepts and ignores the handler-related arguments (i.e., the
@@ -116,7 +139,6 @@ def simple_handler(fn, *args, **kwargs):
     function/coroutine are provided at the time the wrapper is defined. It is assumed
     that the mechanism invoking the handler will add no additional arguments other than
     the ``command`` that is invoking the handler.
-
 
     :param fn: The callable to invoke as a handler.
     :param args: Positional arguments that should be passed to the invoked handler.
@@ -166,7 +188,7 @@ def wrapped_handler(
 
         def _handler(*args: object, **kwargs: object) -> object:
             if asyncio.iscoroutinefunction(handler):
-                return asyncio.ensure_future(
+                return create_task(
                     handler_with_cleanup(handler, cleanup, interface, *args, **kwargs)
                 )
             else:
@@ -177,7 +199,7 @@ def wrapped_handler(
                     traceback.print_exc()
                 else:
                     if inspect.isgenerator(result):
-                        return asyncio.ensure_future(
+                        return create_task(
                             long_running_task(interface, result, cleanup)
                         )
                     else:

--- a/core/tests/app/test_app.py
+++ b/core/tests/app/test_app.py
@@ -826,7 +826,7 @@ def test_deprecated_background_task(app):
         canary()
 
     with pytest.warns(
-        DeprecationWarning, match="App.add_background_task is deprecated"
+        DeprecationWarning, match=r"App.add_background_task\(\) is deprecated"
     ):
         app.add_background_task(background)
 

--- a/core/tests/test_handlers.py
+++ b/core/tests/test_handlers.py
@@ -3,7 +3,13 @@ from unittest.mock import Mock
 
 import pytest
 
-from toga.handlers import AsyncResult, NativeHandler, simple_handler, wrapped_handler
+from toga.handlers import (
+    AsyncResult,
+    NativeHandler,
+    running_tasks,
+    simple_handler,
+    wrapped_handler,
+)
 
 
 class ExampleAsyncResult(AsyncResult):
@@ -184,7 +190,10 @@ def test_generator_handler(event_loop):
     obj = Mock()
     handler_call = {}
 
+    assert len(running_tasks) == 0
+
     def handler(*args, **kwargs):
+        assert len(running_tasks) == 1  # strong reference to task was made
         handler_call["args"] = args
         handler_call["kwargs"] = kwargs
         yield 0.01  # A short sleep
@@ -203,6 +212,9 @@ def test_generator_handler(event_loop):
         event_loop.run_until_complete(wrapped("arg1", "arg2", kwarg1=3, kwarg2=4)) == 42
     )
 
+    # Task for handler is untracked once complete
+    assert len(running_tasks) == 0
+
     # Handler arguments are as expected.
     assert handler_call == {
         "args": (obj, "arg1", "arg2"),
@@ -217,7 +229,10 @@ def test_generator_handler_error(event_loop, capsys):
     obj = Mock()
     handler_call = {}
 
+    assert len(running_tasks) == 0
+
     def handler(*args, **kwargs):
+        assert len(running_tasks) == 1  # strong reference to task was made
         handler_call["args"] = args
         handler_call["kwargs"] = kwargs
         yield 0.01  # A short sleep
@@ -233,6 +248,9 @@ def test_generator_handler_error(event_loop, capsys):
         event_loop.run_until_complete(wrapped("arg1", "arg2", kwarg1=3, kwarg2=4))
         is None
     )
+
+    # Task for handler is untracked once complete
+    assert len(running_tasks) == 0
 
     # Handler arguments are as expected.
     assert handler_call == {
@@ -253,7 +271,10 @@ def test_generator_handler_with_cleanup(event_loop):
     cleanup = Mock()
     handler_call = {}
 
+    assert len(running_tasks) == 0
+
     def handler(*args, **kwargs):
+        assert len(running_tasks) == 1  # strong reference to task was made
         handler_call["args"] = args
         handler_call["kwargs"] = kwargs
         yield 0.01  # A short sleep
@@ -271,6 +292,9 @@ def test_generator_handler_with_cleanup(event_loop):
     assert (
         event_loop.run_until_complete(wrapped("arg1", "arg2", kwarg1=3, kwarg2=4)) == 42
     )
+
+    # Task for handler is untracked once complete
+    assert len(running_tasks) == 0
 
     # Handler arguments are as expected.
     assert handler_call == {
@@ -290,7 +314,10 @@ def test_generator_handler_with_cleanup_error(event_loop, capsys):
     cleanup = Mock(side_effect=Exception("Problem in cleanup"))
     handler_call = {}
 
+    assert len(running_tasks) == 0
+
     def handler(*args, **kwargs):
+        assert len(running_tasks) == 1  # strong reference to task was made
         handler_call["args"] = args
         handler_call["kwargs"] = kwargs
         yield 0.01  # A short sleep
@@ -308,6 +335,9 @@ def test_generator_handler_with_cleanup_error(event_loop, capsys):
     assert (
         event_loop.run_until_complete(wrapped("arg1", "arg2", kwarg1=3, kwarg2=4)) == 42
     )
+
+    # Task for handler is untracked once complete
+    assert len(running_tasks) == 0
 
     # Handler arguments are as expected.
     assert handler_call == {
@@ -332,7 +362,10 @@ def test_coroutine_handler(event_loop):
     obj = Mock()
     handler_call = {}
 
+    assert len(running_tasks) == 0
+
     async def handler(*args, **kwargs):
+        assert len(running_tasks) == 1  # strong reference to task was made
         handler_call["args"] = args
         handler_call["kwargs"] = kwargs
         await asyncio.sleep(0.01)  # A short sleep
@@ -349,6 +382,9 @@ def test_coroutine_handler(event_loop):
         event_loop.run_until_complete(wrapped("arg1", "arg2", kwarg1=3, kwarg2=4)) == 42
     )
 
+    # Task for handler is untracked once complete
+    assert len(running_tasks) == 0
+
     # Handler arguments are as expected.
     assert handler_call == {
         "args": (obj, "arg1", "arg2"),
@@ -362,7 +398,10 @@ def test_coroutine_handler_error(event_loop, capsys):
     obj = Mock()
     handler_call = {}
 
+    assert len(running_tasks) == 0
+
     async def handler(*args, **kwargs):
+        assert len(running_tasks) == 1  # strong reference to task was made
         handler_call["args"] = args
         handler_call["kwargs"] = kwargs
         await asyncio.sleep(0.01)  # A short sleep
@@ -378,6 +417,9 @@ def test_coroutine_handler_error(event_loop, capsys):
         event_loop.run_until_complete(wrapped("arg1", "arg2", kwarg1=3, kwarg2=4))
         is None
     )
+
+    # Task for handler is untracked once complete
+    assert len(running_tasks) == 0
 
     # Handler arguments are as expected.
     assert handler_call == {
@@ -398,7 +440,10 @@ def test_coroutine_handler_with_cleanup(event_loop):
     cleanup = Mock()
     handler_call = {}
 
+    assert len(running_tasks) == 0
+
     async def handler(*args, **kwargs):
+        assert len(running_tasks) == 1  # strong reference to task was made
         handler_call["args"] = args
         handler_call["kwargs"] = kwargs
         await asyncio.sleep(0.01)  # A short sleep
@@ -414,6 +459,9 @@ def test_coroutine_handler_with_cleanup(event_loop):
     assert (
         event_loop.run_until_complete(wrapped("arg1", "arg2", kwarg1=3, kwarg2=4)) == 42
     )
+
+    # Task for handler is untracked once complete
+    assert len(running_tasks) == 0
 
     # Handler arguments are as expected.
     assert handler_call == {
@@ -432,7 +480,10 @@ def test_coroutine_handler_with_cleanup_error(event_loop, capsys):
     cleanup = Mock(side_effect=Exception("Problem in cleanup"))
     handler_call = {}
 
+    assert len(running_tasks) == 0
+
     async def handler(*args, **kwargs):
+        assert len(running_tasks) == 1  # strong reference to task was made
         handler_call["args"] = args
         handler_call["kwargs"] = kwargs
         await asyncio.sleep(0.01)  # A short sleep
@@ -448,6 +499,9 @@ def test_coroutine_handler_with_cleanup_error(event_loop, capsys):
     assert (
         event_loop.run_until_complete(wrapped("arg1", "arg2", kwarg1=3, kwarg2=4)) == 42
     )
+
+    # Task for handler is untracked once complete
+    assert len(running_tasks) == 0
 
     # Handler arguments are as expected.
     assert handler_call == {
@@ -484,7 +538,7 @@ def test_async_result_non_comparable(event_loop):
     result = ExampleAsyncResult(None)
 
     # repr for the result is useful
-    assert repr(result) == "<Async Test result; future=<Future pending>>"
+    assert repr(result).startswith("<Async Test result; future=<Future pending")
 
     # Result cannot be compared.
 


### PR DESCRIPTION
## Changes
- Partially addresses #2809 
- Any asyncio Task directly created by Toga now has a strong reference throughout its life-cycle
- Users are still left to their own devices to avoid this issue in their code

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct