### PR TITLE
Add window refresh lock to block window from updating while handler is running.

### DIFF
--- a/core/src/toga/handlers.py
+++ b/core/src/toga/handlers.py
@@ -91,7 +91,11 @@ async def handler_with_cleanup(
     **kwargs: object,
 ) -> object | None:
     try:
-        result = await handler(interface, *args, **kwargs)
+        if hasattr(interface, "window") and interface.window is not None:
+            with interface.window.refresh_lock():
+                result = await handler(interface, *args, **kwargs)
+        else:
+            result = await handler(interface, *args, **kwargs)
     except Exception as e:
         print("Error in async handler:", e, file=sys.stderr)
         traceback.print_exc()
@@ -170,7 +174,11 @@ def wrapped_handler(
                 )
             else:
                 try:
-                    result = handler(interface, *args, **kwargs)
+                    if hasattr(interface, "window") and interface.window is not None:
+                        with interface.window.refresh_lock():
+                            result = handler(interface, *args, **kwargs)
+                    else:
+                        result = handler(interface, *args, **kwargs)
                 except Exception as e:
                     print("Error in handler:", e, file=sys.stderr)
                     traceback.print_exc()

--- a/core/src/toga/widgets/base.py
+++ b/core/src/toga/widgets/base.py
@@ -268,6 +268,10 @@ class Widget(Node):
         self._impl.set_enabled(bool(value))
 
     def refresh(self) -> None:
+        if self.window is not None and self.window.locked:
+            self.window.dirty(self)
+            return
+
         self._impl.refresh()
 
         # Refresh the layout

--- a/core/tests/test_handlers.py
+++ b/core/tests/test_handlers.py
@@ -1,5 +1,5 @@
 import asyncio
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
 
 import pytest
 
@@ -61,8 +61,14 @@ def test_noop_handler_with_cleanup_error(capsys):
 
 
 def test_function_handler():
-    """A function can be used as a handler."""
-    obj = Mock()
+    """A function can be used as a handler"""
+    obj = MagicMock()
+    obj.return_value.window.return_value.refresh_lock.return_value.__enter__.return_value = (
+        None
+    )
+    obj.return_value.window.return_value.refresh_lock.return_value.__exit__.return_value = (
+        None
+    )
     handler_call = {}
 
     def handler(*args, **kwargs):
@@ -86,8 +92,14 @@ def test_function_handler():
 
 
 def test_function_handler_error(capsys):
-    """A function handler can raise an error."""
-    obj = Mock()
+    """A function handler can raise an error"""
+    obj = MagicMock()
+    obj.return_value.window.return_value.refresh_lock.return_value.__enter__.return_value = (
+        None
+    )
+    obj.return_value.window.return_value.refresh_lock.return_value.__exit__.return_value = (
+        None
+    )
     handler_call = {}
 
     def handler(*args, **kwargs):
@@ -116,8 +128,14 @@ def test_function_handler_error(capsys):
 
 
 def test_function_handler_with_cleanup():
-    """A function handler can have a cleanup method."""
-    obj = Mock()
+    """A function handler can have a cleanup method"""
+    obj = MagicMock()
+    obj.return_value.window.return_value.refresh_lock.return_value.__enter__.return_value = (
+        None
+    )
+    obj.return_value.window.return_value.refresh_lock.return_value.__exit__.return_value = (
+        None
+    )
     cleanup = Mock()
     handler_call = {}
 
@@ -146,7 +164,13 @@ def test_function_handler_with_cleanup():
 
 def test_function_handler_with_cleanup_error(capsys):
     """A function handler can have a cleanup method that raises an error."""
-    obj = Mock()
+    obj = MagicMock()
+    obj.return_value.window.return_value.refresh_lock.return_value.__enter__.return_value = (
+        None
+    )
+    obj.return_value.window.return_value.refresh_lock.return_value.__exit__.return_value = (
+        None
+    )
     cleanup = Mock(side_effect=Exception("Problem in cleanup"))
     handler_call = {}
 
@@ -180,8 +204,14 @@ def test_function_handler_with_cleanup_error(capsys):
 
 
 def test_generator_handler(event_loop):
-    """A generator can be used as a handler."""
-    obj = Mock()
+    """A generator can be used as a handler"""
+    obj = MagicMock()
+    obj.return_value.window.return_value.refresh_lock.return_value.__enter__.return_value = (
+        None
+    )
+    obj.return_value.window.return_value.refresh_lock.return_value.__exit__.return_value = (
+        None
+    )
     handler_call = {}
 
     def handler(*args, **kwargs):
@@ -213,8 +243,14 @@ def test_generator_handler(event_loop):
 
 
 def test_generator_handler_error(event_loop, capsys):
-    """A generator can raise an error."""
-    obj = Mock()
+    """A generator can raise an error"""
+    obj = MagicMock()
+    obj.return_value.window.return_value.refresh_lock.return_value.__enter__.return_value = (
+        None
+    )
+    obj.return_value.window.return_value.refresh_lock.return_value.__exit__.return_value = (
+        None
+    )
     handler_call = {}
 
     def handler(*args, **kwargs):
@@ -248,8 +284,14 @@ def test_generator_handler_error(event_loop, capsys):
 
 
 def test_generator_handler_with_cleanup(event_loop):
-    """A generator can have cleanup."""
-    obj = Mock()
+    """A generator can have cleanup"""
+    obj = MagicMock()
+    obj.return_value.window.return_value.refresh_lock.return_value.__enter__.return_value = (
+        None
+    )
+    obj.return_value.window.return_value.refresh_lock.return_value.__exit__.return_value = (
+        None
+    )
     cleanup = Mock()
     handler_call = {}
 
@@ -285,8 +327,14 @@ def test_generator_handler_with_cleanup(event_loop):
 
 
 def test_generator_handler_with_cleanup_error(event_loop, capsys):
-    """A generator can raise an error during cleanup."""
-    obj = Mock()
+    """A generator can raise an error during cleanup"""
+    obj = MagicMock()
+    obj.return_value.window.return_value.refresh_lock.return_value.__enter__.return_value = (
+        None
+    )
+    obj.return_value.window.return_value.refresh_lock.return_value.__exit__.return_value = (
+        None
+    )
     cleanup = Mock(side_effect=Exception("Problem in cleanup"))
     handler_call = {}
 

--- a/core/tests/window/test_window.py
+++ b/core/tests/window/test_window.py
@@ -8,6 +8,7 @@ from toga_dummy.utils import (
     assert_action_not_performed,
     assert_action_performed,
     assert_action_performed_with,
+    performed_actions,
 )
 
 
@@ -170,6 +171,43 @@ def test_change_content(window, app):
 
     # The original content has been removed
     assert content1.window is None
+
+
+def test_change_content_locked(window, app):
+    """The refresh of a window can be locked"""
+    with window.refresh_lock():
+        assert window.content is None
+        assert window.app == app
+
+        # Set the content of the window
+        content1 = toga.Box()
+        window.content = content1
+
+        # The content has been assigned and not (yet) refreshed
+        assert content1.app == app
+        assert content1.window == window
+        assert_action_performed_with(window, "set content", widget=content1._impl)
+        assert_action_not_performed(content1, "refresh")
+
+        # Set the content of the window to something new
+        content2 = toga.Box()
+        window.content = content2
+
+        # The content has been assigned and not (yet) refreshed
+        assert content2.app == app
+        assert content2.window == window
+        assert_action_performed_with(window, "set content", widget=content2._impl)
+        assert_action_not_performed(content2, "refresh")
+
+        # The original content has been removed
+        assert content1.window is None
+
+    # Action refresh must not have been performed on content1
+    assert_action_not_performed(content1, "refresh")
+
+    # Action refresh must have been performed on content2
+    assert_action_performed(content2, "refresh")
+    assert len(performed_actions(content2, "refresh")) == 2
 
 
 def test_set_position(window):

--- a/dummy/src/toga_dummy/utils.py
+++ b/dummy/src/toga_dummy/utils.py
@@ -245,6 +245,19 @@ class TestStyle(BaseStyle):
 ###############################################################################
 
 
+def performed_actions(_widget, _action):
+    """Retrieve the specified actions executed by the widget
+
+    :param _widget: The interface of the widget to check
+    :param _action: The action.
+    :returns: The events log entries associated with the widget/action pair.
+    """
+    try:
+        return EventLog.performed_actions(_widget, _action)
+    except AttributeError:
+        return ()
+
+
 def attribute_value(_widget, _attr):
     """Retrieve the current value of a widget property.
 


### PR DESCRIPTION
When a handler is running it may add a lot of widgets to a window. The window keeps updating its layout, leading to an O(n^2) in calls to the ``refresh()`` function. When the number of widgets added to a window is doubled, run time is quadrupled (etc).

This leads to slow updates when going from view to view.

My solution is to keep a list of 'dirty' children when a window is locked, so that the children will receive a ``refresh()`` call when the window is unlocked. Also, a window is automatically locked when a handler is called that has a ``window`` in its interface. No interaction from the user or application programmer is needed to use this functionality.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
