### PR TITLE
Added robots.txt to disallow older version docs.

### DIFF
--- a/changes/2708.misc.rst
+++ b/changes/2708.misc.rst
@@ -1,0 +1,2 @@
+Add a robots.txt to disallow search engines to show unstable docs versions.
+Created a new folder for it and configured Sphinx to find it.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -372,3 +372,5 @@ todo_include_todos = True
 
 # If this is True, todolist produce output without file path and line, The default is False.
 # todo_link_only = False
+
+html_extra_path = ["extra"]

--- a/docs/extra/robots.txt
+++ b/docs/extra/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Disallow: /en/latest/
+Disallow: /en/v*
+Allow: /en/stable/


### PR DESCRIPTION
Fixes #2708.
Added a robots.txt file in a new folder to disallow older version docs to show up in search engines. I used Sphinx config option [html_extra_path](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_extra_path) to add the new folder.
I think it makes sense to create a new folder for this, since it can also hold a custom sitemap file, if we decide to add one in the future. However I am open to suggestions on this.
I tested the docs locally and it serves the robots.txt just fine.
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
