### PR TITLE
Fix document mode on macOS

### DIFF
--- a/changes/2860.bugfix.rst
+++ b/changes/2860.bugfix.rst
@@ -1,1 +1,1 @@
-Apps that specify both `document_types` and a `main_window` no longer display the "Document Selection" dialog on startup in macOS.
+On macOS, apps that specify both `document_types` and a `main_window` no longer display the document selection dialog on startup.

--- a/changes/2860.bugfix.rst
+++ b/changes/2860.bugfix.rst
@@ -1,0 +1,1 @@
+Apps that specify both `document_types` and a `main_window` no longer display the "Document Selection" dialog on startup in macOS.

--- a/cocoa/src/toga_cocoa/app.py
+++ b/cocoa/src/toga_cocoa/app.py
@@ -54,7 +54,10 @@ class AppDelegate(NSObject):
 
     @objc_method
     def applicationShouldOpenUntitledFile_(self, sender) -> bool:
-        return bool(self.interface.documents.types)
+        if self.interface._main_window == toga.App._UNDEFINED:
+            return False
+        else:
+            return bool(self.interface.documents.types)
 
     @objc_method
     def application_openFiles_(self, app, filenames) -> None:

--- a/core/src/toga/app.py
+++ b/core/src/toga/app.py
@@ -493,14 +493,14 @@ class App:
 
         def factory(loop, coro, context=None):
             if platform_task_factory is not None:
-                if sys.version_info < (3, 11):
+                if sys.version_info < (3, 11):  # pragma: no-cover-if-gte-py311
                     task = platform_task_factory(loop, coro)
-                else:
+                else:  # pragma: no-cover-if-lt-py311
                     task = platform_task_factory(loop, coro, context=context)
             else:
-                if sys.version_info < (3, 11):
+                if sys.version_info < (3, 11):  # pragma: no-cover-if-gte-py311
                     task = asyncio.Task(coro, loop=loop)
-                else:
+                else:  # pragma: no-cover-if-lt-py311
                     task = asyncio.Task(coro, loop=loop, context=context)
 
             self._running_tasks.add(task)

--- a/core/src/toga/app.py
+++ b/core/src/toga/app.py
@@ -659,6 +659,15 @@ class App:
         # Create any initial windows
         self._create_initial_windows()
 
+        # If the app has document types but has no windows, then show an "Open Document"
+        # Dialog for the user to select a document.
+        if (
+            self.main_window is None
+            and len(self.windows) == 0
+            and self.documents.types != []
+        ):
+            asyncio.create_task(self.documents.request_open())
+
         # Manifest the initial state of the menus. This will cascade down to all
         # open windows if the platform has window-based menus. Then install the
         # on-change handler for menus to respond to any future changes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,8 @@ exclude_lines = [
 no-cover-if-missing-setuptools_scm = "not is_installed('setuptools_scm')"
 no-cover-if-missing-PIL = "not is_installed('PIL')"
 no-cover-if-PIL-installed = "is_installed('PIL')"
+no-cover-if-lt-py311 = "sys_version_info < (3, 11) and os_environ.get('COVERAGE_EXCLUDE_PYTHON_VERSION') != 'disable'"
+no-cover-if-gte-py311 = "sys_version_info > (3, 11) and os_environ.get('COVERAGE_EXCLUDE_PYTHON_VERSION') != 'disable'"
 no-cover-if-lt-py310 = "sys_version_info < (3, 10) and os_environ.get('COVERAGE_EXCLUDE_PYTHON_VERSION') != 'disable'"
 no-cover-if-gte-py310 = "sys_version_info > (3, 10) and os_environ.get('COVERAGE_EXCLUDE_PYTHON_VERSION') != 'disable'"
 no-cover-if-lt-py39 = "sys_version_info < (3, 9) and os_environ.get('COVERAGE_EXCLUDE_PYTHON_VERSION') != 'disable'"


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Apps that specify both `document_types` and a `main_window` no longer display the "Document Selection" dialog on startup in macOS.
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Fixes #2860
## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
