### PR TITLE
Install prerelease versions of Toga's dependencies for testbed testing

### DIFF
--- a/changes/3004.misc.rst
+++ b/changes/3004.misc.rst
@@ -1,0 +1,1 @@
+Toga's testbed Briefcase project now builds with and tests against prerelease versions of dependencies.

--- a/testbed/pyproject.toml
+++ b/testbed/pyproject.toml
@@ -34,6 +34,9 @@ test_sources = [
     "tests",
 ]
 requires = [
+    # install prerelease versions of Toga's dependencies.
+    # this can catch issues with upcoming releases before final release.
+    "--pre",
     "../core",
 ]
 


### PR DESCRIPTION
Back when `pygobject==3.50.0` was released, it [broke](https://github.com/beeware/toga/pull/2550#issuecomment-2346726477) existing releases of Toga. PyGobject had published a [prerelease version](https://pypi.org/project/PyGObject/3.49.0.dev0/) of 3.50.0 that would have triggered this failure prior to general release (albeit, only 6 days sooner at most in this example).

So, this change simply lets us test Toga with prereleases of dependencies published to PyPI. At worst, I think the risk is small (assuming others see at least some gain) given this is easily revertable.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct