### PR TITLE
Replacing lru_cache with cache, post-3.8

### DIFF
--- a/changes/2912.misc.rst
+++ b/changes/2912.misc.rst
@@ -1,0 +1,1 @@
+Use of functools.lru_cache has been replaced with functools.cache, now that Python 3.8 is no longer supported.

--- a/core/src/toga/images.py
+++ b/core/src/toga/images.py
@@ -4,7 +4,7 @@ import importlib
 import os
 import sys
 import warnings
-from functools import lru_cache
+from functools import cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, TypeVar
 from warnings import warn
@@ -155,7 +155,7 @@ class Image:
             raise TypeError("Unsupported source type for Image")
 
     @classmethod
-    @lru_cache(maxsize=None)
+    @cache
     def _converters(cls) -> list[ImageConverter]:
         """Return list of registered image plugin converters. Only loaded once."""
         converters = []

--- a/core/src/toga/platform.py
+++ b/core/src/toga/platform.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import importlib
 import os
 import sys
-from functools import lru_cache
+from functools import cache
 from types import ModuleType
 
 if sys.version_info >= (3, 10):  # pragma: no-cover-if-lt-py310
@@ -51,7 +51,7 @@ def find_backends():
     return sorted(set(entry_points(group="toga.backends")))
 
 
-@lru_cache(maxsize=1)
+@cache
 def get_platform_factory() -> ModuleType:
     """Determine the current host platform and import the platform factory.
 


### PR DESCRIPTION
Now that Toga's dropping 3.8 support, I remembered a spot in `images` where I used `functools.lru_cache` because `cache` wasn't added until 3.9.

From the [docs](https://docs.python.org/3/library/functools.html#module-functools) on `cache`:
> Returns the same as `lru_cache(maxsize=None)`, creating a thin wrapper around a dictionary lookup for the function arguments. Because it never needs to evict old values, this is smaller and faster than `lru_cache()` with a size limit.

So in that case it's a one-to-one swap. But I noticed one other place too, in `platform`. There it's `maxsize=1` instead of `None`, which *could* behave differently — only keeping the most recent call instead of all calls — except that `get_platform_factory()` accepts no arguments, so it can only ever cache one value anyway. So setting it to `None` makes the result potentially smaller and faster without changing behavior, and that in turn is the same as `cache`.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
