### PR TITLE
Update Android event loop integration for Py3.13.

### DIFF
--- a/android/src/toga_android/libs/events.py
+++ b/android/src/toga_android/libs/events.py
@@ -307,7 +307,8 @@ class AndroidSelector(selectors.SelectSelector):
     def reregister_with_android_soon(self, fileobj):
         def _reregister():
             # If the fileobj got unregistered, exit early.
-            key = self._key_from_fd(fileobj)
+            key = self._fd_to_key.get(fileobj)
+
             if key is None:  # pragma: no cover
                 if self._debug:
                     print(
@@ -344,7 +345,8 @@ class AndroidSelector(selectors.SelectSelector):
         """Accept a FD and the events that it is ready for (read and/or write).
 
         Filter the events to just those that are registered, then notify the loop."""
-        key = self._key_from_fd(fd)
+        key = self._fd_to_key.get(fd)
+
         if key is None:  # pragma: no cover
             print(
                 "Warning: handle_fd_wakeup: wakeup for unregistered fd={fd}".format(

--- a/changes/2907.bugfix.rst
+++ b/changes/2907.bugfix.rst
@@ -1,0 +1,1 @@
+The integration with Android's event loop has been updated to support Python 3.13.


### PR DESCRIPTION
Update the Android event loop integration to replace the use of an internal API that has changed in Python 3.13 with the underlying (also internal) API that has been backing the API that was removed all along.

Fixes #2907.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
