### PR TITLE
Resolve remaining iOS widget memory leaks.

### DIFF
--- a/changes/2849.bugfix.rst
+++ b/changes/2849.bugfix.rst
@@ -1,1 +1,1 @@
-A memory leak when using Divider or Switch widgets on iOS was resolved.
+Widgets on the iOS backend no longer leak memory when destroyed.

--- a/iOS/src/toga_iOS/constraints.py
+++ b/iOS/src/toga_iOS/constraints.py
@@ -34,10 +34,15 @@ class Constraints:
     def _remove_constraints(self):
         if self.container:
             # print(f"Remove constraints for {self.widget} in {self.container}")
-            self.container.native.removeConstraint(self.width_constraint)
-            self.container.native.removeConstraint(self.height_constraint)
-            self.container.native.removeConstraint(self.left_constraint)
-            self.container.native.removeConstraint(self.top_constraint)
+            # Due to the unpredictability of garbage collection, it's possible for
+            # the native object of the window's container to be deleted on the ObjC
+            # side before the constraints for the window have been removed. Protect
+            # against this possibility.
+            if self.container.native:
+                self.container.native.removeConstraint(self.width_constraint)
+                self.container.native.removeConstraint(self.height_constraint)
+                self.container.native.removeConstraint(self.left_constraint)
+                self.container.native.removeConstraint(self.top_constraint)
 
             self.width_constraint.release()
             self.height_constraint.release()

--- a/iOS/src/toga_iOS/container.py
+++ b/iOS/src/toga_iOS/container.py
@@ -72,6 +72,11 @@ class Container(BaseContainer):
 
         self.layout_native = self.native if layout_native is None else layout_native
 
+    def __del__(self):
+        # Mark the contained native object as explicitly None so that the
+        # constraints know the object has been deleted.
+        self.native = None
+
     @property
     def width(self):
         return self.layout_native.bounds.size.width

--- a/iOS/src/toga_iOS/widgets/box.py
+++ b/iOS/src/toga_iOS/widgets/box.py
@@ -12,10 +12,7 @@ class TogaView(UIView):
 
 class Box(Widget):
     def create(self):
-        # This should be a TogaView - but making it a TogaView causes segfaults when
-        # content is added and removed from containers like OptionContainer and
-        # ScrollContainer.
-        self.native = UIView.alloc().init()
+        self.native = TogaView.alloc().init()
         self.native.interface = self.interface
         self.native.impl = self
 

--- a/iOS/src/toga_iOS/widgets/selection.py
+++ b/iOS/src/toga_iOS/widgets/selection.py
@@ -12,9 +12,15 @@ from toga_iOS.libs import (
 from toga_iOS.widgets.base import Widget
 
 
+class TogaBaseTextField(UITextField):
+    interface = objc_property(object, weak=True)
+    impl = objc_property(object, weak=True)
+
+
 class TogaPickerView(UIPickerView):
     interface = objc_property(object, weak=True)
     impl = objc_property(object, weak=True)
+    native = objc_property(object, weak=True)
 
     @objc_method
     def numberOfComponentsInPickerView_(self, pickerView) -> int:
@@ -53,7 +59,7 @@ class TogaPickerView(UIPickerView):
 
 class Selection(Widget):
     def create(self):
-        self.native = UITextField.alloc().init()
+        self.native = TogaBaseTextField.alloc().init()
         self.native.interface = self.interface
         self.native.impl = self
         self.native.tintColor = UIColor.clearColor

--- a/testbed/tests/widgets/test_box.py
+++ b/testbed/tests/widgets/test_box.py
@@ -18,4 +18,4 @@ async def widget():
     return toga.Box(style=Pack(width=100, height=200))
 
 
-test_cleanup = build_cleanup_test(toga.Box, xfail_platforms=("iOS",))
+test_cleanup = build_cleanup_test(toga.Box)

--- a/testbed/tests/widgets/test_imageview.py
+++ b/testbed/tests/widgets/test_imageview.py
@@ -19,7 +19,7 @@ async def widget():
 
 
 test_cleanup = build_cleanup_test(
-    toga.ImageView, kwargs={"image": "resources/sample.png"}, xfail_platforms=("iOS",)
+    toga.ImageView, kwargs={"image": "resources/sample.png"}
 )
 
 

--- a/testbed/tests/widgets/test_optioncontainer.py
+++ b/testbed/tests/widgets/test_optioncontainer.py
@@ -76,7 +76,7 @@ test_cleanup = build_cleanup_test(
     # Pass a function here to prevent init of toga.Box() in a different thread than
     # toga.OptionContainer. This would raise a runtime error on Windows.
     lambda: toga.OptionContainer(content=[("Tab 1", toga.Box())]),
-    xfail_platforms=("android", "iOS", "linux"),
+    xfail_platforms=("android", "linux"),
 )
 
 

--- a/testbed/tests/widgets/test_scrollcontainer.py
+++ b/testbed/tests/widgets/test_scrollcontainer.py
@@ -77,7 +77,7 @@ test_cleanup = build_cleanup_test(
     # Pass a function here to prevent init of toga.Box() in a different thread than
     # toga.ScrollContainer. This would raise a runtime error on Windows.
     lambda: toga.ScrollContainer(content=toga.Box()),
-    xfail_platforms=("android", "iOS", "linux"),
+    xfail_platforms=("android", "linux"),
 )
 
 

--- a/testbed/tests/widgets/test_selection.py
+++ b/testbed/tests/widgets/test_selection.py
@@ -55,7 +55,7 @@ def verify_vertical_alignment():
 test_cleanup = build_cleanup_test(
     toga.Selection,
     kwargs={"items": ["first", "second", "third"]},
-    xfail_platforms=("android", "iOS", "windows"),
+    xfail_platforms=("android", "windows"),
 )
 
 


### PR DESCRIPTION
A follow up to #2850; this resolves the remaining widget memory leaks on iOS.

The underlying issue is one that has been previously solved on macOS, but the fix wasn't ported to iOS. Constraint objects are ObjC instances that are referenced by ObjC widgets; however, if the underlying widget is garbage collected before the constraint, the widget reference no longer exists, and so it can't be removed from the constraint. This causes a segfault when the constraint is disposed. 

macOS added a fix for this some time ago; but the same fix wasn't applied to iOS. This ports the fix over to iOS, which then in turn allows the remaining iOS memory leaks to be resolved.

Refs #2849.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
