### PR TITLE
Always sleep between iterations of generator handlers

### DIFF
--- a/changes/2811.bugfix.rst
+++ b/changes/2811.bugfix.rst
@@ -1,1 +1,1 @@
-When a handler is a generator, control will always be released to the event loop between iterations now.
+When a handler is a generator, control will now always be released to the event loop between iterations, even if no sleep interval or a sleep interval of 0 is yielded.

--- a/changes/2811.bugfix.rst
+++ b/changes/2811.bugfix.rst
@@ -1,0 +1,1 @@
+When a handler is a generator, control will always be released to the event loop between iterations now.

--- a/core/src/toga/handlers.py
+++ b/core/src/toga/handlers.py
@@ -66,8 +66,7 @@ async def long_running_task(
         try:
             while True:
                 delay = next(generator)
-                if delay:
-                    await asyncio.sleep(delay)
+                await asyncio.sleep(delay if delay else 0)
         except StopIteration as e:
             result = e.value
     except Exception as e:


### PR DESCRIPTION
## Changes
- Previously, generator handlers would only sleep if the iteration's return value was truthy
- Now, `asyncio.sleep()` is always invoked for each generator iteration

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct