### PR TITLE
Modify startup on Windows and macOS so event loop is running when startup is called

### DIFF
--- a/changes/2834.bugfix.rst
+++ b/changes/2834.bugfix.rst
@@ -1,0 +1,1 @@
+The event loop is now guaranteed to be running when your app's `startup()` method is invoked. This wasn't previously the case on macOS and Windows.

--- a/changes/2834.bugfix.rst
+++ b/changes/2834.bugfix.rst
@@ -1,1 +1,1 @@
-The event loop is now guaranteed to be running when your app's `startup()` method is invoked. This wasn't previously the case on macOS and Windows.
+The event loop is now guaranteed to be running when your app's ``startup()`` method is invoked. This wasn't previously the case on macOS and Windows.

--- a/cocoa/src/toga_cocoa/app.py
+++ b/cocoa/src/toga_cocoa/app.py
@@ -107,8 +107,8 @@ class App:
         # Create the lookup table for commands and menu items
         self._menu_items = {}
 
-        # Call user code to populate the main window
-        self.interface._startup()
+        # Populate the main window as soon as the event loop is running.
+        self.loop.call_soon_threadsafe(self.interface._startup)
 
     ######################################################################
     # Commands and menus

--- a/examples/handlers/handlers/app.py
+++ b/examples/handlers/handlers/app.py
@@ -44,7 +44,7 @@ class HandlerApp(toga.App):
         self.async_label.text = "Ready."
         widget.enabled = True
 
-    async def do_background_task(self, widget, **kwargs):
+    async def do_background_task(self):
         """A background task."""
         # This task runs in the background, without blocking the main event loop
         while True:
@@ -64,7 +64,7 @@ class HandlerApp(toga.App):
 
         # Add a background task.
         self.counter = 0
-        self.add_background_task(self.do_background_task)
+        asyncio.create_task(self.do_background_task())
 
         # Buttons
         btn_style = Pack(flex=1)

--- a/winforms/src/toga_winforms/app.py
+++ b/winforms/src/toga_winforms/app.py
@@ -123,8 +123,8 @@ class App:
                 "You may experience difficulties accessing some web server content."
             )
 
-        # Call user code to populate the main window
-        self.interface._startup()
+        # Populate the main window as soon as the event loop is running.
+        self.loop.call_soon_threadsafe(self.interface._startup)
 
     ######################################################################
     # Commands and menus


### PR DESCRIPTION
Modifies the startup sequence of Windows and macOS apps so that the event loop is guaranteed to be running at the point startup is invoked. This ensures it is possible to call `asyncio.create_task()`.

This isn't an issue on other platforms:
* On GTK, startup is triggered by the GTK app's `activate` message, which requires the app loop is running
* On iOS, startup is triggered by the receipt of the `application:didFinishLaunchingWithOptions:` selector on the AppDelegate, which requires the app loop is running
* On Android, startup is triggered explicitly when the main loop is started; but the main loop is cooperative, based on the Java context handling events.
* On Web, there's no explicit event loop creation; asyncio works as soon as the interpreter has started.
* On Textual, the app isn't created until the app itself is mounted.

Fixes #2834.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
