### PR TITLE
Hold strong references to asyncio Tasks until they complete (redux)

### DIFF
--- a/android/src/toga_android/app.py
+++ b/android/src/toga_android/app.py
@@ -284,7 +284,7 @@ class App:
 
         # Create and show an info dialog as the about dialog.
         # We don't care about the response.
-        self.interface._create_task(
+        asyncio.create_task(
             self.interface.dialog(
                 InfoDialog(
                     f"About {self.interface.formal_name}",

--- a/android/tests_backend/dialogs.py
+++ b/android/tests_backend/dialogs.py
@@ -24,7 +24,7 @@ class DialogsMixin:
                     # isn't what as expected, so record that in the future.
                     future.set_exception(e)
 
-            asyncio.ensure_future(_close_dialog())
+            asyncio.create_task(_close_dialog(), name="close-dialog")
 
         dialog._impl.show = automated_show
 

--- a/changes/2809.bugfix.rst
+++ b/changes/2809.bugfix.rst
@@ -1,1 +1,1 @@
-Asynchronous tasks created by Toga are now protected from garbage collection while they are running. This could lead to asynchronous tasks terminating unexpectedly with an error under some conditions.
+When Toga creates asyncio Tasks for widget and app handlers, the garbage collector will no longer prematurely destroy these tasks in the unlikely occasions it would occur previously.

--- a/changes/2809.bugfix.rst
+++ b/changes/2809.bugfix.rst
@@ -1,1 +1,0 @@
-When Toga creates asyncio Tasks for widget and app handlers, the garbage collector will no longer prematurely destroy these tasks in the unlikely occasions it would occur previously.

--- a/changes/2809.bugfix.rst
+++ b/changes/2809.bugfix.rst
@@ -1,0 +1,1 @@
+Asynchronous tasks are now protected from garbage collection while they are running. This could lead to asynchronous tasks terminating unexpectedly with an error under some conditions.

--- a/cocoa/src/toga_cocoa/app.py
+++ b/cocoa/src/toga_cocoa/app.py
@@ -49,7 +49,7 @@ class AppDelegate(NSObject):
 
     @objc_method
     def applicationOpenUntitledFile_(self, sender) -> bool:
-        self.interface._create_task(self.interface.documents.request_open())
+        asyncio.create_task(self.interface.documents.request_open())
         return True
 
     @objc_method

--- a/cocoa/src/toga_cocoa/dialogs.py
+++ b/cocoa/src/toga_cocoa/dialogs.py
@@ -94,7 +94,7 @@ class NSAlertDialog(BaseDialog):
             self.native.window.orderOut(None)
 
         # This needs to be queued as a background task
-        toga.App._create_task(_run_app_modal())
+        asyncio.create_task(_run_app_modal())
 
 
 class InfoDialog(NSAlertDialog):

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -126,6 +126,7 @@ source = [
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 filterwarnings = [
     "error",
 ]

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -126,7 +126,6 @@ source = [
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
-asyncio_default_fixture_loop_scope = "function"
 filterwarnings = [
     "error",
 ]

--- a/core/src/toga/app.py
+++ b/core/src/toga/app.py
@@ -14,7 +14,7 @@ from weakref import WeakValueDictionary
 
 from toga.command import Command, CommandSet
 from toga.documents import Document, DocumentSet
-from toga.handlers import create_task, simple_handler, wrapped_handler
+from toga.handlers import simple_handler, wrapped_handler
 from toga.hardware.camera import Camera
 from toga.hardware.location import Location
 from toga.icons import Icon
@@ -146,8 +146,6 @@ class App:
     BACKGROUND: str = "background app"
 
     _UNDEFINED: str = "<main window not assigned>"
-
-    _create_task = staticmethod(create_task)
 
     def __init__(
         self,
@@ -580,7 +578,7 @@ class App:
 
     def _create_initial_windows(self):
         """Internal utility method for creating initial windows based on command line
-        arguments. This method is used when the platform doesn't provide its own
+        arguments. This method is used when the platform doesn't provide it's own
         command-line handling interface.
 
         If document types are defined, try to open every argument on the command line as
@@ -609,7 +607,7 @@ class App:
 
     def _startup(self) -> None:
         # Install the standard commands. This is done *before* startup so the user's
-        # code has the opportunity to remove/change the default commands.
+        # code has the opporuntity to remove/change the default commands.
         self._create_standard_commands()
         self._impl.create_standard_commands()
 
@@ -845,7 +843,7 @@ class App:
         The return value of this method controls whether the app is allowed to exit.
         This can be used to prevent the app exiting with unsaved changes, etc.
 
-        If necessary, the overridden method can be defined as an ``async`` coroutine.
+        If necessary, the overridden method can be defined as as an ``async`` coroutine.
 
         :returns: ``True`` if the app is allowed to exit; ``False`` if the app is not
             allowed to exit.
@@ -885,16 +883,10 @@ class App:
 
     def add_background_task(self, handler: BackgroundTask) -> None:
         """**DEPRECATED** – Use :any:`asyncio.create_task`, or override/assign
-        :meth:`~toga.App.on_running`.
-
-        Please review the Python docs for :any:`asyncio.create_task` and follow the
-        advice to save a reference to the returned task in your app.
-        """
+        :meth:`~toga.App.on_running`."""
         warnings.warn(
-            "App.add_background_task() is deprecated. Use asyncio.create_task(), "
-            "or set an App.on_running() handler. Notice the important note for "
-            "asyncio.create_task() at https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task "
-            "to save a reference to the returned task.",
+            "App.add_background_task is deprecated. Use asyncio.create_task(), "
+            "or set an App.on_running() handler",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/core/src/toga/app.py
+++ b/core/src/toga/app.py
@@ -854,7 +854,7 @@ class App:
     def on_running(self) -> None:
         """The event handler that will be invoked when the app's event loop starts running.
 
-        If necessary, the overridden method can be defined as an ``async`` coroutine.
+        If necessary, the overridden method can be defined as as an ``async`` coroutine.
         """
 
     ######################################################################

--- a/core/src/toga/app.py
+++ b/core/src/toga/app.py
@@ -140,6 +140,7 @@ class App:
     _camera: Camera
     _location: Location
     _main_window: Window | str | None
+    _running_tasks: set[asyncio.Task] = set()
 
     #: A constant that can be used as the main window to indicate that an app will
     #: run in the background without a main window.
@@ -479,6 +480,35 @@ class App:
 
         self._impl.main_loop()
 
+    def _install_task_factory_wrapper(self):
+        """Wrap task creation to track pending and running tasks.
+
+        When tasks are created, asyncio only maintains a weak reference to the task.
+        This allows for the possibility that the garbage collector destroys the task
+        in the midst of its execution. To avoid this, a strong reference is stored on
+        the app and a task callback removes the reference after the task completes.
+        Upstream issue tracked at python/cpython#91887.
+        """
+        platform_task_factory = self.loop.get_task_factory()
+
+        def factory(loop, coro, context=None):
+            if platform_task_factory is not None:
+                if sys.version_info < (3, 11):
+                    task = platform_task_factory(loop, coro)
+                else:
+                    task = platform_task_factory(loop, coro, context=context)
+            else:
+                if sys.version_info < (3, 11):
+                    task = asyncio.Task(coro, loop=loop)
+                else:
+                    task = asyncio.Task(coro, loop=loop, context=context)
+
+            self._running_tasks.add(task)
+            task.add_done_callback(self._running_tasks.discard)
+            return task
+
+        self.loop.set_task_factory(factory)
+
     @property
     def main_window(self) -> Window | str | None:
         """The main window for the app.
@@ -511,7 +541,7 @@ class App:
         else:
             raise ValueError(f"Don't know how to use {window!r} as a main window.")
 
-    def _open_initial_document(self, filename: Path) -> bool:
+    def _open_initial_document(self, filename: Path | str) -> bool:
         """Internal utility method for opening a document provided at the command line.
 
         This is abstracted so that backends that have their own management of command
@@ -578,7 +608,7 @@ class App:
 
     def _create_initial_windows(self):
         """Internal utility method for creating initial windows based on command line
-        arguments. This method is used when the platform doesn't provide it's own
+        arguments. This method is used when the platform doesn't provide its own
         command-line handling interface.
 
         If document types are defined, try to open every argument on the command line as
@@ -606,8 +636,11 @@ class App:
                 )
 
     def _startup(self) -> None:
+        # Wrap the platform's event loop's task factory for task tracking
+        self._install_task_factory_wrapper()
+
         # Install the standard commands. This is done *before* startup so the user's
-        # code has the opporuntity to remove/change the default commands.
+        # code has the opportunity to remove/change the default commands.
         self._create_standard_commands()
         self._impl.create_standard_commands()
 
@@ -843,7 +876,7 @@ class App:
         The return value of this method controls whether the app is allowed to exit.
         This can be used to prevent the app exiting with unsaved changes, etc.
 
-        If necessary, the overridden method can be defined as as an ``async`` coroutine.
+        If necessary, the overridden method can be defined as an ``async`` coroutine.
 
         :returns: ``True`` if the app is allowed to exit; ``False`` if the app is not
             allowed to exit.
@@ -854,7 +887,7 @@ class App:
     def on_running(self) -> None:
         """The event handler that will be invoked when the app's event loop starts running.
 
-        If necessary, the overridden method can be defined as as an ``async`` coroutine.
+        If necessary, the overridden method can be defined as an ``async`` coroutine.
         """
 
     ######################################################################

--- a/core/src/toga/handlers.py
+++ b/core/src/toga/handlers.py
@@ -24,6 +24,8 @@ if TYPE_CHECKING:
     else:
         from typing import TypeAlias
 
+    T = TypeVar("T")
+
     GeneratorReturnT = TypeVar("GeneratorReturnT")
     HandlerGeneratorReturnT: TypeAlias = Generator[
         Union[float, None], object, GeneratorReturnT
@@ -36,13 +38,13 @@ if TYPE_CHECKING:
     WrappedHandlerT: TypeAlias = Callable[..., object]
 
 
-def overridable(method):
+def overridable(method: T) -> T:
     """Decorate the method as being user-overridable"""
     method._overridden = True
     return method
 
 
-def overridden(coroutine_or_method):
+def overridden(coroutine_or_method: Callable) -> bool:
     """Has the user overridden this method?
 
     This is based on the method *not* having a ``_overridden`` attribute. Overridable
@@ -60,7 +62,7 @@ async def long_running_task(
     interface: object,
     generator: HandlerGeneratorReturnT[object],
     cleanup: HandlerSyncT | None,
-) -> None:
+) -> object | None:
     """Run a generator as an asynchronous coroutine."""
     try:
         try:
@@ -88,7 +90,7 @@ async def handler_with_cleanup(
     interface: object,
     *args: object,
     **kwargs: object,
-) -> None:
+) -> object | None:
     try:
         result = await handler(interface, *args, **kwargs)
     except Exception as e:
@@ -104,7 +106,7 @@ async def handler_with_cleanup(
         return result
 
 
-def simple_handler(fn, *args, **kwargs):
+def simple_handler(fn: T, *args: object, **kwargs: object) -> T:
     """Wrap a function (with args and kwargs) so it can be used as a command handler.
 
     This essentially accepts and ignores the handler-related arguments (i.e., the
@@ -115,7 +117,6 @@ def simple_handler(fn, *args, **kwargs):
     function/coroutine are provided at the time the wrapper is defined. It is assumed
     that the mechanism invoking the handler will add no additional arguments other than
     the ``command`` that is invoking the handler.
-
 
     :param fn: The callable to invoke as a handler.
     :param args: Positional arguments that should be passed to the invoked handler.

--- a/core/tests/app/test_app.py
+++ b/core/tests/app/test_app.py
@@ -826,7 +826,7 @@ def test_deprecated_background_task(app):
         canary()
 
     with pytest.warns(
-        DeprecationWarning, match=r"App.add_background_task\(\) is deprecated"
+        DeprecationWarning, match="App.add_background_task is deprecated"
     ):
         app.add_background_task(background)
 

--- a/core/tests/app/test_app.py
+++ b/core/tests/app/test_app.py
@@ -347,7 +347,7 @@ def test_explicit_app_metadata(monkeypatch, event_loop):
 
 
 @pytest.mark.parametrize("construct", [True, False])
-def test_icon_construction(construct, event_loop):
+def test_icon_construction(app, construct, event_loop):
     """The app icon can be set during construction."""
     if construct:
         icon = toga.Icon("path/to/icon")

--- a/core/tests/test_handlers.py
+++ b/core/tests/test_handlers.py
@@ -3,13 +3,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from toga.handlers import (
-    AsyncResult,
-    NativeHandler,
-    running_tasks,
-    simple_handler,
-    wrapped_handler,
-)
+from toga.handlers import AsyncResult, NativeHandler, simple_handler, wrapped_handler
 
 
 class ExampleAsyncResult(AsyncResult):
@@ -190,10 +184,7 @@ def test_generator_handler(event_loop):
     obj = Mock()
     handler_call = {}
 
-    assert len(running_tasks) == 0
-
     def handler(*args, **kwargs):
-        assert len(running_tasks) == 1  # strong reference to task was made
         handler_call["args"] = args
         handler_call["kwargs"] = kwargs
         yield 0.01  # A short sleep
@@ -212,9 +203,6 @@ def test_generator_handler(event_loop):
         event_loop.run_until_complete(wrapped("arg1", "arg2", kwarg1=3, kwarg2=4)) == 42
     )
 
-    # Task for handler is untracked once complete
-    assert len(running_tasks) == 0
-
     # Handler arguments are as expected.
     assert handler_call == {
         "args": (obj, "arg1", "arg2"),
@@ -229,10 +217,7 @@ def test_generator_handler_error(event_loop, capsys):
     obj = Mock()
     handler_call = {}
 
-    assert len(running_tasks) == 0
-
     def handler(*args, **kwargs):
-        assert len(running_tasks) == 1  # strong reference to task was made
         handler_call["args"] = args
         handler_call["kwargs"] = kwargs
         yield 0.01  # A short sleep
@@ -248,9 +233,6 @@ def test_generator_handler_error(event_loop, capsys):
         event_loop.run_until_complete(wrapped("arg1", "arg2", kwarg1=3, kwarg2=4))
         is None
     )
-
-    # Task for handler is untracked once complete
-    assert len(running_tasks) == 0
 
     # Handler arguments are as expected.
     assert handler_call == {
@@ -271,10 +253,7 @@ def test_generator_handler_with_cleanup(event_loop):
     cleanup = Mock()
     handler_call = {}
 
-    assert len(running_tasks) == 0
-
     def handler(*args, **kwargs):
-        assert len(running_tasks) == 1  # strong reference to task was made
         handler_call["args"] = args
         handler_call["kwargs"] = kwargs
         yield 0.01  # A short sleep
@@ -292,9 +271,6 @@ def test_generator_handler_with_cleanup(event_loop):
     assert (
         event_loop.run_until_complete(wrapped("arg1", "arg2", kwarg1=3, kwarg2=4)) == 42
     )
-
-    # Task for handler is untracked once complete
-    assert len(running_tasks) == 0
 
     # Handler arguments are as expected.
     assert handler_call == {
@@ -314,10 +290,7 @@ def test_generator_handler_with_cleanup_error(event_loop, capsys):
     cleanup = Mock(side_effect=Exception("Problem in cleanup"))
     handler_call = {}
 
-    assert len(running_tasks) == 0
-
     def handler(*args, **kwargs):
-        assert len(running_tasks) == 1  # strong reference to task was made
         handler_call["args"] = args
         handler_call["kwargs"] = kwargs
         yield 0.01  # A short sleep
@@ -335,9 +308,6 @@ def test_generator_handler_with_cleanup_error(event_loop, capsys):
     assert (
         event_loop.run_until_complete(wrapped("arg1", "arg2", kwarg1=3, kwarg2=4)) == 42
     )
-
-    # Task for handler is untracked once complete
-    assert len(running_tasks) == 0
 
     # Handler arguments are as expected.
     assert handler_call == {
@@ -362,10 +332,7 @@ def test_coroutine_handler(event_loop):
     obj = Mock()
     handler_call = {}
 
-    assert len(running_tasks) == 0
-
     async def handler(*args, **kwargs):
-        assert len(running_tasks) == 1  # strong reference to task was made
         handler_call["args"] = args
         handler_call["kwargs"] = kwargs
         await asyncio.sleep(0.01)  # A short sleep
@@ -382,9 +349,6 @@ def test_coroutine_handler(event_loop):
         event_loop.run_until_complete(wrapped("arg1", "arg2", kwarg1=3, kwarg2=4)) == 42
     )
 
-    # Task for handler is untracked once complete
-    assert len(running_tasks) == 0
-
     # Handler arguments are as expected.
     assert handler_call == {
         "args": (obj, "arg1", "arg2"),
@@ -398,10 +362,7 @@ def test_coroutine_handler_error(event_loop, capsys):
     obj = Mock()
     handler_call = {}
 
-    assert len(running_tasks) == 0
-
     async def handler(*args, **kwargs):
-        assert len(running_tasks) == 1  # strong reference to task was made
         handler_call["args"] = args
         handler_call["kwargs"] = kwargs
         await asyncio.sleep(0.01)  # A short sleep
@@ -417,9 +378,6 @@ def test_coroutine_handler_error(event_loop, capsys):
         event_loop.run_until_complete(wrapped("arg1", "arg2", kwarg1=3, kwarg2=4))
         is None
     )
-
-    # Task for handler is untracked once complete
-    assert len(running_tasks) == 0
 
     # Handler arguments are as expected.
     assert handler_call == {
@@ -440,10 +398,7 @@ def test_coroutine_handler_with_cleanup(event_loop):
     cleanup = Mock()
     handler_call = {}
 
-    assert len(running_tasks) == 0
-
     async def handler(*args, **kwargs):
-        assert len(running_tasks) == 1  # strong reference to task was made
         handler_call["args"] = args
         handler_call["kwargs"] = kwargs
         await asyncio.sleep(0.01)  # A short sleep
@@ -459,9 +414,6 @@ def test_coroutine_handler_with_cleanup(event_loop):
     assert (
         event_loop.run_until_complete(wrapped("arg1", "arg2", kwarg1=3, kwarg2=4)) == 42
     )
-
-    # Task for handler is untracked once complete
-    assert len(running_tasks) == 0
 
     # Handler arguments are as expected.
     assert handler_call == {
@@ -480,10 +432,7 @@ def test_coroutine_handler_with_cleanup_error(event_loop, capsys):
     cleanup = Mock(side_effect=Exception("Problem in cleanup"))
     handler_call = {}
 
-    assert len(running_tasks) == 0
-
     async def handler(*args, **kwargs):
-        assert len(running_tasks) == 1  # strong reference to task was made
         handler_call["args"] = args
         handler_call["kwargs"] = kwargs
         await asyncio.sleep(0.01)  # A short sleep
@@ -499,9 +448,6 @@ def test_coroutine_handler_with_cleanup_error(event_loop, capsys):
     assert (
         event_loop.run_until_complete(wrapped("arg1", "arg2", kwarg1=3, kwarg2=4)) == 42
     )
-
-    # Task for handler is untracked once complete
-    assert len(running_tasks) == 0
 
     # Handler arguments are as expected.
     assert handler_call == {
@@ -538,7 +484,7 @@ def test_async_result_non_comparable(event_loop):
     result = ExampleAsyncResult(None)
 
     # repr for the result is useful
-    assert repr(result).startswith("<Async Test result; future=<Future pending")
+    assert repr(result) == "<Async Test result; future=<Future pending>>"
 
     # Result cannot be compared.
 

--- a/core/tests/test_handlers.py
+++ b/core/tests/test_handlers.py
@@ -484,7 +484,7 @@ def test_async_result_non_comparable(event_loop):
     result = ExampleAsyncResult(None)
 
     # repr for the result is useful
-    assert repr(result) == "<Async Test result; future=<Future pending>>"
+    assert repr(result).startswith("<Async Test result; future=<Future pending")
 
     # Result cannot be compared.
 

--- a/testbed/tests/conftest.py
+++ b/testbed/tests/conftest.py
@@ -33,6 +33,15 @@ def xfail_on_platforms(*platforms):
         skip(f"not applicable on {current_platform}")
 
 
+@fixture(autouse=True)
+def no_dangling_tasks():
+    """Ensure any tasks for the test were removed when the test finished."""
+    yield
+    if toga.App.app:
+        tasks = toga.App.app._running_tasks
+        assert not tasks, f"the app has dangling tasks: {tasks}"
+
+
 @fixture(scope="session")
 def app():
     return toga.App.app

--- a/testbed/tests/window/test_dialogs.py
+++ b/testbed/tests/window/test_dialogs.py
@@ -32,8 +32,7 @@ async def wait_for_dialog_to_close(main_window):
             break
 
 
-@pytest.mark.usefixtures("wait_for_dialog_to_close")
-async def test_info_dialog(main_window, main_window_probe):
+async def test_info_dialog(main_window, main_window_probe, wait_for_dialog_to_close):
     """An info dialog can be displayed and acknowledged."""
     dialog = toga.InfoDialog("Info", "Some info")
     assert main_window_probe.is_modal_dialog(dialog)
@@ -47,8 +46,12 @@ async def test_info_dialog(main_window, main_window_probe):
 
 
 @pytest.mark.parametrize("result", [False, True])
-@pytest.mark.usefixtures("wait_for_dialog_to_close")
-async def test_question_dialog(main_window, main_window_probe, result):
+async def test_question_dialog(
+    main_window,
+    main_window_probe,
+    result,
+    wait_for_dialog_to_close,
+):
     """A question dialog can be displayed and acknowledged."""
     dialog = toga.QuestionDialog("Question", "Some question")
     assert main_window_probe.is_modal_dialog(dialog)
@@ -64,8 +67,12 @@ async def test_question_dialog(main_window, main_window_probe, result):
 
 
 @pytest.mark.parametrize("result", [False, True])
-@pytest.mark.usefixtures("wait_for_dialog_to_close")
-async def test_confirm_dialog(main_window, main_window_probe, result):
+async def test_confirm_dialog(
+    main_window,
+    main_window_probe,
+    result,
+    wait_for_dialog_to_close,
+):
     """A confirmation dialog can be displayed and acknowledged."""
     dialog = toga.ConfirmDialog("Confirm", "Some confirmation")
     assert main_window_probe.is_modal_dialog(dialog)
@@ -81,8 +88,7 @@ async def test_confirm_dialog(main_window, main_window_probe, result):
     assert actual == result
 
 
-@pytest.mark.usefixtures("wait_for_dialog_to_close")
-async def test_error_dialog(main_window, main_window_probe):
+async def test_error_dialog(main_window, main_window_probe, wait_for_dialog_to_close):
     """An error dialog can be displayed and acknowledged."""
     dialog = toga.ErrorDialog("Error", "Some error")
     assert main_window_probe.is_modal_dialog(dialog)
@@ -96,8 +102,12 @@ async def test_error_dialog(main_window, main_window_probe):
 
 
 @pytest.mark.parametrize("result", [None, False, True])
-@pytest.mark.usefixtures("wait_for_dialog_to_close")
-async def test_stack_trace_dialog(main_window, main_window_probe, result):
+async def test_stack_trace_dialog(
+    main_window,
+    main_window_probe,
+    result,
+    wait_for_dialog_to_close,
+):
     """A confirmation dialog can be displayed and acknowledged."""
     stack = io.StringIO()
     traceback.print_stack(file=stack)
@@ -130,13 +140,13 @@ async def test_stack_trace_dialog(main_window, main_window_probe, result):
         ("/path/to/file.txt", ["txt", "doc"], None),
     ],
 )
-@pytest.mark.usefixtures("wait_for_dialog_to_close")
 async def test_save_file_dialog(
     main_window,
     main_window_probe,
     filename,
     file_types,
     result,
+    wait_for_dialog_to_close,
 ):
     """A file open dialog can be displayed and acknowledged."""
     dialog = toga.SaveFileDialog(
@@ -196,7 +206,6 @@ async def test_save_file_dialog(
         ),
     ],
 )
-@pytest.mark.usefixtures("wait_for_dialog_to_close")
 async def test_open_file_dialog(
     main_window,
     main_window_probe,
@@ -204,6 +213,7 @@ async def test_open_file_dialog(
     file_types,
     multiple_select,
     result,
+    wait_for_dialog_to_close,
 ):
     """A file open dialog can be displayed and acknowledged."""
     dialog = toga.OpenFileDialog(
@@ -246,13 +256,13 @@ async def test_open_file_dialog(
         (TESTS_DIR, True, None),
     ],
 )
-@pytest.mark.usefixtures("wait_for_dialog_to_close")
 async def test_select_folder_dialog(
     main_window,
     main_window_probe,
     initial_directory,
     multiple_select,
     result,
+    wait_for_dialog_to_close,
 ):
     """A folder selection dialog can be displayed and acknowledged."""
     dialog = toga.SelectFolderDialog(

--- a/winforms/tests_backend/dialogs.py
+++ b/winforms/tests_backend/dialogs.py
@@ -28,7 +28,7 @@ class DialogsMixin:
                     # isn't what as expected, so record that in the future.
                     future.set_exception(e)
 
-            asyncio.ensure_future(_close_dialog())
+            asyncio.create_task(_close_dialog(), name="close-dialog")
 
         dialog._impl.show = automated_show
 


### PR DESCRIPTION
## Changes
- This reverts and re-implements #2810
- Now, the asyncio task factory is wrapped so that Toga tracks _all_ tasks created for asyncio
  - In this way, Toga and its users can call `asyncio.create_task()` with abandon
- Closes #2809

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct