### PR TITLE
Remove Java idiom from example code.

### DIFF
--- a/changes/2951.misc.rst
+++ b/changes/2951.misc.rst
@@ -1,0 +1,1 @@
+Some Java idiom was removed from a Python example.

--- a/docs/reference/platforms/android.rst
+++ b/docs/reference/platforms/android.rst
@@ -55,7 +55,7 @@ completes. For example, to dial a phone number with the ``Intent.ACTION_DIAL`` i
     from android.content import Intent
     from android.net import Uri
 
-    intent = new Intent(Intent.ACTION_DIAL)
+    intent = Intent(Intent.ACTION_DIAL)
     intent.setData(Uri.parse("tel:0123456789"))
 
     def number_dialed(result, data):


### PR DESCRIPTION
Removes usage of the `new` keyword in an example of using Java APIs in Python.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
