### PR TITLE
Updated the ActivityIndicator tests to also check for visibility when…

### DIFF
--- a/changes/2838.misc.rst
+++ b/changes/2838.misc.rst
@@ -1,0 +1,1 @@
+The ActivityIndicator tests now check for the correct visibility behavior when started and stopped.

--- a/cocoa/tests_backend/widgets/activityindicator.py
+++ b/cocoa/tests_backend/widgets/activityindicator.py
@@ -5,3 +5,7 @@ from .base import SimpleProbe
 
 class ActivityIndicatorProbe(SimpleProbe):
     native_class = NSProgressIndicator
+
+    @property
+    def is_hidden(self):
+        return self.native.isHidden()

--- a/gtk/tests_backend/widgets/activityindicator.py
+++ b/gtk/tests_backend/widgets/activityindicator.py
@@ -5,3 +5,7 @@ from .base import SimpleProbe
 
 class ActivityIndicatorProbe(SimpleProbe):
     native_class = Gtk.Spinner
+
+    @property
+    def is_hidden(self):
+        return not self.native.get_visible()

--- a/iOS/tests_backend/widgets/activityindicator.py
+++ b/iOS/tests_backend/widgets/activityindicator.py
@@ -5,3 +5,7 @@ from .base import SimpleProbe
 
 class ActivityIndicatorProbe(SimpleProbe):
     native_class = UIActivityIndicatorView
+
+    @property
+    def is_hidden(self):
+        return self.native.isHidden()

--- a/testbed/tests/widgets/test_activityindicator.py
+++ b/testbed/tests/widgets/test_activityindicator.py
@@ -19,7 +19,6 @@ async def test_start_stop(widget, probe):
     "The activity indicator can be started and stopped"
     # Widget should be initially stopped
     assert not widget.is_running
-    assert probe.is_hidden
 
     widget.start()
     await probe.redraw("Activity Indicator should be started")

--- a/testbed/tests/widgets/test_activityindicator.py
+++ b/testbed/tests/widgets/test_activityindicator.py
@@ -19,18 +19,21 @@ async def test_start_stop(widget, probe):
     "The activity indicator can be started and stopped"
     # Widget should be initially stopped
     assert not widget.is_running
+    assert probe.is_hidden
 
     widget.start()
     await probe.redraw("Activity Indicator should be started")
 
     # Widget should now be started
     assert widget.is_running
+    assert not probe.is_hidden
 
     widget.stop()
     await probe.redraw("Activity Indicator should be stopped")
 
     # Widget should now be stopped
     assert not widget.is_running
+    assert probe.is_hidden
 
 
 async def test_fixed_square_widget_size(widget, probe):


### PR DESCRIPTION
… started and stopped

Updates the tests (based on https://github.com/beeware/toga/pull/2829 review comments) to include visibility checks when testing the start/stop function of the ActivityIndicator widget

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
