### PR TITLE
Proposal: Container Widgets as Context Managers

### DIFF
--- a/core/src/toga/widgets/box.py
+++ b/core/src/toga/widgets/box.py
@@ -8,6 +8,7 @@ from .base import StyleT, Widget
 class Box(Widget):
     _MIN_WIDTH = 0
     _MIN_HEIGHT = 0
+    _CONTEXT_MANAGER = True
 
     def __init__(
         self,
@@ -48,3 +49,6 @@ class Box(Widget):
     def focus(self) -> None:
         """No-op; Box cannot accept input focus."""
         pass
+
+    def _process_context(self, context: list[Widget]):
+        self.add(*context)


### PR DESCRIPTION
Take a gander at this and see if it looks like a direction you'd be interested in.

Inspired by the context-manager-based syntax shown in #118, and using techniques similar to those used by [PyMC](https://github.com/pymc-devs/pymc) as helpfully explained in [this StackOverflow question](https://stackoverflow.com/a/51849809/12975140) (credit where credit is due!), I've put together a quick proof of concept.

With these changes, this code from the [Slightly Less Toy Example](https://toga.readthedocs.io/en/stable/tutorial/tutorial-1.html) tutorial:

```python
c_input = toga.TextInput(readonly=True)
f_input = toga.TextInput()

c_label = toga.Label("Celsius", style=Pack(text_align=LEFT))
f_label = toga.Label("Fahrenheit", style=Pack(text_align=LEFT))
join_label = toga.Label("is equivalent to", style=Pack(text_align=RIGHT))

button = toga.Button("Calculate", on_press=calculate)

f_box.add(f_input)
f_box.add(f_label)

c_box.add(join_label)
c_box.add(c_input)
c_box.add(c_label)

box.add(f_box)
box.add(c_box)
box.add(button)
```

can become this:

```python
with toga.Box() as box:
    with toga.Box() as f_box:
        f_input = toga.TextInput()
        f_label = toga.Label("Fahrenheit", style=Pack(text_align=LEFT))

    with toga.Box() as c_box:
        join_label = toga.Label("is equivalent to", style=Pack(text_align=RIGHT))
        c_input = toga.TextInput(readonly=True)
        c_label = toga.Label("Celsius", style=Pack(text_align=LEFT))

    button = toga.Button("Calculate", on_press=calculate)
```

(The variable assignments aren't functionally necessary for what's shown here, but would still be needed if setting the styles afterward like in the tutorial.)

Personally I find it much easier to visually grok the structure in this form — much like in a declarative syntax (which keeps coming up), but in this case directly in Python, with no need to parse a DSL or process a data file.

I don't know if the thread-local storage is overkill or not... I'm not sure if people are likely to create widgets in multiple threads, or if that's even guaranteed to work in Toga as it is. And obviously decisions would have to be made about how to implement it for other widgets — particularly ScrollContainer, which would need a way to be given the flex values alongside the widgets. No sense going down all the roads before checking in though. Thoughts?

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
