### PR TITLE
Bump Pillow dependency for testbed.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,8 @@ jobs:
         # the system Python version to become inconsistent from run to run.
         - backend: "linux-x11"
           platform: "linux"
-          runs-on: "ubuntu-22.04"
+          runs-on: "ubuntu-24.04"
+          python-version: "system"
           # The package list should be the same as in tutorial-0.rst, and the BeeWare
           # tutorial, plus blackbox to provide a window manager. We need a window
           # manager that is reasonably lightweight, honors full screen mode, and
@@ -233,6 +234,7 @@ jobs:
         - backend: "linux-wayland"
           platform: "linux"
           runs-on: "ubuntu-24.04"
+          python-version: "system"
           # The package list should be the same as in tutorial-0.rst, and the BeeWare
           # tutorial, plus mutter to provide a window manager.
           pre-command: |
@@ -261,6 +263,7 @@ jobs:
         - backend: "textual-linux"
           platform: "linux"
           runs-on: "ubuntu-latest"
+          python-version: "system"
           setup-python: false  # Use the system Python packages
           briefcase-run-args: --config 'requires=["../core","../textual"]' --config 'console_app=true'
           app-user-data-path: "$HOME/.local/share/testbed"
@@ -291,6 +294,7 @@ jobs:
         - backend: "android"
           platform: "android"
           runs-on: "ubuntu-latest"
+          python-version: "system"
           briefcase-run-prefix: JAVA_HOME=${JAVA_HOME_17_X64}
           briefcase-run-args: >-
             --device '{"avd":"beePhone","skin":"pixel_3a"}'
@@ -320,11 +324,7 @@ jobs:
       uses: actions/setup-python@v5.2.0
       if: matrix.setup-python
       with:
-        # We're not using Python 3.11 yet, because:
-        # * The testbed's ProxyEventLoop has some problems with it
-        #   (https://github.com/beeware/toga/issues/1982).
-        # * It doesn't have an Android build of Pillow yet.
-        python-version: "3.10"
+        python-version: ${{ matrix.python-version || '3.12' }}
 
     - name: Install Dependencies
       env:

--- a/docs/how-to/contribute/code.rst
+++ b/docs/how-to/contribute/code.rst
@@ -672,12 +672,6 @@ test mode:
       (venv) C:\...>cd testbed
       (venv) C:\...>briefcase dev --test
 
-.. note::
-
-    To test iOS and Android, you *must* use Python 3.10. The testbed app uses a number
-    of binary packages, and the specific combination of versions that are used are
-    currently only available for Python 3.10.
-
 This will display a Toga app window, which will flash as it performs all the GUI
 tests. You'll then see a coverage report for the code that has been executed.
 

--- a/testbed/pyproject.toml
+++ b/testbed/pyproject.toml
@@ -1,8 +1,6 @@
 [project]
 name = "testbed"
 version = "0.0.1"
-# This *should* be a consistent version, but we need to support 3.12 for Wayland testing, and 3.10 for iOS and Android.
-# requires-python = "~=3.10.0"
 
 [project.optional-dependencies]
 test = [
@@ -12,7 +10,7 @@ test = [
     # sys.platform == 'linux' as there's no dependency identifier
     # that can target Android exclusively until 3.13 lands.
     "fonttools==4.54.1 ; sys.platform == 'linux'",
-    "pillow==9.2.0",
+    "pillow==11.0.0",
     "pytest==8.3.3",
     "pytest-asyncio==0.24.0",
 ]


### PR DESCRIPTION
Increase the pinned Pillow version to 11.0.0, which has now been published for 3.9-3.13 for all supported platforms.

This allows us to run the testbed on *any* Python version, not just 3.10; this PR bumps to a consistent 3.12 because that is the system version in Ubuntu 24.04 (and modifies the other Linux-based tests to do the same). As a result, the documentation comment added in #2497 is no longer required.

Also removes a comment associated with running on Python 3.11+. We've been running Wayland tests on 3.12 for a couple of weeks, so the underlying issue with pytest-asyncio has evidently been fixed - probably #2652 when we were able to upgrade pytest-asyncio.

Fixes #2296.
Fixes #1982.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [ ] I have read the **CONTRIBUTING.md** file
- [ ] I will abide by the code of conduct
