### PR TITLE
Correct leaks on Switch and Divider on iOS.

### DIFF
--- a/changes/2849.bugfix.rst
+++ b/changes/2849.bugfix.rst
@@ -1,0 +1,1 @@
+A memory leak when using Divider or Switch widgets on iOS was resolved.

--- a/iOS/src/toga_iOS/widgets/box.py
+++ b/iOS/src/toga_iOS/widgets/box.py
@@ -1,11 +1,20 @@
+from rubicon.objc import objc_property
 from travertino.size import at_least
 
 from toga_iOS.libs import UIView
 from toga_iOS.widgets.base import Widget
 
 
+class TogaView(UIView):
+    interface = objc_property(object, weak=True)
+    impl = objc_property(object, weak=True)
+
+
 class Box(Widget):
     def create(self):
+        # This should be a TogaView - but making it a TogaView causes segfaults when
+        # content is added and removed from containers like OptionContainer and
+        # ScrollContainer.
         self.native = UIView.alloc().init()
         self.native.interface = self.interface
         self.native.impl = self

--- a/iOS/src/toga_iOS/widgets/divider.py
+++ b/iOS/src/toga_iOS/widgets/divider.py
@@ -1,12 +1,14 @@
 from travertino.size import at_least
 
-from toga_iOS.libs import UIColor, UIView
+from toga_iOS.libs import UIColor
 from toga_iOS.widgets.base import Widget
+
+from .box import TogaView
 
 
 class Divider(Widget):
     def create(self):
-        self.native = UIView.alloc().init()
+        self.native = TogaView.alloc().init()
         self.native.interface = self.interface
         self.native.impl = self
 

--- a/iOS/src/toga_iOS/widgets/switch.py
+++ b/iOS/src/toga_iOS/widgets/switch.py
@@ -13,6 +13,11 @@ from toga_iOS.libs import (
 from toga_iOS.widgets.base import Widget
 
 
+class TogaStackView(UIStackView):
+    interface = objc_property(object, weak=True)
+    impl = objc_property(object, weak=True)
+
+
 class TogaSwitch(UISwitch):
     interface = objc_property(object, weak=True)
     impl = objc_property(object, weak=True)
@@ -26,7 +31,7 @@ class Switch(Widget):
     SPACING = 10
 
     def create(self):
-        self.native = UIStackView.alloc().init()
+        self.native = TogaStackView.alloc().init()
         self.native.interface = self.interface
         self.native.impl = self
         self.native.axis = UILayoutConstraintAxis.Horizontal

--- a/testbed/tests/widgets/test_divider.py
+++ b/testbed/tests/widgets/test_divider.py
@@ -16,7 +16,7 @@ async def widget():
     return toga.Divider()
 
 
-test_cleanup = build_cleanup_test(toga.Divider, xfail_platforms=("iOS",))
+test_cleanup = build_cleanup_test(toga.Divider)
 
 
 async def test_directions(widget, probe):

--- a/testbed/tests/widgets/test_switch.py
+++ b/testbed/tests/widgets/test_switch.py
@@ -29,7 +29,7 @@ async def widget():
 
 
 test_cleanup = build_cleanup_test(
-    toga.Switch, args=("Hello",), xfail_platforms=("android", "iOS", "linux")
+    toga.Switch, args=("Hello",), xfail_platforms=("android", "linux")
 )
 
 


### PR DESCRIPTION
The Switch and Divider widgets on iOS  were keeping hard references to the underlying impl/interface, causing leaks.

The same fix *should* be possible on Box as well... but making the change causes a segfault on OptionContainer and ScrollContainer tests. The fix wasn't obvious; I figured it's better to live with the existing leak for now, and fix the leak where we know it exists. There's likely some overlap with the consequences of beeware/rubicon-objc#256.

Refs #2849.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
