### PR TITLE
Fix visibility for descendants of hidden widgets

### DIFF
--- a/changes/2950.bugfix.rst
+++ b/changes/2950.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug that allowed descendents of hidden widgets to be visible.

--- a/core/src/toga/style/pack.py
+++ b/core/src/toga/style/pack.py
@@ -110,6 +110,15 @@ class Pack(BaseStyle):
             elif prop == "background_color":
                 self._applicator.set_background_color(value)
             elif prop == "visibility":
+                if value == VISIBLE:
+                    # If visibility is being set to VISIBLE, look up the chain to see if
+                    # an ancestor is hidden.
+                    widget = self._applicator.widget
+                    while widget := widget.parent:
+                        if widget.style._hidden:
+                            value = HIDDEN
+                            break
+
                 self._applicator.set_hidden(value == HIDDEN)
             elif prop in (
                 "font_family",

--- a/core/tests/style/pack/utils.py
+++ b/core/tests/style/pack/utils.py
@@ -63,6 +63,13 @@ class ExampleNode(Node):
         pass
 
 
+class ExampleParentNode(ExampleNode):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._children = []
+
+
 class ExampleViewport:
     def __init__(self, width, height):
         self.height = height

--- a/testbed/tests/widgets/test_base.py
+++ b/testbed/tests/widgets/test_base.py
@@ -69,7 +69,9 @@ async def test_visibility(widget, probe):
     assert child_probe.is_hidden
     assert grandchild_probe.is_hidden
 
-    # Mark the child style as visible.
+    # Mark the child style as visible. Mark it as hidden first, so that a change is
+    # registered and the property is applied.
+    child.style.visibility = HIDDEN
     child.style.visibility = VISIBLE
     await probe.redraw("Child style of widget should be visible")
 

--- a/testbed/tests/widgets/test_base.py
+++ b/testbed/tests/widgets/test_base.py
@@ -70,7 +70,8 @@ async def test_visibility(widget, probe):
     assert grandchild_probe.is_hidden
 
     # Mark the child style as visible. Mark it as hidden first, so that a change is
-    # registered and the property is applied.
+    # registered and the property is applied. However, regardless, the widget
+    # won't be visible because it has an ancestor that is hidden.
     child.style.visibility = HIDDEN
     child.style.visibility = VISIBLE
     await probe.redraw("Child style of widget should be visible")


### PR DESCRIPTION
Descendants of hidden widgets should always be visually hidden, regardless of what their style is set to. The testbed appears to test for this, in `tests/widgets/test_base.py::test_visibility`:

```python
# Hide the widget again
widget.style.visibility = HIDDEN
await probe.redraw("Widget should be hidden again")

# Widgets are no longer visible.
assert probe.is_hidden
assert child_probe.is_hidden
assert grandchild_probe.is_hidden

# Mark the child style as visible.
child.style.visibility = VISIBLE
await probe.redraw("Child style of widget should be visible")

# Root widget isn't visible, so neither descendent is visible.
assert probe.is_hidden
assert child_probe.is_hidden
assert grandchild_probe.is_hidden
```

However, it's accidentally testing a coincidence. The child widget is already set to visible (or rather its visibility hasn't been set yet, but that's the initial value, so it's essentially the same thing). Therefore setting it to VISIBLE registers no change and doesn't trigger an apply.

If, instead, you set the child to HIDDEN and *then* to VISIBLE, it pops right up — and the test fails. There's not currently any logic to check against the visibility of ancestors.

I've added a loop to run up the chain of ancestors, and apply hidden-ness if it finds one hidden. Also added the toggle-back-and-forth to the test.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
