### PR TITLE
Deprecate Python 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ "macos-latest", "ubuntu-latest", "windows-latest" ]
-        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13-dev" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
         include:
         - experimental: false
 
@@ -90,6 +90,7 @@ jobs:
       uses: actions/setup-python@v5.2.0
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
 
     - name: Install Tox
       uses: beeware/.github/.github/actions/install-requirement@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,24 +75,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ "macos-12", "macos-14", "ubuntu-latest", "windows-latest" ]
-        python-version: [ "3.9", "3.12", "3.13-dev" ]
+        platform: [ "macos-latest", "ubuntu-latest", "windows-latest" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13-dev" ]
         include:
         - experimental: false
-        # Test Python 3.10, 3.11 on Ubuntu only
-        - platform: "ubuntu-latest"
-          python-version: "3.10"
-          experimental: false
-        - platform: "ubuntu-latest"
-          python-version: "3.11"
-          experimental: false
         # Allow development Python to fail without failing entire job.
         - python-version: "3.13-dev"
           experimental: true
-        exclude:
-        # Pillow isn't available for Python 3.13 on Windows
-        - platform: "windows-latest"
-          python-version: "3.13-dev"
+
     steps:
     - name: Checkout
       uses: actions/checkout@v4.2.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,9 +79,6 @@ jobs:
         python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13-dev" ]
         include:
         - experimental: false
-        # Allow development Python to fail without failing entire job.
-        - python-version: "3.13-dev"
-          experimental: true
 
     steps:
     - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ on:
         value: ${{ jobs.package.outputs.artifact-basename }}
 
 env:
-  min_python_version: "3.8"
+  min_python_version: "3.9"
   max_python_version: "3.12"
   FORCE_COLOR: "1"
 
@@ -76,13 +76,10 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ "macos-12", "macos-14", "ubuntu-latest", "windows-latest" ]
-        python-version: [ "3.8", "3.12", "3.13-dev" ]
+        python-version: [ "3.9", "3.12", "3.13-dev" ]
         include:
         - experimental: false
-        # Test Python 3.9-3.11 on Ubuntu only
-        - platform: "ubuntu-latest"
-          python-version: "3.9"
-          experimental: false
+        # Test Python 3.10, 3.11 on Ubuntu only
         - platform: "ubuntu-latest"
           python-version: "3.10"
           experimental: false
@@ -93,9 +90,6 @@ jobs:
         - python-version: "3.13-dev"
           experimental: true
         exclude:
-        # macos-14 (i.e. arm64) does not support Python 3.8
-        - platform: "macos-14"
-          python-version: "3.8"
         # Pillow isn't available for Python 3.13 on Windows
         - platform: "windows-latest"
           python-version: "3.13-dev"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     rev: v3.17.0
     hooks:
       - id: pyupgrade
-        args: [--py38-plus]
+        args: [--py39-plus]
   - repo: https://github.com/PyCQA/isort
     rev: 5.13.2
     hooks:

--- a/android/pyproject.toml
+++ b/android/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = ["version", "dependencies"]
 name = "toga-android"
 description = "An Android backend for the Toga widget toolkit."
 readme = "README.rst"
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 license.text = "New BSD"
 authors = [
     {name="Russell Keith-Magee", email="russell@keith-magee.com"},
@@ -33,7 +33,6 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/changes/2888.removal.rst
+++ b/changes/2888.removal.rst
@@ -1,0 +1,1 @@
+Toga no longer supports Python 3.8.

--- a/cocoa/pyproject.toml
+++ b/cocoa/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = ["version", "dependencies"]
 name = "toga-cocoa"
 description = "A Cocoa (macOS) backend for the Toga widget toolkit."
 readme = "README.rst"
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 license.text = "New BSD"
 authors = [
     {name="Russell Keith-Magee", email="russell@keith-magee.com"},
@@ -34,7 +34,6 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/core/README.rst
+++ b/core/README.rst
@@ -10,13 +10,14 @@ install a backend that implements the core Toga API for that platform:
 * **iOS** `toga-iOS <https://pypi.org/project/toga-iOS>`__
 * **Linux** `toga-gtk <https://pypi.org/project/toga-gtk>`__
 * **macOS** `toga-cocoa <https://pypi.org/project/toga-cocoa>`__
+* **Textual** `toga-textual <https://pypi.org/project/toga-textual>`__
 * **Web** `toga-web <https://pypi.org/project/toga-web>`__
 * **Windows** `toga-winforms <https://pypi.org/project/toga-winforms>`__
 
 Minimum requirements
 --------------------
 
-Toga requires **Python 3.8** or newer. Python 2 is not supported.
+Toga requires **Python 3.9** or newer. Python 2 is not supported.
 
 Each backend also has specific requirements and pre-requisites. See the `platform
 documentation <https://toga.readthedocs.io/en/latest/reference/platforms.html>`__ for

--- a/core/README.rst
+++ b/core/README.rst
@@ -17,7 +17,7 @@ install a backend that implements the core Toga API for that platform:
 Minimum requirements
 --------------------
 
-Toga requires **Python 3.9** or newer. Python 2 is not supported.
+Toga requires **Python 3.9** or newer.
 
 Each backend also has specific requirements and pre-requisites. See the `platform
 documentation <https://toga.readthedocs.io/en/latest/reference/platforms.html>`__ for

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = ["version"]
 name = "toga-core"
 description = "A Python native, OS native GUI toolkit."
 readme = "README.rst"
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 license.text = "New BSD"
 authors = [
     {name="Russell Keith-Magee", email="russell@keith-magee.com"},
@@ -45,7 +45,6 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -69,9 +68,7 @@ dev = [
     "coverage[toml] == 7.6.1",
     "coverage-conditional-plugin == 0.9.0",
     "Pillow == 10.4.0",
-    # Pre-commit 3.6.0 deprecated support for Python 3.8
-    "pre-commit == 3.5.0 ; python_version < '3.9'",
-    "pre-commit == 4.0.0 ; python_version >= '3.9'",
+    "pre-commit == 4.0.0",
     "pytest == 8.3.3",
     "pytest-asyncio == 0.24.0",
     "pytest-freezer == 0.4.8",

--- a/core/src/toga/command.py
+++ b/core/src/toga/command.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import Iterator
-from typing import TYPE_CHECKING, MutableMapping, MutableSet, Protocol
+from collections.abc import Iterator, MutableMapping, MutableSet
+from typing import TYPE_CHECKING, Protocol
 
 from toga.handlers import simple_handler, wrapped_handler
 from toga.icons import Icon

--- a/core/src/toga/documents.py
+++ b/core/src/toga/documents.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import itertools
+import sys
 from abc import ABC, abstractmethod
 from collections.abc import Iterator, Mapping, Sequence
 from pathlib import Path
@@ -224,7 +225,12 @@ class DocumentSet(Sequence[Document], Mapping[Path, Document]):
             return self.elements[path_or_index]
 
         # Look up by path
-        path = Path(path_or_index).resolve()
+        if sys.version_info < (3, 10):  # pragma: no-cover-if-gte-py310
+            # resolve() *should* turn the path into an absolute path;
+            # but on Windows, with Python 3.9, it doesn't.
+            path = Path(path_or_index).absolute().resolve()
+        else:  # pragma: no-cover-if-lt-py310
+            path = Path(path_or_index).resolve()
         for item in self.elements:
             if item.path == path:
                 return item
@@ -314,7 +320,12 @@ class DocumentSet(Sequence[Document], Mapping[Path, Document]):
             match a registered document type.
         """
         try:
-            path = Path(path).resolve()
+            if sys.version_info < (3, 10):  # pragma: no-cover-if-gte-py310
+                # resolve() *should* turn the path into an absolute path;
+                # but on Windows, with Python 3.9, it doesn't.
+                path = Path(path).absolute().resolve()
+            else:  # pragma: no-cover-if-lt-py310
+                path = Path(path).resolve()
             document = self.app.documents[path]
             document.focus()
             return document

--- a/core/src/toga/documents.py
+++ b/core/src/toga/documents.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
 import itertools
-import sys
 from abc import ABC, abstractmethod
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping, Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Mapping, Sequence
+from typing import TYPE_CHECKING
 
 import toga
 from toga import dialogs
@@ -225,12 +224,7 @@ class DocumentSet(Sequence[Document], Mapping[Path, Document]):
             return self.elements[path_or_index]
 
         # Look up by path
-        if sys.version_info < (3, 9):  # pragma: no-cover-if-gte-py39
-            # resolve() *should* turn the path into an absolute path;
-            # but on Windows, with Python 3.8, it doesn't.
-            path = Path(path_or_index).absolute().resolve()
-        else:  # pragma: no-cover-if-lt-py39
-            path = Path(path_or_index).resolve()
+        path = Path(path_or_index).resolve()
         for item in self.elements:
             if item.path == path:
                 return item
@@ -320,12 +314,7 @@ class DocumentSet(Sequence[Document], Mapping[Path, Document]):
             match a registered document type.
         """
         try:
-            if sys.version_info < (3, 9):  # pragma: no-cover-if-gte-py39
-                # resolve() *should* turn the path into an absolute path;
-                # but on Windows, with Python 3.8, it doesn't.
-                path = Path(path).absolute().resolve()
-            else:  # pragma: no-cover-if-lt-py39
-                path = Path(path).resolve()
+            path = Path(path).resolve()
             document = self.app.documents[path]
             document.focus()
             return document

--- a/core/src/toga/handlers.py
+++ b/core/src/toga/handlers.py
@@ -6,12 +6,11 @@ import sys
 import traceback
 import warnings
 from abc import ABC
+from collections.abc import Awaitable, Generator
 from typing import (
     TYPE_CHECKING,
     Any,
-    Awaitable,
     Callable,
-    Generator,
     NoReturn,
     Protocol,
     TypeVar,

--- a/core/src/toga/sources/tree_source.py
+++ b/core/src/toga/sources/tree_source.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import Iterator
-from typing import Iterable, Mapping, TypeVar
+from collections.abc import Iterable, Iterator, Mapping
+from typing import TypeVar
 
 from .base import Source
 from .list_source import Row, _find_item

--- a/core/src/toga/statusicons.py
+++ b/core/src/toga/statusicons.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import sys
 from abc import abstractmethod
-from collections.abc import Iterator
-from typing import TYPE_CHECKING, Mapping, Sequence
+from collections.abc import Iterator, Mapping, Sequence
+from typing import TYPE_CHECKING
 
 import toga
 from toga.command import Command, CommandSet, Group

--- a/core/src/toga/window.py
+++ b/core/src/toga/window.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import warnings
 from builtins import id as identifier
-from collections.abc import Coroutine, Iterator
+from collections.abc import Coroutine, Iterator, MutableSet
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, MutableSet, Protocol, TypeVar
+from typing import TYPE_CHECKING, Any, Protocol, TypeVar
 
 import toga
 from toga import dialogs

--- a/demo/pyproject.toml
+++ b/demo/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = ["version", "dependencies"]
 name = "toga-demo"
 description = "A demonstration of the capabilities of the Toga widget toolkit."
 readme = "README.rst"
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 license.text = "New BSD"
 authors = [
     {name="Russell Keith-Magee", email="russell@keith-magee.com"},
@@ -40,7 +40,6 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/dummy/pyproject.toml
+++ b/dummy/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = ["version", "dependencies"]
 name = "toga-dummy"
 description = "A dummy testing backend for the Toga widget toolkit."
 readme = "README.rst"
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 license.text = "New BSD"
 authors = [
     {name="Russell Keith-Magee", email="russell@keith-magee.com"},
@@ -32,7 +32,6 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/gtk/pyproject.toml
+++ b/gtk/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = ["version", "dependencies"]
 name = "toga-gtk"
 description = "A GTK backend for the Toga widget toolkit."
 readme = "README.rst"
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 license.text = "New BSD"
 authors = [
     {name="Russell Keith-Magee", email="russell@keith-magee.com"},
@@ -35,7 +35,6 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/iOS/pyproject.toml
+++ b/iOS/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = ["version", "dependencies"]
 name = "toga-iOS"
 description = "An iOS backend for the Toga widget toolkit."
 readme = "README.rst"
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 license.text = "New BSD"
 authors = [
     {name="Russell Keith-Magee", email="russell@keith-magee.com"},
@@ -33,7 +33,6 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,9 +42,6 @@ no-cover-if-lt-py311 = "sys_version_info < (3, 11) and os_environ.get('COVERAGE_
 no-cover-if-gte-py311 = "sys_version_info > (3, 11) and os_environ.get('COVERAGE_EXCLUDE_PYTHON_VERSION') != 'disable'"
 no-cover-if-lt-py310 = "sys_version_info < (3, 10) and os_environ.get('COVERAGE_EXCLUDE_PYTHON_VERSION') != 'disable'"
 no-cover-if-gte-py310 = "sys_version_info > (3, 10) and os_environ.get('COVERAGE_EXCLUDE_PYTHON_VERSION') != 'disable'"
-no-cover-if-lt-py39 = "sys_version_info < (3, 9) and os_environ.get('COVERAGE_EXCLUDE_PYTHON_VERSION') != 'disable'"
-no-cover-if-gte-py39 = "sys_version_info > (3, 9) and os_environ.get('COVERAGE_EXCLUDE_PYTHON_VERSION') != 'disable'"
-
 
 [tool.isort]
 profile = "black"

--- a/textual/pyproject.toml
+++ b/textual/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = ["version", "dependencies"]
 name = "toga-textual"
 description = "A Textual backend for the Toga widget toolkit."
 readme = "README.rst"
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 license.text = "New BSD"
 authors = [
     {name="Russell Keith-Magee", email="russell@keith-magee.com"},
@@ -34,7 +34,6 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/toga/pyproject.toml
+++ b/toga/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = ["version", "dependencies"]
 name = "toga"
 description = "A Python native, OS native GUI toolkit."
 readme = "README.rst"
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 license.text = "New BSD"
 authors = [
     {name="Russell Keith-Magee", email="russell@keith-magee.com"},
@@ -45,7 +45,6 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/tox.ini
+++ b/tox.ini
@@ -7,17 +7,15 @@ extend-ignore =
     E203,
 
 [tox]
-# Add Python 3.13 once a wheel for Pillow is available
-envlist = py{38,39,310,311,312}-cov,coverage
+envlist = py{39,310,311,312,313}-cov,coverage
 labels =
     test = py-cov,coverage
-    test38 = py38-cov,coverage38
     test39 = py39-cov,coverage39
     test310 = py310-cov,coverage310
     test311 = py311-cov,coverage311
     test312 = py312-cov,coverage312
     test313 = py313-cov,coverage313
-    ci = towncrier-check,docs-lint,pre-commit,py{38,39,310,311,312}-cov,coverage-fail-platform
+    ci = towncrier-check,docs-lint,pre-commit,py{39,310,311,312,313}-cov,coverage-fail-platform
 skip_missing_interpreters = True
 
 [testenv:pre-commit]
@@ -27,7 +25,7 @@ deps =
 commands = pre-commit run --all-files --show-diff-on-failure --color=always
 
 # The leading comma generates the "py" environment
-[testenv:py{,38,39,310,311,312,313}{,-cov}]
+[testenv:py{,39,310,311,312,313}{,-cov}]
 depends = pre-commit
 changedir = core
 skip_install = True
@@ -42,14 +40,13 @@ commands =
     !cov: python -m pytest {posargs:-vv --color yes}
     cov : python -m coverage run -m pytest {posargs:-vv --color yes}
 
-[testenv:coverage{,38,39,310,311,312,313}{,-html}{,-keep}{,-fail}{,-platform}]
-depends = pre-commit,py{,38,39,310,311,312,313}{,-cov}
+[testenv:coverage{,39,310,311,312,313}{,-html}{,-keep}{,-fail}{,-platform}]
+depends = pre-commit,py{,39,310,311,312,313}{,-cov}
 changedir = core
 skip_install = True
 # by default, coverage should run on oldest supported Python for testing platform coverage.
 # however, coverage for a particular Python version should match the version used for pytest.
 base_python =
-    coverage38: py38
     coverage39: py39
     coverage310: py310
     coverage311: py311

--- a/web/pyproject.toml
+++ b/web/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = ["version", "dependencies"]
 name = "toga-web"
 description = "A Web backend for the Toga widget toolkit."
 readme = "README.rst"
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 license.text = "New BSD"
 authors = [
     {name="Russell Keith-Magee", email="russell@keith-magee.com"},
@@ -35,7 +35,6 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/winforms/pyproject.toml
+++ b/winforms/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = ["version", "dependencies"]
 name = "toga-winforms"
 description = "A Windows backend for the Toga widget toolkit using the WinForms API."
 readme = "README.rst"
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 license.text = "New BSD"
 authors = [
     {name="Russell Keith-Magee", email="russell@keith-magee.com"},
@@ -34,7 +34,6 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
Python 3.8 is EOL at the end of this month, and #2886 highlights that we've reached the point where maintaining dependencies for 3.8 is becoming increasingly problematic.

This PR bumps the minimum Python requirement for Toga to 3.9, and removes the Python 3.8 compatibility workarounds.

As part of this change, the CI matrix for core has been modified slightly. 

It turns out that we *do* need to run the test matrix on every version of Python - because we have conditional branches that are conditional on every version of Python on every platform. The "min and max only" testing approach was masking the fact that one of the conditional branches was using a "< 3.9" check, when it should have been a "< 3.10" check, because of a windows-specific issue.

However, we *don't* need to test core on both x86_64 and ARM64 macOS, as there is no logic in core that is architecture specific for macOS (or, for that matter, macOS version specific). x86_64 handling is still tested by the *testbed* - just not core.

Lastly, we can restore testing for Windows on Python 3.13 because a Pillow release is now available.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
