### PR TITLE
Use a consistent bundle ID for all examples.

### DIFF
--- a/changes/3020.misc.rst
+++ b/changes/3020.misc.rst
@@ -1,0 +1,1 @@
+Inconsistencies in bundle IDs in the example apps were normalized.

--- a/examples/hardware/hardware/app.py
+++ b/examples/hardware/hardware/app.py
@@ -231,7 +231,7 @@ class ExampleHardwareApp(toga.App):
 
 
 def main():
-    return ExampleHardwareApp("Hardware", "org.beeware.examples.hardware")
+    return ExampleHardwareApp("Hardware", "org.beeware.toga.examples.hardware")
 
 
 if __name__ == "__main__":

--- a/examples/hardware/pyproject.toml
+++ b/examples/hardware/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "Hardware"
-bundle = "org.beeware.examples"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license.file = "LICENSE"

--- a/examples/simpleapp/pyproject.toml
+++ b/examples/simpleapp/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "Simple App"
-bundle = "org.beeware"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license.file = "LICENSE"

--- a/examples/simpleapp/simpleapp/app.py
+++ b/examples/simpleapp/simpleapp/app.py
@@ -24,7 +24,7 @@ class ExampleSimpleApp(toga.App):
 
 
 def main():
-    return ExampleSimpleApp("Simple App", "org.beeware.simpleapp")
+    return ExampleSimpleApp("Simple App", "org.beeware.toga.examples.simpleapp")
 
 
 if __name__ == "__main__":

--- a/examples/tutorial0/pyproject.toml
+++ b/examples/tutorial0/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "Tutorial 0"
-bundle = "org.beeware.toga"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license.file = "LICENSE"

--- a/examples/tutorial0/tutorial/app.py
+++ b/examples/tutorial0/tutorial/app.py
@@ -17,7 +17,7 @@ def build(app):
 
 
 def main():
-    return toga.App("First App", "org.beeware.toga.tutorial", startup=build)
+    return toga.App("First App", "org.beeware.toga.examples.tutorial", startup=build)
 
 
 if __name__ == "__main__":

--- a/examples/tutorial1/pyproject.toml
+++ b/examples/tutorial1/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "Tutorial 1"
-bundle = "org.beeware.toga"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license.file = "LICENSE"

--- a/examples/tutorial1/tutorial/app.py
+++ b/examples/tutorial1/tutorial/app.py
@@ -49,7 +49,11 @@ def build(app):
 
 
 def main():
-    return toga.App("Temperature Converter", "org.beeware.toga.tutorial", startup=build)
+    return toga.App(
+        "Temperature Converter",
+        "org.beeware.toga.examples.tutorial",
+        startup=build,
+    )
 
 
 if __name__ == "__main__":

--- a/examples/tutorial2/pyproject.toml
+++ b/examples/tutorial2/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "Tutorial 2"
-bundle = "org.beeware.toga"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license.file = "LICENSE"

--- a/examples/tutorial2/tutorial/app.py
+++ b/examples/tutorial2/tutorial/app.py
@@ -154,7 +154,7 @@ class Tutorial2App(toga.App):
 
 
 def main():
-    return Tutorial2App("Tutorial 2", "org.beeware.toga.tutorial")
+    return Tutorial2App("Tutorial 2", "org.beeware.toga.examples.tutorial")
 
 
 if __name__ == "__main__":

--- a/examples/tutorial3/pyproject.toml
+++ b/examples/tutorial3/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["briefcase"]
 
 [tool.briefcase]
 project_name = "Tutorial 3"
-bundle = "org.beeware.toga"
+bundle = "org.beeware.toga.examples"
 version = "0.0.1"
 url = "https://beeware.org"
 license.file = "LICENSE"

--- a/examples/tutorial3/tutorial/app.py
+++ b/examples/tutorial3/tutorial/app.py
@@ -49,7 +49,7 @@ class Graze(toga.App):
 
 
 def main():
-    return Graze("Graze", "org.beeware.tutorial")
+    return Graze("Graze", "org.beeware.toga.examples.tutorial")
 
 
 if __name__ == "__main__":

--- a/examples/tutorial4/tutorial/app.py
+++ b/examples/tutorial4/tutorial/app.py
@@ -137,7 +137,7 @@ class StartApp(toga.App):
 
 
 def main():
-    return StartApp("Tutorial 4", "org.beeware.toga.tutorial")
+    return StartApp("Tutorial 4", "org.beeware.toga.examples.tutorial")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Modifies the example code to use `org.beeware.toga.examples` as a consistent bundle definition.

This is partially for consistency, but also because the inconsistency in bundle ID naming between ``pyproject.toml`` and the app code in tutorial 4 led to [this change](https://github.com/beeware/briefcase/pull/802#issuecomment-1195795545), which added a Flatpak security default which was a little more liberal than was needed.

Refs beeware/briefcase#2074.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
