### PR TITLE
Ensure Gtk about dialog is destroyed

### DIFF
--- a/changes/2812.bugfix.rst
+++ b/changes/2812.bugfix.rst
@@ -1,0 +1,1 @@
+When the X button is clicked for the About dialog on Gtk, it is now properly destroyed.

--- a/gtk/src/toga_gtk/app.py
+++ b/gtk/src/toga_gtk/app.py
@@ -187,7 +187,7 @@ class App:
     def beep(self):
         Gdk.beep()
 
-    def _close_about(self, dialog, **kwargs):
+    def _close_about(self, dialog, *args, **kwargs):
         self.native_about_dialog.destroy()
         self.native_about_dialog = None
 


### PR DESCRIPTION
## Changes
- If the About Dialog's X button was clicked, a `TypeError` for the number of arguments for `_close_about()` was thrown
- Now, an arbitrary number of positional arguments is accepted; it should be noted that pressing Escape does not send an extra pos arg...

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
