### PR TITLE
Skip failing camera tests on macOS when using 'briefcase dev'

### DIFF
--- a/changes/2991.misc.rst
+++ b/changes/2991.misc.rst
@@ -1,0 +1,1 @@
+Camera tests which failed on macOS due to a lack of privacy permissions are now skipped upfront.

--- a/testbed/tests/conftest.py
+++ b/testbed/tests/conftest.py
@@ -33,6 +33,16 @@ def xfail_on_platforms(*platforms, reason=None):
         skip(reason or f"not applicable on {current_platform}")
 
 
+# Use this for widgets or tests which trip up macOS privacy controls, and requires
+# properties or entitlements defined in Info.plist
+def skip_if_unbundled_app(reason=None):
+    if not toga.App.app.is_bundled:
+        skip(
+            reason
+            or "test requires a full application, use 'briefcase run' instead of 'briefcase dev'"
+        )
+
+
 @fixture(autouse=True)
 def no_dangling_tasks():
     """Ensure any tasks for the test were removed when the test finished."""

--- a/testbed/tests/hardware/test_camera.py
+++ b/testbed/tests/hardware/test_camera.py
@@ -4,13 +4,14 @@ import pytest
 
 from toga.constants import FlashMode
 
-from ..conftest import skip_on_platforms
+from ..conftest import skip_if_unbundled_app, skip_on_platforms
 from .probe import get_probe
 
 
 @pytest.fixture
 async def camera_probe(monkeypatch, app_probe):
     skip_on_platforms("linux", "windows")
+    skip_if_unbundled_app()
     probe = get_probe(monkeypatch, app_probe, "Camera")
     yield probe
     probe.cleanup()


### PR DESCRIPTION
When using `briefcase dev --test` on the test bed, the Camera tests fail on macOS.

This is because the `Python.app` bundle does not include `NSCameraUsageDescription` in its `Info.Plist`.

`pyproject.toml` is configured to emit this with `permission.camera`, but `briefcase dev` does not use this. To use this permission we must call `briefcase run` instead, which emits a .xcodeproj file and builds a full macOS application.

This PR skips the test when using `briefcase dev` and instructs the user to test under `briefcase run` instead.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
