### PR TITLE
Add a handler for ListView.SearchForVirtualItem in winforms backend for keyboard navigation in tables and detailed lists

### DIFF
--- a/android/tests_backend/widgets/table.py
+++ b/android/tests_backend/widgets/table.py
@@ -95,5 +95,5 @@ class TableProbe(SimpleProbe):
     def text_size(self):
         return self._row_view(0).getChildAt(0).getTextSize()
 
-    async def assert_keyboard_navigation(self):
+    async def acquire_keyboard_focus(self):
         pytest.skip("test not implemented for this platform")

--- a/android/tests_backend/widgets/table.py
+++ b/android/tests_backend/widgets/table.py
@@ -94,3 +94,6 @@ class TableProbe(SimpleProbe):
     @property
     def text_size(self):
         return self._row_view(0).getChildAt(0).getTextSize()
+
+    async def assert_keyboard_navigation(self):
+        pytest.skip("test not implemented for this platform")

--- a/changes/2956.bugfix.rst
+++ b/changes/2956.bugfix.rst
@@ -1,0 +1,1 @@
+Multi-letter keyboard navigation in Tables and DetailedLists with the winforms backend is now functional.

--- a/cocoa/tests_backend/widgets/base.py
+++ b/cocoa/tests_backend/widgets/base.py
@@ -114,6 +114,8 @@ class SimpleProbe(BaseProbe, FontMixin):
         key_code = {
             "<backspace>": 51,
             "<esc>": 53,
+            "<down>": 125,
+            "<up>": 126,
             " ": 49,
             "\n": 36,
             "a": 0,

--- a/cocoa/tests_backend/widgets/table.py
+++ b/cocoa/tests_backend/widgets/table.py
@@ -147,7 +147,9 @@ class TableProbe(SimpleProbe):
         )
 
     async def acquire_keyboard_focus(self):
-        self.native_table.window.makeFirstResponder(self.native_table)
+        self.native_table.window.makeFirstResponder(
+            self.native_table
+        )  # switch to widget.focus() when possible.
         # Insure first row is selected.
         await self.type_character("<down>")
         await self.type_character("<up>")

--- a/cocoa/tests_backend/widgets/table.py
+++ b/cocoa/tests_backend/widgets/table.py
@@ -144,3 +144,29 @@ class TableProbe(SimpleProbe):
             delay=0.1,
             clickCount=2,
         )
+
+    async def assert_keyboard_navigation(self):
+        # Insure that the list has keyboard focus
+        self.native_table.window.makeFirstResponder(self.native_table)
+        await self.redraw(f"Table is focused sel {self.native_table.selectedRow}")
+        # Navigate down then up, with a letter then 2 arrow keys.
+        await self.type_character("a")
+        await self.redraw("First row is selected")
+        assert self.native_table.selectedRow == 0
+        await self.type_character("<down>")
+        await self.redraw("Second row is selected")
+        assert self.native_table.selectedRow == 1
+        await self.type_character("<up>")
+        await self.redraw("First row is selected")
+        assert self.native_table.selectedRow == 0
+
+        # Move down 3 rows, with letter, arrow, then letter.
+        await self.type_character("a")
+        await self.redraw("Second row is selected")
+        assert self.native_table.selectedRow == 1
+        await self.type_character("<down>")
+        await self.redraw("Third row is selected")
+        assert self.native_table.selectedRow == 2
+        await self.type_character("a")
+        await self.redraw("Forth row is selected")
+        assert self.native_table.selectedRow == 3

--- a/cocoa/tests_backend/widgets/table.py
+++ b/cocoa/tests_backend/widgets/table.py
@@ -13,6 +13,7 @@ class TableProbe(SimpleProbe):
     native_class = NSScrollView
     supports_icons = 2  # All columns
     supports_keyboard_shortcuts = True
+    supports_keyboard_boundary_shortcuts = False
     supports_widgets = True
 
     def __init__(self, widget):
@@ -145,28 +146,8 @@ class TableProbe(SimpleProbe):
             clickCount=2,
         )
 
-    async def assert_keyboard_navigation(self):
-        # Insure that the list has keyboard focus
+    async def acquire_keyboard_focus(self):
         self.native_table.window.makeFirstResponder(self.native_table)
-        await self.redraw(f"Table is focused sel {self.native_table.selectedRow}")
-        # Navigate down then up, with a letter then 2 arrow keys.
-        await self.type_character("a")
-        await self.redraw("First row is selected")
-        assert self.native_table.selectedRow == 0
+        # Insure first row is selected.
         await self.type_character("<down>")
-        await self.redraw("Second row is selected")
-        assert self.native_table.selectedRow == 1
         await self.type_character("<up>")
-        await self.redraw("First row is selected")
-        assert self.native_table.selectedRow == 0
-
-        # Move down 3 rows, with letter, arrow, then letter.
-        await self.type_character("a")
-        await self.redraw("Second row is selected")
-        assert self.native_table.selectedRow == 1
-        await self.type_character("<down>")
-        await self.redraw("Third row is selected")
-        assert self.native_table.selectedRow == 2
-        await self.type_character("a")
-        await self.redraw("Forth row is selected")
-        assert self.native_table.selectedRow == 3

--- a/cocoa/tests_backend/widgets/table.py
+++ b/cocoa/tests_backend/widgets/table.py
@@ -149,7 +149,7 @@ class TableProbe(SimpleProbe):
     async def acquire_keyboard_focus(self):
         self.native_table.window.makeFirstResponder(
             self.native_table
-        )  # switch to widget.focus() when possible.
+        )  # switch to widget.focus() when possible (#2972).
         # Insure first row is selected.
         await self.type_character("<down>")
         await self.type_character("<up>")

--- a/gtk/tests_backend/widgets/table.py
+++ b/gtk/tests_backend/widgets/table.py
@@ -84,3 +84,6 @@ class TableProbe(SimpleProbe):
             Gtk.TreePath(row),
             self.native_table.get_columns()[0],
         )
+
+    async def assert_keyboard_navigation(self):
+        pytest.skip("test not implemented for this platform")

--- a/gtk/tests_backend/widgets/table.py
+++ b/gtk/tests_backend/widgets/table.py
@@ -85,5 +85,5 @@ class TableProbe(SimpleProbe):
             self.native_table.get_columns()[0],
         )
 
-    async def assert_keyboard_navigation(self):
+    async def acquire_keyboard_focus(self):
         pytest.skip("test not implemented for this platform")

--- a/testbed/tests/widgets/test_table.py
+++ b/testbed/tests/widgets/test_table.py
@@ -161,26 +161,7 @@ async def test_scroll(widget, probe):
 
 async def test_keyboard_navigation(widget, source, probe):
     """The list can be navigated using a keyboard."""
-    if toga.platform.current_platform != "windows":
-        pytest.skip("test only applies on windows at present")
-    # Focus the list by pressing tab.
-    await probe.type_character("\t")
-
-    # Navigate 2 items down. In this dataset, all items start with "A".
-    await probe.type_character("a")
-    await probe.type_character("a")
-    await probe.redraw("Third row is selected")
-    assert widget.selection == source[2]
-
-    # Select the last item with the end key.
-    await probe.type_character("<end>")
-    await probe.redraw("Last row is selected")
-    assert widget.selection == source[-1]
-
-    # Navigate by 1 item, wrapping around.
-    await probe.type_character("a")
-    await probe.redraw("First row is selected")
-    assert widget.selection == source[0]
+    await probe.assert_keyboard_navigation()
 
 
 async def test_select(widget, probe, source, on_select_handler):

--- a/testbed/tests/widgets/test_table.py
+++ b/testbed/tests/widgets/test_table.py
@@ -159,6 +159,30 @@ async def test_scroll(widget, probe):
     assert -100 < probe.scroll_position <= 0
 
 
+async def test_keyboard_navigation(widget, source, probe):
+    """The list can be navigated using a keyboard."""
+    if toga.platform.current_platform != "windows":
+        pytest.skip("test only applies on windows at present")
+    # Focus the list by pressing tab.
+    await probe.type_character("\t")
+
+    # Navigate 2 items down. In this dataset, all items start with "A".
+    await probe.type_character("a")
+    await probe.type_character("a")
+    await probe.redraw("Third row is selected")
+    assert widget.selection == source[2]
+
+    # Select the last item with the end key.
+    await probe.type_character("<end>")
+    await probe.redraw("Last row is selected")
+    assert widget.selection == source[-1]
+
+    # Navigate by 1 item, wrapping around.
+    await probe.type_character("a")
+    await probe.redraw("First row is selected")
+    assert widget.selection == source[0]
+
+
 async def test_select(widget, probe, source, on_select_handler):
     """Rows can be selected"""
     # Initial selection is empty

--- a/testbed/tests/widgets/test_table.py
+++ b/testbed/tests/widgets/test_table.py
@@ -196,6 +196,12 @@ async def test_keyboard_navigation(widget, source, probe):
     await probe.redraw("Invalid letter pressed - first row is still selected")
     assert widget.selection == widget.data[0]
 
+    # clear the table and verify with an empty selection.
+    widget.data.clear()
+    await probe.type_character("a")
+    await probe.redraw("Letter pressed - no row selected")
+    assert not widget.selection
+
 
 async def test_select(widget, probe, source, on_select_handler):
     """Rows can be selected"""

--- a/winforms/src/toga_winforms/widgets/table.py
+++ b/winforms/src/toga_winforms/widgets/table.py
@@ -115,8 +115,7 @@ class Table(Widget):
         if (
             not e.IsTextSearch or not self._accessors or not self._data
         ):  # pragma: no cover
-            # If winforms fires this event as a location based search,
-            # or with any invalid parameters, return gracefully.
+            # The list might be empty, or else winforms fired an unsupported location based search.
             return
         find_previous = e.Direction in [
             WinForms.SearchDirectionHint.Up,
@@ -125,11 +124,9 @@ class Table(Widget):
         i = e.StartIndex
         found_item = False
         while True:
-            # Either winforms might provide a starting index out of bounds if searching at list borders,
-            # or this loop may travel out of bounds itself while searching. In either case, wrap around.
             if i < 0:  # pragma: no cover
-                # This could theoretically happen if this event is fired with a backwards search direction,
-                # however this edgecase should not take place within Toga's intended use of this event.
+                # This could happen if this event is fired searching backwards,
+                # however this should not happen in Toga's use of it.
                 # i = len(self._data) - 1
                 raise NotImplementedError("backwards search unsupported")
             elif i >= len(self._data):

--- a/winforms/src/toga_winforms/widgets/table.py
+++ b/winforms/src/toga_winforms/widgets/table.py
@@ -122,7 +122,7 @@ class Table(Widget):
         found_item = False
         while True:
             # Either winforms might provide a starting index out of bounds if searching at list borders,
-            # or we may travel out of bounds ourself when searching. In either case, wrap around.
+            # or this loop may travel out of bounds itself while searching. In either case, wrap around.
             if i < 0:
                 i = len(self._data) - 1
             elif i >= len(self._data):

--- a/winforms/src/toga_winforms/widgets/table.py
+++ b/winforms/src/toga_winforms/widgets/table.py
@@ -124,6 +124,8 @@ class Table(Widget):
         i = e.StartIndex
         found_item = False
         while True:
+            # It is possible for e.StartIndex to be received out-of-range if the user
+            # performs keyboard navigation at it's edge, so check before accessing data
             if i < 0:  # pragma: no cover
                 # This could happen if this event is fired searching backwards,
                 # however this should not happen in Toga's use of it.

--- a/winforms/src/toga_winforms/widgets/table.py
+++ b/winforms/src/toga_winforms/widgets/table.py
@@ -112,10 +112,9 @@ class Table(Widget):
             self._cache.append(self._new_item(i + self._first_item))
 
     def winforms_search_for_virtual_item(self, sender, e):
-        if (
-            not e.IsTextSearch or not self._accessors or not self._data
-        ):  # pragma: no cover
-            # The list might be empty, or else winforms fired an unsupported location based search.
+        if not e.IsTextSearch or not self._accessors or not self._data:
+            # If this list is empty, or has no columns, or it's an unsupported search
+            # type, there's no search to be done.
             return
         find_previous = e.Direction in [
             WinForms.SearchDirectionHint.Up,
@@ -125,7 +124,7 @@ class Table(Widget):
         found_item = False
         while True:
             # It is possible for e.StartIndex to be received out-of-range if the user
-            # performs keyboard navigation at it's edge, so check before accessing data
+            # performs keyboard navigation at its edge, so check before accessing data
             if i < 0:  # pragma: no cover
                 # This could happen if this event is fired searching backwards,
                 # however this should not happen in Toga's use of it.

--- a/winforms/src/toga_winforms/widgets/table.py
+++ b/winforms/src/toga_winforms/widgets/table.py
@@ -112,9 +112,12 @@ class Table(Widget):
             self._cache.append(self._new_item(i + self._first_item))
 
     def winforms_search_for_virtual_item(self, sender, e):
-        if not e.IsTextSearch or not self._accessors or not self._data:
+        if (
+            not e.IsTextSearch or not self._accessors or not self._data
+        ):  # pragma: no cover
             # If this list is empty, or has no columns, or it's an unsupported search
-            # type, there's no search to be done.
+            # type, there's no search to be done. These situation are difficult to
+            # trigger in CI; they're here as a safety catch.
             return
         find_previous = e.Direction in [
             WinForms.SearchDirectionHint.Up,

--- a/winforms/src/toga_winforms/widgets/table.py
+++ b/winforms/src/toga_winforms/widgets/table.py
@@ -112,7 +112,11 @@ class Table(Widget):
             self._cache.append(self._new_item(i + self._first_item))
 
     def winforms_search_for_virtual_item(self, sender, e):
-        if not e.IsTextSearch or not self._accessors or not self._data:
+        if (
+            not e.IsTextSearch or not self._accessors or not self._data
+        ):  # pragma: no cover
+            # If winforms fires this event as a location based search,
+            # or with any invalid parameters, return gracefully.
             return
         find_previous = e.Direction in [
             WinForms.SearchDirectionHint.Up,

--- a/winforms/src/toga_winforms/widgets/table.py
+++ b/winforms/src/toga_winforms/widgets/table.py
@@ -123,8 +123,11 @@ class Table(Widget):
         while True:
             # Either winforms might provide a starting index out of bounds if searching at list borders,
             # or this loop may travel out of bounds itself while searching. In either case, wrap around.
-            if i < 0:
-                i = len(self._data) - 1
+            if i < 0:  # pragma: no cover
+                # This could theoretically happen if this event is fired with a backwards search direction,
+                # however this edgecase should not take place within Toga's intended use of this event.
+                # i = len(self._data) - 1
+                raise NotImplementedError("backwards search unsupported")
             elif i >= len(self._data):
                 i = 0
             if (
@@ -135,8 +138,10 @@ class Table(Widget):
             ):
                 found_item = True
                 break
-            if find_previous:
-                i -= 1
+            if find_previous:  # pragma: no cover
+                # Toga does not currently need backwards searching functionality.
+                # i -= 1
+                raise NotImplementedError("backwards search unsupported")
             else:
                 i += 1
             if i == e.StartIndex:

--- a/winforms/tests_backend/probe.py
+++ b/winforms/tests_backend/probe.py
@@ -10,7 +10,7 @@ from .fonts import FontMixin
 
 KEY_CODES = {
     f"<{name}>": f"{{{name.upper()}}}"
-    for name in ["esc", "up", "down", "left", "right"]
+    for name in ["esc", "up", "down", "left", "right", "home", "end"]
 }
 KEY_CODES.update(
     {

--- a/winforms/tests_backend/widgets/table.py
+++ b/winforms/tests_backend/widgets/table.py
@@ -15,6 +15,7 @@ class TableProbe(SimpleProbe):
     background_supports_alpha = False
     supports_icons = 1  # First column only
     supports_keyboard_shortcuts = False
+    supports_keyboard_boundary_shortcuts = True
     supports_widgets = False
 
     @property
@@ -100,27 +101,6 @@ class TableProbe(SimpleProbe):
             )
         )
 
-    async def assert_keyboard_navigation(self):
-        # Focus the list by pressing tab.
+    async def acquire_keyboard_focus(self):
         await self.type_character("\t")
-
-        # Navigate 2 items down. In this dataset, all items start with "A".
-        await self.type_character("a")
-        await self.type_character("a")
-        await self.redraw("Third row is selected")
-        assert self.native.Items[2].Selected
-
-        # Select the last item with the end key.
-        await self.type_character("<end>")
-        await self.redraw("Last row is selected")
-        assert self.native.Items[self.row_count - 1].Selected
-
-        # Navigate by 1 item, wrapping around.
-        await self.type_character("a")
-        await self.redraw("First row is selected")
-        assert self.native.Items[0].Selected
-
-        # Type a letter that no items start with to verify the selection doesn't change.
-        await self.type_character("x")
-        await self.redraw("First row is selected")
-        assert self.native.Items[0].Selected
+        await self.type_character(" ")  # select first row

--- a/winforms/tests_backend/widgets/table.py
+++ b/winforms/tests_backend/widgets/table.py
@@ -99,3 +99,23 @@ class TableProbe(SimpleProbe):
                 delta=0,
             )
         )
+
+    async def assert_keyboard_navigation(self):
+        # Focus the list by pressing tab.
+        await self.type_character("\t")
+
+        # Navigate 2 items down. In this dataset, all items start with "A".
+        await self.type_character("a")
+        await self.type_character("a")
+        await self.redraw("Third row is selected")
+        assert self.native.Items[2].Selected
+
+        # Select the last item with the end key.
+        await self.type_character("<end>")
+        await self.redraw("Last row is selected")
+        assert self.native.Items[self.row_count - 1].Selected
+
+        # Navigate by 1 item, wrapping around.
+        await self.type_character("a")
+        await self.redraw("First row is selected")
+        assert self.native.Items[0].Selected

--- a/winforms/tests_backend/widgets/table.py
+++ b/winforms/tests_backend/widgets/table.py
@@ -119,3 +119,8 @@ class TableProbe(SimpleProbe):
         await self.type_character("a")
         await self.redraw("First row is selected")
         assert self.native.Items[0].Selected
+
+        # Type a letter that no items start with to verify the selection doesn't change.
+        await self.type_character("x")
+        await self.redraw("First row is selected")
+        assert self.native.Items[0].Selected

--- a/winforms/tests_backend/widgets/table.py
+++ b/winforms/tests_backend/widgets/table.py
@@ -102,5 +102,7 @@ class TableProbe(SimpleProbe):
         )
 
     async def acquire_keyboard_focus(self):
-        await self.type_character("\t")  # switch to widget.focus() when possible
+        await self.type_character(
+            "\t"
+        )  # switch to widget.focus() when possible (#2972)
         await self.type_character(" ")  # select first row

--- a/winforms/tests_backend/widgets/table.py
+++ b/winforms/tests_backend/widgets/table.py
@@ -102,5 +102,5 @@ class TableProbe(SimpleProbe):
         )
 
     async def acquire_keyboard_focus(self):
-        await self.type_character("\t")
+        await self.type_character("\t")  # switch to widget.focus() when possible
         await self.type_character(" ")  # select first row


### PR DESCRIPTION
This introduces the ability to perform first-letter keyboard navigation in tables and lists on windows. In the majority of native lists and tables, it is possible to type the first couple of letters of an item that exists in the list to instantly scroll to that item. As a completely blind computer programmer, this method of list navigation is invaluable to me and other visually impaired computer users when navigating a list containing content we are already somewhat familiar with. I am creating a Toga application with a list containing hundreds of items, and discovered that, though it already works on MacOS with the Voice Over screen reader, I was unable to navigate to list items by letter on windows, making my large list much more difficult to navigate, as now I must use page up/down to hopefully get near the item I'm looking for then use the arrow keys and listen to my screen reader announce items until I find what I want. This confused me as such keyboard navigation is already a built-in feature of these native ListView controls on windows, and so I set out to figure out why this was broken in Toga as this library has a great API and is beautifully accessible to screen readers otherwise and I was hoping to get one of the few accessibility flaws I noticed officially resolved.

It turns out that Toga didn't register a handler for the SearchForVirtualItem event on it's ListView control in the Table widget, which is a requirement for such keyboard navigation to work in lists that are in virtual mode. While the microsoft documentation indicates that this event is used for the ListView.FindItemWithText method / location searching, it does not very clearly indicate that it also enables such first-letter keyboard navigation within the ListView.

This pull request implements a handler for the aforementioned event which, at least on my system, successfully enables keyboard navigation within my large list.
* The handler uses the text of the first column in the table, or self._aliases[0] to check against, which is usually what is wanted at least in an accessibility context.
* The _new_item method in the winforms Table widget class had 2 submethods, text and icon. Since the item text was needed by this handler, I cut the text() function out of the _new_item function and turned it into an _item_text method of the Table class to avoid duplicated code.
* The Microsoft winforms documentation mentions an IsPrefixSearch property in the SearchForVirtualItemEventArgs object which if True should match items if their text starts with that in the event, or else should match items containing text that exactly match that in the event. However when doing keyboard navigation in tables (which requires partial matches) and printing the value of this property, it always seemed to be False. Considering the purpose of this implementation and since I don't think the FindItemWithText method is used by Toga, I opted not to handle this property at present. The IncludeSubItemsInSearch property is similarly left unhandled both do to the fact that it doesn't seem to be needed for the goal of this handler and because Microsoft documentation seems unclear on how/when to implement it.
* This handler only responds to text searches and is a no-op if e.IsTextSearch is False, I have not comprehended the location search API and it was beyond the scope of what I was hoping to accomplish with this fix.
* Most importantly, if it's necessary how should I write a test for this? The biggest issue is that though all core tests pass on my machine, the testbed crashes with some sort of access violation in the webview2 loader. I was honestly not surprised by this, screen reader applications tend to do a lot of process injection to retrieve enough accessibility information to do their work, and with the rate at which windowed processes were launching in the UI testbed I would not be surprised to find out that my screen reader made it choke for any myriad of reasons assuming that something unrelated isn't going on. Regardless I did try to comprehend the testbed/probe setup encase it's needed and understand that perhaps I need to create some sort of test case which spawns a list and calls probe.type_character in combination  with assertions to check whether the selection moved where intended? However I'm confused as to how to put that all together. Do I create a new async def test_keyboard_select function in test_table.py that uses the skip_on_platforms function to only run it on windows? Especially since I am having a hard time running the test bed in my environment, I figured it was best to ask here instead of messing with it much myself yet. The code does function in that keyboard navigation works exactly as intended in my tables now, but is untested otherwise.

Thanks for considering this contribution!

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
