### PR TITLE
Rephrase web-specific language in docs

### DIFF
--- a/changes/2939.misc.rst
+++ b/changes/2939.misc.rst
@@ -1,0 +1,1 @@
+Rephrase web-specific language in docs.

--- a/core/src/toga/widgets/base.py
+++ b/core/src/toga/widgets/base.py
@@ -53,10 +53,7 @@ class Widget(Node):
 
     @property
     def id(self) -> str:
-        """The DOM identifier for the widget.
-
-        This id can be used to target CSS directives.
-        """
+        """A unique identifier for the widget."""
         return self._id
 
     @property

--- a/docs/reference/style/pack.rst
+++ b/docs/reference/style/pack.rst
@@ -29,10 +29,10 @@ Pack style properties
 
 **Initial value:** ``pack``
 
-Used to define the how to display the element. A value of ``pack`` will apply
+Used to define how to display the widget. A value of ``pack`` will apply
 the pack layout algorithm to this node and its descendants. A value of
-``none`` removes the element from the layout entirely. Space will be allocated
-for the element as if it were there, but the element itself will not be
+``none`` removes the widget from the layout entirely. Space will be allocated
+for the widget as if it were there, but the widget itself will not be
 visible.
 
 ``visibility``
@@ -42,13 +42,13 @@ visible.
 
 **Initial value:** ``visible``
 
-Used to define whether the element should be drawn. A value of ``visible`` means
-the element will be displayed. A value of ``hidden`` removes the element from
-view, but allocates space for the element as if it were still in the layout.
+Used to define whether the widget should be drawn. A value of ``visible`` means
+the widget will be displayed. A value of ``hidden`` removes the widget from
+view, but allocates space for the widget as if it were still in the layout.
 
-Any children of a hidden element are implicitly removed from view.
+Any children of a hidden widget are implicitly removed from view.
 
-If a previously hidden element is made visible, any children of the element with
+If a previously hidden widget is made visible, any children of the widget with
 a visibility of ``hidden`` will remain hidden. Any descendants of the hidden
 child will also remain hidden, regardless of their visibility.
 
@@ -309,14 +309,14 @@ The mapping that can be used to establish the reference implementation is:
          <body></body>
       </html>
 
-* The root element of the Pack layout can be mapped to the ``<body>`` element of
+* The root widget of the Pack layout can be mapped to the ``<body>`` element of
   the HTML reference document. The rendering area of the browser window becomes
   the view area that Pack will fill.
 
 * ImageViews map to ``<img>`` elements. The ``<img>`` element has an additional style of
   ``object-fit: contain`` unless *both* ``height`` and ``width`` are defined.
 
-* All other elements in the DOM tree are mapped to ``<div>`` elements.
+* All other widgets are mapped to ``<div>`` elements.
 
 * The following Pack declarations can be mapped to equivalent CSS declarations:
 

--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -144,9 +144,9 @@ Now we will make the button take up all the available width::
 
        button.style.flex = 1
 
-The ``flex`` attribute specifies how an element is sized with respect to other
-elements along its direction. The default direction is row (horizontal) and
-since the button is the only element here, it will take up the whole width.
+The ``flex`` attribute specifies how a widget is sized with respect to other
+widgets along its direction. The default direction is row (horizontal) and
+since the button is the only widget here, it will take up the whole width.
 Check out `style docs
 <https://toga.readthedocs.io/en/latest/reference/style/pack.html#flex>`_ for
 more information on how to use the ``flex`` attribute.


### PR DESCRIPTION
In non-web-related contexts, terms such as "DOM" and "element" are potentially confusing to users with no web development experience. Replace with the terminology used elsewhere in the docs.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
