### PR TITLE
Update window.py to be able to create dialogs in Textual

### DIFF
--- a/changes/2949.bugfix.rst
+++ b/changes/2949.bugfix.rst
@@ -1,0 +1,1 @@
+An issue with creating dialogs on the Textual backend was resolved.

--- a/textual/src/toga_textual/window.py
+++ b/textual/src/toga_textual/window.py
@@ -83,9 +83,9 @@ class TitleBar(TextualWidget):
     }
     """
 
-    def __init__(self):
+    def __init__(self, title="Toga"):
         super().__init__()
-        self.title = TitleText("Toga")
+        self.title = TitleText(title)
 
     @property
     def text(self):


### PR DESCRIPTION
When trying to create a dialog using the Textual backend, I get a TypeError warning about too many inputs 
The code used works on GTK.
This change solves that error

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
