### PR TITLE
Speculative fix for intermittent Wayland issue.

### DIFF
--- a/changes/2871.bugfix.rst
+++ b/changes/2871.bugfix.rst
@@ -1,0 +1,1 @@
+An intermittent failure in the testbed focus tests under Wayland on Linux was resolved.

--- a/testbed/tests/widgets/properties.py
+++ b/testbed/tests/widgets/properties.py
@@ -63,6 +63,11 @@ async def test_focus(widget, probe, other, other_probe, verify_focus_handlers):
         widget.on_gain_focus = on_gain_handler
         widget.on_lose_focus = on_lose_handler
 
+    # Wayland seems to have an intermittent issue where focus can't be assigned
+    # immediately (See #2871). The working theory is that the widgets aren't quite
+    # ready to accept focus yet; wait for a moment to ensure the widget is ready.
+    await probe.redraw("Wait for the widgets to be ready", delay=0.1)
+
     other.focus()
     await probe.redraw("A separate widget should be given focus")
     assert not probe.has_focus
@@ -98,6 +103,11 @@ async def test_focus(widget, probe, other, other_probe, verify_focus_handlers):
 
 async def test_focus_noop(widget, probe, other, other_probe):
     "The widget cannot be given focus"
+    # Wayland seems to have an intermittent issue where focus can't be assigned
+    # immediately (See #2871). The working theory is that the widgets aren't quite
+    # ready to accept focus yet; wait for a moment to ensure the widget is ready.
+    await probe.redraw("Wait for the widgets to be ready", delay=0.1)
+
     other.focus()
     await probe.redraw("A separate widget should be given focus")
     assert not probe.has_focus

--- a/testbed/tests/widgets/properties.py
+++ b/testbed/tests/widgets/properties.py
@@ -65,7 +65,7 @@ async def ensure_initial_focus(widget, probe):
         widget.focus()
         await probe.redraw("A separate widget should be given focus")
 
-        if widget.has_focus:
+        if probe.has_focus:
             return
         else:
             attempt += 1


### PR DESCRIPTION
A speculative fix for the intermittent Wayland issue. Experimentally from #2873, the issue appears to be that *no* widget has focus as a result of the `other.focus()` call; one theory is that due to the timing on *some* machines, the "other" widget isn't *quite* ready to receive focus. Add a short delay before assigning focus to test that theory.

Fixes #2871.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
