### PR TITLE
cocoa: fix default icon search when standalone app is not an .app bundle

### DIFF
--- a/changes/2852.bugfix.rst
+++ b/changes/2852.bugfix.rst
@@ -1,0 +1,1 @@
+Fix default icon search in standalone/frozen macOS applications that are not built as .app bundles (e.g., POSIX build made with PyInstaller).

--- a/changes/2852.bugfix.rst
+++ b/changes/2852.bugfix.rst
@@ -1,1 +1,1 @@
-Fix default icon search in standalone/frozen macOS applications that are not built as .app bundles (e.g., POSIX build made with PyInstaller).
+Apps bundled as standalone frozen binaries (e.g., POSIX builds made with PyInstaller) no longer crash on startup when trying to resolve the app icon.

--- a/cocoa/src/toga_cocoa/icons.py
+++ b/cocoa/src/toga_cocoa/icons.py
@@ -18,11 +18,14 @@ class Icon:
             # as an indicator that this is the app's default icon.
             # This bundle icon file definition might not contain an extension,
             # even thought the actual file will; so force the .icns extension.
-            bundle_icon = Path(
-                NSBundle.mainBundle.objectForInfoDictionaryKey("CFBundleIconFile")
+            bundle_icon = NSBundle.mainBundle.objectForInfoDictionaryKey(
+                "CFBundleIconFile"
             )
+            if bundle_icon is None:
+                # Not an .app bundle (e.g., POSIX build made with PyInstaller)
+                raise FileNotFoundError()  # pragma: no cover
             path = NSBundle.mainBundle.pathForResource(
-                bundle_icon.stem,
+                Path(bundle_icon).stem,
                 ofType=".icns",
             )
             # If the icon file doesn't exist, raise the problem as FileNotFoundError

--- a/cocoa/src/toga_cocoa/icons.py
+++ b/cocoa/src/toga_cocoa/icons.py
@@ -23,6 +23,7 @@ class Icon:
             )
             if bundle_icon is None:
                 # Not an .app bundle (e.g., POSIX build made with PyInstaller)
+                # This can't be tested as the testbed app is bundled by Briefcase.
                 raise FileNotFoundError()  # pragma: no cover
             path = NSBundle.mainBundle.pathForResource(
                 Path(bundle_icon).stem,


### PR DESCRIPTION
When trying to obtain the default application icon in macOS standalone application by querying `CFBundleIconFile` key, account for possibility that application is not built as an .app bundle. I.e., ensure that the returned string is not `None` before trying to construct `pathlib.Path` with it. If returned string is `None`, raise `FileNotFoundError`, which is handled by the calling layer.

This fixes `TypeError: argument should be a str or an os.PathLike object where __fspath__ returns a str, not 'NoneType'` error when application has no icon set and PyInstaller is used to build a POSIX executable (as opposed to an .app bundle).

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
