### PR TITLE
Removed superfluous returns in compat section

### DIFF
--- a/changes/3062.misc.rst
+++ b/changes/3062.misc.rst
@@ -1,0 +1,1 @@
+Functionally innocuous but superfluous returns have been removed from dunder methods added in PR #3033.

--- a/core/src/toga/style/pack.py
+++ b/core/src/toga/style/pack.py
@@ -232,16 +232,14 @@ class Pack(BaseStyle):
             setattr(self, name, value)
             return
 
-        return super().__setitem__(
-            self._update_property_name(name.replace("-", "_")), value
-        )
+        super().__setitem__(self._update_property_name(name.replace("-", "_")), value)
 
     def __delitem__(self, name):
         if name in {"padding", "margin"}:
             delattr(self, name)
             return
 
-        return super().__delitem__(self._update_property_name(name.replace("-", "_")))
+        super().__delitem__(self._update_property_name(name.replace("-", "_")))
 
     ######################################################################
     # End backwards compatibility


### PR DESCRIPTION
There's no functional difference, but I noticed I was returning the value from `__setitem__` and `__delitem__`, which doesn't make any sense.

Refs #3033, #3044, #3048

I can't seem to stop amending this one PR...

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
