### PR TITLE
Workaround to Toga quick start for `uv` users

### DIFF
--- a/docs/tutorial/get-started.rst
+++ b/docs/tutorial/get-started.rst
@@ -15,5 +15,9 @@ then run it:
 This will pop up a GUI window showing the full range of widgets available
 to an application using Toga.
 
+.. note::
+
+   Users of `uv` on MacOS who do a uv workspace install `uv add toga-demo` will need to instead run `uv pip install toga-demo` to install the toga demo app. This is due to an `issue <https://github.com/beeware/beeware/issues/451>`_.
+
 If you want to see how to write a Toga app of your own, you can :doc:`start the tutorial
 <tutorial-0>`.


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Addition to quick start documentation for users of the `uv` python package manager.
<!--- What problem does this change solve? -->
Quck start documentation steps fail for some `uv` users. Am warning them and offering a workaround.
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
See https://github.com/beeware/beeware/issues/451

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X ] All new features have been tested
- [ X] All new features have been documented
- [ X] I have read the **CONTRIBUTING.md** file
- [ X] I will abide by the code of conduct
