### PR TITLE
Fix `test_window_state_assignment` testbed on macOS-arm64

### DIFF
--- a/android/src/toga_android/window.py
+++ b/android/src/toga_android/window.py
@@ -147,17 +147,18 @@ class Window(Container):
     ######################################################################
 
     def get_window_state(self, in_progress_state=False):
-        decor_view = self.app.native.getWindow().getDecorView()
-        system_ui_flags = decor_view.getSystemUiVisibility()
-        if system_ui_flags & (
-            decor_view.SYSTEM_UI_FLAG_FULLSCREEN
-            | decor_view.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-            | decor_view.SYSTEM_UI_FLAG_IMMERSIVE
-        ):
-            if self._in_presentation_mode:
-                return WindowState.PRESENTATION
-            else:
-                return WindowState.FULLSCREEN
+        if getattr(self, "app", None) is not None:
+            decor_view = self.app.native.getWindow().getDecorView()
+            system_ui_flags = decor_view.getSystemUiVisibility()
+            if system_ui_flags & (
+                decor_view.SYSTEM_UI_FLAG_FULLSCREEN
+                | decor_view.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                | decor_view.SYSTEM_UI_FLAG_IMMERSIVE
+            ):
+                if self._in_presentation_mode:
+                    return WindowState.PRESENTATION
+                else:
+                    return WindowState.FULLSCREEN
         return WindowState.NORMAL
 
     def set_window_state(self, state):

--- a/changes/3016.misc.rst
+++ b/changes/3016.misc.rst
@@ -1,0 +1,1 @@
+The testbed test `test_window_state_rapid_change` now correctly passes through the macOS-arm64 CI.

--- a/cocoa/tests_backend/window.py
+++ b/cocoa/tests_backend/window.py
@@ -32,7 +32,7 @@ class WindowProbe(BaseProbe, DialogsMixin):
         await self.redraw(
             message,
             delay=(
-                2.5
+                1.75
                 if state_switch_not_from_normal
                 else 0.75 if full_screen else 0.5 if minimize else 0.1
             ),

--- a/cocoa/tests_backend/window.py
+++ b/cocoa/tests_backend/window.py
@@ -34,7 +34,7 @@ class WindowProbe(BaseProbe, DialogsMixin):
             delay=(
                 1.75
                 if state_switch_not_from_normal
-                else 0.75 if full_screen else 0.5 if minimize else 0.1
+                else 1 if full_screen else 0.5 if minimize else 0.1
             ),
         )
 

--- a/cocoa/tests_backend/window.py
+++ b/cocoa/tests_backend/window.py
@@ -32,9 +32,9 @@ class WindowProbe(BaseProbe, DialogsMixin):
         await self.redraw(
             message,
             delay=(
-                1.75
+                2.5
                 if state_switch_not_from_normal
-                else 1 if full_screen else 0.5 if minimize else 0.1
+                else 0.75 if full_screen else 0.5 if minimize else 0.1
             ),
         )
 

--- a/testbed/tests/conftest.py
+++ b/testbed/tests/conftest.py
@@ -100,6 +100,7 @@ async def window_cleanup(app, app_probe, main_window, main_window_probe):
         window.close()
         await main_window_probe.wait_for_window(
             "Closing window",
+            minimize=True if window_state == WindowState.MINIMIZED else False,
             full_screen=True if window_state == WindowState.FULLSCREEN else False,
         )
         del window

--- a/testbed/tests/conftest.py
+++ b/testbed/tests/conftest.py
@@ -96,8 +96,12 @@ async def window_cleanup(app, app_probe, main_window, main_window_probe):
     # Then purge everything on the kill list.
     while kill_list:
         window = kill_list.pop()
+        window_state = window.state
         window.close()
-        await main_window_probe.wait_for_window("Closing window")
+        await main_window_probe.wait_for_window(
+            "Closing window",
+            full_screen=True if window_state == WindowState.FULLSCREEN else False,
+        )
         del window
 
     # Force a GC pass on the main thread. This isn't perfect, but it helps


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Fixes #3016 
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
The testbed test was failing since the test assertion was being done even before the window state change was completed. The failure only affected macOS-arm64, since a longer delay before assertion is required on macOS-arm64 for fullscreen transition. Since, we cannot differentiate between macOS-x86_64 and macOS-arm64, so on the cocoa backend the delay for fullscreen is 1s now.

I apologise for causing any inconveniences. 
## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
