### PR TITLE
Web backend font fixes

### DIFF
--- a/changes/3035.bugfix.rst
+++ b/changes/3035.bugfix.rst
@@ -1,0 +1,1 @@
+The web backend now uses the Shoelace default font in all browsers.

--- a/web/src/toga_web/factory.py
+++ b/web/src/toga_web/factory.py
@@ -3,8 +3,7 @@ from toga import NotImplementedWarning
 from . import dialogs
 from .app import App
 from .command import Command
-
-# from .fonts import Font
+from .fonts import Font
 from .icons import Icon
 
 # from .images import Image
@@ -49,7 +48,7 @@ __all__ = [
     "App",
     "Command",
     # Resources
-    # 'Font',
+    "Font",
     "Icon",
     # 'Image',
     "Paths",

--- a/web/src/toga_web/fonts.py
+++ b/web/src/toga_web/fonts.py
@@ -1,0 +1,4 @@
+# Fonts are implemented via Pack.__css__, so this class doesn't need to do anything.
+class Font:
+    def __init__(self, *args, **kwargs):
+        pass

--- a/web/src/toga_web/static/toga.css
+++ b/web/src/toga_web/static/toga.css
@@ -12,6 +12,11 @@ html, body {
     margin: 0;
 }
 
+#app-placeholder {
+    font-family: var(--sl-font-sans);
+    font-size: var(--sl-font-size-medium);
+}
+
 /* If a custom element hasn't been defined yet, hide it from rendering */
 :not(:defined) {
     visibility: hidden;


### PR DESCRIPTION
This fixes the issue mentioned at https://github.com/beeware/briefcase-web-static-template/pull/16#issuecomment-2408411025:

> Style appears to have been lost from dialogs. The about dialog in Tutorial 0 displays in "browser default serif", not the Shoelace sans-serif default.

It looks like the style sheet simply never set a font on the top-level element, so the browser default was used on any elements which didn't specify their own font. This affected not only dialogs, but also Toga labels. 

Also added a dummy Font implementation class, to fix the following error, which I guess may have been introduced by #2937:
```
  File "/lib/python3.12/site-packages/tutorial/app.py", line 9, in build
    box = toga.Box()
          ^^^^^^^^^^
  File "/lib/python3.12/site-packages/toga/widgets/box.py", line 25, in __init__
    super().__init__(id=id, style=style)
  File "/lib/python3.12/site-packages/toga/widgets/base.py", line 83, in __init__
    self.style.reapply()
  File "/lib/python3.12/site-packages/travertino/declaration.py", line 96, in reapply
    self.apply(style, getattr(self, style))
  File "/lib/python3.12/site-packages/toga/style/pack.py", line 131, in apply
    Font(
  File "/lib/python3.12/site-packages/toga/fonts.py", line 59, in __init__
    self._impl = self.factory.Font(self)
                 ^^^^^^^^^^^^^^^^^
  File "/lib/python3.12/site-packages/toga_web/factory.py", line 91, in __getattr__
    raise NotImplementedError(f"Toga's Web backend doesn't implement {name}")
NotImplementedError: Toga's Web backend doesn't implement Font
```

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
