### PR TITLE
Hide right-sidebar element's parents.

### DIFF
--- a/changes/2715.misc.rst
+++ b/changes/2715.misc.rst
@@ -1,0 +1,1 @@
+Right-sidebar only shows the element's name, without any parents, to prevent bad wrapping.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -372,3 +372,6 @@ todo_include_todos = True
 
 # If this is True, todolist produce output without file path and line, The default is False.
 # todo_link_only = False
+
+# Hide the class and module name on the right sidebar to prevent wrapping
+toc_object_entries_show_parents = "hide"


### PR DESCRIPTION
Fixes #2715.
I set the Sphinx [toc_object_entries_show_parents](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-toc_object_entries_show_parents) config option to "hide" to fix the bad wrapping on longer element names.

Before:
![default](https://github.com/user-attachments/assets/e55f1ef9-ae62-4df6-aa22-c8f2bf1892ac)
After:
![hide_parents](https://github.com/user-attachments/assets/ce10ad4d-d780-46ad-8a03-1e2e0090224a)

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
