### PR TITLE
For Wayland, run testbed on Ubuntu 24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,14 +232,15 @@ jobs:
 
         - backend: "linux-wayland"
           platform: "linux"
-          runs-on: "ubuntu-22.04"
+          runs-on: "ubuntu-24.04"
           # The package list should be the same as in tutorial-0.rst, and the BeeWare
-          # tutorial, plus mutter to provide a window manager, and libjpeg-dev for Pillow.
+          # tutorial, plus mutter to provide a window manager.
           pre-command: |
             sudo apt update -y
             sudo apt install -y --no-install-recommends \
               mutter pkg-config python3-dev libgirepository1.0-dev libcairo2-dev \
-              gir1.2-webkit2-4.1 gir1.2-xapp-1.0
+              gir1.2-webkit2-4.1 gir1.2-xapp-1.0 \
+              libjpeg-dev  # remove once the version of Pillow has a wheel on PyPI for Python 3.12
 
             # Start Virtual X Server
             echo "Start X server..."
@@ -333,6 +334,8 @@ jobs:
         python-version: "3.10"
 
     - name: Install Dependencies
+      env:
+        PIP_BREAK_SYSTEM_PACKAGES: "1"
       run: |
         ${{ matrix.pre-command }}
         # Use the development version of Briefcase

--- a/changes/2893.misc.rst
+++ b/changes/2893.misc.rst
@@ -1,0 +1,1 @@
+For Wayland, the testbed runs on Ubuntu 24.04 instead of Ubuntu 22.04.


### PR DESCRIPTION
## Changes
- Closes https://github.com/beeware/toga/issues/2871
- When I use a newer version of mutter locally, the issue goes away...
- Seven [successful runs](https://github.com/beeware/toga/actions/runs/11245617170/job/31267033524) with Ubuntu 24.04

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
