### PR TITLE
Set App.app to initial value of None  to avoid AttributeError in teardown

### DIFF
--- a/changes/2918.bugfix.rst
+++ b/changes/2918.bugfix.rst
@@ -1,0 +1,1 @@
+App.app is now set to an initial value of None, before an app instance is created. This avoids a potential Attribute Error in testing teardown.

--- a/core/src/toga/app.py
+++ b/core/src/toga/app.py
@@ -134,7 +134,8 @@ class WidgetRegistry:
 
 class App:
     #: The currently running :class:`~toga.App`. Since there can only be one running
-    #: Toga app in a process, this is available as a class property via ``toga.App.app``.
+    #: Toga app in a process, this is available as a class property via
+    #: ``toga.App.app``. If no app has been created yet, this is set to ``None``.
     app: App | None = None
     _impl: Any
     _camera: Camera

--- a/core/src/toga/app.py
+++ b/core/src/toga/app.py
@@ -135,7 +135,7 @@ class WidgetRegistry:
 class App:
     #: The currently running :class:`~toga.App`. Since there can only be one running
     #: Toga app in a process, this is available as a class property via ``toga.App.app``.
-    app: App
+    app: App | None = None
     _impl: Any
     _camera: Camera
     _location: Location


### PR DESCRIPTION
Running the entire core test suite completes successfully. But at least one test (and probably others), when run individually, fail. Running `tests/style/pack/layout/test_rtl.py` by itself gets six instances of this:

```
    @pytest.fixture(autouse=True)
    def no_dangling_tasks():
        """Ensure any tasks for the test were removed when the test finished."""
        yield
>       if toga.App.app:
E       AttributeError: type object 'App' has no attribute 'app'

tests/conftest.py:22: AttributeError
```

This is fine if a previous test has created an app instance, which is why it only fails in isolation. Changing it to a `hasattr` check fixes it, but then it still needs an additional truthiness or `None` check to avoid failing `test_window_created_without_app`, which sets `App.app` to `None`. At that point, why not just set `None` as the initial value in the class definition? It makes semantic sense for it to be `None` if there's no running app.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct