### PR TITLE
Ensure that the top bar size is included in iOS layout calculations.

### DIFF
--- a/android/tests_backend/window.py
+++ b/android/tests_backend/window.py
@@ -1,3 +1,4 @@
+from android.content import Context
 from androidx.appcompat import R as appcompat_R
 
 from .dialogs import DialogsMixin
@@ -19,6 +20,16 @@ class WindowProbe(BaseProbe, DialogsMixin):
             self.root_view.getWidth() / self.scale_factor,
             self.root_view.getHeight() / self.scale_factor,
         )
+
+    @property
+    def top_bar_height(self):
+        # Android doesn't require explicit allowances for the top bar in content layout;
+        # the size of the top bar is the difference between the screen and the root
+        # window content size.
+        context = self.app._impl.native.getApplicationContext()
+        window_manager = context.getSystemService(Context.WINDOW_SERVICE)
+        display = window_manager.getDefaultDisplay()
+        return (display.getHeight() - self.root_view.getHeight()) / self.scale_factor
 
     def _native_menu(self):
         return self.native.findViewById(appcompat_R.id.action_bar).getMenu()

--- a/changes/2836.bugfix.rst
+++ b/changes/2836.bugfix.rst
@@ -1,0 +1,1 @@
+iOS apps now correctly account for the size of the navigation bar when laying out app content.

--- a/iOS/src/toga_iOS/container.py
+++ b/iOS/src/toga_iOS/container.py
@@ -78,7 +78,7 @@ class Container(BaseContainer):
 
     @property
     def height(self):
-        return self.layout_native.bounds.size.height
+        return self.layout_native.bounds.size.height - self.top_offset
 
     @property
     def top_offset(self):
@@ -148,11 +148,6 @@ class RootContainer(Container):
 
         # Set the controller's view to be the root content widget
         self.controller.view = self.native
-
-    # The testbed app won't instantiate a simple app, so we can't test these properties
-    @property
-    def height(self):  # pragma: no cover
-        return self.layout_native.bounds.size.height - self.top_offset
 
     # The testbed app won't instantiate a simple app, so we can't test these properties
     @property

--- a/iOS/tests_backend/window.py
+++ b/iOS/tests_backend/window.py
@@ -30,5 +30,12 @@ class WindowProbe(BaseProbe, DialogsMixin):
             ),
         )
 
+    @property
+    def top_bar_height(self):
+        return (
+            UIApplication.sharedApplication.statusBarFrame.size.height
+            + self.native.rootViewController.navigationBar.frame.size.height
+        )
+
     def has_toolbar(self):
         pytest.skip("Toolbars not implemented on iOS")

--- a/testbed/tests/app/test_mobile.py
+++ b/testbed/tests/app/test_mobile.py
@@ -1,12 +1,30 @@
 import pytest
 
 import toga
+from toga.colors import REBECCAPURPLE
+from toga.style import Pack
 
 ####################################################################################
 # Mobile platform tests
 ####################################################################################
 if toga.platform.current_platform not in {"iOS", "android"}:
     pytest.skip("Test is specific to desktop platforms", allow_module_level=True)
+
+
+async def test_content_size(app, main_window, main_window_probe):
+    """The content size doesn't spill outsize the viewable area."""
+
+    box = toga.Box(style=Pack(background_color=REBECCAPURPLE))
+    main_window.content = box
+
+    await main_window_probe.redraw("Content is a box")
+
+    # The overall layout has both the box, plus the top bar.
+    assert main_window.screen.size.height >= (
+        box.layout.content_height + main_window_probe.top_bar_height
+    )
+    # The box is the same width as the screen.
+    assert main_window.screen.size.width == box.layout.content_width
 
 
 async def test_show_hide_cursor(app):


### PR DESCRIPTION
As part of the introduction of simple apps in #2649, the handling of containers on iOS was refactored to introduce NavigationContainer (which has a navigation bar) as distinct from RootContainer (which doesn't). However, this refactor inadvertently altered the calculation of the available height of the container in the NavigationContainer case to *not* include the height of the navigation bar itself. The mechansim to compute the top bar height was present - but due to inheritance, the top bar height wasn't subtracted from the container height.

This restores the use of top bar height in container calculations, and adds a testbed test to ensure that content fits in the available area in mobile layouts.

Fixes #2836.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
