### PR TITLE
Updated Pack property names to match CSS

### DIFF
--- a/android/src/toga_android/widgets/base.py
+++ b/android/src/toga_android/widgets/base.py
@@ -161,7 +161,7 @@ class Widget(ABC, Scalable):
             else PorterDuffColorFilter(native_color(value), PorterDuff.Mode.SRC_IN)
         )
 
-    def set_alignment(self, alignment):
+    def set_text_alignment(self, alignment):
         pass  # If appropriate, a widget subclass will implement this.
 
     def set_color(self, color):
@@ -190,7 +190,7 @@ class Widget(ABC, Scalable):
         pass
 
 
-def align(value):
+def android_text_align(value):
     """Convert toga alignment values into Android alignment values."""
     return {
         LEFT: Gravity.LEFT,

--- a/android/src/toga_android/widgets/label.py
+++ b/android/src/toga_android/widgets/label.py
@@ -10,7 +10,7 @@ from travertino.size import at_least
 from toga.constants import JUSTIFY
 from toga_android.colors import native_color
 
-from .base import Widget, align
+from .base import Widget, android_text_align
 
 
 def set_textview_font(tv, font, default_typeface, default_size):
@@ -51,7 +51,7 @@ class TextViewWidget(Widget):
                 else Layout.JUSTIFICATION_MODE_NONE
             )
 
-        self.native.setGravity(vertical_gravity | align(value))
+        self.native.setGravity(vertical_gravity | android_text_align(value))
 
 
 class Label(TextViewWidget):
@@ -80,5 +80,5 @@ class Label(TextViewWidget):
             at_least(self.native.getMeasuredWidth()), ROUND_UP
         )
 
-    def set_alignment(self, value):
+    def set_text_alignment(self, value):
         self.set_textview_alignment(value, Gravity.TOP)

--- a/android/src/toga_android/widgets/multilinetextinput.py
+++ b/android/src/toga_android/widgets/multilinetextinput.py
@@ -23,7 +23,7 @@ class MultilineTextInput(TextInput):
     def _on_lose_focus(self):
         pass  # The interface doesn't support this event.
 
-    def set_alignment(self, value):
+    def set_text_alignment(self, value):
         self.set_textview_alignment(value, Gravity.TOP)
 
     # This method is necessary to override the TextInput base class.

--- a/android/src/toga_android/widgets/textinput.py
+++ b/android/src/toga_android/widgets/textinput.py
@@ -98,7 +98,7 @@ class TextInput(TextViewWidget):
     def set_placeholder(self, value):
         self.native.setHint(value)
 
-    def set_alignment(self, value):
+    def set_text_alignment(self, value):
         self.set_textview_alignment(value, Gravity.CENTER_VERTICAL)
 
     def set_error(self, error_message):

--- a/android/tests_backend/widgets/base.py
+++ b/android/tests_backend/widgets/base.py
@@ -37,8 +37,8 @@ class SimpleProbe(BaseProbe, FontMixin):
         assert self.widget._impl.container is None
         assert self.native.getParent() is None
 
-    def assert_alignment(self, expected):
-        actual = self.alignment
+    def assert_text_alignment(self, expected):
+        actual = self.text_alignment
         if expected == JUSTIFY and (
             Build.VERSION.SDK_INT < 26 or not self.supports_justify
         ):

--- a/android/tests_backend/widgets/label.py
+++ b/android/tests_backend/widgets/label.py
@@ -2,7 +2,7 @@ from android.os import Build
 from java import jclass
 
 from .base import SimpleProbe
-from .properties import toga_alignment, toga_color
+from .properties import toga_color, toga_text_alignment
 
 
 class LabelProbe(SimpleProbe):
@@ -26,8 +26,8 @@ class LabelProbe(SimpleProbe):
         return self.native.getTextSize()
 
     @property
-    def alignment(self):
+    def text_alignment(self):
         justification_mode = (
             None if Build.VERSION.SDK_INT < 26 else self.native.getJustificationMode()
         )
-        return toga_alignment(self.native.getGravity(), justification_mode)
+        return toga_text_alignment(self.native.getGravity(), justification_mode)

--- a/android/tests_backend/widgets/properties.py
+++ b/android/tests_backend/widgets/properties.py
@@ -22,7 +22,7 @@ def toga_color(color_int):
         )
 
 
-def toga_alignment(gravity, justification_mode=None):
+def toga_text_alignment(gravity, justification_mode=None):
     horizontal_gravity = gravity & Gravity.HORIZONTAL_GRAVITY_MASK
     if (Build.VERSION.SDK_INT < 26) or (
         justification_mode in (None, Layout.JUSTIFICATION_MODE_NONE)

--- a/android/tests_backend/widgets/selection.py
+++ b/android/tests_backend/widgets/selection.py
@@ -12,8 +12,8 @@ class SelectionProbe(SimpleProbe):
         xfail("Selection doesn't resize on content changes on this backend")
 
     @property
-    def alignment(self):
-        xfail("Can't change the alignment of Selection on this backend")
+    def text_alignment(self):
+        xfail("Can't change the text alignment of Selection on this backend")
 
     @property
     def color(self):

--- a/cocoa/src/toga_cocoa/hardware/camera.py
+++ b/cocoa/src/toga_cocoa/hardware/camera.py
@@ -131,7 +131,7 @@ class TogaCameraWindow(toga.Window):
                             style=Pack(flex=1),
                         ),
                     ],
-                    style=Pack(padding=10),
+                    style=Pack(margin=10),
                 ),
             ],
             style=Pack(direction=COLUMN),

--- a/cocoa/src/toga_cocoa/widgets/base.py
+++ b/cocoa/src/toga_cocoa/widgets/base.py
@@ -59,7 +59,7 @@ class Widget:
         # print(f"SET BOUNDS ON {self.interface} {width}x{height} @ ({x},{y})")
         self.constraints.update(x, y, width, height)
 
-    def set_alignment(self, alignment):
+    def set_text_alignment(self, alignment):
         pass
 
     def set_hidden(self, hidden):

--- a/cocoa/src/toga_cocoa/widgets/label.py
+++ b/cocoa/src/toga_cocoa/widgets/label.py
@@ -17,7 +17,7 @@ class Label(Widget):
         # Add the layout constraints
         self.add_constraints()
 
-    def set_alignment(self, value):
+    def set_text_alignment(self, value):
         self.native.alignment = NSTextAlignment(value)
 
     def set_color(self, value):

--- a/cocoa/src/toga_cocoa/widgets/multilinetextinput.py
+++ b/cocoa/src/toga_cocoa/widgets/multilinetextinput.py
@@ -95,7 +95,7 @@ class MultilineTextInput(Widget):
             self.native_text.drawsBackground = True
             self.native_text.backgroundColor = native_color(color)
 
-    def set_alignment(self, value):
+    def set_text_alignment(self, value):
         self.native_text.alignment = NSTextAlignment(value)
 
     def set_font(self, font):

--- a/cocoa/src/toga_cocoa/widgets/numberinput.py
+++ b/cocoa/src/toga_cocoa/widgets/numberinput.py
@@ -214,7 +214,7 @@ class NumberInput(Widget):
         else:
             self.native_stepper.maxValue = float(value)
 
-    def set_alignment(self, value):
+    def set_text_alignment(self, value):
         self.native_input.alignment = NSTextAlignment(value)
 
     def set_font(self, font):

--- a/cocoa/src/toga_cocoa/widgets/textinput.py
+++ b/cocoa/src/toga_cocoa/widgets/textinput.py
@@ -184,7 +184,7 @@ class TextInput(Widget):
     def set_placeholder(self, value):
         self.native.cell.placeholderString = value
 
-    def set_alignment(self, value):
+    def set_text_alignment(self, value):
         self.native.alignment = NSTextAlignment(value)
         # The alert label should be on the trailing edge
         if value == RIGHT:

--- a/cocoa/tests_backend/widgets/base.py
+++ b/cocoa/tests_backend/widgets/base.py
@@ -33,8 +33,8 @@ class SimpleProbe(BaseProbe, FontMixin):
         assert self.native.superview is None
         assert self.native.window is None
 
-    def assert_alignment(self, expected):
-        assert self.alignment == expected
+    def assert_text_alignment(self, expected):
+        assert self.text_alignment == expected
 
     async def redraw(self, message=None, delay=0):
         """Request a redraw of the app, waiting until that redraw has completed."""

--- a/cocoa/tests_backend/widgets/label.py
+++ b/cocoa/tests_backend/widgets/label.py
@@ -1,7 +1,7 @@
 from toga_cocoa.libs import NSTextField
 
 from .base import SimpleProbe
-from .properties import toga_alignment, toga_color
+from .properties import toga_color, toga_text_alignment
 
 
 class LabelProbe(SimpleProbe):
@@ -16,8 +16,8 @@ class LabelProbe(SimpleProbe):
         return toga_color(self.native.textColor)
 
     @property
-    def alignment(self):
-        return toga_alignment(self.native.alignment)
+    def text_alignment(self):
+        return toga_text_alignment(self.native.alignment)
 
     def assert_vertical_alignment(self, expected):
         # Vertical alignment isn't configurable on NSTextField

--- a/cocoa/tests_backend/widgets/multilinetextinput.py
+++ b/cocoa/tests_backend/widgets/multilinetextinput.py
@@ -2,7 +2,7 @@ from toga.colors import TRANSPARENT
 from toga_cocoa.libs import NSRange, NSScrollView, NSTextView
 
 from .base import SimpleProbe
-from .properties import toga_alignment, toga_color
+from .properties import toga_color, toga_text_alignment
 
 
 class MultilineTextInputProbe(SimpleProbe):
@@ -58,8 +58,8 @@ class MultilineTextInputProbe(SimpleProbe):
         return self.native_text.font
 
     @property
-    def alignment(self):
-        return toga_alignment(self.native_text.alignment)
+    def text_alignment(self):
+        return toga_text_alignment(self.native_text.alignment)
 
     def assert_vertical_alignment(self, expected):
         # Vertical alignment isn't configurable on NSTextView

--- a/cocoa/tests_backend/widgets/numberinput.py
+++ b/cocoa/tests_backend/widgets/numberinput.py
@@ -11,7 +11,7 @@ from toga_cocoa.libs import (
 )
 
 from .base import SimpleProbe
-from .properties import toga_alignment, toga_color
+from .properties import toga_color, toga_text_alignment
 
 
 class NumberInputProbe(SimpleProbe):
@@ -86,8 +86,8 @@ class NumberInputProbe(SimpleProbe):
         return self.native_input.font
 
     @property
-    def alignment(self):
-        return toga_alignment(self.native_input.alignment)
+    def text_alignment(self):
+        return toga_text_alignment(self.native_input.alignment)
 
     def assert_vertical_alignment(self, expected):
         # Vertical alignment isn't configurable on NSTextField

--- a/cocoa/tests_backend/widgets/properties.py
+++ b/cocoa/tests_backend/widgets/properties.py
@@ -20,7 +20,7 @@ def toga_color(color):
         return None
 
 
-def toga_alignment(alignment):
+def toga_text_alignment(alignment):
     return {
         NSLeftTextAlignment: LEFT,
         NSRightTextAlignment: RIGHT,

--- a/cocoa/tests_backend/widgets/selection.py
+++ b/cocoa/tests_backend/widgets/selection.py
@@ -13,8 +13,8 @@ class SelectionProbe(SimpleProbe):
         pass
 
     @property
-    def alignment(self):
-        xfail("Can't change the alignment of Selection on macOS")
+    def text_alignment(self):
+        xfail("Can't change the text alignment of Selection on macOS")
 
     @property
     def color(self):

--- a/cocoa/tests_backend/widgets/textinput.py
+++ b/cocoa/tests_backend/widgets/textinput.py
@@ -9,7 +9,7 @@ from toga_cocoa.libs import (
 )
 
 from .base import SimpleProbe
-from .properties import toga_alignment, toga_color
+from .properties import toga_color, toga_text_alignment
 
 
 class TextInputProbe(SimpleProbe):
@@ -60,15 +60,15 @@ class TextInputProbe(SimpleProbe):
         return self.native.font
 
     @property
-    def alignment(self):
-        result = toga_alignment(self.native.alignment)
+    def text_alignment(self):
+        result = toga_text_alignment(self.native.alignment)
         if result == RIGHT:
             assert self.impl.error_label.alignment == NSLeftTextAlignment
         else:
             assert self.impl.error_label.alignment == NSRightTextAlignment
         return result
 
-    def assert_vertical_alignment(self, expected):
+    def assert_vertical_text_alignment(self, expected):
         # Vertical alignment isn't configurable on NSTextField
         pass
 

--- a/core/src/toga/style/applicator.py
+++ b/core/src/toga/style/applicator.py
@@ -46,7 +46,7 @@ class TogaApplicator:
             child.applicator.set_bounds()
 
     def set_text_alignment(self, alignment: str) -> None:
-        self.widget._impl.set_alignment(alignment)
+        self.widget._impl.set_text_alignment(alignment)
 
     def set_hidden(self, hidden: bool) -> None:
         self.widget._impl.set_hidden(hidden)

--- a/core/tests/style/pack/layout/test_beeliza.py
+++ b/core/tests/style/pack/layout/test_beeliza.py
@@ -21,11 +21,11 @@ def test_beeliza():
                 children=[
                     ExampleNode(
                         "input",
-                        style=Pack(flex=1, padding=5),
+                        style=Pack(flex=1, margin=5),
                         size=(at_least(100), 15),
                     ),
                     ExampleNode(
-                        "button", style=Pack(padding=5), size=(at_least(40), 10)
+                        "button", style=Pack(margin=5), size=(at_least(40), 10)
                     ),
                 ],
             ),

--- a/core/tests/style/pack/layout/test_column_alignment.py
+++ b/core/tests/style/pack/layout/test_column_alignment.py
@@ -6,20 +6,20 @@ from ..utils import ExampleNode, ExampleViewport, assert_layout
 def test_left():
     root = ExampleNode(
         "root",
-        style=Pack(direction=COLUMN, alignment=LEFT, height=300),
+        style=Pack(direction=COLUMN, align_items=LEFT, height=300),
         children=[
             ExampleNode("space_filler", style=Pack(width=540, height=100)),
             ExampleNode(
                 "container",
-                style=Pack(direction=ROW, padding_left=110, padding_right=120),
+                style=Pack(direction=ROW, margin_left=110, margin_right=120),
                 children=[
                     ExampleNode(
                         "widget_a",
-                        style=Pack(width=30, padding_left=32, padding_right=34),
+                        style=Pack(width=30, margin_left=32, margin_right=34),
                     ),
                     ExampleNode(
                         "widget_b",
-                        style=Pack(width=36, padding_left=38, padding_right=40),
+                        style=Pack(width=36, margin_left=38, margin_right=40),
                     ),
                 ],
             ),
@@ -52,20 +52,20 @@ def test_left():
 def test_center():
     root = ExampleNode(
         "root",
-        style=Pack(direction=COLUMN, alignment=CENTER, height=300),
+        style=Pack(direction=COLUMN, align_items=CENTER, height=300),
         children=[
             ExampleNode("space_filler", style=Pack(width=540, height=100)),
             ExampleNode(
                 "container",
-                style=Pack(direction=ROW, padding_left=110, padding_right=120),
+                style=Pack(direction=ROW, margin_left=110, margin_right=120),
                 children=[
                     ExampleNode(
                         "widget_a",
-                        style=Pack(width=30, padding_left=32, padding_right=34),
+                        style=Pack(width=30, margin_left=32, margin_right=34),
                     ),
                     ExampleNode(
                         "widget_b",
-                        style=Pack(width=36, padding_left=38, padding_right=40),
+                        style=Pack(width=36, margin_left=38, margin_right=40),
                     ),
                 ],
             ),
@@ -98,20 +98,20 @@ def test_center():
 def test_right():
     root = ExampleNode(
         "root",
-        style=Pack(direction=COLUMN, alignment=RIGHT, height=300),
+        style=Pack(direction=COLUMN, align_items=RIGHT, height=300),
         children=[
             ExampleNode("space_filler", style=Pack(width=540, height=100)),
             ExampleNode(
                 "container",
-                style=Pack(direction=ROW, padding_left=110, padding_right=120),
+                style=Pack(direction=ROW, margin_left=110, margin_right=120),
                 children=[
                     ExampleNode(
                         "widget_a",
-                        style=Pack(width=30, padding_left=32, padding_right=34),
+                        style=Pack(width=30, margin_left=32, margin_right=34),
                     ),
                     ExampleNode(
                         "widget_b",
-                        style=Pack(width=36, padding_left=38, padding_right=40),
+                        style=Pack(width=36, margin_left=38, margin_right=40),
                     ),
                 ],
             ),
@@ -141,10 +141,10 @@ def test_right():
     )
 
 
-def test_no_padding():
+def test_no_margin():
     root = ExampleNode(
         "root",
-        style=Pack(direction=COLUMN, alignment=CENTER, height=300),
+        style=Pack(direction=COLUMN, align_items=CENTER, height=300),
         children=[
             ExampleNode("space_filler", style=Pack(width=540, height=100)),
             ExampleNode("widget", style=Pack(width=440)),
@@ -170,23 +170,23 @@ def test_no_padding():
 def test_column_box():
     root = ExampleNode(
         "root",
-        style=Pack(direction=COLUMN, alignment=CENTER),
+        style=Pack(direction=COLUMN, align_items=CENTER),
         children=[
             ExampleNode("space_filler", style=Pack(width=430, height=100)),
             ExampleNode(
                 "container",
-                style=Pack(direction=COLUMN, padding_left=110, padding_right=120),
+                style=Pack(direction=COLUMN, margin_left=110, margin_right=120),
                 children=[
                     ExampleNode(
                         "widget_a",
                         style=Pack(
-                            width=100, height=30, padding_top=32, padding_bottom=34
+                            width=100, height=30, margin_top=32, margin_bottom=34
                         ),
                     ),
                     ExampleNode(
                         "widget_b",
                         style=Pack(
-                            width=100, height=36, padding_top=38, padding_bottom=40
+                            width=100, height=36, margin_top=38, margin_bottom=40
                         ),
                     ),
                 ],

--- a/core/tests/style/pack/layout/test_row_alignment.py
+++ b/core/tests/style/pack/layout/test_row_alignment.py
@@ -6,20 +6,20 @@ from ..utils import ExampleNode, ExampleViewport, assert_layout
 def test_top():
     root = ExampleNode(
         "root",
-        style=Pack(direction=ROW, alignment=TOP, width=300),
+        style=Pack(direction=ROW, align_items=TOP, width=300),
         children=[
             ExampleNode("space_filler", style=Pack(width=100, height=540)),
             ExampleNode(
                 "container",
-                style=Pack(direction=COLUMN, padding_top=110, padding_bottom=120),
+                style=Pack(direction=COLUMN, margin_top=110, margin_bottom=120),
                 children=[
                     ExampleNode(
                         "widget_a",
-                        style=Pack(height=30, padding_top=32, padding_bottom=34),
+                        style=Pack(height=30, margin_top=32, margin_bottom=34),
                     ),
                     ExampleNode(
                         "widget_b",
-                        style=Pack(height=36, padding_top=38, padding_bottom=40),
+                        style=Pack(height=36, margin_top=38, margin_bottom=40),
                     ),
                 ],
             ),
@@ -52,20 +52,20 @@ def test_top():
 def test_center():
     root = ExampleNode(
         "root",
-        style=Pack(direction=ROW, alignment=CENTER, width=300),
+        style=Pack(direction=ROW, align_items=CENTER, width=300),
         children=[
             ExampleNode("space_filler", style=Pack(width=100, height=540)),
             ExampleNode(
                 "container",
-                style=Pack(direction=COLUMN, padding_top=110, padding_bottom=120),
+                style=Pack(direction=COLUMN, margin_top=110, margin_bottom=120),
                 children=[
                     ExampleNode(
                         "widget_a",
-                        style=Pack(height=30, padding_top=32, padding_bottom=34),
+                        style=Pack(height=30, margin_top=32, margin_bottom=34),
                     ),
                     ExampleNode(
                         "widget_b",
-                        style=Pack(height=36, padding_top=38, padding_bottom=40),
+                        style=Pack(height=36, margin_top=38, margin_bottom=40),
                     ),
                 ],
             ),
@@ -98,20 +98,20 @@ def test_center():
 def test_bottom():
     root = ExampleNode(
         "root",
-        style=Pack(direction=ROW, alignment=BOTTOM, width=300),
+        style=Pack(direction=ROW, align_items=BOTTOM, width=300),
         children=[
             ExampleNode("space_filler", style=Pack(width=100, height=540)),
             ExampleNode(
                 "container",
-                style=Pack(direction=COLUMN, padding_top=110, padding_bottom=120),
+                style=Pack(direction=COLUMN, margin_top=110, margin_bottom=120),
                 children=[
                     ExampleNode(
                         "widget_a",
-                        style=Pack(height=30, padding_top=32, padding_bottom=34),
+                        style=Pack(height=30, margin_top=32, margin_bottom=34),
                     ),
                     ExampleNode(
                         "widget_b",
-                        style=Pack(height=36, padding_top=38, padding_bottom=40),
+                        style=Pack(height=36, margin_top=38, margin_bottom=40),
                     ),
                 ],
             ),
@@ -141,10 +141,10 @@ def test_bottom():
     )
 
 
-def test_no_padding():
+def test_no_margin():
     root = ExampleNode(
         "root",
-        style=Pack(direction=ROW, alignment=CENTER, width=300),
+        style=Pack(direction=ROW, align_items=CENTER, width=300),
         children=[
             ExampleNode("space_filler", style=Pack(width=100, height=540)),
             ExampleNode("widget", style=Pack(height=440)),
@@ -170,23 +170,23 @@ def test_no_padding():
 def test_row_box():
     root = ExampleNode(
         "root",
-        style=Pack(direction=ROW, alignment=CENTER),
+        style=Pack(direction=ROW, align_items=CENTER),
         children=[
             ExampleNode("space_filler", style=Pack(width=100, height=430)),
             ExampleNode(
                 "container",
-                style=Pack(direction=ROW, padding_top=110, padding_bottom=120),
+                style=Pack(direction=ROW, margin_top=110, margin_bottom=120),
                 children=[
                     ExampleNode(
                         "widget_a",
                         style=Pack(
-                            width=30, height=100, padding_left=32, padding_right=34
+                            width=30, height=100, margin_left=32, margin_right=34
                         ),
                     ),
                     ExampleNode(
                         "widget_b",
                         style=Pack(
-                            width=36, height=100, padding_left=38, padding_right=40
+                            width=36, height=100, margin_left=38, margin_right=40
                         ),
                     ),
                 ],

--- a/core/tests/style/pack/layout/test_rtl.py
+++ b/core/tests/style/pack/layout/test_rtl.py
@@ -10,11 +10,11 @@ def test_row_box_child_layout():
         children=[
             ExampleNode(
                 "widget_a",
-                style=Pack(width=30, height=100, padding_left=32, padding_right=34),
+                style=Pack(width=30, height=100, margin_left=32, margin_right=34),
             ),
             ExampleNode(
                 "widget_b",
-                style=Pack(width=36, height=100, padding_left=38, padding_right=40),
+                style=Pack(width=36, height=100, margin_left=38, margin_right=40),
             ),
         ],
     )
@@ -42,11 +42,11 @@ def test_column_box_child_layout():
         children=[
             ExampleNode(
                 "widget_a",
-                style=Pack(width=100, height=30, padding_top=32, padding_bottom=34),
+                style=Pack(width=100, height=30, margin_top=32, margin_bottom=34),
             ),
             ExampleNode(
                 "widget_b",
-                style=Pack(width=100, height=36, padding_top=38, padding_bottom=40),
+                style=Pack(width=100, height=36, margin_top=38, margin_bottom=40),
             ),
         ],
     )
@@ -68,10 +68,10 @@ def test_column_box_child_layout():
     )
 
 
-def test_alignment_top():
+def test_align_items_top():
     root = ExampleNode(
         "root",
-        style=Pack(text_direction=RTL, direction=ROW, alignment=TOP),
+        style=Pack(text_direction=RTL, direction=ROW, align_items=TOP),
         children=[
             ExampleNode("space_filler", style=Pack(width=30, height=100)),
             ExampleNode("widget", style=Pack(width=30, height=30)),
@@ -94,10 +94,10 @@ def test_alignment_top():
     )
 
 
-def test_alignment_bottom():
+def test_align_items_bottom():
     root = ExampleNode(
         "root",
-        style=Pack(text_direction=RTL, direction=ROW, alignment=BOTTOM),
+        style=Pack(text_direction=RTL, direction=ROW, align_items=BOTTOM),
         children=[
             ExampleNode("space_filler", style=Pack(width=30, height=100)),
             ExampleNode("widget", style=Pack(width=30, height=30)),
@@ -120,10 +120,10 @@ def test_alignment_bottom():
     )
 
 
-def test_alignment_left():
+def test_align_items_left():
     root = ExampleNode(
         "root",
-        style=Pack(text_direction=RTL, direction=COLUMN, alignment=LEFT),
+        style=Pack(text_direction=RTL, direction=COLUMN, align_items=LEFT),
         children=[
             ExampleNode("space_filler", style=Pack(width=100, height=30)),
             ExampleNode("widget", style=Pack(width=30, height=30)),
@@ -146,10 +146,10 @@ def test_alignment_left():
     )
 
 
-def test_alignment_right():
+def test_align_items_right():
     root = ExampleNode(
         "root",
-        style=Pack(text_direction=RTL, direction=COLUMN, alignment=RIGHT),
+        style=Pack(text_direction=RTL, direction=COLUMN, align_items=RIGHT),
         children=[
             ExampleNode("space_filler", style=Pack(width=100, height=30)),
             ExampleNode("widget", style=Pack(width=30, height=30)),

--- a/core/tests/style/pack/layout/test_tutorial0.py
+++ b/core/tests/style/pack/layout/test_tutorial0.py
@@ -11,7 +11,7 @@ def test_tutorial_0():
         style=Pack(),
         children=[
             ExampleNode(
-                "button", style=Pack(flex=1, padding=50), size=(at_least(120), 30)
+                "button", style=Pack(flex=1, margin=50), size=(at_least(120), 30)
             ),
         ],
     )
@@ -36,7 +36,7 @@ def test_vertical():
         children=[
             # ExampleNode('button', style=Pack(flex=1), size=(30, at_least(120))),
             ExampleNode(
-                "button", style=Pack(flex=1, padding=50), size=(30, at_least(120))
+                "button", style=Pack(flex=1, margin=50), size=(30, at_least(120))
             ),
         ],
     )

--- a/core/tests/style/pack/layout/test_tutorial1.py
+++ b/core/tests/style/pack/layout/test_tutorial1.py
@@ -8,31 +8,31 @@ from ..utils import ExampleNode, ExampleViewport, assert_layout
 def test_tutorial_1():
     root = ExampleNode(
         "app",
-        style=Pack(direction=COLUMN, padding_top=10),
+        style=Pack(direction=COLUMN, margin_top=10),
         children=[
             ExampleNode(
                 "f_box",
-                style=Pack(direction=ROW, padding=5),
+                style=Pack(direction=ROW, margin=5),
                 children=[
                     ExampleNode(
                         "f_input",
-                        style=Pack(flex=1, padding_left=160),
+                        style=Pack(flex=1, margin_left=160),
                         size=(at_least(100), 15),
                     ),
                     ExampleNode(
                         "f_label",
-                        style=Pack(width=100, padding_left=10),
+                        style=Pack(width=100, margin_left=10),
                         size=(at_least(40), 10),
                     ),
                 ],
             ),
             ExampleNode(
                 "c_box",
-                style=Pack(direction=ROW, padding=5),
+                style=Pack(direction=ROW, margin=5),
                 children=[
                     ExampleNode(
                         "join_label",
-                        style=Pack(width=150, padding_right=10),
+                        style=Pack(width=150, margin_right=10),
                         size=(at_least(80), 10),
                     ),
                     ExampleNode(
@@ -40,13 +40,13 @@ def test_tutorial_1():
                     ),
                     ExampleNode(
                         "c_label",
-                        style=Pack(width=100, padding_left=10),
+                        style=Pack(width=100, margin_left=10),
                         size=(at_least(40), 10),
                     ),
                 ],
             ),
             ExampleNode(
-                "button", style=Pack(flex=1, padding=15), size=(at_least(120), 30)
+                "button", style=Pack(flex=1, margin=15), size=(at_least(120), 30)
             ),
         ],
     )

--- a/core/tests/style/pack/layout/test_tutorial3.py
+++ b/core/tests/style/pack/layout/test_tutorial3.py
@@ -16,12 +16,12 @@ def test_tutorial_3():
                 children=[
                     ExampleNode(
                         "input",
-                        style=Pack(flex=1, padding=5),
+                        style=Pack(flex=1, margin=5),
                         size=(at_least(100), 15),
                     ),
                     ExampleNode(
                         "button",
-                        style=Pack(width=50, padding=5),
+                        style=Pack(width=50, margin=5),
                         size=(at_least(40), 10),
                     ),
                 ],

--- a/core/tests/style/pack/test_apply.py
+++ b/core/tests/style/pack/test_apply.py
@@ -20,7 +20,7 @@ def test_set_default_right_textalign_when_rtl():
     root.style.reapply()
     # Two calls; one caused by text_align, one because text_direction
     # implies a change to text alignment.
-    assert root._impl.set_alignment.mock_calls == [call(RIGHT), call(RIGHT)]
+    assert root._impl.set_text_alignment.mock_calls == [call(RIGHT), call(RIGHT)]
 
 
 def test_set_default_left_textalign_when_no_rtl():
@@ -28,13 +28,13 @@ def test_set_default_left_textalign_when_no_rtl():
     root.style.reapply()
     # Two calls; one caused by text_align, one because text_direction
     # implies a change to text alignment.
-    assert root._impl.set_alignment.mock_calls == [call(LEFT), call(LEFT)]
+    assert root._impl.set_text_alignment.mock_calls == [call(LEFT), call(LEFT)]
 
 
-def test_set_center_alignment():
+def test_set_center_text_alignment():
     root = ExampleNode("app", style=Pack(text_align="center"))
     root.style.reapply()
-    root._impl.set_alignment.assert_called_once_with(CENTER)
+    root._impl.set_text_alignment.assert_called_once_with(CENTER)
 
 
 def test_set_color():

--- a/core/tests/style/pack/test_css.py
+++ b/core/tests/style/pack/test_css.py
@@ -222,137 +222,137 @@ from toga.style.pack import (
         ),
         # Alignment - default layout
         pytest.param(
-            Pack(alignment=LEFT),
+            Pack(align_items=LEFT),
             "flex-direction: row; flex: 0.0 0 auto; align-items: start;",
-            id="alignment-left",
+            id="align-items-left",
         ),
         pytest.param(
-            Pack(alignment=RIGHT),
+            Pack(align_items=RIGHT),
             "flex-direction: row; flex: 0.0 0 auto; align-items: end;",
-            id="alignment-right",
+            id="align-items-right",
         ),
-        pytest.param(  # alignment is ignored
-            Pack(alignment=TOP),
+        pytest.param(  # align_items is ignored
+            Pack(align_items=TOP),
             "flex-direction: row; flex: 0.0 0 auto;",
-            id="alignment-top",
+            id="align-items-top",
         ),
-        pytest.param(  # alignment is ignored
-            Pack(alignment=BOTTOM),
+        pytest.param(  # align_items is ignored
+            Pack(align_items=BOTTOM),
             "flex-direction: row; flex: 0.0 0 auto;",
-            id="alignment-bottom",
+            id="align-items-bottom",
         ),
         pytest.param(
-            Pack(alignment=CENTER),
+            Pack(align_items=CENTER),
             "flex-direction: row; flex: 0.0 0 auto; align-items: center;",
-            id="alignment-center",
+            id="align-items-center",
         ),
         # Alignment - row layout
         pytest.param(
-            Pack(direction=ROW, alignment=LEFT),
+            Pack(direction=ROW, align_items=LEFT),
             "flex-direction: row; flex: 0.0 0 auto; align-items: start;",
-            id="row-alignment-left",
+            id="row-align_items-left",
         ),
         pytest.param(
-            Pack(direction=ROW, alignment=RIGHT),
+            Pack(direction=ROW, align_items=RIGHT),
             "flex-direction: row; flex: 0.0 0 auto; align-items: end;",
-            id="row-alignment-right",
+            id="row-align_items-right",
         ),
-        pytest.param(  # alignment is ignored
-            Pack(direction=ROW, alignment=TOP),
+        pytest.param(  # align_items is ignored
+            Pack(direction=ROW, align_items=TOP),
             "flex-direction: row; flex: 0.0 0 auto;",
-            id="row-alignment-top",
+            id="row-align_items-top",
         ),
-        pytest.param(  # alignment is ignored
-            Pack(direction=ROW, alignment=BOTTOM),
+        pytest.param(  # align_items is ignored
+            Pack(direction=ROW, align_items=BOTTOM),
             "flex-direction: row; flex: 0.0 0 auto;",
-            id="row-alignment-bottom",
+            id="row-align_items-bottom",
         ),
         pytest.param(
-            Pack(direction=ROW, alignment=CENTER),
+            Pack(direction=ROW, align_items=CENTER),
             "flex-direction: row; flex: 0.0 0 auto; align-items: center;",
-            id="row-alignment-center",
+            id="row-align_items-center",
         ),
         # Alignment - column layout
-        pytest.param(  # alignment is ignored
-            Pack(direction=COLUMN, alignment=LEFT),
+        pytest.param(  # align_items is ignored
+            Pack(direction=COLUMN, align_items=LEFT),
             "flex-direction: column; flex: 0.0 0 auto;",
-            id="column-alignment-left",
+            id="column-align_items-left",
         ),
-        pytest.param(  # alignment is ignored
-            Pack(direction=COLUMN, alignment=RIGHT),
+        pytest.param(  # align_items is ignored
+            Pack(direction=COLUMN, align_items=RIGHT),
             "flex-direction: column; flex: 0.0 0 auto;",
-            id="column-alignment-right",
+            id="column-align_items-right",
         ),
         pytest.param(
-            Pack(direction=COLUMN, alignment=TOP),
+            Pack(direction=COLUMN, align_items=TOP),
             "flex-direction: column; flex: 0.0 0 auto; align-items: start;",
-            id="column-alignment-top",
+            id="column-align_items-top",
         ),
         pytest.param(
-            Pack(direction=COLUMN, alignment=BOTTOM),
+            Pack(direction=COLUMN, align_items=BOTTOM),
             "flex-direction: column; flex: 0.0 0 auto; align-items: end;",
-            id="column-alignment-bottom",
+            id="column-align_items-bottom",
         ),
         pytest.param(
-            Pack(direction=COLUMN, alignment=CENTER),
+            Pack(direction=COLUMN, align_items=CENTER),
             "flex-direction: column; flex: 0.0 0 auto; align-items: center;",
-            id="column-alignment-center",
+            id="column-align_items-center",
         ),
-        # Padding
+        # Margin
         pytest.param(
-            Pack(padding_top=42),
+            Pack(margin_top=42),
             "flex-direction: row; flex: 0.0 0 auto; margin-top: 42px;",
-            id="padding-top",
+            id="margin-top",
         ),
         pytest.param(
-            Pack(padding_bottom=42),
+            Pack(margin_bottom=42),
             "flex-direction: row; flex: 0.0 0 auto; margin-bottom: 42px;",
-            id="padding-bottom",
+            id="margin-bottom",
         ),
         pytest.param(
-            Pack(padding_left=42),
+            Pack(margin_left=42),
             "flex-direction: row; flex: 0.0 0 auto; margin-left: 42px;",
-            id="padding-left",
+            id="margin-left",
         ),
         pytest.param(
-            Pack(padding_right=42),
+            Pack(margin_right=42),
             "flex-direction: row; flex: 0.0 0 auto; margin-right: 42px;",
-            id="padding-right",
+            id="margin-right",
         ),
         pytest.param(
-            Pack(padding=42),
+            Pack(margin=42),
             (
                 "flex-direction: row; flex: 0.0 0 auto; "
                 "margin-top: 42px; margin-bottom: 42px; "
                 "margin-left: 42px; margin-right: 42px;"
             ),
-            id="padding",
+            id="margin",
         ),
-        # Explicitly 0 padding
+        # Explicitly 0 margin
         pytest.param(
-            Pack(padding_top=0),
+            Pack(margin_top=0),
             "flex-direction: row; flex: 0.0 0 auto;",
-            id="padding-top-0",
-        ),
-        pytest.param(
-            Pack(padding_bottom=0),
-            "flex-direction: row; flex: 0.0 0 auto;",
-            id="padding-bottom-0",
+            id="margin-top-0",
         ),
         pytest.param(
-            Pack(padding_left=0),
+            Pack(margin_bottom=0),
             "flex-direction: row; flex: 0.0 0 auto;",
-            id="padding-left-0",
+            id="margin-bottom-0",
         ),
         pytest.param(
-            Pack(padding_right=0),
+            Pack(margin_left=0),
             "flex-direction: row; flex: 0.0 0 auto;",
-            id="padding-right-0",
+            id="margin-left-0",
         ),
         pytest.param(
-            Pack(padding=0),
+            Pack(margin_right=0),
             "flex-direction: row; flex: 0.0 0 auto;",
-            id="padding-0",
+            id="margin-right-0",
+        ),
+        pytest.param(
+            Pack(margin=0),
+            "flex-direction: row; flex: 0.0 0 auto;",
+            id="margin-0",
         ),
         # Color
         pytest.param(

--- a/core/tests/style/pack/test_deprecated_properties.py
+++ b/core/tests/style/pack/test_deprecated_properties.py
@@ -1,0 +1,58 @@
+import pytest
+
+from toga.style.pack import Pack
+
+
+def setitem(obj, name, value):
+    obj[name] = value
+
+
+def getitem(obj, name):
+    return obj[name]
+
+
+@pytest.mark.parametrize(
+    "old_name, new_name, value",
+    [
+        # Travertino 0.3.0 doesn't support accessing a directional property via bracket
+        # notation.
+        # ("padding", "margin", (5, 5, 5, 5)),
+        ("padding_top", "margin_top", 5),
+        ("padding_right", "margin_right", 5),
+        ("padding_bottom", "margin_bottom", 5),
+        ("padding_left", "margin_left", 5),
+        ("alignment", "align_items", "center"),
+    ],
+)
+@pytest.mark.parametrize("set_fn", (setattr, setitem))
+@pytest.mark.parametrize("get_fn", (getattr, getitem))
+def test_deprecated_properties(old_name, new_name, value, set_fn, get_fn):
+    """Deprecated names alias to new names, and issue deprecation warnings."""
+
+    # Set the old name, then check the new name.
+    style = Pack()
+    with pytest.warns(DeprecationWarning):
+        set_fn(style, old_name, value)
+    assert get_fn(style, new_name) == value
+
+    # Set the new name, then check the old name.
+    style = Pack()
+    set_fn(style, new_name, value)
+    with pytest.warns(DeprecationWarning):
+        assert get_fn(style, old_name) == value
+
+
+def test_padding_margin():
+    """Padding aliases margin, but can't be checked with bracket notation."""
+
+    # Set the old name, then check the new name.
+    style = Pack()
+    with pytest.warns(DeprecationWarning):
+        style.padding = (5, 5, 5, 5)
+    assert style.margin == (5, 5, 5, 5)
+
+    # Set the new name, then check the old name.
+    style = Pack()
+    style.margin = (5, 5, 5, 5)
+    with pytest.warns(DeprecationWarning):
+        assert style.padding == (5, 5, 5, 5)

--- a/core/tests/style/test_applicator.py
+++ b/core/tests/style/test_applicator.py
@@ -71,7 +71,7 @@ def test_text_alignment(widget):
     """Text alignment can be set on a widget."""
     widget.applicator.set_text_alignment(RIGHT)
 
-    assert_action_performed_with(widget, "set alignment", alignment=RIGHT)
+    assert_action_performed_with(widget, "set text alignment", alignment=RIGHT)
 
 
 @pytest.mark.parametrize(

--- a/core/tests/widgets/test_base.py
+++ b/core/tests/widgets/test_base.py
@@ -36,7 +36,7 @@ class WidgetSubclassWithoutCreate(toga.Widget):
 @pytest.fixture
 def widget(app):
     # App fixture is needed to ensure a fresh widget registry is created
-    return ExampleWidget(id="widget_id", style=Pack(padding=666))
+    return ExampleWidget(id="widget_id", style=Pack(margin=666))
 
 
 def test_simple_widget():
@@ -50,7 +50,7 @@ def test_simple_widget():
     # Base properties of the widget have been set
     assert widget.id == str(id(widget))
     assert isinstance(widget.style, Pack)
-    assert widget.style.padding == (0, 0, 0, 0)
+    assert widget.style.margin == (0, 0, 0, 0)
 
 
 def test_widget_created(widget):
@@ -63,7 +63,7 @@ def test_widget_created(widget):
     assert widget.enabled
     assert widget.id == "widget_id"
     assert isinstance(widget.style, Pack)
-    assert widget.style.padding == (666, 666, 666, 666)
+    assert widget.style.margin == (666, 666, 666, 666)
 
 
 def test_add_child_to_leaf():

--- a/demo/toga_demo/app.py
+++ b/demo/toga_demo/app.py
@@ -50,7 +50,7 @@ class TogaDemo(toga.App):
                 toga.Button(
                     "Hello world %s" % b,
                     on_press=self.button_handler,
-                    style=Pack(padding=20),
+                    style=Pack(margin=20),
                 )
             )
 

--- a/docs/reference/api/containers/box.rst
+++ b/docs/reference/api/containers/box.rst
@@ -41,7 +41,7 @@ Alternatively, children can be specified at the time the box is constructed:
 
 In most apps, a layout is constructed by building a tree of boxes inside boxes, with
 concrete widgets (such as :class:`~toga.Label` or :class:`~toga.Button`) forming the
-leaf nodes of the tree. Style directives can be applied to enforce padding around the
+leaf nodes of the tree. Style directives can be applied to enforce margin around the
 outside of the box, direction of child stacking inside the box, and background color of
 the box.
 

--- a/docs/reference/api/widgets/divider.rst
+++ b/docs/reference/api/widgets/divider.rst
@@ -63,7 +63,7 @@ To separate two labels stacked vertically with a horizontal line:
             toga.Divider(),
             toga.Label("Second section"),
         ],
-        style=Pack(direction=COLUMN, flex=1, padding=10)
+        style=Pack(direction=COLUMN, flex=1, margin=10)
     )
 
 The direction (horizontal or vertical) can be given as an argument. If not

--- a/docs/reference/api/widgets/label.rst
+++ b/docs/reference/api/widgets/label.rst
@@ -63,7 +63,7 @@ Usage
 Notes
 -----
 
-* Winforms does not support an alignment value of ``JUSTIFIED``. If this
+* Winforms does not support a text alignment value of ``JUSTIFIED``. If this
   alignment value is used, the label will default to left alignment.
 
 Reference

--- a/docs/reference/api/widgets/selection.rst
+++ b/docs/reference/api/widgets/selection.rst
@@ -105,7 +105,7 @@ Notes
 * On macOS and Android, you cannot change the font of a Selection.
 
 * On macOS, GTK and Android, you cannot change the text color, background color, or
-  alignment of labels in a Selection.
+  text alignment of labels in a Selection.
 
 * On GTK, a Selection widget with flexible sizing will expand its width (to the
   extent possible possible) to accommodate any changes in content (for example,

--- a/docs/reference/style/pack.rst
+++ b/docs/reference/style/pack.rst
@@ -64,7 +64,7 @@ children will be stacked vertically, from top to bottom. A value of ``row``
 indicates children will be packed horizontally; left-to-right if
 ``text_direction`` is ``ltr``, or right-to-left if ``text_direction`` is ``rtl``.
 
-``alignment``
+``align_items``
 -------------
 
 **Values:** ``top`` | ``bottom`` | ``left`` | ``right`` | ``center``
@@ -121,16 +121,16 @@ Once fixed space allocations have been performed, this box will assume ``flex
 / (sum of all flex for all siblings)`` of all remaining available space in the
 direction of the parent's layout.
 
-``padding_top``
+``margin_top``
 ---------------
 
-``padding_right``
+``margin_right``
 -----------------
 
-``padding_bottom``
+``margin_bottom``
 ------------------
 
-``padding_left``
+``margin_left``
 ----------------
 
 **Values:** ``<integer>``
@@ -140,20 +140,20 @@ direction of the parent's layout.
 The amount of space to allocate between the edge of the box, and the edge of the content
 in the box, in :ref:`CSS pixels <css-units>`.
 
-``padding``
+``margin``
 -----------
 
 **Values:** ``<integer>`` or ``<tuple>`` of length 1-4
 
-A shorthand for setting the top, right, bottom and left padding with a single declaration.
+A shorthand for setting the top, right, bottom and left margin with a single declaration.
 
-If 1 integer is provided, that value will be used as the padding for all sides.
+If 1 integer is provided, that value will be used as the margin for all sides.
 
-If 2 integers are provided, the first value will be used as the padding for the top and bottom; the second will be used as the value for the left and right.
+If 2 integers are provided, the first value will be used as the margin for the top and bottom; the second will be used as the value for the left and right.
 
-If 3 integers are provided, the first value will be used as the top padding, the second for the left and right padding, and the third for the bottom padding.
+If 3 integers are provided, the first value will be used as the top margin, the second for the left and right margin, and the third for the bottom margin.
 
-If 4 integers are provided, they will be used as the top, right, bottom and left padding, respectively.
+If 4 integers are provided, they will be used as the top, right, bottom and left margin, respectively.
 
 ``color``
 ---------
@@ -323,7 +323,7 @@ The mapping that can be used to establish the reference implementation is:
    ============================= ===================================================
    Pack property                 CSS property
    ============================= ===================================================
-   ``alignment: top``            ``align-items: start`` if ``direction == row``;
+   ``align_items: top``          ``align-items: start`` if ``direction == row``;
                                  otherwise ignored.
    ``alignment: bottom``         ``align-items: end`` if ``direction == row``;
                                  otherwise ignored.
@@ -340,10 +340,10 @@ The mapping that can be used to establish the reference implementation is:
    ``font_size: <int>``          ``font-size: <int>pt``
    ``height: <value>``           ``height: <value>px`` if value is an integer;
                                  ``height: auto`` if value is ``none``.
-   ``padding_top: <int>``        ``margin-top: <int>px``
-   ``padding_bottom: <int>``     ``margin-bottom: <int>px``
-   ``padding_left: <int>``       ``margin-left: <int>px``
-   ``padding_right: <int>``      ``margin-right: <int>px``
+   ``margin_top: <int>``         ``margin-top: <int>px``
+   ``margin_bottom: <int>``      ``margin-bottom: <int>px``
+   ``margin_left: <int>``        ``margin-left: <int>px``
+   ``margin_right: <int>``       ``margin-right: <int>px``
    ``text_direction: <str>``     ``direction: <str>``
    ``width: <value>``            ``width: <value>px`` if value is an integer;
                                  ``width: auto`` if value is ``none``.

--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -119,7 +119,7 @@ fill the entire app window, we can't just put the button into the app window.
 Instead, we need create a box, and put the button in the box.
 
 A box is an object that can be used to hold multiple widgets, and to
-define padding around widgets. So, we define a box::
+define margin around widgets. So, we define a box::
 
         box = toga.Box()
 
@@ -133,12 +133,12 @@ Now we have to define how the button will appear in the window. By default,
 Toga uses a style algorithm called ``Pack``, which is a bit like "CSS-lite".
 We can set style properties of the button::
 
-        button.style.padding = 50
+        button.style.margin = 50
 
-What we've done here is say that the button will have a padding of 50 pixels
-on all sides. If we wanted to define padding of 20 pixels on top of the
-button, we could have defined ``padding_top = 20``, or we could have specified
-the ``padding = (20, 50, 50, 50)``.
+What we've done here is say that the button will have a margin of 50 pixels
+on all sides. If we wanted to define margin of 20 pixels on top of the
+button, we could have defined ``margin_top = 20``, or we could have specified
+the ``margin = (20, 50, 50, 50)``.
 
 Now we will make the button take up all the available width::
 

--- a/docs/tutorial/tutorial-1.rst
+++ b/docs/tutorial/tutorial-1.rst
@@ -20,5 +20,5 @@ Since there's no width styling on the horizontal boxes, they'll try to
 fit the widgets they contain into the available space. The ``TextInput``
 widgets have a style of ``flex=1``, but the ``Label`` widgets have a fixed
 width; as a result, the ``TextInput`` widgets will be stretched to fit the
-available horizontal space. The margin and padding terms then ensure that the
+available horizontal space. The margin terms then ensure that the
 widgets will be aligned vertically and horizontally.

--- a/dummy/src/toga_dummy/widgets/base.py
+++ b/dummy/src/toga_dummy/widgets/base.py
@@ -44,8 +44,8 @@ class Widget(LoggedObject):
     def set_bounds(self, x, y, width, height):
         self._action("set bounds", x=x, y=y, width=width, height=height)
 
-    def set_alignment(self, alignment):
-        self._action("set alignment", alignment=alignment)
+    def set_text_alignment(self, alignment):
+        self._action("set text alignment", alignment=alignment)
 
     def set_hidden(self, hidden):
         self._action("set hidden", hidden=hidden)

--- a/examples/.template/{{ cookiecutter.name }}/{{ cookiecutter.name }}/app.py
+++ b/examples/.template/{{ cookiecutter.name }}/{{ cookiecutter.name }}/app.py
@@ -38,7 +38,7 @@ class Example{{ cookiecutter.widget_name }}App(toga.App):
             style=Pack(
                 flex=1,
                 direction=COLUMN,
-                padding=10,
+                margin=10,
                 width=500,
                 height=300
             )

--- a/examples/activityindicator/activityindicator/app.py
+++ b/examples/activityindicator/activityindicator/app.py
@@ -17,14 +17,14 @@ class ExampleActivityIndicatorApp(toga.App):
         # Set up main window
         self.main_window = toga.MainWindow()
 
-        self.spinner = toga.ActivityIndicator(style=Pack(padding_left=10))
+        self.spinner = toga.ActivityIndicator(style=Pack(margin_left=10))
         self.button = toga.Button(
-            "Start", on_press=self.do_stuff, style=Pack(padding_right=10)
+            "Start", on_press=self.do_stuff, style=Pack(margin_right=10)
         )
 
         box = toga.Box(
             children=[self.button, self.spinner],
-            style=Pack(direction=ROW, height=20, padding=20, alignment=CENTER, flex=1),
+            style=Pack(direction=ROW, height=20, margin=20, align_items=CENTER, flex=1),
         )
 
         # Add the content on the main window

--- a/examples/beeliza/beeliza/app.py
+++ b/examples/beeliza/beeliza/app.py
@@ -63,13 +63,13 @@ class BeelizaApp(toga.App):
 
         # Buttons
         self.text_input = toga.TextInput(
-            style=Pack(flex=1, padding=5),
+            style=Pack(flex=1, margin=5),
             on_confirm=self.handle_input,
         )
         send_button = toga.Button(
             "Send",
             on_press=self.handle_input,
-            style=Pack(padding=5),
+            style=Pack(margin=5),
         )
         input_box = toga.Box(
             children=[self.text_input, send_button],

--- a/examples/button/button/app.py
+++ b/examples/button/button/app.py
@@ -55,7 +55,7 @@ class ExampleButtonApp(toga.App):
         )
 
         # Button with text and margin style
-        button5 = toga.Button("Far from home", style=Pack(padding=50, color=BLUE))
+        button5 = toga.Button("Far from home", style=Pack(margin=50, color=BLUE))
 
         # Button with text and RGB color
         button6 = toga.Button("RGB : Fashion", style=Pack(background_color=RED))

--- a/examples/canvas/canvas/app.py
+++ b/examples/canvas/canvas/app.py
@@ -103,14 +103,14 @@ class ExampleCanvasApp(toga.App):
         )
         self.italic_switch = toga.Switch(text="italic", on_change=self.refresh_canvas)
         self.bold_switch = toga.Switch(text="bold", on_change=self.refresh_canvas)
-        label_style = Pack(padding=5)
+        label_style = Pack(margin=5)
 
         # Add the content on the main window
         box = toga.Box(
             style=Pack(direction=COLUMN),
             children=[
                 toga.Box(
-                    style=Pack(direction=ROW, padding=5),
+                    style=Pack(direction=ROW, margin=5),
                     children=[
                         self.context_selection,
                         self.shape_selection,
@@ -119,7 +119,7 @@ class ExampleCanvasApp(toga.App):
                     ],
                 ),
                 toga.Box(
-                    style=Pack(direction=ROW, padding=5),
+                    style=Pack(direction=ROW, margin=5),
                     children=[
                         toga.Label("Line Width:", style=label_style),
                         self.line_width_slider,
@@ -127,7 +127,7 @@ class ExampleCanvasApp(toga.App):
                     ],
                 ),
                 toga.Box(
-                    style=Pack(direction=ROW, padding=5),
+                    style=Pack(direction=ROW, margin=5),
                     children=[
                         toga.Label("X Scale:", style=label_style),
                         self.scale_x_slider,
@@ -139,7 +139,7 @@ class ExampleCanvasApp(toga.App):
                     ],
                 ),
                 toga.Box(
-                    style=Pack(direction=ROW, padding=5),
+                    style=Pack(direction=ROW, margin=5),
                     children=[
                         toga.Label("Font Family:", style=label_style),
                         self.font_selection,

--- a/examples/colors/colors/app.py
+++ b/examples/colors/colors/app.py
@@ -31,24 +31,24 @@ class ColorsApp(toga.App):
         self.main_window = toga.MainWindow(size=(700, 800))
 
         # create widgets to test colors on
-        button = toga.Button("This is a button", style=Pack(padding=5))
-        label = toga.Label("This is a Label", style=Pack(padding=5))
+        button = toga.Button("This is a button", style=Pack(margin=5))
+        label = toga.Label("This is a Label", style=Pack(margin=5))
         multiline_text_input = toga.MultilineTextInput(
             value="This is a Multiline Text Input field!",
             placeholder="placeholder",
-            style=Pack(padding=5, flex=1),
+            style=Pack(margin=5, flex=1),
         )
-        number_input = toga.NumberInput(value=1337, style=Pack(padding=5))
-        password_input = toga.PasswordInput(value="adminadmin", style=Pack(padding=5))
+        number_input = toga.NumberInput(value=1337, style=Pack(margin=5))
+        password_input = toga.PasswordInput(value="adminadmin", style=Pack(margin=5))
         progress_bar = toga.ProgressBar(
-            max=100, value=50, running=True, style=Pack(padding=5)
+            max=100, value=50, running=True, style=Pack(margin=5)
         )
         selection = toga.Selection(
             items=["item 1", "item 2", "item 3", "item 4", "item 5", "item 6"],
-            style=Pack(padding=5),
+            style=Pack(margin=5),
         )
-        slider = toga.Slider(style=Pack(padding=5))
-        switch = toga.Switch("Switch", style=Pack(padding=5))
+        slider = toga.Slider(style=Pack(margin=5))
+        switch = toga.Switch("Switch", style=Pack(margin=5))
         table = toga.Table(
             headings=["Heading 1", "Heading 2"],
             data=[
@@ -60,12 +60,12 @@ class ColorsApp(toga.App):
                 ("value 1", "value 2"),
             ],
             missing_value="none",
-            style=Pack(padding=5, flex=1),
+            style=Pack(margin=5, flex=1),
         )
         text_input = toga.TextInput(
             value="This is a Text input field!",
             placeholder="placeholder",
-            style=Pack(padding=5),
+            style=Pack(margin=5),
         )
 
         scroll_container = toga.ScrollContainer(
@@ -81,8 +81,8 @@ class ColorsApp(toga.App):
             temp_box.add(toga.Label(f"Label {x}"))
         scroll_container.content = temp_box
 
-        box_label = toga.Label("This is a Box:", style=Pack(padding=5))
-        box = toga.Box(style=Pack(flex=1, padding=5))
+        box_label = toga.Label("This is a Box:", style=Pack(margin=5))
+        box = toga.Box(style=Pack(flex=1, margin=5))
 
         self.widget_box = toga.Box(
             children=[
@@ -103,10 +103,10 @@ class ColorsApp(toga.App):
                         box_label,
                         box,
                     ],
-                    # Stack widgets vertically, and add padding so the
+                    # Stack widgets vertically, and add margin so the
                     # background cyan of the parent is a border around the
                     # widgets
-                    style=Pack(direction=COLUMN, flex=1, padding=10),
+                    style=Pack(direction=COLUMN, flex=1, margin=10),
                 )
             ],
             # Use a cyan background so that color changes are obvious
@@ -130,7 +130,7 @@ class ColorsApp(toga.App):
         ]
 
         # setup control box
-        button_style = Pack(padding=2, width=100)
+        button_style = Pack(margin=2, width=100)
         change_fcolor_r = toga.Button(
             "Red",
             on_press=self.change_color_foreground(colors.RED),
@@ -184,14 +184,14 @@ class ColorsApp(toga.App):
                 change_fcolor_g,
                 change_fcolor_b,
                 change_fcolor_reset,
-                toga.Label("Background", style=Pack(padding_top=10)),
+                toga.Label("Background", style=Pack(margin_top=10)),
                 change_bcolor_r,
                 change_bcolor_g,
                 change_bcolor_b,
                 change_bcolor_t,
                 change_bcolor_reset,
             ],
-            style=Pack(direction=COLUMN, padding=5),
+            style=Pack(direction=COLUMN, margin=5),
         )
 
         # Outermost box

--- a/examples/command/command/app.py
+++ b/examples/command/command/app.py
@@ -157,7 +157,7 @@ class ExampleTestCommandApp(toga.App):
         # Outermost box
         outer_box = toga.Box(
             children=[btn_box, self.textpanel],
-            style=Pack(flex=1, direction=COLUMN, padding=10),
+            style=Pack(flex=1, direction=COLUMN, margin=10),
         )
 
         # Add the content on the main window

--- a/examples/detailedlist/detailedlist/app.py
+++ b/examples/detailedlist/detailedlist/app.py
@@ -60,7 +60,7 @@ class ExampleDetailedListApp(toga.App):
         self.main_window = toga.MainWindow()
 
         # Buttons
-        btn_style = Pack(flex=1, padding=10)
+        btn_style = Pack(flex=1, margin=10)
         self.btn_insert = toga.Button(
             "Insert Row", on_press=self.insert_handler, style=btn_style
         )
@@ -72,7 +72,7 @@ class ExampleDetailedListApp(toga.App):
         )
 
         # Switches to enable/disable actions
-        switch_style = Pack(padding=10)
+        switch_style = Pack(margin=10)
         self.switch_box = toga.Box(
             style=Pack(direction=ROW),
             children=[
@@ -130,7 +130,7 @@ class ExampleDetailedListApp(toga.App):
             style=Pack(
                 flex=1,
                 direction=COLUMN,
-                padding=10,
+                margin=10,
             ),
         )
 

--- a/examples/dialogs/dialogs/app.py
+++ b/examples/dialogs/dialogs/app.py
@@ -222,7 +222,7 @@ class ExampleDialogsApp(toga.App):
         self.set_window_label_text(len(self.windows) - 1)
         secondary_label = toga.Label(text="You are in a secondary window!")
         window.content = toga.Box(
-            children=[secondary_label], style=Pack(flex=1, direction=COLUMN, padding=10)
+            children=[secondary_label], style=Pack(flex=1, direction=COLUMN, margin=10)
         )
         window.on_close = self.window_close_handler
         window.show()
@@ -253,8 +253,8 @@ class ExampleDialogsApp(toga.App):
         self.on_exit = self.exit_handler
 
         # Label to show responses.
-        self.label = toga.Label("Ready.", style=Pack(padding_top=20))
-        self.window_label = toga.Label("", style=Pack(padding_top=20))
+        self.label = toga.Label("Ready.", style=Pack(margin_top=20))
+        self.window_label = toga.Label("", style=Pack(margin_top=20))
         self.window_counter = 0
         self.close_attempts = set()
         self.set_window_label_text(0)
@@ -362,7 +362,7 @@ class ExampleDialogsApp(toga.App):
                 self.label,
                 self.window_label,
             ],
-            style=Pack(flex=1, direction=COLUMN, padding=10),
+            style=Pack(flex=1, direction=COLUMN, margin=10),
         )
 
         # Add the content on the main window

--- a/examples/divider/divider/app.py
+++ b/examples/divider/divider/app.py
@@ -7,8 +7,8 @@ class DividerApp(toga.App):
     def startup(self):
         self.main_window = toga.MainWindow(size=(300, 150))
 
-        style = Pack(padding_top=24)
-        substyle = Pack(padding_right=12, padding_left=12, flex=1)
+        style = Pack(margin_top=24)
+        substyle = Pack(margin_right=12, margin_left=12, flex=1)
 
         # Add the content on the main window
         self.main_window.content = toga.Box(
@@ -24,10 +24,10 @@ class DividerApp(toga.App):
                         toga.Divider(direction=toga.Divider.VERTICAL, style=substyle),
                         toga.TextInput(placeholder="Second textbox"),
                     ],
-                    style=Pack(direction=ROW, padding=24, flex=1),
+                    style=Pack(direction=ROW, margin=24, flex=1),
                 ),
             ],
-            style=Pack(direction=COLUMN, padding=24),
+            style=Pack(direction=COLUMN, margin=24),
         )
 
         # Show the main window

--- a/examples/examples_overview/examples_overview/app.py
+++ b/examples/examples_overview/examples_overview/app.py
@@ -50,7 +50,7 @@ class ExampleExamplesOverviewApp(toga.App):
         # Label for user instructions
         label = toga.Label(
             "Please select an example to run",
-            style=Pack(padding_bottom=10),
+            style=Pack(margin_bottom=10),
         )
 
         # ==== Table with examples =====================================================
@@ -72,15 +72,15 @@ class ExampleExamplesOverviewApp(toga.App):
             data=self.examples,
             on_activate=self.run,
             on_select=self.on_example_selected,
-            style=Pack(padding_bottom=10, flex=1),
+            style=Pack(margin_bottom=10, flex=1),
         )
 
         # Buttons
         self.btn_run = toga.Button(
-            "Run Example", on_press=self.run, style=Pack(flex=1, padding_right=5)
+            "Run Example", on_press=self.run, style=Pack(flex=1, margin_right=5)
         )
         self.btn_open = toga.Button(
-            "Open folder", on_press=self.open, style=Pack(flex=1, padding_left=5)
+            "Open folder", on_press=self.open, style=Pack(flex=1, margin_left=5)
         )
 
         button_box = toga.Box(children=[self.btn_run, self.btn_open])
@@ -88,7 +88,7 @@ class ExampleExamplesOverviewApp(toga.App):
         # ==== View of example README ==================================================
 
         self.info_view = toga.MultilineTextInput(
-            placeholder="Please select example", readonly=True, style=Pack(padding=1)
+            placeholder="Please select example", readonly=True, style=Pack(margin=1)
         )
 
         # ==== Assemble layout =========================================================
@@ -97,7 +97,7 @@ class ExampleExamplesOverviewApp(toga.App):
             children=[self.table, button_box],
             style=Pack(
                 direction=COLUMN,
-                padding=1,
+                margin=1,
                 flex=1,
             ),
         )
@@ -109,7 +109,7 @@ class ExampleExamplesOverviewApp(toga.App):
 
         outer_box = toga.Box(
             children=[label, split_container],
-            style=Pack(padding=10, direction=COLUMN, flex=1),
+            style=Pack(margin=10, direction=COLUMN, flex=1),
         )
 
         # Add the content on the main window

--- a/examples/font/font/app.py
+++ b/examples/font/font/app.py
@@ -56,7 +56,7 @@ class ExampleFontExampleApp(toga.App):
 
         # Buttons
         btn_box1 = toga.Box(
-            style=Pack(direction=ROW, padding_bottom=10),
+            style=Pack(direction=ROW, margin_bottom=10),
             children=[
                 toga.Button("Clear", on_press=self.do_clear),
                 toga.Button("Weight", on_press=self.do_weight),
@@ -89,7 +89,7 @@ class ExampleFontExampleApp(toga.App):
             style=Pack(font_family="awesome-free-solid", font_size=14, width=50),
         )
         btn_box2 = toga.Box(
-            style=Pack(direction=ROW, padding_bottom=10),
+            style=Pack(direction=ROW, margin_bottom=10),
             children=[btn1, btn2, btn3, btn4],
         )
 
@@ -176,7 +176,7 @@ class ExampleFontExampleApp(toga.App):
                 self.labels,
                 self.textpanel,
             ],
-            style=Pack(flex=1, direction=COLUMN, padding=10),
+            style=Pack(flex=1, direction=COLUMN, margin=10),
         )
 
         # Add the content on the main window

--- a/examples/handlers/handlers/app.py
+++ b/examples/handlers/handlers/app.py
@@ -78,12 +78,12 @@ class HandlerApp(toga.App):
         self.main_window = toga.MainWindow()
 
         # Labels to show responses.
-        self.on_running_label = toga.Label("Ready.", style=Pack(padding=10))
-        self.background_label = toga.Label("Ready.", style=Pack(padding=10))
-        self.function_label = toga.Label("Ready.", style=Pack(padding=10))
-        self.generator_label = toga.Label("Ready.", style=Pack(padding=10))
-        self.async_label = toga.Label("Ready.", style=Pack(padding=10))
-        self.web_label = toga.Label("Ready.", style=Pack(padding=10))
+        self.on_running_label = toga.Label("Ready.", style=Pack(margin=10))
+        self.background_label = toga.Label("Ready.", style=Pack(margin=10))
+        self.function_label = toga.Label("Ready.", style=Pack(margin=10))
+        self.generator_label = toga.Label("Ready.", style=Pack(margin=10))
+        self.async_label = toga.Label("Ready.", style=Pack(margin=10))
+        self.web_label = toga.Label("Ready.", style=Pack(margin=10))
 
         # Add a background task.
         self.counter = 0
@@ -120,7 +120,7 @@ class HandlerApp(toga.App):
                 self.web_label,
                 btn_clear,
             ],
-            style=Pack(flex=1, direction=COLUMN, padding=10),
+            style=Pack(flex=1, direction=COLUMN, margin=10),
         )
 
         # Add the content on the main window

--- a/examples/hardware/hardware/app.py
+++ b/examples/hardware/hardware/app.py
@@ -27,18 +27,18 @@ class ExampleHardwareApp(toga.App):
                         toga.Button(
                             "Take Photo",
                             on_press=self.take_photo,
-                            style=Pack(flex=1, padding=5),
+                            style=Pack(flex=1, margin=5),
                         ),
                         # Select a photo from the photo library
                         # toga.Button(
                         #     "Select Photo",
                         #     on_press=self.select_photo,
-                        #     style=Pack(flex=1, padding=5),
+                        #     style=Pack(flex=1, margin=5),
                         # ),
                     ],
                 ),
             ],
-            style=Pack(direction=COLUMN, padding_bottom=20),
+            style=Pack(direction=COLUMN, margin_bottom=20),
         )
 
         #############################################################
@@ -73,7 +73,7 @@ class ExampleHardwareApp(toga.App):
                             style=Pack(flex=1),
                         ),
                     ],
-                    style=Pack(padding=5),
+                    style=Pack(margin=5),
                 ),
             ],
             style=Pack(direction=COLUMN),

--- a/examples/imageview/imageview/app.py
+++ b/examples/imageview/imageview/app.py
@@ -12,8 +12,8 @@ class ImageViewApp(toga.App):
 
         box = toga.Box(
             style=Pack(
-                padding=10,
-                alignment=CENTER,
+                margin=10,
+                align_items=CENTER,
                 direction=COLUMN,
             )
         )

--- a/examples/layout/layout/app.py
+++ b/examples/layout/layout/app.py
@@ -7,49 +7,49 @@ class ExampleLayoutApp(toga.App):
     def startup(self):
         self.button_hide = toga.Button(
             text="Hide label",
-            style=Pack(padding=10, width=120),
+            style=Pack(margin=10, width=120),
             on_press=self.hide_label,
         )
 
         self.button_add = toga.Button(
             text="Add image",
-            style=Pack(padding=10, width=120),
+            style=Pack(margin=10, width=120),
             on_press=self.add_image,
         )
 
         self.button_remove = toga.Button(
             text="Remove image",
-            style=Pack(padding=10, width=120),
+            style=Pack(margin=10, width=120),
             on_press=self.remove_image,
             enabled=False,
         )
 
         self.button_insert = toga.Button(
             text="Insert image",
-            style=Pack(padding=10, width=120),
+            style=Pack(margin=10, width=120),
             on_press=self.insert_image,
         )
 
         self.button_reparent = toga.Button(
             text="Reparent image",
-            style=Pack(padding=10, width=120),
+            style=Pack(margin=10, width=120),
             on_press=self.reparent_image,
             enabled=False,
         )
 
         self.button_add_to_scroll = toga.Button(
             text="Add new label",
-            style=Pack(padding=10, width=120),
+            style=Pack(margin=10, width=120),
             on_press=self.add_label,
         )
 
         self.content_box = toga.Box(
-            children=[], style=Pack(direction=COLUMN, padding=10, flex=1)
+            children=[], style=Pack(direction=COLUMN, margin=10, flex=1)
         )
 
         image = toga.Image("resources/tiberius.png")
         self.image_view = toga.ImageView(
-            image, style=Pack(padding=10, width=60, height=60)
+            image, style=Pack(margin=10, width=60, height=60)
         )
 
         # this tests adding children during init, before we have an implementation
@@ -66,7 +66,8 @@ class ExampleLayoutApp(toga.App):
         )
 
         self.box = toga.Box(
-            children=[], style=Pack(direction=ROW, padding=10, alignment=CENTER, flex=1)
+            children=[],
+            style=Pack(direction=ROW, margin=10, align_items=CENTER, flex=1),
         )
 
         # this tests adding children when we already have an impl but no window or app
@@ -123,7 +124,7 @@ class ExampleLayoutApp(toga.App):
     def add_label(self, sender=None):
         # this tests adding children when we already have an impl, window and app
         new_label = toga.Label(
-            f"Label {len(self.content_box.children)}", style=Pack(padding=2, width=70)
+            f"Label {len(self.content_box.children)}", style=Pack(margin=2, width=70)
         )
         self.content_box.add(new_label)
         self.labels.append(new_label)

--- a/examples/mapview/mapview/app.py
+++ b/examples/mapview/mapview/app.py
@@ -79,7 +79,7 @@ class ExampleMapViewApp(toga.App):
         btn_where = toga.Button("???", on_press=self.where_am_i, style=btn_style)
         location_box = toga.Box(
             children=[btn_perth, btn_london, btn_austin, btn_rio, btn_where],
-            style=Pack(direction=ROW, padding=5),
+            style=Pack(direction=ROW, margin=5),
         )
 
         # Zoom buttons
@@ -88,7 +88,7 @@ class ExampleMapViewApp(toga.App):
                 toga.Button(i, on_press=self.zoom(i), style=btn_style)
                 for i in range(0, 20, 3)
             ],
-            style=Pack(direction=ROW, padding=5),
+            style=Pack(direction=ROW, margin=5),
         )
 
         # Point Of Interest buttons
@@ -98,11 +98,11 @@ class ExampleMapViewApp(toga.App):
         btn_move = toga.Button("Move", on_press=self.move_carmen, style=btn_style)
         pin_box = toga.Box(
             children=[btn_pin_1, btn_pin_2, btn_pin_3, btn_move],
-            style=Pack(direction=ROW, padding=5),
+            style=Pack(direction=ROW, margin=5),
         )
 
         # Label to show responses.
-        self.label = toga.Label("Ready.", style=Pack(padding=5))
+        self.label = toga.Label("Ready.", style=Pack(margin=5))
 
         # Add the content on the main window
         self.main_window.content = toga.Box(

--- a/examples/multilinetextinput/multilinetextinput/app.py
+++ b/examples/multilinetextinput/multilinetextinput/app.py
@@ -68,14 +68,14 @@ class ExampleMultilineTextInputApp(toga.App):
                 button_toggle_enabled,
                 button_toggle_readonly,
             ],
-            style=Pack(direction=ROW, padding_bottom=10),
+            style=Pack(direction=ROW, margin_bottom=10),
         )
         btn_box2 = toga.Box(
             children=[
                 button_add_content,
                 button_clear,
             ],
-            style=Pack(direction=ROW, padding_bottom=10),
+            style=Pack(direction=ROW, margin_bottom=10),
         )
         btn_box3 = toga.Box(
             children=[
@@ -83,13 +83,13 @@ class ExampleMultilineTextInputApp(toga.App):
                 button_scroll_bottom,
                 toga.TextInput(style=Pack(flex=1)),
             ],
-            style=Pack(direction=ROW, padding_bottom=10),
+            style=Pack(direction=ROW, margin_bottom=10),
         )
         self.label = toga.Label("Nothing has been written yet")
 
         outer_box = toga.Box(
             children=[btn_box1, btn_box2, btn_box3, self.multiline_input, self.label],
-            style=Pack(direction=COLUMN, padding=10),
+            style=Pack(direction=COLUMN, margin=10),
         )
 
         self.main_window.content = outer_box

--- a/examples/numberinput/numberinput/app.py
+++ b/examples/numberinput/numberinput/app.py
@@ -42,11 +42,11 @@ class ExampleNumberInputApp(toga.App):
         )
         box1 = toga.Box(
             children=[label1, self.input1],
-            style=Pack(direction=ROW, padding=5),
+            style=Pack(direction=ROW, margin=5),
         )
         box2 = toga.Box(
             children=[label2, self.input2],
-            style=Pack(direction=ROW, padding=5),
+            style=Pack(direction=ROW, margin=5),
         )
         # Buttons
         btn_style = Pack(flex=1)
@@ -59,7 +59,7 @@ class ExampleNumberInputApp(toga.App):
         # Outermost box
         outer_box = toga.Box(
             children=[btn_box, box1, box2, self.label],
-            style=Pack(flex=1, direction=COLUMN, padding=10),
+            style=Pack(flex=1, direction=COLUMN, margin=10),
         )
 
         # Add the content on the main window

--- a/examples/optioncontainer/optioncontainer/app.py
+++ b/examples/optioncontainer/optioncontainer/app.py
@@ -14,7 +14,7 @@ class ExampleOptionContainerApp(toga.App):
         result = (
             f"Option {self._box_count}",
             toga.Box(
-                style=Pack(background_color="cyan", padding=10),
+                style=Pack(background_color="cyan", margin=10),
                 children=[toga.Label(f"This is Box {self._box_count}")],
             ),
         )
@@ -89,11 +89,11 @@ class ExampleOptionContainerApp(toga.App):
         self.main_window = toga.MainWindow()
 
         # styles
-        style_flex = Pack(flex=1, padding=5)
+        style_flex = Pack(flex=1, margin=5)
 
         # select
         label_select = toga.Label("Select an Option position:", style=style_flex)
-        self.select_option = toga.Selection(style=Pack(padding=5, width=50))
+        self.select_option = toga.Selection(style=Pack(margin=5, width=50))
         # buttons
         btn_activate = toga.Button(
             "Activate", on_press=self.on_activate_option, style=style_flex
@@ -111,7 +111,7 @@ class ExampleOptionContainerApp(toga.App):
         )
 
         box_select = toga.Box(
-            style=Pack(direction=ROW, padding_right=10, width=200),
+            style=Pack(direction=ROW, margin_right=10, width=200),
             children=[label_select, self.select_option],
         )
         box_actions_1 = toga.Box(
@@ -125,20 +125,20 @@ class ExampleOptionContainerApp(toga.App):
 
         self.selected_label = toga.Label("")
         self.optioncontainer = toga.OptionContainer(
-            on_select=self.on_select_tab, style=Pack(padding_bottom=20, flex=1)
+            on_select=self.on_select_tab, style=Pack(margin_bottom=20, flex=1)
         )
         self._create_options()
 
         btn_add = toga.Button(
-            "Append new option", style=Pack(padding=5), on_press=self.on_add_option
+            "Append new option", style=Pack(margin=5), on_press=self.on_add_option
         )
         btn_insert = toga.Button(
             "Insert new option before active option",
-            style=Pack(padding=5),
+            style=Pack(margin=5),
             on_press=self.on_insert_option,
         )
         box_general_actions = toga.Box(
-            style=Pack(padding_bottom=10), children=[btn_add, btn_insert]
+            style=Pack(margin_bottom=10), children=[btn_add, btn_insert]
         )
 
         # Outermost box
@@ -154,7 +154,7 @@ class ExampleOptionContainerApp(toga.App):
             style=Pack(
                 flex=1,
                 direction=COLUMN,
-                padding=10,
+                margin=10,
             ),
         )
 

--- a/examples/passwordinput/passwordinput/app.py
+++ b/examples/passwordinput/passwordinput/app.py
@@ -35,13 +35,13 @@ class PasswordInputApp(toga.App):
         # Label to show responses.
         self.label = toga.Label("Testing Password")
         self.password_content_label = toga.Label(
-            EMPTY_PASSWORD, style=Pack(padding_bottom=PADDING)
+            EMPTY_PASSWORD, style=Pack(margin_bottom=PADDING)
         )
 
         # Padding box only
         self.password_input = toga.PasswordInput(
             placeholder="Password...",
-            style=Pack(padding=PADDING),
+            style=Pack(margin=PADDING),
             on_change=self.on_password_change,
             validators=[
                 validators.MinLength(10),
@@ -60,7 +60,7 @@ class PasswordInputApp(toga.App):
         ]
         outer_box = toga.Box(
             children=children,
-            style=Pack(flex=1, direction=COLUMN, padding=10, width=500, height=300),
+            style=Pack(flex=1, direction=COLUMN, margin=10, width=500, height=300),
         )
 
         # Add the content on the main window

--- a/examples/progressbar/progressbar/app.py
+++ b/examples/progressbar/progressbar/app.py
@@ -15,10 +15,10 @@ class ProgressBarApp(toga.App):
         self.progress_adder = toga.ProgressBar(max=MAX_PROGRESSBAR_VALUE)
 
         # set up common styles
-        label_style = Pack(flex=1, padding_right=5)
-        row_box_style = Pack(direction=ROW, padding=10)
-        col_box_style = Pack(direction=COLUMN, padding=10)
-        pbar_style = Pack(width=150, padding_right=5)
+        label_style = Pack(flex=1, margin_right=5)
+        row_box_style = Pack(direction=ROW, margin=10)
+        col_box_style = Pack(direction=COLUMN, margin=10)
+        pbar_style = Pack(width=150, margin_right=5)
 
         # Add the content on the main window
         self.main_window.content = toga.Box(

--- a/examples/resize/resize/app.py
+++ b/examples/resize/resize/app.py
@@ -24,7 +24,7 @@ class SizePanel(toga.Box):
         )
         self.flex = SizeButton("F", value=0, max=3, on_press=self.on_press)
         super().__init__(
-            style=Pack(direction=COLUMN, alignment="center"),
+            style=Pack(direction=COLUMN, align_items="center"),
             children=[
                 toga.Label(title.upper(), style=Pack(font_weight="bold")),
                 toga.Box(

--- a/examples/screenshot/screenshot/app.py
+++ b/examples/screenshot/screenshot/app.py
@@ -16,7 +16,7 @@ class ScreenshotGeneratorApp(toga.App):
         return toga.Box(
             children=[
                 toga.Box(style=Pack(flex=1)),
-                toga.ActivityIndicator(running=True, style=Pack(padding=10)),
+                toga.ActivityIndicator(running=True, style=Pack(margin=10)),
                 toga.Box(style=Pack(flex=1)),
             ],
             style=Pack(width=100),
@@ -27,14 +27,14 @@ class ScreenshotGeneratorApp(toga.App):
             children=[
                 toga.Button(
                     "Launch rocket",
-                    style=Pack(padding=10, flex=1),
+                    style=Pack(margin=10, flex=1),
                 )
             ],
             style=Pack(width=300),
         )
 
     def create_canvas(self):
-        canvas = toga.Canvas(style=Pack(padding=10, width=280, height=290))
+        canvas = toga.Canvas(style=Pack(margin=10, width=280, height=290))
         draw_tiberius(canvas)
 
         return toga.Box(children=[canvas], style=Pack(width=280, height=290))
@@ -43,7 +43,7 @@ class ScreenshotGeneratorApp(toga.App):
         return toga.Box(
             children=[
                 toga.Box(style=Pack(flex=1)),
-                toga.DateInput(value=date(2014, 4, 21), style=Pack(padding=10)),
+                toga.DateInput(value=date(2014, 4, 21), style=Pack(margin=10)),
                 toga.Box(style=Pack(flex=1)),
             ],
             style=Pack(width=300),
@@ -75,18 +75,18 @@ class ScreenshotGeneratorApp(toga.App):
                     "subtitle": "I can quote the fights historical!",
                 },
             ],
-            style=Pack(padding=10, width=self.MAX_WIDTH, height=300),
+            style=Pack(margin=10, width=self.MAX_WIDTH, height=300),
         )
 
     def create_divider(self):
         return toga.Box(
             children=[
                 toga.Label(
-                    "I'm on top", style=Pack(flex=1, padding=5, text_align=CENTER)
+                    "I'm on top", style=Pack(flex=1, margin=5, text_align=CENTER)
                 ),
-                toga.Divider(direction=toga.Divider.HORIZONTAL, style=Pack(padding=5)),
+                toga.Divider(direction=toga.Divider.HORIZONTAL, style=Pack(margin=5)),
                 toga.Label(
-                    "I'm below", style=Pack(flex=1, padding=5, text_align=CENTER)
+                    "I'm below", style=Pack(flex=1, margin=5, text_align=CENTER)
                 ),
             ],
             style=Pack(width=300, direction=COLUMN),
@@ -97,7 +97,7 @@ class ScreenshotGeneratorApp(toga.App):
             children=[
                 toga.Label(
                     "Brutus was here!",
-                    style=Pack(padding=10, text_align=CENTER, flex=1),
+                    style=Pack(margin=10, text_align=CENTER, flex=1),
                 )
             ],
             style=Pack(width=300),
@@ -107,7 +107,7 @@ class ScreenshotGeneratorApp(toga.App):
         return toga.MapView(
             zoom=3,
             pins=[toga.MapPin((-31.95064, 115.85889), title="Yagan Square")],
-            style=Pack(padding=10, width=self.MAX_WIDTH, height=300),
+            style=Pack(margin=10, width=self.MAX_WIDTH, height=300),
         )
 
     def create_multilinetextinput(self):
@@ -129,7 +129,7 @@ class ScreenshotGeneratorApp(toga.App):
                     "I am the very model of a modern Major-General.",
                 ]
             ),
-            style=Pack(padding=10, width=self.MAX_WIDTH, height=200),
+            style=Pack(margin=10, width=self.MAX_WIDTH, height=200),
         )
 
     def create_numberinput(self):
@@ -138,7 +138,7 @@ class ScreenshotGeneratorApp(toga.App):
                 toga.NumberInput(
                     value=2.71818,
                     step=0.00001,
-                    style=Pack(padding=10, flex=1),
+                    style=Pack(margin=10, flex=1),
                 )
             ],
             style=Pack(width=300),
@@ -149,7 +149,7 @@ class ScreenshotGeneratorApp(toga.App):
             children=[
                 toga.PasswordInput(
                     value="secret",
-                    style=Pack(padding=10, flex=1),
+                    style=Pack(margin=10, flex=1),
                 )
             ],
             style=Pack(width=300),
@@ -161,7 +161,7 @@ class ScreenshotGeneratorApp(toga.App):
                 toga.ProgressBar(
                     value=42,
                     max=100,
-                    style=Pack(padding=10, flex=1),
+                    style=Pack(margin=10, flex=1),
                 )
             ],
             style=Pack(width=300),
@@ -172,7 +172,7 @@ class ScreenshotGeneratorApp(toga.App):
             children=[
                 toga.Selection(
                     items=["Titanium", "Yttrium", "Yterbium"],
-                    style=Pack(padding=10, flex=1),
+                    style=Pack(margin=10, flex=1),
                 )
             ],
             style=Pack(width=300),
@@ -184,7 +184,7 @@ class ScreenshotGeneratorApp(toga.App):
                 toga.Slider(
                     value=42,
                     max=100,
-                    style=Pack(padding=10, flex=1),
+                    style=Pack(margin=10, flex=1),
                 )
             ],
             style=Pack(width=300),
@@ -197,7 +197,7 @@ class ScreenshotGeneratorApp(toga.App):
                 toga.Switch(
                     "Turbo",
                     value=True,
-                    style=Pack(padding=10),
+                    style=Pack(margin=10),
                 ),
                 toga.Box(style=Pack(flex=1)),
             ],
@@ -213,7 +213,7 @@ class ScreenshotGeneratorApp(toga.App):
                 ("Tricia McMillan", 38, "Earth"),
                 ("Slartibartfast", 1005, "Magrathea"),
             ],
-            style=Pack(padding=10, width=self.MAX_WIDTH, height=200),
+            style=Pack(margin=10, width=self.MAX_WIDTH, height=200),
         )
 
     def create_textinput(self):
@@ -221,7 +221,7 @@ class ScreenshotGeneratorApp(toga.App):
             children=[
                 toga.TextInput(
                     value="Brutus was here!",
-                    style=Pack(padding=10, flex=1),
+                    style=Pack(margin=10, flex=1),
                 )
             ],
             style=Pack(width=300),
@@ -231,7 +231,7 @@ class ScreenshotGeneratorApp(toga.App):
         return toga.Box(
             children=[
                 toga.Box(style=Pack(flex=1)),
-                toga.TimeInput(value=time(9, 7, 37), style=Pack(padding=10)),
+                toga.TimeInput(value=time(9, 7, 37), style=Pack(margin=10)),
                 toga.Box(style=Pack(flex=1)),
             ],
             style=Pack(width=300),
@@ -252,7 +252,7 @@ class ScreenshotGeneratorApp(toga.App):
                     ("Slartibartfast", 1005, "Annoyed"): None,
                 },
             },
-            style=Pack(padding=10, width=self.MAX_WIDTH, height=200),
+            style=Pack(margin=10, width=self.MAX_WIDTH, height=200),
         )
         tree.expand()
         return tree
@@ -260,7 +260,7 @@ class ScreenshotGeneratorApp(toga.App):
     def create_webview(self):
         return toga.WebView(
             url="https://beeware.org",
-            style=Pack(padding=10, width=self.MAX_WIDTH, height=300),
+            style=Pack(margin=10, width=self.MAX_WIDTH, height=300),
         )
 
     def create_optioncontainer(self):
@@ -274,7 +274,7 @@ class ScreenshotGeneratorApp(toga.App):
                 ("Green", toga.Box(), "resources/landmark"),
                 ("Red", toga.Box()),
             ],
-            style=Pack(padding=10, width=self.MAX_WIDTH, height=300),
+            style=Pack(margin=10, width=self.MAX_WIDTH, height=300),
         )
 
         return container
@@ -291,7 +291,7 @@ class ScreenshotGeneratorApp(toga.App):
                 ],
                 style=Pack(direction=COLUMN),
             ),
-            style=Pack(padding=10, width=self.MAX_WIDTH, height=300),
+            style=Pack(margin=10, width=self.MAX_WIDTH, height=300),
         )
 
         return container
@@ -302,7 +302,7 @@ class ScreenshotGeneratorApp(toga.App):
                 toga.Box(style=Pack(background_color="goldenrod")),
                 toga.Box(style=Pack(background_color="cornflowerblue")),
             ],
-            style=Pack(padding=10, width=self.MAX_WIDTH, height=300),
+            style=Pack(margin=10, width=self.MAX_WIDTH, height=300),
         )
 
         return container
@@ -327,7 +327,7 @@ class ScreenshotGeneratorApp(toga.App):
         proceed_button = toga.Button(
             "Done",
             on_press=proceed,
-            style=Pack(padding=10),
+            style=Pack(margin=10),
         )
 
         if content:

--- a/examples/scrollcontainer/scrollcontainer/app.py
+++ b/examples/scrollcontainer/scrollcontainer/app.py
@@ -5,12 +5,12 @@ from toga.style import Pack
 
 class Item(toga.Box):
     def __init__(self, width, text):
-        super().__init__(style=Pack(direction=ROW, padding=10, background_color="lime"))
+        super().__init__(style=Pack(direction=ROW, margin=10, background_color="lime"))
 
         for x in range(width):
             label = toga.Label(
                 text + "," + str(x),
-                style=Pack(padding_right=10, background_color="cyan"),
+                style=Pack(margin_right=10, background_color="cyan"),
             )
             self.add(label)
 
@@ -47,13 +47,13 @@ class ScrollContainerApp(toga.App):
         )
 
         self.inner_box = toga.Box(
-            style=Pack(direction=COLUMN, padding=10, background_color="yellow")
+            style=Pack(direction=COLUMN, margin=10, background_color="yellow")
         )
         self.scroller = toga.ScrollContainer(
             horizontal=self.hswitch.value,
             vertical=self.vswitch.value,
             on_scroll=self.on_scroll,
-            style=Pack(flex=1, padding=10, background_color="pink"),
+            style=Pack(flex=1, margin=10, background_color="pink"),
         )
         self.update_content()
 

--- a/examples/selection/selection/app.py
+++ b/examples/selection/selection/app.py
@@ -18,8 +18,8 @@ class SelectionApp(toga.App):
         self.main_window = toga.MainWindow(size=(640, 400))
 
         # set up common styles
-        label_style = Pack(flex=1, padding_right=24)
-        box_style = Pack(direction=ROW, padding=10)
+        label_style = Pack(flex=1, margin_right=24)
+        box_style = Pack(direction=ROW, margin=10)
 
         # Add the content on the main window
         self.selection = toga.Selection(items=self.OPTIONS)
@@ -93,7 +93,7 @@ class SelectionApp(toga.App):
                     children=[
                         toga.Label("Use some style!", style=label_style),
                         toga.Selection(
-                            style=Pack(width=200, padding=24),
+                            style=Pack(width=200, margin=24),
                             items=["Curium", "Titanium", "Copernicium"],
                         ),
                     ],
@@ -117,7 +117,7 @@ class SelectionApp(toga.App):
                     ],
                 ),
             ],
-            style=Pack(direction=COLUMN, padding=24),
+            style=Pack(direction=COLUMN, margin=24),
         )
 
         self.main_window.show()

--- a/examples/simpleapp/simpleapp/app.py
+++ b/examples/simpleapp/simpleapp/app.py
@@ -13,7 +13,7 @@ class ExampleSimpleApp(toga.App):
         # Outermost box
         outer_box = toga.Box(
             children=[self.label],
-            style=Pack(padding=10),
+            style=Pack(margin=10),
         )
 
         # Add the content on the main window

--- a/examples/slider/slider/app.py
+++ b/examples/slider/slider/app.py
@@ -11,8 +11,8 @@ class SliderApp(toga.App):
         self.main_window = toga.MainWindow(size=(1000, 500))
 
         # set up common styles
-        label_style = Pack(flex=1, padding_right=24)
-        box_style = Pack(direction=ROW, padding=10)
+        label_style = Pack(flex=1, margin_right=24)
+        box_style = Pack(direction=ROW, margin=10)
         slider_style = Pack(flex=1)
 
         self.continuous_label = toga.Label("Continuous", style=label_style)
@@ -61,7 +61,7 @@ class SliderApp(toga.App):
                     children=[self.scared_label, self.scared_slider],
                 ),
             ],
-            style=Pack(direction=COLUMN, padding=24),
+            style=Pack(direction=COLUMN, margin=24),
         )
 
         self.commands.add(

--- a/examples/splitcontainer/splitcontainer/app.py
+++ b/examples/splitcontainer/splitcontainer/app.py
@@ -25,7 +25,7 @@ class ContentControls(toga.Box):
         self.sw_flexible.enabled = self.sw_content.value
 
         if self.sw_content.value:
-            box = toga.Box(style=Pack(padding=10, background_color="cyan"))
+            box = toga.Box(style=Pack(margin=10, background_color="cyan"))
             if not self.sw_flexible.value:
                 box.style.update(width=100, height=100)
         else:
@@ -38,7 +38,7 @@ class ContentControls(toga.Box):
 
 class SplitControls(toga.Box):
     def __init__(self, split):
-        super().__init__(style=Pack(direction=COLUMN, alignment=CENTER, flex=1))
+        super().__init__(style=Pack(direction=COLUMN, align_items=CENTER, flex=1))
         self.split = split
 
         self.add(
@@ -73,7 +73,7 @@ class SplitControls(toga.Box):
 
 class SplitContainerApp(toga.App):
     def startup(self):
-        self.split = toga.SplitContainer(style=Pack(padding=10, flex=1))
+        self.split = toga.SplitContainer(style=Pack(margin=10, flex=1))
 
         main_box = toga.Box(
             style=Pack(direction=COLUMN),

--- a/examples/switch_demo/switch_demo/app.py
+++ b/examples/switch_demo/switch_demo/app.py
@@ -14,14 +14,14 @@ class SwitchApp(toga.App):
                 # Simple switch with label and callback function called toggled
                 toga.Switch("Change Label", on_change=self.callbackLabel),
                 # Switch with initial state
-                toga.Switch("Initial state", value=True, style=Pack(padding_top=24)),
+                toga.Switch("Initial state", value=True, style=Pack(margin_top=24)),
                 # Switch with label and enable option
-                toga.Switch("Disabled", enabled=False, style=Pack(padding_top=24)),
+                toga.Switch("Disabled", enabled=False, style=Pack(margin_top=24)),
                 # Switch with a big font
                 toga.Switch(
                     "Big and colorful",
                     style=Pack(
-                        padding_top=24,
+                        margin_top=24,
                         font_family="serif",
                         font_size=20,
                         font_weight="bold",
@@ -29,7 +29,7 @@ class SwitchApp(toga.App):
                     ),
                 ),
             ],
-            style=Pack(direction=COLUMN, padding=24),
+            style=Pack(direction=COLUMN, margin=24),
         )
 
         # Show the main window

--- a/examples/table/table/app.py
+++ b/examples/table/table/app.py
@@ -101,13 +101,13 @@ class ExampleTableApp(toga.App):
         self.main_window = toga.MainWindow()
 
         # Label to show which row is currently selected.
-        self.label_table1 = toga.Label("Ready.", style=Pack(flex=1, padding_right=5))
+        self.label_table1 = toga.Label("Ready.", style=Pack(flex=1, margin_right=5))
         self.label_table2 = toga.Label(
-            "Try multiple row selection.", style=Pack(flex=1, padding_left=5)
+            "Try multiple row selection.", style=Pack(flex=1, margin_left=5)
         )
         labelbox = toga.Box(
             children=[self.label_table1, self.label_table2],
-            style=Pack(flex=0, padding_top=5),
+            style=Pack(flex=0, margin_top=5),
         )
 
         # Change font size
@@ -146,7 +146,7 @@ class ExampleTableApp(toga.App):
             data=table_data,
             style=Pack(
                 flex=1,
-                padding_right=5,
+                margin_right=5,
                 font_family="monospace",
                 font_size=int(self.lbl_fontsize.text),
                 font_style="italic",
@@ -162,7 +162,7 @@ class ExampleTableApp(toga.App):
             accessors=[h.lower() for h in headings],
             data=self.table1.data,
             multiple_select=True,
-            style=Pack(flex=1, padding_left=5),
+            style=Pack(flex=1, margin_left=5),
             on_select=self.on_select_handler2,
             on_activate=self.on_activate2,
             missing_value="?",
@@ -190,11 +190,11 @@ class ExampleTableApp(toga.App):
 
         controls_1 = toga.Box(
             children=[font_box, btn_insert, btn_delete, btn_clear],
-            style=Pack(direction=ROW, padding_bottom=5),
+            style=Pack(direction=ROW, margin_bottom=5),
         )
         controls_2 = toga.Box(
             children=[btn_reset, btn_toggle, btn_top, btn_bottom],
-            style=Pack(direction=ROW, padding_bottom=5),
+            style=Pack(direction=ROW, margin_bottom=5),
         )
 
         # Most outer box
@@ -203,7 +203,7 @@ class ExampleTableApp(toga.App):
             style=Pack(
                 flex=1,
                 direction=COLUMN,
-                padding=10,
+                margin=10,
             ),
         )
 

--- a/examples/table_source/table_source/app.py
+++ b/examples/table_source/table_source/app.py
@@ -187,7 +187,7 @@ class ExampleTableSourceApp(toga.App):
             style=Pack(
                 flex=1,
                 direction=COLUMN,
-                padding=10,
+                margin=10,
             ),
         )
 

--- a/examples/textinput/textinput/app.py
+++ b/examples/textinput/textinput/app.py
@@ -52,32 +52,32 @@ class TextInputApp(toga.App):
 
         # Labels to show responses.
         self.label = toga.Label(
-            "Enter some values and press extract.", style=Pack(padding=PADDING)
+            "Enter some values and press extract.", style=Pack(margin=PADDING)
         )
-        self.text_label = toga.Label("Ready.", style=Pack(padding=PADDING))
-        self.password_label = toga.Label("Ready.", style=Pack(padding=PADDING))
+        self.text_label = toga.Label("Ready.", style=Pack(margin=PADDING))
+        self.password_label = toga.Label("Ready.", style=Pack(margin=PADDING))
         self.password_content_label = toga.Label(
-            EMPTY_PASSWORD, style=Pack(padding_bottom=PADDING, font_size=9)
+            EMPTY_PASSWORD, style=Pack(margin_bottom=PADDING, font_size=9)
         )
-        self.number_label = toga.Label("Ready.", style=Pack(padding=PADDING))
+        self.number_label = toga.Label("Ready.", style=Pack(margin=PADDING))
 
         # Text inputs and a button
         self.text_input = toga.TextInput(
             value="Initial value, and on_confirm handler",
             placeholder="Type something...",
-            style=Pack(padding=PADDING),
+            style=Pack(margin=PADDING),
             on_confirm=self.do_extract_values,
         )
         self.right_aligned_input = toga.TextInput(
             placeholder="Right aligned text",
-            style=Pack(padding=PADDING, text_align=RIGHT),
+            style=Pack(margin=PADDING, text_align=RIGHT),
         )
         self.text_input_placeholder = toga.TextInput(
-            placeholder="Type something...", style=Pack(padding=PADDING)
+            placeholder="Type something...", style=Pack(margin=PADDING)
         )
         self.password_input = toga.PasswordInput(
             placeholder="Password...",
-            style=Pack(padding=PADDING),
+            style=Pack(margin=PADDING),
             on_change=self.on_password_change,
             validators=[
                 validators.MinLength(10),
@@ -89,17 +89,17 @@ class TextInputApp(toga.App):
         )
         self.email_input = toga.TextInput(
             placeholder="Email...",
-            style=Pack(padding=PADDING),
+            style=Pack(margin=PADDING),
             validators=[validators.Email()],
         )
-        self.number_input = toga.NumberInput(style=Pack(padding=PADDING))
+        self.number_input = toga.NumberInput(style=Pack(margin=PADDING))
         btn_extract = toga.Button(
             "Extract values",
             on_press=self.do_extract_values,
             style=Pack(flex=1),
         )
         self.right_aligned_number_input = toga.NumberInput(
-            style=Pack(padding=PADDING, text_align=RIGHT)
+            style=Pack(margin=PADDING, text_align=RIGHT)
         )
 
         children = [
@@ -129,7 +129,7 @@ class TextInputApp(toga.App):
             style=Pack(
                 flex=1,
                 direction=COLUMN,
-                padding=PADDING,
+                margin=PADDING,
             ),
         )
 

--- a/examples/tree/tree/app.py
+++ b/examples/tree/tree/app.py
@@ -92,7 +92,7 @@ class ExampleTreeApp(toga.App):
         self.main_window = toga.MainWindow()
 
         # Label to show responses.
-        self.label = toga.Label("Ready.", style=Pack(padding=10))
+        self.label = toga.Label("Ready.", style=Pack(margin=10))
 
         self.tree = toga.Tree(
             headings=["Year", "Title", "Rating", "Genre"],
@@ -124,7 +124,7 @@ class ExampleTreeApp(toga.App):
         )
 
         # Buttons
-        btn_style = Pack(flex=1, padding=10)
+        btn_style = Pack(flex=1, margin=10)
         self.btn_insert = toga.Button(
             "Insert Row", on_press=self.insert_handler, style=btn_style
         )

--- a/examples/tree_source/tree_source/app.py
+++ b/examples/tree_source/tree_source/app.py
@@ -152,7 +152,7 @@ class ExampleTreeSourceApp(toga.App):
             on_activate=self.activate_handler,
         )
         self.label = toga.Label(
-            "A view of the current directory!", style=Pack(padding=10)
+            "A view of the current directory!", style=Pack(margin=10)
         )
 
         # Outermost box

--- a/examples/tutorial0/tutorial/app.py
+++ b/examples/tutorial0/tutorial/app.py
@@ -9,7 +9,7 @@ def build(app):
     box = toga.Box()
 
     button = toga.Button("Hello world", on_press=button_handler)
-    button.style.padding = 50
+    button.style.margin = 50
     button.style.flex = 1
     box.add(button)
 

--- a/examples/tutorial1/tutorial/app.py
+++ b/examples/tutorial1/tutorial/app.py
@@ -33,17 +33,17 @@ def build(app):
     box.add(c_box)
     box.add(button)
 
-    box.style.update(direction=COLUMN, padding=10)
-    f_box.style.update(direction=ROW, padding=5)
-    c_box.style.update(direction=ROW, padding=5)
+    box.style.update(direction=COLUMN, margin=10)
+    f_box.style.update(direction=ROW, margin=5)
+    c_box.style.update(direction=ROW, margin=5)
 
     c_input.style.update(flex=1)
-    f_input.style.update(flex=1, padding_left=210)
-    c_label.style.update(width=100, padding_left=10)
-    f_label.style.update(width=100, padding_left=10)
-    join_label.style.update(width=200, padding_right=10)
+    f_input.style.update(flex=1, margin_left=210)
+    c_label.style.update(width=100, margin_left=10)
+    f_label.style.update(width=100, margin_left=10)
+    join_label.style.update(width=200, margin_right=10)
 
-    button.style.update(padding=15)
+    button.style.update(margin=15)
 
     return box
 

--- a/examples/tutorial2/tutorial/app.py
+++ b/examples/tutorial2/tutorial/app.py
@@ -43,14 +43,14 @@ class Tutorial2App(toga.App):
 
         left_container = toga.Table(headings=["Hello", "World"], data=data)
 
-        right_content = toga.Box(style=Pack(direction=COLUMN, padding_top=50))
+        right_content = toga.Box(style=Pack(direction=COLUMN, margin_top=50))
 
         for b in range(0, 10):
             right_content.add(
                 toga.Button(
                     "Hello world %s" % b,
                     on_press=button_handler,
-                    style=Pack(width=200, padding=20),
+                    style=Pack(width=200, margin=20),
                 )
             )
 

--- a/examples/tutorial3/tutorial/app.py
+++ b/examples/tutorial3/tutorial/app.py
@@ -21,13 +21,13 @@ class Graze(toga.App):
                         toga.Button(
                             "Go",
                             on_press=self.load_page,
-                            style=Pack(width=50, padding_left=5),
+                            style=Pack(width=50, margin_left=5),
                         ),
                     ],
                     style=Pack(
                         direction=ROW,
-                        alignment=CENTER,
-                        padding=5,
+                        align_items=CENTER,
+                        margin=5,
                     ),
                 ),
                 self.webview,

--- a/examples/webview/webview/app.py
+++ b/examples/webview/webview/app.py
@@ -54,7 +54,7 @@ class ExampleWebView(toga.App):
 
     def startup(self):
         self.main_window = toga.MainWindow()
-        self.label = toga.Label("www is loading |", style=Pack(flex=1, padding=5))
+        self.label = toga.Label("www is loading |", style=Pack(flex=1, margin=5))
 
         button_box = toga.Box(
             children=[
@@ -84,7 +84,7 @@ class ExampleWebView(toga.App):
                     ],
                 ),
             ],
-            style=Pack(flex=0, direction=COLUMN, padding=5),
+            style=Pack(flex=0, direction=COLUMN, margin=5),
         )
 
         self.webview = toga.WebView(

--- a/examples/window/window/app.py
+++ b/examples/window/window/app.py
@@ -235,7 +235,7 @@ class WindowDemoApp(toga.App):
         self.label = toga.Label("Ready.")
 
         # Buttons
-        btn_style = Pack(flex=1, padding=5)
+        btn_style = Pack(flex=1, margin=5)
 
         row_move = toga.Box(
             style=Pack(direction=ROW),
@@ -331,14 +331,14 @@ class WindowDemoApp(toga.App):
                     style=Pack(width=200, text_align=RIGHT),
                 )
             ],
-            style=Pack(padding=5),
+            style=Pack(margin=5),
         )
         for index, screen in sorted(enumerate(self.screens), key=lambda s: s[1].origin):
             screen_change_btns_box.add(
                 toga.Button(
                     text=f"{index}: {screen.name}",
                     on_press=partial(self.do_screen_change, screen),
-                    style=Pack(padding_left=5),
+                    style=Pack(margin_left=5),
                 )
             )
         screen_as_image_btns_box = toga.Box(
@@ -348,14 +348,14 @@ class WindowDemoApp(toga.App):
                     style=Pack(width=200, text_align=RIGHT),
                 )
             ],
-            style=Pack(padding=5),
+            style=Pack(margin=5),
         )
         for index, screen in sorted(enumerate(self.screens), key=lambda s: s[1].origin):
             screen_as_image_btns_box.add(
                 toga.Button(
                     text=f"{index}: {screen.name}",
                     on_press=partial(self.do_save_screenshot, screen),
-                    style=Pack(padding_left=5),
+                    style=Pack(margin_left=5),
                 )
             )
 

--- a/gtk/src/toga_gtk/libs/utils.py
+++ b/gtk/src/toga_gtk/libs/utils.py
@@ -3,8 +3,8 @@ from toga.constants import CENTER, JUSTIFY, LEFT, RIGHT
 from . import Gtk
 
 
-def gtk_alignment(alignment):
-    """Convert Toga alignments into arguments compatible with Gtk."""
+def gtk_text_alignment(alignment):
+    """Convert Toga text alignments into arguments compatible with Gtk."""
     return {
         LEFT: (0.0, Gtk.Justification.LEFT),
         RIGHT: (1.0, Gtk.Justification.RIGHT),

--- a/gtk/src/toga_gtk/widgets/base.py
+++ b/gtk/src/toga_gtk/widgets/base.py
@@ -141,7 +141,7 @@ class Widget:
         # Any position changes are applied by the container during do_size_allocate.
         self.container.make_dirty()
 
-    def set_alignment(self, alignment):
+    def set_text_alignment(self, alignment):
         # By default, alignment can't be changed
         pass
 

--- a/gtk/src/toga_gtk/widgets/label.py
+++ b/gtk/src/toga_gtk/widgets/label.py
@@ -1,6 +1,6 @@
 from travertino.size import at_least
 
-from ..libs import Gtk, gtk_alignment
+from ..libs import Gtk, gtk_text_alignment
 from .base import Widget
 
 
@@ -9,8 +9,8 @@ class Label(Widget):
         self.native = Gtk.Label()
         self.native.set_line_wrap(False)
 
-    def set_alignment(self, value):
-        xalign, justify = gtk_alignment(value)
+    def set_text_alignment(self, value):
+        xalign, justify = gtk_text_alignment(value)
         self.native.set_xalign(xalign)  # Aligns the whole text block within the widget.
         self.native.set_yalign(0.0)  # Aligns the text block to the top
         self.native.set_justify(

--- a/gtk/src/toga_gtk/widgets/multilinetextinput.py
+++ b/gtk/src/toga_gtk/widgets/multilinetextinput.py
@@ -5,7 +5,7 @@ from ..libs import (
     get_background_color_css,
     get_color_css,
     get_font_css,
-    gtk_alignment,
+    gtk_text_alignment,
 )
 from .base import Widget
 
@@ -113,8 +113,8 @@ class MultilineTextInput(Widget):
             self.placeholder.get_end_iter(),
         )  # make the placeholder text gray.
 
-    def set_alignment(self, value):
-        _, justification = gtk_alignment(value)
+    def set_text_alignment(self, value):
+        _, justification = gtk_text_alignment(value)
         self.native_textview.set_justification(justification)
 
     def focus(self):

--- a/gtk/src/toga_gtk/widgets/numberinput.py
+++ b/gtk/src/toga_gtk/widgets/numberinput.py
@@ -5,7 +5,7 @@ from travertino.size import at_least
 
 from toga.widgets.numberinput import _clean_decimal
 
-from ..libs import Gtk, gtk_alignment
+from ..libs import Gtk, gtk_text_alignment
 from .base import Widget
 
 
@@ -59,9 +59,9 @@ class NumberInput(Widget):
         else:
             self.native.set_value(value)
 
-    def set_alignment(self, value):
-        xalign, justify = gtk_alignment(value)
-        self.native.set_alignment(xalign)
+    def set_text_alignment(self, value):
+        xalign, justify = gtk_text_alignment(value)
+        self.native.set_text_alignment(xalign)
 
     def rehint(self):
         width = self.native.get_preferred_width()

--- a/gtk/src/toga_gtk/widgets/textinput.py
+++ b/gtk/src/toga_gtk/widgets/textinput.py
@@ -3,7 +3,7 @@ from travertino.size import at_least
 from toga.keys import Key
 from toga_gtk.keys import toga_key
 
-from ..libs import Gtk, gtk_alignment
+from ..libs import Gtk, gtk_text_alignment
 from .base import Widget
 
 
@@ -41,9 +41,9 @@ class TextInput(Widget):
     def set_placeholder(self, value):
         self.native.set_placeholder_text(value)
 
-    def set_alignment(self, value):
-        xalign, justify = gtk_alignment(value)
-        self.native.set_alignment(
+    def set_text_alignment(self, value):
+        xalign, justify = gtk_text_alignment(value)
+        self.native.set_text_alignment(
             xalign
         )  # Aligns the whole text block within the widget.
 

--- a/gtk/src/toga_gtk/window.py
+++ b/gtk/src/toga_gtk/window.py
@@ -57,7 +57,7 @@ class Window:
         # Because expand and fill are True, the container will fill the available
         # space, and will get a size_allocate callback if the window is resized.
         self.container = TogaContainer()
-        self.layout.pack_end(self.container, expand=True, fill=True, padding=0)
+        self.layout.pack_end(self.container, expand=True, fill=True, margin=0)
 
         self.native.add(self.layout)
 
@@ -387,6 +387,6 @@ class MainWindow(Window):
                 self.native_toolbar,
                 expand=False,
                 fill=False,
-                padding=0,
+                margin=0,
             )
             self.native_toolbar.show_all()

--- a/gtk/tests_backend/widgets/base.py
+++ b/gtk/tests_backend/widgets/base.py
@@ -38,8 +38,8 @@ class SimpleProbe(BaseProbe, FontMixin):
         assert self.widget._impl.container is None
         assert self.native.get_parent() is None
 
-    def assert_alignment(self, expected):
-        assert self.alignment == expected
+    def assert_align_items(self, expected):
+        assert self.align_items == expected
 
     def repaint_needed(self):
         return self.impl.container.needs_redraw or super().repaint_needed()

--- a/gtk/tests_backend/widgets/label.py
+++ b/gtk/tests_backend/widgets/label.py
@@ -12,12 +12,12 @@ class LabelProbe(SimpleProbe):
         return self.native.get_label()
 
     @property
-    def alignment(self):
+    def text_alignment(self):
         return toga_xalignment(self.native.get_xalign(), self.native.get_justify())
 
     @property
-    def vertical_alignment(self):
+    def vertical_text_alignment(self):
         return
 
-    def assert_vertical_alignment(self, expected):
+    def assert_vertical_text_alignment(self, expected):
         assert toga_yalignment(self.native.get_yalign()) == expected

--- a/gtk/tests_backend/widgets/multilinetextinput.py
+++ b/gtk/tests_backend/widgets/multilinetextinput.py
@@ -3,7 +3,7 @@ import pytest
 from toga_gtk.libs import Gtk
 
 from .base import SimpleProbe
-from .properties import toga_alignment_from_justification, toga_color
+from .properties import toga_color, toga_text_alignment_from_justification
 
 
 class MultilineTextInputProbe(SimpleProbe):
@@ -88,12 +88,12 @@ class MultilineTextInputProbe(SimpleProbe):
         return sc.get_property("font", sc.get_state())
 
     @property
-    def alignment(self):
-        return toga_alignment_from_justification(
+    def text_alignment(self):
+        return toga_text_alignment_from_justification(
             self.native_textview.get_justification(),
         )
 
-    def assert_vertical_alignment(self, expected):
+    def assert_vertical_text_alignment(self, expected):
         # GTK.TextView vertical alignment is non-configurable
         pass
 

--- a/gtk/tests_backend/widgets/numberinput.py
+++ b/gtk/tests_backend/widgets/numberinput.py
@@ -31,10 +31,10 @@ class NumberInputProbe(SimpleProbe):
         )
 
     @property
-    def alignment(self):
+    def text_alignment(self):
         return toga_xalignment(self.native.get_alignment())
 
-    def assert_alignment(self, expected):
+    def assert_text_alignment(self, expected):
         if expected == JUSTIFY:
             assert self.alignment == LEFT
         else:

--- a/gtk/tests_backend/widgets/properties.py
+++ b/gtk/tests_backend/widgets/properties.py
@@ -23,7 +23,7 @@ def toga_color(color):
         return None
 
 
-def toga_xalignment(xalign, justify=None):
+def toga_x_text_alignment(xalign, justify=None):
     try:
         return {
             0.0: JUSTIFY if justify == Gtk.Justification.FILL else LEFT,
@@ -31,10 +31,12 @@ def toga_xalignment(xalign, justify=None):
             0.5: CENTER,
         }[xalign]
     except KeyError:
-        pytest.fail(f"Can't interpret GTK x alignment {xalign} with justify {justify}")
+        pytest.fail(
+            f"Can't interpret GTK x text alignment {xalign} with justify {justify}"
+        )
 
 
-def toga_yalignment(yalign):
+def toga_y_text_alignment(yalign):
     try:
         return {
             0.0: TOP,
@@ -42,10 +44,10 @@ def toga_yalignment(yalign):
             1.0: BOTTOM,
         }[yalign]
     except KeyError:
-        pytest.fail(f"Can't interpret GTK y alignment {yalign}")
+        pytest.fail(f"Can't interpret GTK y text alignment {yalign}")
 
 
-def toga_alignment_from_justification(justify):
+def toga_text_alignment_from_justification(justify):
     return {
         Gtk.Justification.LEFT: LEFT,
         Gtk.Justification.RIGHT: RIGHT,

--- a/gtk/tests_backend/widgets/selection.py
+++ b/gtk/tests_backend/widgets/selection.py
@@ -16,8 +16,8 @@ class SelectionProbe(SimpleProbe):
         return False
 
     @property
-    def alignment(self):
-        xfail("Can't change the alignment of Selection on GTK")
+    def text_alignment(self):
+        xfail("Can't change the text alignment of Selection on GTK")
 
     @property
     def color(self):

--- a/gtk/tests_backend/widgets/textinput.py
+++ b/gtk/tests_backend/widgets/textinput.py
@@ -33,16 +33,16 @@ class TextInputProbe(SimpleProbe):
         return False
 
     @property
-    def alignment(self):
+    def text_alignment(self):
         return toga_xalignment(self.native.get_alignment())
 
-    def assert_alignment(self, expected):
+    def assert_text_alignment(self, expected):
         if expected == JUSTIFY:
             assert self.alignment == LEFT
         else:
             assert self.alignment == expected
 
-    def assert_vertical_alignment(self, expected):
+    def assert_vertical_text_alignment(self, expected):
         # GTK.Entry vertical alignment is non-configurable
         pass
 

--- a/iOS/src/toga_iOS/widgets/base.py
+++ b/iOS/src/toga_iOS/widgets/base.py
@@ -73,7 +73,7 @@ class Widget:
         # print("SET BOUNDS", self, x, y, width, height, self.container.top_offset)
         self.constraints.update(x, y + self.container.top_offset, width, height)
 
-    def set_alignment(self, alignment):
+    def set_text_alignment(self, alignment):
         pass
 
     def set_hidden(self, hidden):

--- a/iOS/src/toga_iOS/widgets/label.py
+++ b/iOS/src/toga_iOS/widgets/label.py
@@ -41,7 +41,7 @@ class Label(Widget):
         # Add the layout constraints
         self.add_constraints()
 
-    def set_alignment(self, value):
+    def set_text_alignment(self, value):
         self.native.textAlignment = NSTextAlignment(value)
 
     def set_color(self, value):

--- a/iOS/src/toga_iOS/widgets/multilinetextinput.py
+++ b/iOS/src/toga_iOS/widgets/multilinetextinput.py
@@ -144,7 +144,7 @@ class MultilineTextInput(Widget):
     def set_background_color(self, color):
         self.set_background_color_simple(color)
 
-    def set_alignment(self, value):
+    def set_text_alignment(self, value):
         self.native.textAlignment = NSTextAlignment(value)
 
     def set_font(self, font):

--- a/iOS/src/toga_iOS/widgets/numberinput.py
+++ b/iOS/src/toga_iOS/widgets/numberinput.py
@@ -108,7 +108,7 @@ class NumberInput(Widget):
             self.native.text = str(value)
         self.interface.on_change()
 
-    def set_alignment(self, value):
+    def set_text_alignment(self, value):
         self.native.textAlignment = NSTextAlignment(value)
 
     def set_font(self, font):

--- a/iOS/src/toga_iOS/widgets/selection.py
+++ b/iOS/src/toga_iOS/widgets/selection.py
@@ -77,7 +77,7 @@ class Selection(Widget):
 
         self.add_constraints()
 
-    def set_alignment(self, value):
+    def set_text_alignment(self, value):
         self.native.textAlignment = NSTextAlignment(value)
 
     def set_color(self, color):

--- a/iOS/src/toga_iOS/widgets/textinput.py
+++ b/iOS/src/toga_iOS/widgets/textinput.py
@@ -128,7 +128,7 @@ class TextInput(Widget):
         self.native.text = value
         self.interface._value_changed()
 
-    def set_alignment(self, value):
+    def set_text_alignment(self, value):
         self.native.textAlignment = NSTextAlignment(value)
         if value == RIGHT:
             self.error_label.textAlignment = NSTextAlignment(LEFT)

--- a/iOS/tests_backend/widgets/base.py
+++ b/iOS/tests_backend/widgets/base.py
@@ -63,8 +63,8 @@ class SimpleProbe(BaseProbe, FontMixin):
         assert self.widget._impl.container is None
         assert self.native.superview() is None
 
-    def assert_alignment(self, expected):
-        assert self.alignment == expected
+    def assert_align_items(self, expected):
+        assert self.align_items == expected
 
     async def redraw(self, message=None, delay=0):
         """Request a redraw of the app, waiting until that redraw has completed."""

--- a/iOS/tests_backend/widgets/label.py
+++ b/iOS/tests_backend/widgets/label.py
@@ -1,7 +1,7 @@
 from toga_iOS.libs import UILabel
 
 from .base import SimpleProbe
-from .properties import toga_alignment, toga_color
+from .properties import toga_color, toga_text_alignment
 
 
 class LabelProbe(SimpleProbe):
@@ -19,10 +19,10 @@ class LabelProbe(SimpleProbe):
         return toga_color(self.native.textColor)
 
     @property
-    def alignment(self):
-        return toga_alignment(self.native.textAlignment)
+    def text_alignment(self):
+        return toga_text_alignment(self.native.textAlignment)
 
-    def assert_vertical_alignment(self, alignment):
+    def assert_vertical_text_alignment(self, alignment):
         # iOS has a custom draw method that always draw the text at the top;
         # this location isn't configurable
         pass

--- a/iOS/tests_backend/widgets/numberinput.py
+++ b/iOS/tests_backend/widgets/numberinput.py
@@ -4,7 +4,7 @@ from rubicon.objc import NSRange
 from toga_iOS.libs import UITextField
 
 from .base import SimpleProbe
-from .properties import toga_alignment, toga_color
+from .properties import toga_color, toga_text_alignment
 
 
 class NumberInputProbe(SimpleProbe):
@@ -29,10 +29,10 @@ class NumberInputProbe(SimpleProbe):
         return toga_color(self.native.textColor)
 
     @property
-    def alignment(self):
-        return toga_alignment(self.native.textAlignment)
+    def text_alignment(self):
+        return toga_text_alignment(self.native.textAlignment)
 
-    def assert_vertical_alignment(self, expected):
+    def assert_vertical_text_alignment(self, expected):
         # Vertical alignment isn't configurable on a UITextField
         pass
 

--- a/iOS/tests_backend/widgets/properties.py
+++ b/iOS/tests_backend/widgets/properties.py
@@ -33,7 +33,7 @@ def toga_color(color):
         return None
 
 
-def toga_alignment(alignment):
+def toga_text_alignment(alignment):
     return {
         NSLeftTextAlignment: LEFT,
         NSRightTextAlignment: RIGHT,

--- a/iOS/tests_backend/widgets/selection.py
+++ b/iOS/tests_backend/widgets/selection.py
@@ -5,7 +5,7 @@ from pytest import xfail
 from toga_iOS.libs import UIPickerView, UITextField
 
 from .base import SimpleProbe
-from .properties import toga_alignment, toga_color
+from .properties import toga_color, toga_text_alignment
 
 
 class SelectionProbe(SimpleProbe):
@@ -20,11 +20,11 @@ class SelectionProbe(SimpleProbe):
         xfail("Selection doesn't resize on content changes")
 
     @property
-    def alignment(self):
-        return toga_alignment(self.native.textAlignment)
+    def text_alignment(self):
+        return toga_text_alignment(self.native.textAlignment)
 
-    def assert_vertical_alignment(self, expected):
-        # Vertical alignment isn't configurable on UITextField
+    def assert_vertical_text_alignment(self, expected):
+        # Vertical text alignment isn't configurable on UITextField
         pass
 
     @property

--- a/iOS/tests_backend/widgets/textinput.py
+++ b/iOS/tests_backend/widgets/textinput.py
@@ -4,7 +4,7 @@ from rubicon.objc import SEL, send_message
 from toga_iOS.libs import UITextField
 
 from .base import SimpleProbe
-from .properties import toga_alignment, toga_color
+from .properties import toga_color, toga_text_alignment
 
 
 class TextInputProbe(SimpleProbe):
@@ -43,11 +43,11 @@ class TextInputProbe(SimpleProbe):
         return toga_color(self.native.textColor)
 
     @property
-    def alignment(self):
-        return toga_alignment(self.native.textAlignment)
+    def text_alignment(self):
+        return toga_text_alignment(self.native.textAlignment)
 
-    def assert_vertical_alignment(self, expected):
-        # Vertical alignment isn't configurable on UITextField
+    def assert_vertical_text_alignment(self, expected):
+        # Vertical text alignment isn't configurable on UITextField
         pass
 
     @property

--- a/testbed/tests/app/test_desktop.py
+++ b/testbed/tests/app/test_desktop.py
@@ -546,7 +546,7 @@ async def test_system_dpi_change(
     try:
         main_window.toolbar.add(toga.Command(None, "Test command"))
 
-        # Include widgets which are sized in different ways, with padding and fixed
+        # Include widgets which are sized in different ways, with margin and fixed
         # sizes in both dimensions.
         main_window.content = toga.Box(
             style=Pack(direction="row"),
@@ -554,7 +554,7 @@ async def test_system_dpi_change(
                 toga.Label(
                     "fixed",
                     id="fixed",
-                    style=Pack(background_color="yellow", padding_left=20, width=100),
+                    style=Pack(background_color="yellow", margin_left=20, width=100),
                 ),
                 toga.Label(
                     "minimal",  # Shrink to fit content
@@ -565,7 +565,7 @@ async def test_system_dpi_change(
                     "flex",
                     id="flex",
                     style=Pack(
-                        background_color="pink", flex=1, padding_top=15, height=50
+                        background_color="pink", flex=1, margin_top=15, height=50
                     ),
                 ),
             ],

--- a/testbed/tests/widgets/properties.py
+++ b/testbed/tests/widgets/properties.py
@@ -414,41 +414,41 @@ async def test_background_color_transparent(widget, probe):
     assert_color(probe.background_color, TRANSPARENT if supports_alpha else original)
 
 
-async def test_alignment(widget, probe, verify_vertical_alignment):
+async def test_text_alignment(widget, probe, verify_vertical_text_alignment):
     """Widget honors alignment settings."""
-    # Use column alignment to ensure widget uses all available width
+    # Use column direction to ensure widget uses all available width
     widget.parent.style.direction = COLUMN
 
-    # Initial alignment is LEFT, initial direction is LTR
+    # Initial text alignment is LEFT, initial direction is LTR
     await probe.redraw("Text direction should be LTR")
-    probe.assert_alignment(LEFT)
+    probe.assert_text_alignment(LEFT)
 
-    for alignment in [RIGHT, CENTER, JUSTIFY]:
-        widget.style.text_align = alignment
-        await probe.redraw("Text direction should be %s" % alignment)
-        probe.assert_alignment(alignment)
-        probe.assert_vertical_alignment(verify_vertical_alignment)
+    for text_alignment in [RIGHT, CENTER, JUSTIFY]:
+        widget.style.text_align = text_alignment
+        await probe.redraw("Text alignment should be %s" % text_alignment)
+        probe.assert_text_alignment(text_alignment)
+        probe.assert_vertical_text_alignment(verify_vertical_text_alignment)
 
-    # Clearing the alignment reverts to default alignment of LEFT
+    # Clearing the text alignment reverts to default text alignment of LEFT
     del widget.style.text_align
-    await probe.redraw("Text direction should be reverted to LEFT")
-    probe.assert_alignment(LEFT)
+    await probe.redraw("Text alignment should be reverted to LEFT")
+    probe.assert_text_alignment(LEFT)
 
-    # If text direction is RTL, default alignment is RIGHT
+    # If text direction is RTL, default text alignment is RIGHT
     widget.style.text_direction = RTL
-    await probe.redraw("Text direction should be RTL")
-    probe.assert_alignment(RIGHT)
+    await probe.redraw("Text direction is RTL, so text alignment should be RIGHT")
+    probe.assert_text_alignment(RIGHT)
 
-    # If text direction is expliclty LTR, default alignment is LEFT
+    # If text direction is expliclty LTR, default text alignment is LEFT
     widget.style.text_direction = LTR
-    await probe.redraw("Text direction should be LTR")
-    probe.assert_alignment(LEFT)
+    await probe.redraw("Text direction is LTR, so text alignment should be LEFT")
+    probe.assert_text_alignment(LEFT)
 
-    # If the widget has an explicit height, the vertical alignment of the widget
+    # If the widget has an explicit height, the vertical text alignment of the widget
     # is unchanged.
     widget.style.height = 200
-    await probe.redraw(f"Text should be at the {verify_vertical_alignment}")
-    probe.assert_vertical_alignment(verify_vertical_alignment)
+    await probe.redraw(f"Text should be at the {verify_vertical_text_alignment}")
+    probe.assert_vertical_text_alignment(verify_vertical_text_alignment)
 
 
 async def test_readonly(widget, probe):

--- a/testbed/tests/widgets/test_label.py
+++ b/testbed/tests/widgets/test_label.py
@@ -4,7 +4,6 @@ import toga
 
 from .conftest import build_cleanup_test
 from .properties import (  # noqa: F401
-    test_alignment,
     test_background_color,
     test_background_color_reset,
     test_background_color_transparent,
@@ -16,6 +15,7 @@ from .properties import (  # noqa: F401
     test_font,
     test_font_attrs,
     test_text,
+    test_text_alignment,
     test_text_width_change,
 )
 

--- a/testbed/tests/widgets/test_multilinetextinput.py
+++ b/testbed/tests/widgets/test_multilinetextinput.py
@@ -5,7 +5,6 @@ from toga.style import Pack
 
 from .conftest import build_cleanup_test
 from .properties import (  # noqa: F401
-    test_alignment,
     test_background_color,
     test_background_color_reset,
     test_background_color_transparent,
@@ -20,6 +19,7 @@ from .properties import (  # noqa: F401
     test_placeholder_color,
     test_placeholder_focus,
     test_readonly,
+    test_text_alignment,
     test_text_value,
 )
 from .test_textinput import (  # noqa: F401

--- a/testbed/tests/widgets/test_numberinput.py
+++ b/testbed/tests/widgets/test_numberinput.py
@@ -8,7 +8,6 @@ import toga
 from ..conftest import skip_on_platforms
 from .conftest import build_cleanup_test
 from .properties import (  # noqa: F401
-    test_alignment,
     test_background_color,
     test_background_color_reset,
     test_background_color_transparent,
@@ -20,9 +19,10 @@ from .properties import (  # noqa: F401
     test_font,
     test_font_attrs,
     test_readonly,
+    test_text_alignment,
 )
 from .test_textinput import (  # noqa: F401
-    verify_vertical_alignment,
+    verify_vertical_text_alignment,
 )
 
 

--- a/testbed/tests/widgets/test_passwordinput.py
+++ b/testbed/tests/widgets/test_passwordinput.py
@@ -4,7 +4,6 @@ import toga
 
 from .conftest import build_cleanup_test
 from .properties import (  # noqa: F401
-    test_alignment,
     test_background_color,
     test_background_color_reset,
     test_background_color_transparent,
@@ -19,6 +18,7 @@ from .properties import (  # noqa: F401
     test_placeholder_color,
     test_placeholder_focus,
     test_readonly,
+    test_text_alignment,
 )
 from .test_textinput import (  # noqa: F401
     placeholder,
@@ -30,7 +30,7 @@ from .test_textinput import (  # noqa: F401
     test_undo_redo,
     test_validation,
     verify_focus_handlers,
-    verify_vertical_alignment,
+    verify_vertical_text_alignment,
 )
 
 

--- a/testbed/tests/widgets/test_scrollcontainer.py
+++ b/testbed/tests/widgets/test_scrollcontainer.py
@@ -25,7 +25,7 @@ async def content():
             toga.Label(
                 f"I am line {i}",
                 style=Pack(
-                    padding=20,
+                    margin=20,
                     height=20,
                     width=160,
                     background_color=CORNFLOWERBLUE if i % 2 else REBECCAPURPLE,
@@ -49,7 +49,7 @@ async def small_content():
             toga.Label(
                 "I am content",
                 style=Pack(
-                    padding=20,
+                    margin=20,
                     height=20,
                     width=160,
                     background_color=CORNFLOWERBLUE,
@@ -96,7 +96,7 @@ async def test_clear_content(widget, probe, small_content):
 
     # Apply a style to guarantee a set_bounds() call has been made
     # when there is no content.
-    widget.style.padding = 10
+    widget.style.margin = 10
     await probe.redraw("Widget has definitely been refreshed")
     assert not probe.has_content
 
@@ -107,22 +107,22 @@ async def test_clear_content(widget, probe, small_content):
     assert probe.document_height == probe.height
 
 
-async def test_padding(widget, probe, content):
-    "Padding works correctly on the root widget"
+async def test_margin(widget, probe, content):
+    "Margin works correctly on the root widget"
     original_width = probe.width
     original_height = probe.height
     original_document_width = probe.document_width
     original_document_height = probe.document_height
 
-    content.style.padding = 21
-    await probe.redraw("Add padding")
+    content.style.margin = 21
+    await probe.redraw("Add margin")
     assert probe.width == original_width
     assert probe.height == original_height
     assert probe.document_width == original_document_width
     assert probe.document_height == original_document_height + 42
 
-    content.style.padding = 0
-    await probe.redraw("Remove padding")
+    content.style.margin = 0
+    await probe.redraw("Remove margin")
     assert probe.width == original_width
     assert probe.height == original_height
     assert probe.document_width == original_document_width
@@ -139,7 +139,7 @@ async def test_enable_horizontal_scrolling(widget, probe, content, on_scroll):
             style=Pack(
                 width=2000,
                 background_color=CORNFLOWERBLUE,
-                padding=20,
+                margin=20,
                 height=20,
             ),
         ),
@@ -207,7 +207,7 @@ async def test_enable_vertical_scrolling(widget, probe, content, on_scroll):
             style=Pack(
                 width=2000,
                 background_color=CORNFLOWERBLUE,
-                padding=20,
+                margin=20,
                 height=20,
             ),
         ),
@@ -412,7 +412,7 @@ async def test_scroll_both(widget, probe, content, on_scroll):
             style=Pack(
                 width=2000,
                 background_color=CORNFLOWERBLUE,
-                padding=20,
+                margin=20,
                 height=20,
             ),
         )

--- a/testbed/tests/widgets/test_selection.py
+++ b/testbed/tests/widgets/test_selection.py
@@ -8,7 +8,6 @@ from toga.sources import ListSource
 
 from .conftest import build_cleanup_test
 from .properties import (  # noqa: F401
-    test_alignment,
     test_background_color,
     test_background_color_reset,
     test_background_color_transparent,
@@ -18,6 +17,7 @@ from .properties import (  # noqa: F401
     test_flex_horizontal_widget_size,
     test_font,
     test_font_attrs,
+    test_text_alignment,
 )
 
 # FIXME: 2023-05-31 GTK's focus APIs are completely broken for GTK.ComboBox. The
@@ -48,7 +48,7 @@ def verify_font_sizes():
 
 
 @pytest.fixture
-def verify_vertical_alignment():
+def verify_vertical_text_alignment():
     return CENTER
 
 

--- a/testbed/tests/widgets/test_textinput.py
+++ b/testbed/tests/widgets/test_textinput.py
@@ -8,7 +8,6 @@ from toga.constants import CENTER
 from ..data import TEXTS
 from .conftest import build_cleanup_test
 from .properties import (  # noqa: F401
-    test_alignment,
     test_background_color,
     test_background_color_reset,
     test_background_color_transparent,
@@ -23,6 +22,7 @@ from .properties import (  # noqa: F401
     test_placeholder_color,
     test_placeholder_focus,
     test_readonly,
+    test_text_alignment,
 )
 
 
@@ -32,7 +32,7 @@ async def widget():
 
 
 @pytest.fixture
-def verify_vertical_alignment():
+def verify_vertical_text_alignment():
     return CENTER
 
 

--- a/textual/src/toga_textual/widgets/base.py
+++ b/textual/src/toga_textual/widgets/base.py
@@ -143,7 +143,7 @@ class Widget(Scalable):
             self.scale_in_horizontal(margin_left),
         )
 
-    def set_alignment(self, alignment):
+    def set_text_alignment(self, alignment):
         pass
 
     def set_hidden(self, hidden):

--- a/web/src/toga_web/widgets/base.py
+++ b/web/src/toga_web/widgets/base.py
@@ -99,7 +99,7 @@ class Widget:
     def set_bounds(self, x, y, width, height):
         self._reapply_style()
 
-    def set_alignment(self, alignment):
+    def set_text_alignment(self, alignment):
         self._reapply_style()
 
     def set_hidden(self, hidden):

--- a/web/src/toga_web/widgets/label.py
+++ b/web/src/toga_web/widgets/label.py
@@ -11,7 +11,7 @@ class Label(Widget):
     def set_text(self, value):
         self.native.innerHTML = value
 
-    def set_alignment(self, value):
+    def set_text_alignment(self, value):
         pass
 
     def rehint(self):

--- a/web/src/toga_web/widgets/textinput.py
+++ b/web/src/toga_web/widgets/textinput.py
@@ -27,7 +27,7 @@ class TextInput(Widget):
     def set_font(self, font):
         pass
 
-    def set_alignment(self, value):
+    def set_text_alignment(self, value):
         pass
 
     def rehint(self):

--- a/winforms/src/toga_winforms/widgets/base.py
+++ b/winforms/src/toga_winforms/widgets/base.py
@@ -120,8 +120,8 @@ class Widget(Scalable, ABC):
         self.native.Size = Size(*map(self.scale_in, (width, height)))
         self.native.Location = Point(*map(self.scale_in, (x, y)))
 
-    def set_alignment(self, alignment):
-        # By default, alignment can't be changed
+    def set_text_alignment(self, alignment):
+        # By default, text alignment can't be changed
         pass
 
     def set_hidden(self, hidden):

--- a/winforms/src/toga_winforms/widgets/label.py
+++ b/winforms/src/toga_winforms/widgets/label.py
@@ -13,7 +13,7 @@ class Label(Widget):
         self.native = WinForms.Label()
         self.native.AutoSizeMode = WinForms.AutoSizeMode.GrowAndShrink
 
-    def set_alignment(self, value):
+    def set_text_alignment(self, value):
         self.native.TextAlign = TextAlignment(value)
 
     def get_text(self):

--- a/winforms/src/toga_winforms/widgets/multilinetextinput.py
+++ b/winforms/src/toga_winforms/widgets/multilinetextinput.py
@@ -89,7 +89,7 @@ class MultilineTextInput(TextInput):
         if not self._placeholder_visible:
             self.native.ForeColor = self._color
 
-    def set_alignment(self, value):
+    def set_text_alignment(self, value):
         original_selection = (self.native.SelectionStart, self.native.SelectionLength)
         self.native.SelectAll()
         self.native.SelectionAlignment = HorizontalTextAlignment(value)

--- a/winforms/src/toga_winforms/widgets/numberinput.py
+++ b/winforms/src/toga_winforms/widgets/numberinput.py
@@ -63,7 +63,7 @@ class NumberInput(Widget):
         else:
             self.native.Value = native_decimal(value)
 
-    def set_alignment(self, value):
+    def set_text_alignment(self, value):
         self.native.TextAlign = HorizontalTextAlignment(value)
 
     def rehint(self):

--- a/winforms/src/toga_winforms/widgets/textinput.py
+++ b/winforms/src/toga_winforms/widgets/textinput.py
@@ -61,7 +61,7 @@ class TextInput(Widget):
     def set_value(self, value):
         self.native.Text = value
 
-    def set_alignment(self, value):
+    def set_text_alignment(self, value):
         self.native.TextAlign = HorizontalTextAlignment(value)
 
     def set_color(self, color):

--- a/winforms/tests_backend/widgets/base.py
+++ b/winforms/tests_backend/widgets/base.py
@@ -31,8 +31,8 @@ class SimpleProbe(BaseProbe):
         assert self.widget._impl.container is None
         assert self.native.Parent is None
 
-    def assert_alignment(self, expected):
-        # Winforms doesn't have a "Justified" alignment; it falls back to LEFT
+    def assert_text_alignment(self, expected):
+        # Winforms doesn't have a "Justified" text alignment; it falls back to LEFT
         actual = self.alignment
         if expected == JUSTIFY:
             assert actual == LEFT

--- a/winforms/tests_backend/widgets/label.py
+++ b/winforms/tests_backend/widgets/label.py
@@ -1,7 +1,7 @@
 import System.Windows.Forms
 
 from .base import SimpleProbe
-from .properties import toga_xalignment, toga_yalignment
+from .properties import toga_x_text_alignment, toga_y_text_alignment
 
 
 class LabelProbe(SimpleProbe):
@@ -12,8 +12,8 @@ class LabelProbe(SimpleProbe):
         return self.native.Text
 
     @property
-    def alignment(self):
-        return toga_xalignment(self.native.TextAlign)
+    def text_alignment(self):
+        return toga_x_text_alignment(self.native.TextAlign)
 
-    def assert_vertical_alignment(self, expected):
-        assert toga_yalignment(self.native.TextAlign) == expected
+    def assert_vertical_text_alignment(self, expected):
+        assert toga_y_text_alignment(self.native.TextAlign) == expected

--- a/winforms/tests_backend/widgets/multilinetextinput.py
+++ b/winforms/tests_backend/widgets/multilinetextinput.py
@@ -1,7 +1,7 @@
 import System.Windows.Forms
 from System.Drawing import SystemColors
 
-from .properties import toga_xalignment
+from .properties import toga_x_text_alignment
 from .textinput import TextInputProbe
 
 
@@ -56,6 +56,6 @@ class MultilineTextInputProbe(TextInputProbe):
     # SelectionAlignment.Left when the text selection contains multiple paragraphs with
     # mixed alignment."
     @property
-    def alignment(self):
+    def text_alignment(self):
         self.native.SelectAll()
-        return toga_xalignment(self.native.SelectionAlignment)
+        return toga_x_text_alignment(self.native.SelectionAlignment)

--- a/winforms/tests_backend/widgets/numberinput.py
+++ b/winforms/tests_backend/widgets/numberinput.py
@@ -2,7 +2,7 @@ import pytest
 from System.Windows.Forms import NumericUpDown
 
 from .base import SimpleProbe
-from .properties import toga_xalignment
+from .properties import toga_x_text_alignment
 
 
 class NumberInputProbe(SimpleProbe):
@@ -33,11 +33,11 @@ class NumberInputProbe(SimpleProbe):
         await self.type_character("<down>")
 
     @property
-    def alignment(self):
-        return toga_xalignment(self.native.TextAlign)
+    def text_alignment(self):
+        return toga_x_text_alignment(self.native.TextAlign)
 
-    def assert_vertical_alignment(self, expected):
-        # Vertical alignment isn't configurable in this native widget.
+    def assert_vertical_text_alignment(self, expected):
+        # Vertical text alignment isn't configurable in this native widget.
         pass
 
     def set_cursor_at_end(self):

--- a/winforms/tests_backend/widgets/properties.py
+++ b/winforms/tests_backend/widgets/properties.py
@@ -9,7 +9,7 @@ def toga_color(color):
     return rgba(color.R, color.G, color.B, color.A / 255)
 
 
-def toga_xalignment(alignment):
+def toga_x_text_alignment(alignment):
     return {
         ContentAlignment.TopLeft: LEFT,
         ContentAlignment.MiddleLeft: LEFT,
@@ -27,7 +27,7 @@ def toga_xalignment(alignment):
     }[alignment]
 
 
-def toga_yalignment(alignment):
+def toga_y_text_alignment(alignment):
     return {
         ContentAlignment.TopLeft: TOP,
         ContentAlignment.TopCenter: TOP,

--- a/winforms/tests_backend/widgets/selection.py
+++ b/winforms/tests_backend/widgets/selection.py
@@ -13,8 +13,8 @@ class SelectionProbe(SimpleProbe):
         xfail("Selection doesn't resize on content changes on this backend")
 
     @property
-    def alignment(self):
-        xfail("Can't change the alignment of Selection on this backend")
+    def text_alignment(self):
+        xfail("Can't change the text alignment of Selection on this backend")
 
     @property
     def titles(self):

--- a/winforms/tests_backend/widgets/textinput.py
+++ b/winforms/tests_backend/widgets/textinput.py
@@ -6,7 +6,7 @@ import pytest
 from System.Windows.Forms import TextBox
 
 from .base import SimpleProbe
-from .properties import toga_xalignment
+from .properties import toga_x_text_alignment
 
 
 class TextInputProbe(SimpleProbe):
@@ -48,11 +48,11 @@ class TextInputProbe(SimpleProbe):
         return self.native.ReadOnly
 
     @property
-    def alignment(self):
-        return toga_xalignment(self.native.TextAlign)
+    def text_alignment(self):
+        return toga_x_text_alignment(self.native.TextAlign)
 
-    def assert_vertical_alignment(self, expected):
-        # Vertical alignment isn't configurable in this native widget.
+    def assert_vertical_text_alignment(self, expected):
+        # Vertical text alignment isn't configurable in this native widget.
         pass
 
     def set_cursor_at_end(self):


### PR DESCRIPTION
@mhsmith pointed out in #3011 that the `padding` (et al) and `alignment` Pack properties would be better named `margin` and `align_items`, to match their corresponding CSS properties. I've renamed them throughout the codebase, and set up an aliasing system for backwards compatibility (with tests). I've also taken the liberty of clarifying the name of *text* alignment whenever I encountered it in my searching-and-replacing.


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
