### PR TITLE
Add hardware ABCs to encode platform implementation requrements

### DIFF
--- a/dummy/src/toga_dummy/hardware/camera.py
+++ b/dummy/src/toga_dummy/hardware/camera.py
@@ -1,7 +1,9 @@
+from toga.hardware.camera import PlatformCamera, PlatformCameraDevice
+
 from ..utils import LoggedObject
 
 
-class CameraDevice:
+class CameraDevice(PlatformCameraDevice):
     def __init__(self, id, name, has_flash):
         self._id = id
         self._name = name
@@ -17,12 +19,12 @@ class CameraDevice:
         return self._has_flash
 
 
-class Camera(LoggedObject):
+class Camera(LoggedObject, PlatformCamera):
     CAMERA_1 = CameraDevice(id="camera-1", name="Camera 1", has_flash=True)
     CAMERA_2 = CameraDevice(id="camera-2", name="Camera 2", has_flash=False)
 
     def __init__(self, interface):
-        self.interface = interface
+        super().__init__(interface)
 
         # -1: permission *could* be granted, but hasn't been
         # 1: permission has been granted

--- a/dummy/src/toga_dummy/hardware/location.py
+++ b/dummy/src/toga_dummy/hardware/location.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 from toga import LatLng
+from toga.hardware.location import PlatformLocation
 
 from ..utils import LoggedObject
 
 
-class Location(LoggedObject):
+class Location(LoggedObject, PlatformLocation):
     def __init__(self, interface):
         self.interface = interface
 


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Refs https://github.com/beeware/toga/issues/3022

This is just a draft to demonstrate the idea I've proposed in the related issue.

Nothing here is a strong recommendation, and I wouldn't be surprised if there are better ways to organise this or approach the problem overall. Mostly focused on making it easy to talk about the idea in the issue. I've only tested it with the dummy platform, so if there are circular importing issues related to defnining it directly in the `toga.hardware.*` modules, I haven't uncovered those yet :nerd_face:.

For this PR to be complete, the new ABCs should be used in each platform without modifications required beyond adding the new base class. Of course a changelog entry would be needed as well, and perhaps an update to the prose contribution documentation to point platform implementers to these base classes existence.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
