### PR TITLE
Add BeeWare Tutorial 1 support for GTK4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -449,8 +449,7 @@ jobs:
       timeout-minutes: 15
       run: |
         ${{ matrix.briefcase-run-prefix }} \
-          briefcase run ${{ matrix.platform }} --log --test ${{ matrix.briefcase-run-args }} \
-          -- ${{ matrix.briefcase-test-args }} --ci
+          briefcase run ${{ matrix.platform }} --log --test ${{ matrix.briefcase-run-args }} -- --ci
 
     - name: Upload Logs
       uses: actions/upload-artifact@v4.6.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,7 +350,7 @@ jobs:
             sudo apt update -y
             sudo apt install -y --no-install-recommends \
               mutter pkg-config python3-dev libgirepository1.0-dev libcairo2-dev \
-              gir1.2-webkit2-4.1 gir1.2-xapp-1.0 gir1.2-geoclue-2.0 gir1.2-flatpak-1.0 \
+              gir1.2-webkit-6.0 gir1.2-xapp-1.0 gir1.2-geoclue-2.0 gir1.2-flatpak-1.0 \
               gir1.2-gtk-4.0
 
             # Start Virtual X Server

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,8 +256,9 @@ jobs:
         - "macOS-x86_64"
         - "macOS-arm64"
         - "windows"
-        - "linux-x11"
-        - "linux-wayland"
+        - "linux-x11-gtk3"
+        - "linux-wayland-gtk3"
+        - "linux-wayland-gtk4"
         - "android"
         - "iOS"
         - "textual-linux"
@@ -282,7 +283,7 @@ jobs:
         # We use a fixed Ubuntu version rather than `-latest` because at some point,
         # `-latest` will be updated, but it will be a soft changeover, which would cause
         # the system Python version to become inconsistent from run to run.
-        - backend: "linux-x11"
+        - backend: "linux-x11-gtk3"
           platform: "linux"
           runs-on: "ubuntu-24.04"
           # The package list should be the same as in unix-prerequisites.rst, and the BeeWare
@@ -311,7 +312,7 @@ jobs:
           setup-python: false  # Use the system Python packages
           app-user-data-path: "$HOME/.local/share/testbed"
 
-        - backend: "linux-wayland"
+        - backend: "linux-wayland-gtk3"
           platform: "linux"
           runs-on: "ubuntu-24.04"
           # The package list should be the same as in unix-prerequisites.rst, and the BeeWare
@@ -330,11 +331,42 @@ jobs:
             # Start Window Manager
             echo "Start window manager..."
             # mutter is being run inside a virtual X server because mutter's headless
-            # mode is not compatible with Gtk
+            # mode does not provide a Gdk.Display
             DISPLAY=:99 MUTTER_DEBUG_DUMMY_MODE_SPECS=2048x1536 \
               mutter --nested --wayland --no-x11 --wayland-display toga &
             sleep 1
           briefcase-run-prefix: "WAYLAND_DISPLAY=toga"
+          setup-python: false  # Use the system Python packages
+          app-user-data-path: "$HOME/.local/share/testbed"
+
+        - backend: "linux-wayland-gtk4"
+          platform: "linux"
+          runs-on: "ubuntu-24.04"
+          env:
+            XDG_RUNTIME_DIR: "/tmp"
+          # The package list should be the same as in unix-prerequisites.rst, and the BeeWare
+          # tutorial, plus mutter to provide a window manager.
+          pre-command: |
+            sudo apt update -y
+            sudo apt install -y --no-install-recommends \
+              mutter pkg-config python3-dev libgirepository1.0-dev libcairo2-dev \
+              gir1.2-webkit2-4.1 gir1.2-xapp-1.0 gir1.2-geoclue-2.0 gir1.2-flatpak-1.0 \
+              gir1.2-gtk-4.0
+
+            # Start Virtual X Server
+            echo "Start X server..."
+            Xvfb :99 -screen 0 2048x1536x24 &
+            sleep 1
+
+            # Start Window Manager
+            echo "Start window manager..."
+            # mutter is being run inside a virtual X server because mutter's headless
+            # mode does not provide a Gdk.Display
+            DISPLAY=:99 MUTTER_DEBUG_DUMMY_MODE_SPECS=2048x1536 \
+              mutter --nested --wayland --no-x11 --wayland-display toga &
+            sleep 1
+          briefcase-run-prefix: "WAYLAND_DISPLAY=toga TOGA_GTK=4"
+          briefcase-test-args: -k 'test_window or test_desktop or test_app and not test_app_icon'
           setup-python: false  # Use the system Python packages
           app-user-data-path: "$HOME/.local/share/testbed"
 
@@ -418,7 +450,8 @@ jobs:
       timeout-minutes: 15
       run: |
         ${{ matrix.briefcase-run-prefix }} \
-          briefcase run ${{ matrix.platform }} --log --test ${{ matrix.briefcase-run-args }} -- --ci
+          briefcase run ${{ matrix.platform }} --log --test ${{ matrix.briefcase-run-args }} \
+          -- ${{ matrix.briefcase-test-args }} --ci
 
     - name: Upload Logs
       uses: actions/upload-artifact@v4.6.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,7 +366,6 @@ jobs:
               mutter --nested --wayland --no-x11 --wayland-display toga &
             sleep 1
           briefcase-run-prefix: "WAYLAND_DISPLAY=toga TOGA_GTK=4"
-          briefcase-test-args: -k 'test_window or test_desktop or test_app and not test_app_icon'
           setup-python: false  # Use the system Python packages
           app-user-data-path: "$HOME/.local/share/testbed"
 

--- a/android/tests_backend/window.py
+++ b/android/tests_backend/window.py
@@ -12,6 +12,7 @@ from .probe import BaseProbe
 class WindowProbe(BaseProbe, DialogsMixin):
     supports_fullscreen = True
     supports_presentation = True
+    supports_as_image = True
 
     def __init__(self, app, window):
         super().__init__(app)

--- a/android/tests_backend/window.py
+++ b/android/tests_backend/window.py
@@ -13,6 +13,7 @@ class WindowProbe(BaseProbe, DialogsMixin):
     supports_fullscreen = True
     supports_presentation = True
     supports_as_image = True
+    supports_focus = True
 
     def __init__(self, app, window):
         super().__init__(app)

--- a/changes/3087.feature.rst
+++ b/changes/3087.feature.rst
@@ -1,0 +1,1 @@
+Toga GTK now supports GTK4 for BeeWare Tutorial 1 by setting `TOGA_GTK=4`.

--- a/changes/3087.feature.rst
+++ b/changes/3087.feature.rst
@@ -1,1 +1,1 @@
-Toga GTK now supports GTK4 for BeeWare Tutorial 1 by setting `TOGA_GTK=4`.
+Initial experimental support for GTK4 has been added to Toga's GTK backend. This support can be enabled by setting ``TOGA_GTK=4`` in your environment.

--- a/cocoa/tests_backend/window.py
+++ b/cocoa/tests_backend/window.py
@@ -16,6 +16,7 @@ class WindowProbe(BaseProbe, DialogsMixin):
     supports_unminimize = True
     supports_minimize = True
     supports_placement = True
+    supports_as_image = True
 
     def __init__(self, app, window):
         super().__init__()

--- a/cocoa/tests_backend/window.py
+++ b/cocoa/tests_backend/window.py
@@ -17,6 +17,7 @@ class WindowProbe(BaseProbe, DialogsMixin):
     supports_minimize = True
     supports_placement = True
     supports_as_image = True
+    supports_focus = True
 
     def __init__(self, app, window):
         super().__init__()

--- a/docs/how-to/contribute/code.rst
+++ b/docs/how-to/contribute/code.rst
@@ -447,6 +447,25 @@ that you could try to implement.
 Again, you'll need to add unit tests and/or backend probes for any new features
 you add.
 
+Contribute to the GTK4 update
+-----------------------------
+
+Toga's GTK support is currently based on the GTK3 API. This API works, and ships with
+most Linux distributions, but is no longer maintained by the GTK team. We're in the
+process of adding GTK4 support to Toga's GTK backend. You can help with this update
+process.
+
+GTK4 support can be enabled by setting the ``TOGA_GTK=4`` environment variable. To
+contribute to the update, pick a widget that currently has GTK3 support, and try
+updating the widget's API to support GTK4 as well. You can identify a widget that hasn't
+been ported by looking at the :ref:`GTK probe for the widget <testbed-probe>` - widgets
+that aren't ported yet will have an "if GTK4, skip" block at the top of the probe
+definition.
+
+The code needs to support both GTK3 and GTK4; if there are significant differences in
+API, you can add conditional branches based on the GTK version. See one of the widgets
+that *has* been ported (e.g., Label) for examples of how this can be done.
+
 Implement an entirely new platform backend
 ------------------------------------------
 

--- a/docs/how-to/contribute/code.rst
+++ b/docs/how-to/contribute/code.rst
@@ -832,6 +832,11 @@ run``.
 You can also use slow mode or pytest specifiers with ``briefcase run``, using
 the same ``--`` syntax as you used in developer mode.
 
+Finally, if you would like to run the tests against GTK4 on Linux, set the
+environmental variable ``TOGA_GTK=4``. This is experimental and only partially
+implemented, but we would greatly appreciate your help translating widgets from
+GTK3 to GTK4.
+
 .. _testbed-probe:
 
 How the testbed works

--- a/docs/reference/api/widgets/mapview.rst
+++ b/docs/reference/api/widgets/mapview.rst
@@ -116,6 +116,11 @@ System requirements
   - OpenSUSE Tumbleweed: ``libwebkit2gtk3 typelib(WebKit2)``
   - FreeBSD: ``webkit2-gtk3``
 
+  MapView is not fully supported on GTK4. If you want to contribute to the GTK4 MapView
+  implementation, you will require v6.0 of the WebKit2 libraries. This is provided by
+  ``gir1.2-webkit-6.0`` on Ubuntu/Debian, and ``webkitgtk6.0`` on Fedora; for other
+  distributions, consult your distributions's platform documentation.
+
 * Using MapView on Android requires the OSMDroid package in your project's Gradle
   dependencies. Ensure your app declares a dependency on
   ``org\.osmdroid:osmdroid-android:6.1.20`` or later.

--- a/docs/reference/api/widgets/webview.rst
+++ b/docs/reference/api/widgets/webview.rst
@@ -83,8 +83,10 @@ System requirements
   - OpenSUSE Tumbleweed: ``libwebkit2gtk3 typelib(WebKit2)``
   - FreeBSD: ``webkit2-gtk3``
 
-  Additionally, if you are helping to develop support for GTK4, you need to install
-  ``gir1.2-webkit-6.0`` (currently experimental / not fully implemented).
+  WebView is not fully supported on GTK4. If you want to contribute to the GTK4 WebView
+  implementation, you will require v6.0 of the WebKit2 libraries. This is provided by
+  ``gir1.2-webkit-6.0`` on Ubuntu/Debian, and ``webkitgtk6.0`` on Fedora; for other
+  distributions, consult your distributions's platform documentation.
 
 Notes
 -----

--- a/docs/reference/api/widgets/webview.rst
+++ b/docs/reference/api/widgets/webview.rst
@@ -83,6 +83,9 @@ System requirements
   - OpenSUSE Tumbleweed: ``libwebkit2gtk3 typelib(WebKit2)``
   - FreeBSD: ``webkit2-gtk3``
 
+  Additionally, if you are helping to develop support for GTK4, you need to install
+  ``gir1.2-webkit-6.0`` (currently experimental / not fully implemented).
+
 Notes
 -----
 

--- a/docs/reference/platforms/unix-prerequisites.rst
+++ b/docs/reference/platforms/unix-prerequisites.rst
@@ -42,7 +42,9 @@ libraries for ``python3``, ``cairo``, and ``gobject-introspection`` (and please 
 know so we can improve this documentation!)
 
 In addition to the dependencies above, if you would like to help add additional support
-for GTK4, you need to also install ``gir1.2-gtk-4.0`` or equivalent on your system.
+for GTK4, you need to also install ``gir1.2-gtk-4.0`` on Ubuntu/Debian, or ``gtk4`` on
+Fedora or Arch. For other distributions, consult your distributions's platform
+documentation.
 
 Some widgets (most notably, the :ref:`WebView <webview-system-requires>` and
 :ref:`MapView <mapview-system-requires>` widgets) have additional system requirements.

--- a/docs/reference/platforms/unix-prerequisites.rst
+++ b/docs/reference/platforms/unix-prerequisites.rst
@@ -41,6 +41,9 @@ If you're not using one of these, you'll need to work out how to install the dev
 libraries for ``python3``, ``cairo``, and ``gobject-introspection`` (and please let us
 know so we can improve this documentation!)
 
+In addition to the dependencies above, if you would like to help add additional support
+for GTK4, you need to also install ``gir1.2-gtk-4.0`` or equivalent on your system.
+
 Some widgets (most notably, the :ref:`WebView <webview-system-requires>` and
 :ref:`MapView <mapview-system-requires>` widgets) have additional system requirements.
 Likewise, certain hardware features (:ref:`Location <location-system-requires>`) have

--- a/gtk/src/toga_gtk/app.py
+++ b/gtk/src/toga_gtk/app.py
@@ -61,15 +61,13 @@ class App:
             context.add_provider_for_screen(
                 Gdk.Screen.get_default(), css_provider, Gtk.STYLE_PROVIDER_PRIORITY_USER
             )
+        elif GTK_VERSION >= (4, 12, 0):  # pragma: no-cover-if-gtk3
+            css_provider.load_from_string(TOGA_DEFAULT_STYLES)
+        elif GTK_VERSION >= (4, 8, 0):  # pragma: no-cover-if-gtk3
+            css_provider.load_from_data(TOGA_DEFAULT_STYLES, len(TOGA_DEFAULT_STYLES))
         else:  # pragma: no-cover-if-gtk3
-            if Gtk.get_minor_version() >= 12:
-                css_provider.load_from_string(TOGA_DEFAULT_STYLES)
-            elif Gtk.get_minor_version() > 8:
-                css_provider.load_from_data(
-                    TOGA_DEFAULT_STYLES, len(TOGA_DEFAULT_STYLES)
-                )
-            else:
-                css_provider.load_from_data(TOGA_DEFAULT_STYLES.encode("utf-8"))
+            # Earlier than GTK 4.8
+            css_provider.load_from_data(TOGA_DEFAULT_STYLES.encode("utf-8"))
 
     ######################################################################
     # Commands and menus

--- a/gtk/src/toga_gtk/app.py
+++ b/gtk/src/toga_gtk/app.py
@@ -6,6 +6,7 @@ from toga.command import Separator
 
 from .keys import gtk_accel
 from .libs import (
+    GTK_VERSION,
     IS_WAYLAND,
     TOGA_DEFAULT_STYLES,
     Gdk,
@@ -34,7 +35,7 @@ class App:
         # Stimulate the build of the app
         self.native = Gtk.Application(
             application_id=self.interface.app_id,
-            flags=Gio.ApplicationFlags.FLAGS_NONE,
+            flags=Gio.ApplicationFlags.DEFAULT_FLAGS,
         )
         self.native_about_dialog = None
 
@@ -53,12 +54,22 @@ class App:
 
         # Set any custom styles
         css_provider = Gtk.CssProvider()
-        css_provider.load_from_data(TOGA_DEFAULT_STYLES)
 
-        context = Gtk.StyleContext()
-        context.add_provider_for_screen(
-            Gdk.Screen.get_default(), css_provider, Gtk.STYLE_PROVIDER_PRIORITY_USER
-        )
+        if GTK_VERSION < (4, 0, 0):
+            css_provider.load_from_data(TOGA_DEFAULT_STYLES)
+            context = Gtk.StyleContext()
+            context.add_provider_for_screen(
+                Gdk.Screen.get_default(), css_provider, Gtk.STYLE_PROVIDER_PRIORITY_USER
+            )
+        else:
+            if Gtk.get_minor_version() >= 12:
+                css_provider.load_from_string(TOGA_DEFAULT_STYLES)
+            elif Gtk.get_minor_version() > 8:
+                css_provider.load_from_data(
+                    TOGA_DEFAULT_STYLES, len(TOGA_DEFAULT_STYLES)
+                )
+            else:
+                css_provider.load_from_data(TOGA_DEFAULT_STYLES.encode("utf-8"))
 
     ######################################################################
     # Commands and menus
@@ -173,20 +184,24 @@ class App:
 
     def get_screens(self):
         display = Gdk.Display.get_default()
-        if IS_WAYLAND:  # pragma: no-cover-if-linux-x
-            # `get_primary_monitor()` doesn't work on wayland, so return as it is.
-            return [
-                ScreenImpl(native=display.get_monitor(i))
-                for i in range(display.get_n_monitors())
-            ]
-        else:  # pragma: no-cover-if-linux-wayland
-            primary_screen = ScreenImpl(display.get_primary_monitor())
-            screen_list = [primary_screen] + [
-                ScreenImpl(native=display.get_monitor(i))
-                for i in range(display.get_n_monitors())
-                if display.get_monitor(i) != primary_screen.native
-            ]
-            return screen_list
+        if GTK_VERSION < (4, 0, 0):
+            if IS_WAYLAND:  # pragma: no-cover-if-linux-x
+                # `get_primary_monitor()` doesn't work on wayland, so return as it is.
+                return [
+                    ScreenImpl(native=display.get_monitor(i))
+                    for i in range(display.get_n_monitors())
+                ]
+
+            else:  # pragma: no-cover-if-linux-wayland
+                primary_screen = ScreenImpl(display.get_primary_monitor())
+                screen_list = [primary_screen] + [
+                    ScreenImpl(native=display.get_monitor(i))
+                    for i in range(display.get_n_monitors())
+                    if display.get_monitor(i) != primary_screen.native
+                ]
+                return screen_list
+        else:
+            return [ScreenImpl(native=monitor) for monitor in display.get_monitors()]
 
     ######################################################################
     # App state
@@ -201,7 +216,10 @@ class App:
     ######################################################################
 
     def beep(self):
-        Gdk.beep()
+        if GTK_VERSION < (4, 0, 0):
+            Gdk.beep()
+        else:
+            Gdk.Display.get_default().beep()
 
     def _close_about(self, dialog, *args, **kwargs):
         self.native_about_dialog.destroy()

--- a/gtk/src/toga_gtk/app.py
+++ b/gtk/src/toga_gtk/app.py
@@ -55,13 +55,13 @@ class App:
         # Set any custom styles
         css_provider = Gtk.CssProvider()
 
-        if GTK_VERSION < (4, 0, 0):
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             css_provider.load_from_data(TOGA_DEFAULT_STYLES)
             context = Gtk.StyleContext()
             context.add_provider_for_screen(
                 Gdk.Screen.get_default(), css_provider, Gtk.STYLE_PROVIDER_PRIORITY_USER
             )
-        else:
+        else:  # pragma: no-cover-if-gtk3
             if Gtk.get_minor_version() >= 12:
                 css_provider.load_from_string(TOGA_DEFAULT_STYLES)
             elif Gtk.get_minor_version() > 8:
@@ -184,7 +184,7 @@ class App:
 
     def get_screens(self):
         display = Gdk.Display.get_default()
-        if GTK_VERSION < (4, 0, 0):
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             if IS_WAYLAND:  # pragma: no-cover-if-linux-x
                 # `get_primary_monitor()` doesn't work on wayland, so return as it is.
                 return [
@@ -200,7 +200,7 @@ class App:
                     if display.get_monitor(i) != primary_screen.native
                 ]
                 return screen_list
-        else:
+        else:  # pragma: no-cover-if-gtk3
             return [ScreenImpl(native=monitor) for monitor in display.get_monitors()]
 
     ######################################################################
@@ -216,9 +216,9 @@ class App:
     ######################################################################
 
     def beep(self):
-        if GTK_VERSION < (4, 0, 0):
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             Gdk.beep()
-        else:
+        else:  # pragma: no-cover-if-gtk3
             Gdk.Display.get_default().beep()
 
     def _close_about(self, dialog, *args, **kwargs):

--- a/gtk/src/toga_gtk/container.py
+++ b/gtk/src/toga_gtk/container.py
@@ -287,33 +287,27 @@ class TogaContainer(Gtk.Box):
                 # WARNING! This is the list of children of the *container*, not
                 # the Toga widget. Toga maintains a tree of children; all nodes
                 # in that tree are direct children of the container.
-                children = self.get_children()
-                if children is not None:
-                    for widget in children:
-                        if widget.get_visible():
-                            # Set the size of the child widget to the computed
-                            # layout size.
-                            # print(
-                            #     f"  allocate child {widget.interface}: "
-                            #     f"{widget.interface.layout}"
-                            # )
-                            widget_allocation = Gdk.Rectangle()
-                            widget_allocation.x = (
-                                widget.interface.layout.absolute_content_left
-                                + allocation.x
-                            )
-                            widget_allocation.y = (
-                                widget.interface.layout.absolute_content_top
-                                + allocation.y
-                            )
-                            widget_allocation.width = (
-                                widget.interface.layout.content_width
-                            )
-                            widget_allocation.height = (
-                                widget.interface.layout.content_height
-                            )
+                for widget in self.get_children():
+                    if widget.get_visible():
+                        # Set the size of the child widget to the computed
+                        # layout size.
+                        # print(
+                        #     f"  allocate child {widget.interface}: "
+                        #     f"{widget.interface.layout}"
+                        # )
+                        widget_allocation = Gdk.Rectangle()
+                        widget_allocation.x = (
+                            widget.interface.layout.absolute_content_left + allocation.x
+                        )
+                        widget_allocation.y = (
+                            widget.interface.layout.absolute_content_top + allocation.y
+                        )
+                        widget_allocation.width = widget.interface.layout.content_width
+                        widget_allocation.height = (
+                            widget.interface.layout.content_height
+                        )
 
-                            widget.size_allocate(widget_allocation)
+                        widget.size_allocate(widget_allocation)
 
             # The layout has been redrawn
             self.needs_redraw = False

--- a/gtk/src/toga_gtk/container.py
+++ b/gtk/src/toga_gtk/container.py
@@ -103,7 +103,7 @@ class TogaContainer(Gtk.Box):
     def __init__(self):
         super().__init__()
 
-        if GTK_VERSION >= (4, 0):  # pragma: no-cover-if-gtk3
+        if GTK_VERSION >= (4, 0, 0):  # pragma: no-cover-if-gtk3
             # Because we don’t have access to the existing layout manager, we must
             # create our custom layout manager class.
             layout_manager = TogaContainerLayoutManager()

--- a/gtk/src/toga_gtk/container.py
+++ b/gtk/src/toga_gtk/container.py
@@ -14,7 +14,7 @@ else:  # pragma: no-cover-if-gtk3
     LayoutManager = Gtk.LayoutManager
 
 
-class TogaContainerLayoutManager(LayoutManager):
+class TogaContainerLayoutManager(LayoutManager):  # pragma: no-cover-if-gtk3
     def __init__(self):
         super().__init__()
 

--- a/gtk/src/toga_gtk/container.py
+++ b/gtk/src/toga_gtk/container.py
@@ -14,84 +14,86 @@ else:  # pragma: no-cover-if-gtk3
     LayoutManager = Gtk.LayoutManager
 
 
-class TogaContainerLayoutManager(LayoutManager):  # pragma: no-cover-if-gtk3
-    def __init__(self):
-        super().__init__()
+if GTK_VERSION >= (4, 0, 0):  # pragma: no-cover-if-gtk3
 
-    def do_get_request_mode(self, container):
-        return Gtk.SizeRequestMode.CONSTANT_SIZE
+    class TogaContainerLayoutManager(LayoutManager):
+        def __init__(self):
+            super().__init__()
 
-    def do_measure(self, container, orientation, for_size):
-        """Return (recomputing if necessary) the preferred size for the container.
+        def do_get_request_mode(self, container):
+            return Gtk.SizeRequestMode.CONSTANT_SIZE
 
-        The preferred size of the container is its minimum size. This preference
-        will be overridden with the layout size when the layout is applied.
+        def do_measure(self, container, orientation, for_size):
+            """Return (recomputing if necessary) the preferred size for the container.
 
-        If the container does not yet have content, the minimum size is set to 0x0.
-        """
-        # print("GET PREFERRED SIZE", self._content)
-        if container._content is None:
-            return 0, 0, -1, -1
+            The preferred size of the container is its minimum size. This preference
+            will be overridden with the layout size when the layout is applied.
 
-        # Ensure we have an accurate min layout size
-        container.recompute()
+            If the container does not yet have content, the minimum size is set to 0x0.
+            """
+            # print("GET PREFERRED SIZE", self._content)
+            if container._content is None:
+                return 0, 0, -1, -1
 
-        # The container will conform to the size of the allocation it is given,
-        # so the min and preferred size are the same.
-        if orientation == Gtk.Orientation.HORIZONTAL:
-            return container.min_width, container.min_width, -1, -1
-        elif orientation == Gtk.Orientation.VERTICAL:
-            return container.min_height, container.min_height, -1, -1
+            # Ensure we have an accurate min layout size
+            container.recompute()
 
-    def do_allocate(self, container, width, height, baseline):
-        """Perform the actual layout for the all widget's children.
+            # The container will conform to the size of the allocation it is given,
+            # so the min and preferred size are the same.
+            if orientation == Gtk.Orientation.HORIZONTAL:
+                return container.min_width, container.min_width, -1, -1
+            elif orientation == Gtk.Orientation.VERTICAL:
+                return container.min_height, container.min_height, -1, -1
 
-        The manager will assume whatever size it has been given by GTK - usually the
-        full space of the window that holds the container (`widget`). The layout will
-        then be re-computed based on this new available size, and that new geometry
-        will be applied to all child widgets of the container.
-        """
-        # print(widget._content, f"Container layout {width}x{height} @ 0x0")
+        def do_allocate(self, container, width, height, baseline):
+            """Perform the actual layout for the all widget's children.
 
-        if container._content:
-            # Re-evaluate the layout using the  size as the basis for geometry
-            # print("REFRESH LAYOUT", width, height)
-            container._content.interface.style.layout(container)
+            The manager will assume whatever size it has been given by GTK - usually
+            the full space of the window that holds the container (`widget`). The
+            layout will then be re-computed based on this new available size, and
+            that new geometry will be applied to all child widgets of the container.
+            """
+            # print(widget._content, f"Container layout {width}x{height} @ 0x0")
 
-            # Ensure the minimum content size from the layout is retained
-            container.min_width = container._content.interface.layout.min_width
-            container.min_height = container._content.interface.layout.min_height
+            if container._content:
+                # Re-evaluate the layout using the  size as the basis for geometry
+                # print("REFRESH LAYOUT", width, height)
+                container._content.interface.style.layout(container)
 
-            # WARNING! This is the list of children of the *container*, not
-            # the Toga widget. Toga maintains a tree of children; all nodes
-            # in that tree are direct children of the container.
-            child_widget = container.get_last_child()
-            while child_widget is not None:
-                if child_widget.get_visible():
-                    # Set the allocation of the child widget to the computed
-                    # layout size.
-                    # print(
-                    #     f" allocate child {child_widget.interface}: "
-                    #     "{child_widget.interface.layout}"
-                    # )
-                    child_widget_allocation = Gdk.Rectangle()
-                    child_widget_allocation.x = (
-                        child_widget.interface.layout.absolute_content_left
-                    )
-                    child_widget_allocation.y = (
-                        child_widget.interface.layout.absolute_content_top
-                    )
-                    child_widget_allocation.width = (
-                        child_widget.interface.layout.content_width
-                    )
-                    child_widget_allocation.height = (
-                        child_widget.interface.layout.content_height
-                    )
-                    child_widget.size_allocate(child_widget_allocation, -1)
-                child_widget = child_widget.get_prev_sibling()
+                # Ensure the minimum content size from the layout is retained
+                container.min_width = container._content.interface.layout.min_width
+                container.min_height = container._content.interface.layout.min_height
 
-        # The layout has been redrawn
-        container.needs_redraw = False
+                # WARNING! This is the list of children of the *container*, not
+                # the Toga widget. Toga maintains a tree of children; all nodes
+                # in that tree are direct children of the container.
+                child_widget = container.get_last_child()
+                while child_widget is not None:
+                    if child_widget.get_visible():
+                        # Set the allocation of the child widget to the computed
+                        # layout size.
+                        # print(
+                        #     f" allocate child {child_widget.interface}: "
+                        #     "{child_widget.interface.layout}"
+                        # )
+                        child_widget_allocation = Gdk.Rectangle()
+                        child_widget_allocation.x = (
+                            child_widget.interface.layout.absolute_content_left
+                        )
+                        child_widget_allocation.y = (
+                            child_widget.interface.layout.absolute_content_top
+                        )
+                        child_widget_allocation.width = (
+                            child_widget.interface.layout.content_width
+                        )
+                        child_widget_allocation.height = (
+                            child_widget.interface.layout.content_height
+                        )
+                        child_widget.size_allocate(child_widget_allocation, -1)
+                    child_widget = child_widget.get_prev_sibling()
+
+            # The layout has been redrawn
+            container.needs_redraw = False
 
 
 class TogaContainer(Gtk.Box):

--- a/gtk/src/toga_gtk/container.py
+++ b/gtk/src/toga_gtk/container.py
@@ -96,129 +96,119 @@ if GTK_VERSION >= (4, 0, 0):  # pragma: no-cover-if-gtk3
             container.needs_redraw = False
 
 
-class TogaContainer(Gtk.Box):
-    """A GTK container widget implementing Toga's layout.
+if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk3
 
-    This is a GTK widget, with no Toga interface manifestation.
-    """
+    class TogaContainer(Gtk.Fixed):
+        """A GTK container widget implementing Toga's layout.
 
-    def __init__(self):
-        super().__init__()
-
-        if GTK_VERSION >= (4, 0, 0):  # pragma: no-cover-if-gtk3
-            # Because we don’t have access to the existing layout manager, we must
-            # create our custom layout manager class.
-            layout_manager = TogaContainerLayoutManager()
-            self.set_layout_manager(layout_manager)
-
-        self._content = None
-        self.min_width = 100
-        self.min_height = 100
-
-        self.dpi = 96
-        self.baseline_dpi = self.dpi
-
-        # The dirty widgets are the set of widgets that are known to need
-        # re-hinting before any redraw occurs.
-        self._dirty_widgets = set()
-
-        # A flag that can be used to explicitly flag that a redraw is required.
-        self.needs_redraw = True
-
-    def refreshed(self):
-        pass
-
-    def make_dirty(self, widget=None):
-        """Mark the container (or a specific widget in the container) as dirty.
-
-        :param widget: If provided, this widget will be rehinted before the next layout.
+        This is a GTK widget, with no Toga interface manifestation.
         """
-        self.needs_redraw = True
-        if widget is not None:
-            self._dirty_widgets.add(widget)
-        self.queue_resize()
 
-    @property
-    def width(self):
-        """The display width of the container.
+        def __init__(self):
+            super().__init__()
+            self._content = None
+            self.min_width = 100
+            self.min_height = 100
 
-        If the container doesn't have any content yet, the width is 0.
-        """
-        if self._content is None:
-            return 0
-        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            self.dpi = 96
+            self.baseline_dpi = self.dpi
+
+            # The dirty widgets are the set of widgets that are known to need
+            # re-hinting before any redraw occurs.
+            self._dirty_widgets = set()
+
+            # A flag that can be used to explicitly flag that a redraw is required.
+            self.needs_redraw = True
+
+        def refreshed(self):
+            pass
+
+        def make_dirty(self, widget=None):
+            """Mark the container (or a specific widget in the container) as dirty.
+
+            :param widget: If provided, rehint this widget before the next layout.
+            """
+            self.needs_redraw = True
+            if widget is not None:
+                self._dirty_widgets.add(widget)
+            self.queue_resize()
+
+        @property
+        def width(self):
+            """The display width of the container.
+
+            If the container doesn't have any content yet, the width is 0.
+            """
+            if self._content is None:
+                return 0
             return self.get_allocated_width()
-        else:  # pragma: no-cover-if-gtk3
-            return self.compute_bounds(self)[1].get_width()
 
-    @property
-    def height(self):
-        """The display height of the container.
+        @property
+        def height(self):
+            """The display height of the container.
 
-        If the container doesn't have any content yet, the height is 0.
-        """
-        if self._content is None:
-            return 0
-        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            If the container doesn't have any content yet, the height is 0.
+            """
+            if self._content is None:
+                return 0
             return self.get_allocated_height()
-        else:  # pragma: no-cover-if-gtk3
-            return self.compute_bounds(self)[1].get_height()
 
-    @property
-    def content(self):
-        """The Toga implementation widget that is the root content of this container.
+        @property
+        def content(self):
+            """The Toga implementation widget that is the root content of this
+            container.
 
-        All children of the root content will also be added to the container as a result
-        of assigning content.
+            All children of the root content will also be added to the container
+            as a result of assigning content.
 
-        If the container already has content, the old content will be replaced. The old
-        root content and all it's children will be removed from the container.
-        """
-        return self._content
+            If the container already has content, the old content will be replaced.
+            The old root content and all it's children will be removed from the
+            container.
+            """
+            return self._content
 
-    @content.setter
-    def content(self, widget):
-        if self._content:
-            self._content.container = None
+        @content.setter
+        def content(self, widget):
+            if self._content:
+                self._content.container = None
 
-        self._content = widget
-        if widget:
-            widget.container = self
-            self.make_dirty(widget)
-        else:
-            self.make_dirty()
+            self._content = widget
+            if widget:
+                widget.container = self
+                self.make_dirty(widget)
+            else:
+                self.make_dirty()
 
-    def recompute(self):
-        """Rehint and re-layout the container's content, if necessary.
+        def recompute(self):
+            """Rehint and re-layout the container's content, if necessary.
 
-        Any widgets known to be dirty will be rehinted. The minimum possible layout size
-        for the container will also be recomputed.
-        """
-        if self._content and self._dirty_widgets:
-            # If any of the widgets have been marked as dirty,
-            # recompute their bounds, and re-evaluate the minimum
-            # allowed size for the layout.
-            while self._dirty_widgets:
-                widget = self._dirty_widgets.pop()
-                widget.rehint()
+            Any widgets known to be dirty will be rehinted. The minimum possible
+            layout size for the container will also be recomputed.
+            """
+            if self._content and self._dirty_widgets:
+                # If any of the widgets have been marked as dirty,
+                # recompute their bounds, and re-evaluate the minimum
+                # allowed size for the layout.
+                while self._dirty_widgets:
+                    widget = self._dirty_widgets.pop()
+                    widget.rehint()
 
-            # Recompute the layout
-            self._content.interface.style.layout(self)
+                # Recompute the layout
+                self._content.interface.style.layout(self)
 
-            self.min_width = self._content.interface.layout.min_width
-            self.min_height = self._content.interface.layout.min_height
+                self.min_width = self._content.interface.layout.min_width
+                self.min_height = self._content.interface.layout.min_height
 
-    def do_get_preferred_width(self):
-        """Return (recomputing if necessary) the preferred width for the container.
+        def do_get_preferred_width(self):
+            """Return (recomputing if necessary) the preferred width for the container.
 
-        The preferred size of the container is its minimum size. This
-        preference will be overridden with the layout size when the layout is
-        applied.
+            The preferred size of the container is its minimum size. This
+            preference will be overridden with the layout size when the layout is
+            applied.
 
-        If the container does not yet have content, the minimum width is set to
-        0.
-        """
-        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            If the container does not yet have content, the minimum width is set to
+            0.
+            """
             # print("GET PREFERRED WIDTH", self._content)
             if self._content is None:
                 return 0, 0
@@ -229,18 +219,15 @@ class TogaContainer(Gtk.Box):
             # The container will conform to the size of the allocation it is given,
             # so the min and preferred size are the same.
             return self.min_width, self.min_width
-        else:  # pragma: no-cover-if-gtk3
-            pass
 
-    def do_get_preferred_height(self):
-        """Return (recomputing if necessary) the preferred height for the container.
+        def do_get_preferred_height(self):
+            """Return (recomputing if necessary) the preferred height for the container.
 
-        The preferred size of the container is its minimum size. This preference will be
-        overridden with the layout size when the layout is applied.
+            The preferred size of the container is its minimum size. This preference
+            will be overridden with the layout size when the layout is applied.
 
-        If the container does not yet have content, the minimum height is set to 0.
-        """
-        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            If the container does not yet have content, the minimum height is set to 0.
+            """
             # print("GET PREFERRED HEIGHT", self._content)
             if self._content is None:
                 return 0, 0
@@ -251,18 +238,15 @@ class TogaContainer(Gtk.Box):
             # The container will conform to the size of the allocation it is given,
             # so the min and preferred size are the same.
             return self.min_height, self.min_height
-        else:  # pragma: no-cover-if-gtk3
-            pass
 
-    def do_size_allocate(self, allocation):
-        """Perform the actual layout for the widget, and all it's children.
+        def do_size_allocate(self, allocation):
+            """Perform the actual layout for the widget, and all it's children.
 
-        The container will assume whatever size it has been given by GTK - usually the
-        full space of the window that holds the container. The layout will then be re-
-        computed based on this new available size, and that new geometry will be applied
-        to all child widgets of the container.
-        """
-        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            The container will assume whatever size it has been given by GTK - usually
+            the full space of the window that holds the container. The layout will then
+            be recomputed based on this new available size, and that new geometry will
+            be applied to all child widgets of the container.
+            """
             # print(
             #     self._content,
             #     f"Container layout {allocation.width}x{allocation.height} "
@@ -313,5 +297,143 @@ class TogaContainer(Gtk.Box):
 
             # The layout has been redrawn
             self.needs_redraw = False
-        else:  # pragma: no-cover-if-gtk3
+
+else:  # pragma: no-cover-if-gtk3
+
+    class TogaContainer(Gtk.Box):
+        """A GTK container widget implementing Toga's layout.
+
+        This is a GTK widget, with no Toga interface manifestation.
+        """
+
+        def __init__(self):
+            super().__init__()
+
+            # Because we don’t have access to the existing layout manager, we must
+            # create our custom layout manager class.
+            layout_manager = TogaContainerLayoutManager()
+            self.set_layout_manager(layout_manager)
+
+            self._content = None
+            self.min_width = 100
+            self.min_height = 100
+
+            self.dpi = 96
+            self.baseline_dpi = self.dpi
+
+            # The dirty widgets are the set of widgets that are known to need
+            # re-hinting before any redraw occurs.
+            self._dirty_widgets = set()
+
+            # A flag that can be used to explicitly flag that a redraw is required.
+            self.needs_redraw = True
+
+        def refreshed(self):
+            pass
+
+        def make_dirty(self, widget=None):
+            """Mark the container (or a specific widget in the container) as dirty.
+
+            :param widget: If provided, rehint this widget before the next layout.
+            """
+            self.needs_redraw = True
+            if widget is not None:
+                self._dirty_widgets.add(widget)
+            self.queue_resize()
+
+        @property
+        def width(self):
+            """The display width of the container.
+
+            If the container doesn't have any content yet, the width is 0.
+            """
+            if self._content is None:
+                return 0
+            return self.compute_bounds(self)[1].get_width()
+
+        @property
+        def height(self):
+            """The display height of the container.
+
+            If the container doesn't have any content yet, the height is 0.
+            """
+            if self._content is None:
+                return 0
+            return self.compute_bounds(self)[1].get_height()
+
+        @property
+        def content(self):
+            """The Toga implementation widget that is the root content of this
+            container.
+
+            All children of the root content will also be added to the container
+            as a result of assigning content.
+
+            If the container already has content, the old content will be replaced. The
+            old root content and all it's children will be removed from the container.
+            """
+            return self._content
+
+        @content.setter
+        def content(self, widget):
+            if self._content:
+                self._content.container = None
+
+            self._content = widget
+            if widget:
+                widget.container = self
+                self.make_dirty(widget)
+            else:
+                self.make_dirty()
+
+        def recompute(self):
+            """Rehint and re-layout the container's content, if necessary.
+
+            Any widgets known to be dirty will be rehinted. The minimum possible
+            layout size for the container will also be recomputed.
+            """
+            if self._content and self._dirty_widgets:
+                # If any of the widgets have been marked as dirty,
+                # recompute their bounds, and re-evaluate the minimum
+                # allowed size for the layout.
+                while self._dirty_widgets:
+                    widget = self._dirty_widgets.pop()
+                    widget.rehint()
+
+                # Recompute the layout
+                self._content.interface.style.layout(self)
+
+                self.min_width = self._content.interface.layout.min_width
+                self.min_height = self._content.interface.layout.min_height
+
+        def do_get_preferred_width(self):
+            """Return (recomputing if necessary) the preferred width for the container.
+
+            The preferred size of the container is its minimum size. This
+            preference will be overridden with the layout size when the layout is
+            applied.
+
+            If the container does not yet have content, the minimum width is set to
+            0.
+            """
+            pass
+
+        def do_get_preferred_height(self):
+            """Return (recomputing if necessary) the preferred height for the container.
+
+            The preferred size of the container is its minimum size. This preference
+            will be overridden with the layout size when the layout is applied.
+
+            If the container does not yet have content, the minimum height is set to 0.
+            """
+            pass
+
+        def do_size_allocate(self, allocation):
+            """Perform the actual layout for the widget, and all it's children.
+
+            The container will assume whatever size it has been given by GTK - usually
+            the full space of the window that holds the container. The layout will then
+            be recomputed based on this new available size, and that new geometry will
+            be applied to all child widgets of the container.
+            """
             pass

--- a/gtk/src/toga_gtk/container.py
+++ b/gtk/src/toga_gtk/container.py
@@ -56,9 +56,7 @@ class TogaContainerLayoutManager(LayoutManager):
         if container._content:
             # Re-evaluate the layout using the  size as the basis for geometry
             # print("REFRESH LAYOUT", width, height)
-            container._content.interface.style.layout(
-                container._content.interface, container
-            )
+            container._content.interface.style.layout(container)
 
             # Ensure the minimum content size from the layout is retained
             container.min_width = container._content.interface.layout.min_width
@@ -274,8 +272,8 @@ class TogaContainer(Gtk.Box):
             self.set_allocation(allocation)
 
             if self._content:
-                # This function may be called in response to irrelevant events like button
-                # clicks, so only refresh if we really need to.
+                # This function may be called in response to irrelevant events like
+                # button clicks, so only refresh if we really need to.
                 if resized or self.needs_redraw:
                     # Re-evaluate the layout using the allocation size as the basis
                     # for geometry

--- a/gtk/src/toga_gtk/container.py
+++ b/gtk/src/toga_gtk/container.py
@@ -1,4 +1,4 @@
-from .libs import Gdk, Gtk
+from .libs import GTK_VERSION, Gdk, Gtk
 
 #######################################################################################
 # Implementation notes:
@@ -8,8 +8,95 @@ from .libs import Gdk, Gtk
 # details.
 #######################################################################################
 
+if GTK_VERSION < (4, 0, 0):
+    LayoutManager = object
+else:
+    LayoutManager = Gtk.LayoutManager
 
-class TogaContainer(Gtk.Fixed):
+
+class TogaContainerLayoutManager(LayoutManager):
+    def __init__(self):
+        super().__init__()
+
+    def do_get_request_mode(self, container):
+        return Gtk.SizeRequestMode.CONSTANT_SIZE
+
+    def do_measure(self, container, orientation, for_size):
+        """Return (recomputing if necessary) the preferred size for the container.
+
+        The preferred size of the container is its minimum size. This preference
+        will be overridden with the layout size when the layout is applied.
+
+        If the container does not yet have content, the minimum size is set to 0x0.
+        """
+        # print("GET PREFERRED SIZE", self._content)
+        if container._content is None:
+            return 0, 0, -1, -1
+
+        # Ensure we have an accurate min layout size
+        container.recompute()
+
+        # The container will conform to the size of the allocation it is given,
+        # so the min and preferred size are the same.
+        if orientation == Gtk.Orientation.HORIZONTAL:
+            return container.min_width, container.min_width, -1, -1
+        elif orientation == Gtk.Orientation.VERTICAL:
+            return container.min_height, container.min_height, -1, -1
+
+    def do_allocate(self, container, width, height, baseline):
+        """Perform the actual layout for the all widget's children.
+
+        The manager will assume whatever size it has been given by GTK - usually the
+        full space of the window that holds the container (`widget`). The layout will
+        then be re-computed based on this new available size, and that new geometry
+        will be applied to all child widgets of the container.
+        """
+        # print(widget._content, f"Container layout {width}x{height} @ 0x0")
+
+        if container._content:
+            # Re-evaluate the layout using the  size as the basis for geometry
+            # print("REFRESH LAYOUT", width, height)
+            container._content.interface.style.layout(
+                container._content.interface, container
+            )
+
+            # Ensure the minimum content size from the layout is retained
+            container.min_width = container._content.interface.layout.min_width
+            container.min_height = container._content.interface.layout.min_height
+
+            # WARNING! This is the list of children of the *container*, not
+            # the Toga widget. Toga maintains a tree of children; all nodes
+            # in that tree are direct children of the container.
+            child_widget = container.get_last_child()
+            while child_widget is not None:
+                if child_widget.get_visible():
+                    # Set the allocation of the child widget to the computed
+                    # layout size.
+                    # print(
+                    #     f" allocate child {child_widget.interface}: "
+                    #     "{child_widget.interface.layout}"
+                    # )
+                    child_widget_allocation = Gdk.Rectangle()
+                    child_widget_allocation.x = (
+                        child_widget.interface.layout.absolute_content_left
+                    )
+                    child_widget_allocation.y = (
+                        child_widget.interface.layout.absolute_content_top
+                    )
+                    child_widget_allocation.width = (
+                        child_widget.interface.layout.content_width
+                    )
+                    child_widget_allocation.height = (
+                        child_widget.interface.layout.content_height
+                    )
+                    child_widget.size_allocate(child_widget_allocation, -1)
+                child_widget = child_widget.get_prev_sibling()
+
+        # The layout has been redrawn
+        container.needs_redraw = False
+
+
+class TogaContainer(Gtk.Box):
     """A GTK container widget implementing Toga's layout.
 
     This is a GTK widget, with no Toga interface manifestation.
@@ -17,6 +104,13 @@ class TogaContainer(Gtk.Fixed):
 
     def __init__(self):
         super().__init__()
+
+        if GTK_VERSION >= (4, 0):
+            # Because we don’t have access to the existing layout manager, we must
+            # create our custom layout manager class.
+            layout_manager = TogaContainerLayoutManager()
+            self.set_layout_manager(layout_manager)
+
         self._content = None
         self.min_width = 100
         self.min_height = 100
@@ -52,7 +146,10 @@ class TogaContainer(Gtk.Fixed):
         """
         if self._content is None:
             return 0
-        return self.get_allocated_width()
+        if GTK_VERSION < (4, 0, 0):
+            return self.get_allocated_width()
+        else:
+            return self.compute_bounds(self)[1].get_width()
 
     @property
     def height(self):
@@ -62,7 +159,10 @@ class TogaContainer(Gtk.Fixed):
         """
         if self._content is None:
             return 0
-        return self.get_allocated_height()
+        if GTK_VERSION < (4, 0, 0):
+            return self.get_allocated_height()
+        else:
+            return self.compute_bounds(self)[1].get_height()
 
     @property
     def content(self):
@@ -118,16 +218,19 @@ class TogaContainer(Gtk.Fixed):
         If the container does not yet have content, the minimum width is set to
         0.
         """
-        # print("GET PREFERRED WIDTH", self._content)
-        if self._content is None:
-            return 0, 0
+        if GTK_VERSION < (4, 0, 0):
+            # print("GET PREFERRED WIDTH", self._content)
+            if self._content is None:
+                return 0, 0
 
-        # Ensure we have an accurate min layout size
-        self.recompute()
+            # Ensure we have an accurate min layout size
+            self.recompute()
 
-        # The container will conform to the size of the allocation it is given,
-        # so the min and preferred size are the same.
-        return self.min_width, self.min_width
+            # The container will conform to the size of the allocation it is given,
+            # so the min and preferred size are the same.
+            return self.min_width, self.min_width
+        else:
+            pass
 
     def do_get_preferred_height(self):
         """Return (recomputing if necessary) the preferred height for the container.
@@ -137,16 +240,19 @@ class TogaContainer(Gtk.Fixed):
 
         If the container does not yet have content, the minimum height is set to 0.
         """
-        # print("GET PREFERRED HEIGHT", self._content)
-        if self._content is None:
-            return 0, 0
+        if GTK_VERSION < (4, 0, 0):
+            # print("GET PREFERRED HEIGHT", self._content)
+            if self._content is None:
+                return 0, 0
 
-        # Ensure we have an accurate min layout size
-        self.recompute()
+            # Ensure we have an accurate min layout size
+            self.recompute()
 
-        # The container will conform to the size of the allocation it is given,
-        # so the min and preferred size are the same.
-        return self.min_height, self.min_height
+            # The container will conform to the size of the allocation it is given,
+            # so the min and preferred size are the same.
+            return self.min_height, self.min_height
+        else:
+            pass
 
     def do_size_allocate(self, allocation):
         """Perform the actual layout for the widget, and all it's children.
@@ -156,50 +262,55 @@ class TogaContainer(Gtk.Fixed):
         computed based on this new available size, and that new geometry will be applied
         to all child widgets of the container.
         """
-        # print(
-        #     self._content,
-        #     f"Container layout {allocation.width}x{allocation.height} "
-        #     f"@ {allocation.x}x{allocation.y}",
-        # )
+        if GTK_VERSION < (4, 0, 0):
+            # print(
+            #     self._content,
+            #     f"Container layout {allocation.width}x{allocation.height} "
+            #     f"@ {allocation.x}x{allocation.y}",
+            # )
 
-        # The container will occupy the full space it has been allocated.
-        resized = (allocation.width, allocation.height) != (self.width, self.height)
-        self.set_allocation(allocation)
+            # The container will occupy the full space it has been allocated.
+            resized = (allocation.width, allocation.height) != (self.width, self.height)
+            self.set_allocation(allocation)
 
-        if self._content:
-            # This function may be called in response to irrelevant events like button
-            # clicks, so only refresh if we really need to.
-            if resized or self.needs_redraw:
-                # Re-evaluate the layout using the allocation size as the basis
-                # for geometry
-                # print("REFRESH LAYOUT", allocation.width, allocation.height)
-                self._content.interface.style.layout(self)
+            if self._content:
+                # This function may be called in response to irrelevant events like button
+                # clicks, so only refresh if we really need to.
+                if resized or self.needs_redraw:
+                    # Re-evaluate the layout using the allocation size as the basis
+                    # for geometry
+                    # print("REFRESH LAYOUT", allocation.width, allocation.height)
+                    self._content.interface.style.layout(self)
 
-                # Ensure the minimum content size from the layout is retained
-                self.min_width = self._content.interface.layout.min_width
-                self.min_height = self._content.interface.layout.min_height
+                    # Ensure the minimum content size from the layout is retained
+                    self.min_width = self._content.interface.layout.min_width
+                    self.min_height = self._content.interface.layout.min_height
 
-            # WARNING! This is the list of children of the *container*, not
-            # the Toga widget. Toga maintains a tree of children; all nodes
-            # in that tree are direct children of the container.
-            for widget in self.get_children():
-                if widget.get_visible():
-                    # Set the size of the child widget to the computed layout size.
-                    # print(
-                    #     f"  allocate child {widget.interface}: "
-                    #     f"{widget.interface.layout}"
-                    # )
-                    widget_allocation = Gdk.Rectangle()
-                    widget_allocation.x = (
-                        widget.interface.layout.absolute_content_left + allocation.x
-                    )
-                    widget_allocation.y = (
-                        widget.interface.layout.absolute_content_top + allocation.y
-                    )
-                    widget_allocation.width = widget.interface.layout.content_width
-                    widget_allocation.height = widget.interface.layout.content_height
+                # WARNING! This is the list of children of the *container*, not
+                # the Toga widget. Toga maintains a tree of children; all nodes
+                # in that tree are direct children of the container.
+                for widget in self.get_children():
+                    if widget.get_visible():
+                        # Set the size of the child widget to the computed layout size.
+                        # print(
+                        #     f"  allocate child {widget.interface}: "
+                        #     f"{widget.interface.layout}"
+                        # )
+                        widget_allocation = Gdk.Rectangle()
+                        widget_allocation.x = (
+                            widget.interface.layout.absolute_content_left + allocation.x
+                        )
+                        widget_allocation.y = (
+                            widget.interface.layout.absolute_content_top + allocation.y
+                        )
+                        widget_allocation.width = widget.interface.layout.content_width
+                        widget_allocation.height = (
+                            widget.interface.layout.content_height
+                        )
 
-                    widget.size_allocate(widget_allocation)
+                        widget.size_allocate(widget_allocation)
 
-        # The layout has been redrawn
-        self.needs_redraw = False
+            # The layout has been redrawn
+            self.needs_redraw = False
+        else:
+            pass

--- a/gtk/src/toga_gtk/container.py
+++ b/gtk/src/toga_gtk/container.py
@@ -123,12 +123,6 @@ class TogaContainer(Gtk.Box):
         # A flag that can be used to explicitly flag that a redraw is required.
         self.needs_redraw = True
 
-    def get_children(self):
-        if GTK_VERSION < (4, 0, 0):
-            return self.get_children()
-        else:
-            return None
-
     def refreshed(self):
         pass
 
@@ -293,26 +287,33 @@ class TogaContainer(Gtk.Box):
                 # WARNING! This is the list of children of the *container*, not
                 # the Toga widget. Toga maintains a tree of children; all nodes
                 # in that tree are direct children of the container.
-                for widget in self.get_children():
-                    if widget.get_visible():
-                        # Set the size of the child widget to the computed layout size.
-                        # print(
-                        #     f"  allocate child {widget.interface}: "
-                        #     f"{widget.interface.layout}"
-                        # )
-                        widget_allocation = Gdk.Rectangle()
-                        widget_allocation.x = (
-                            widget.interface.layout.absolute_content_left + allocation.x
-                        )
-                        widget_allocation.y = (
-                            widget.interface.layout.absolute_content_top + allocation.y
-                        )
-                        widget_allocation.width = widget.interface.layout.content_width
-                        widget_allocation.height = (
-                            widget.interface.layout.content_height
-                        )
+                children = self.get_children()
+                if children is not None:
+                    for widget in children:
+                        if widget.get_visible():
+                            # Set the size of the child widget to the computed
+                            # layout size.
+                            # print(
+                            #     f"  allocate child {widget.interface}: "
+                            #     f"{widget.interface.layout}"
+                            # )
+                            widget_allocation = Gdk.Rectangle()
+                            widget_allocation.x = (
+                                widget.interface.layout.absolute_content_left
+                                + allocation.x
+                            )
+                            widget_allocation.y = (
+                                widget.interface.layout.absolute_content_top
+                                + allocation.y
+                            )
+                            widget_allocation.width = (
+                                widget.interface.layout.content_width
+                            )
+                            widget_allocation.height = (
+                                widget.interface.layout.content_height
+                            )
 
-                        widget.size_allocate(widget_allocation)
+                            widget.size_allocate(widget_allocation)
 
             # The layout has been redrawn
             self.needs_redraw = False

--- a/gtk/src/toga_gtk/container.py
+++ b/gtk/src/toga_gtk/container.py
@@ -123,6 +123,12 @@ class TogaContainer(Gtk.Box):
         # A flag that can be used to explicitly flag that a redraw is required.
         self.needs_redraw = True
 
+    def get_children(self):
+        if GTK_VERSION < (4, 0, 0):
+            return self.get_children()
+        else:
+            return None
+
     def refreshed(self):
         pass
 

--- a/gtk/src/toga_gtk/container.py
+++ b/gtk/src/toga_gtk/container.py
@@ -8,9 +8,9 @@ from .libs import GTK_VERSION, Gdk, Gtk
 # details.
 #######################################################################################
 
-if GTK_VERSION < (4, 0, 0):
+if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
     LayoutManager = object
-else:
+else:  # pragma: no-cover-if-gtk3
     LayoutManager = Gtk.LayoutManager
 
 
@@ -105,7 +105,7 @@ class TogaContainer(Gtk.Box):
     def __init__(self):
         super().__init__()
 
-        if GTK_VERSION >= (4, 0):
+        if GTK_VERSION >= (4, 0):  # pragma: no-cover-if-gtk3
             # Because we don’t have access to the existing layout manager, we must
             # create our custom layout manager class.
             layout_manager = TogaContainerLayoutManager()
@@ -146,9 +146,9 @@ class TogaContainer(Gtk.Box):
         """
         if self._content is None:
             return 0
-        if GTK_VERSION < (4, 0, 0):
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             return self.get_allocated_width()
-        else:
+        else:  # pragma: no-cover-if-gtk3
             return self.compute_bounds(self)[1].get_width()
 
     @property
@@ -159,9 +159,9 @@ class TogaContainer(Gtk.Box):
         """
         if self._content is None:
             return 0
-        if GTK_VERSION < (4, 0, 0):
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             return self.get_allocated_height()
-        else:
+        else:  # pragma: no-cover-if-gtk3
             return self.compute_bounds(self)[1].get_height()
 
     @property
@@ -218,7 +218,7 @@ class TogaContainer(Gtk.Box):
         If the container does not yet have content, the minimum width is set to
         0.
         """
-        if GTK_VERSION < (4, 0, 0):
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             # print("GET PREFERRED WIDTH", self._content)
             if self._content is None:
                 return 0, 0
@@ -229,7 +229,7 @@ class TogaContainer(Gtk.Box):
             # The container will conform to the size of the allocation it is given,
             # so the min and preferred size are the same.
             return self.min_width, self.min_width
-        else:
+        else:  # pragma: no-cover-if-gtk3
             pass
 
     def do_get_preferred_height(self):
@@ -240,7 +240,7 @@ class TogaContainer(Gtk.Box):
 
         If the container does not yet have content, the minimum height is set to 0.
         """
-        if GTK_VERSION < (4, 0, 0):
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             # print("GET PREFERRED HEIGHT", self._content)
             if self._content is None:
                 return 0, 0
@@ -251,7 +251,7 @@ class TogaContainer(Gtk.Box):
             # The container will conform to the size of the allocation it is given,
             # so the min and preferred size are the same.
             return self.min_height, self.min_height
-        else:
+        else:  # pragma: no-cover-if-gtk3
             pass
 
     def do_size_allocate(self, allocation):
@@ -262,7 +262,7 @@ class TogaContainer(Gtk.Box):
         computed based on this new available size, and that new geometry will be applied
         to all child widgets of the container.
         """
-        if GTK_VERSION < (4, 0, 0):
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             # print(
             #     self._content,
             #     f"Container layout {allocation.width}x{allocation.height} "
@@ -312,5 +312,5 @@ class TogaContainer(Gtk.Box):
 
             # The layout has been redrawn
             self.needs_redraw = False
-        else:
+        else:  # pragma: no-cover-if-gtk3
             pass

--- a/gtk/src/toga_gtk/dialogs.py
+++ b/gtk/src/toga_gtk/dialogs.py
@@ -178,7 +178,7 @@ class FileDialog(BaseDialog):
         )
         if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             self.native.add_button("_Cancel", Gtk.ResponseType.CANCEL)
-            self.native.add_button(ok_icon, Gtk.ResponseType.OK)
+            self.native.add_button("_OK", Gtk.ResponseType.OK)
             self.native.set_modal(True)
 
             if filename:
@@ -230,7 +230,7 @@ class SaveFileDialog(FileDialog):
         initial_directory,
         file_types=None,
     ):
-        save_icon = Gtk.Image.new_from_icon_name("document-save")
+        save_icon = "_Save"
         super().__init__(
             title=title,
             filename=filename,
@@ -252,7 +252,7 @@ class OpenFileDialog(FileDialog):
         file_types,
         multiple_select,
     ):
-        open_icon = Gtk.Image.new_from_icon_name("document-open")
+        open_icon = "_OK"
         super().__init__(
             title=title,
             filename=None,
@@ -271,7 +271,7 @@ class SelectFolderDialog(FileDialog):
         initial_directory,
         multiple_select,
     ):
-        open_icon = Gtk.Image.new_from_icon_name("document-open")
+        open_icon = "_Open"
         super().__init__(
             title=title,
             filename=None,

--- a/gtk/src/toga_gtk/dialogs.py
+++ b/gtk/src/toga_gtk/dialogs.py
@@ -197,6 +197,8 @@ class FileDialog(BaseDialog):
             self.multiple_select = multiple_select
             if self.multiple_select:
                 self.native.set_select_multiple(True)
+        else:  # pragma: no cover-if-gtk3
+            pass
 
         self.native.connect("response", self.gtk_response)
 
@@ -242,6 +244,8 @@ class SaveFileDialog(FileDialog):
         )
         if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             self.native.set_do_overwrite_confirmation(True)
+        else:  # pragma: no-cover-if-gtk3
+            pass
 
 
 class OpenFileDialog(FileDialog):

--- a/gtk/src/toga_gtk/dialogs.py
+++ b/gtk/src/toga_gtk/dialogs.py
@@ -176,26 +176,27 @@ class FileDialog(BaseDialog):
             title=title,
             action=action,
         )
-        self.native.add_button(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)
-        self.native.add_button(ok_icon, Gtk.ResponseType.OK)
-        self.native.set_modal(True)
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            self.native.add_button("_Cancel", Gtk.ResponseType.CANCEL)
+            self.native.add_button(ok_icon, Gtk.ResponseType.OK)
+            self.native.set_modal(True)
 
-        if filename:
-            self.native.set_current_name(filename)
+            if filename:
+                self.native.set_current_name(filename)
 
-        if initial_directory:
-            self.native.set_current_folder(str(initial_directory))
+            if initial_directory:
+                self.native.set_current_folder(str(initial_directory))
 
-        if file_types:
-            for file_type in file_types:
-                filter_filetype = Gtk.FileFilter()
-                filter_filetype.set_name("." + file_type + " files")
-                filter_filetype.add_pattern("*." + file_type)
-                self.native.add_filter(filter_filetype)
+            if file_types:
+                for file_type in file_types:
+                    filter_filetype = Gtk.FileFilter()
+                    filter_filetype.set_name("." + file_type + " files")
+                    filter_filetype.add_pattern("*." + file_type)
+                    self.native.add_filter(filter_filetype)
 
-        self.multiple_select = multiple_select
-        if self.multiple_select:
-            self.native.set_select_multiple(True)
+            self.multiple_select = multiple_select
+            if self.multiple_select:
+                self.native.set_select_multiple(True)
 
         self.native.connect("response", self.gtk_response)
 

--- a/gtk/src/toga_gtk/dialogs.py
+++ b/gtk/src/toga_gtk/dialogs.py
@@ -229,6 +229,7 @@ class SaveFileDialog(FileDialog):
         initial_directory,
         file_types=None,
     ):
+        save_icon = Gtk.Image.new_from_icon_name("document-save")
         super().__init__(
             title=title,
             filename=filename,
@@ -236,9 +237,10 @@ class SaveFileDialog(FileDialog):
             file_types=file_types,
             multiple_select=False,
             action=Gtk.FileChooserAction.SAVE,
-            ok_icon=Gtk.STOCK_SAVE,
+            ok_icon=save_icon,
         )
-        self.native.set_do_overwrite_confirmation(True)
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            self.native.set_do_overwrite_confirmation(True)
 
 
 class OpenFileDialog(FileDialog):
@@ -249,6 +251,7 @@ class OpenFileDialog(FileDialog):
         file_types,
         multiple_select,
     ):
+        open_icon = Gtk.Image.new_from_icon_name("document-open")
         super().__init__(
             title=title,
             filename=None,
@@ -256,7 +259,7 @@ class OpenFileDialog(FileDialog):
             file_types=file_types,
             multiple_select=multiple_select,
             action=Gtk.FileChooserAction.OPEN,
-            ok_icon=Gtk.STOCK_OPEN,
+            ok_icon=open_icon,
         )
 
 
@@ -267,6 +270,7 @@ class SelectFolderDialog(FileDialog):
         initial_directory,
         multiple_select,
     ):
+        open_icon = Gtk.Image.new_from_icon_name("document-open")
         super().__init__(
             title=title,
             filename=None,
@@ -274,5 +278,5 @@ class SelectFolderDialog(FileDialog):
             file_types=None,
             multiple_select=multiple_select,
             action=Gtk.FileChooserAction.SELECT_FOLDER,
-            ok_icon=Gtk.STOCK_OPEN,
+            ok_icon=open_icon,
         )

--- a/gtk/src/toga_gtk/dialogs.py
+++ b/gtk/src/toga_gtk/dialogs.py
@@ -7,7 +7,7 @@ from .libs import GTK_VERSION, Gtk
 
 class BaseDialog:
     def show(self, host_window, future):
-        if GTK_VERSION < (4, 0, 0):
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             self.future = future
 
             # If this is a modal dialog, set the window as transient to the host window.
@@ -18,7 +18,7 @@ class BaseDialog:
 
             # Show the dialog.
             self.native.show()
-        else:
+        else:  # pragma: no-cover-if-gtk3
             self.interface.factory.not_implemented("BaseDialog.show()")
 
 
@@ -32,7 +32,7 @@ class MessageDialog(BaseDialog):
         **kwargs,
     ):
         super().__init__()
-        if GTK_VERSION < (4, 0, 0):
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             self.success_result = success_result
 
             self.native = Gtk.MessageDialog(
@@ -46,7 +46,7 @@ class MessageDialog(BaseDialog):
 
             self.native.connect("response", self.gtk_response)
 
-        else:
+        else:  # pragma: no-cover-if-gtk3
             toga.NotImplementedWarning("Dialog()")
 
     def build_dialog(self, message):

--- a/gtk/src/toga_gtk/dialogs.py
+++ b/gtk/src/toga_gtk/dialogs.py
@@ -1,20 +1,25 @@
 from pathlib import Path
 
-from .libs import Gtk
+import toga
+
+from .libs import GTK_VERSION, Gtk
 
 
 class BaseDialog:
     def show(self, host_window, future):
-        self.future = future
+        if GTK_VERSION < (4, 0, 0):
+            self.future = future
 
-        # If this is a modal dialog, set the window as transient to the host window.
-        if host_window:
-            self.native.set_transient_for(host_window._impl.native)
+            # If this is a modal dialog, set the window as transient to the host window.
+            if host_window:
+                self.native.set_transient_for(host_window._impl.native)
+            else:
+                self.native.set_transient_for(None)
+
+            # Show the dialog.
+            self.native.show()
         else:
-            self.native.set_transient_for(None)
-
-        # Show the dialog.
-        self.native.show()
+            self.interface.factory.not_implemented("BaseDialog.show()")
 
 
 class MessageDialog(BaseDialog):
@@ -27,18 +32,22 @@ class MessageDialog(BaseDialog):
         **kwargs,
     ):
         super().__init__()
-        self.success_result = success_result
+        if GTK_VERSION < (4, 0, 0):
+            self.success_result = success_result
 
-        self.native = Gtk.MessageDialog(
-            flags=0,
-            message_type=message_type,
-            buttons=buttons,
-            text=title,
-        )
-        self.native.set_modal(True)
-        self.build_dialog(**kwargs)
+            self.native = Gtk.MessageDialog(
+                flags=0,
+                message_type=message_type,
+                buttons=buttons,
+                text=title,
+            )
+            self.native.set_modal(True)
+            self.build_dialog(**kwargs)
 
-        self.native.connect("response", self.gtk_response)
+            self.native.connect("response", self.gtk_response)
+
+        else:
+            toga.NotImplementedWarning("Dialog()")
 
     def build_dialog(self, message):
         self.native.format_secondary_text(message)

--- a/gtk/src/toga_gtk/icons.py
+++ b/gtk/src/toga_gtk/icons.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import toga
 
-from .libs import GdkPixbuf, GLib
+from .libs import GTK_VERSION, Gdk, GdkPixbuf, GLib, Gtk
 
 
 class Icon:
@@ -32,9 +32,14 @@ class Icon:
         # Preload all the required icon sizes
         try:
             for size, path in self.paths.items():
-                native = GdkPixbuf.Pixbuf.new_from_file(str(path)).scale_simple(
-                    size, size, GdkPixbuf.InterpType.BILINEAR
-                )
+                if GTK_VERSION < (4, 0, 0):
+                    native = GdkPixbuf.Pixbuf.new_from_file(str(path)).scale_simple(
+                        size, size, GdkPixbuf.InterpType.BILINEAR
+                    )
+                else:
+                    native = Gtk.Image.new_from_paintable(
+                        Gdk.Texture.new_from_filename(str(path))
+                    )
                 self._native[size] = native
         except GLib.GError:
             raise ValueError(f"Unable to load icon from {path}")
@@ -43,11 +48,14 @@ class Icon:
         try:
             return self._native[size]
         except KeyError:
-            # self._native will have at least one entry, and it will have been populated
-            # in reverse size order, so the first value returned will be the largest
-            # size discovered.
-            native = self._native[next(iter(self._native))].scale_simple(
-                size, size, GdkPixbuf.InterpType.BILINEAR
-            )
-            self._native[size] = native
-            return native
+            if GTK_VERSION < (4, 0, 0):
+                # self._native will have at least one entry, and it will have been
+                # populated in reverse size order, so the first value returned will
+                # be the largest size discovered.
+                native = self._native[next(iter(self._native))].scale_simple(
+                    size, size, GdkPixbuf.InterpType.BILINEAR
+                )
+                self._native[size] = native
+                return native
+            else:
+                return None

--- a/gtk/src/toga_gtk/icons.py
+++ b/gtk/src/toga_gtk/icons.py
@@ -32,11 +32,11 @@ class Icon:
         # Preload all the required icon sizes
         try:
             for size, path in self.paths.items():
-                if GTK_VERSION < (4, 0, 0):
+                if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
                     native = GdkPixbuf.Pixbuf.new_from_file(str(path)).scale_simple(
                         size, size, GdkPixbuf.InterpType.BILINEAR
                     )
-                else:
+                else:  # pragma: no-cover-if-gtk3
                     native = Gtk.Image.new_from_paintable(
                         Gdk.Texture.new_from_filename(str(path))
                     )
@@ -48,7 +48,7 @@ class Icon:
         try:
             return self._native[size]
         except KeyError:
-            if GTK_VERSION < (4, 0, 0):
+            if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
                 # self._native will have at least one entry, and it will have been
                 # populated in reverse size order, so the first value returned will
                 # be the largest size discovered.
@@ -57,5 +57,5 @@ class Icon:
                 )
                 self._native[size] = native
                 return native
-            else:
+            else:  # pragma: no-cover-if-gtk3
                 return None

--- a/gtk/src/toga_gtk/libs/gtk.py
+++ b/gtk/src/toga_gtk/libs/gtk.py
@@ -23,9 +23,9 @@ GTK_VERSION: tuple[int, int, int] = (
     Gtk.get_micro_version(),
 )
 
-if GTK_VERSION < (4, 0, 0):
+if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
     default_display = Gdk.Screen.get_default()
-else:
+else:  # pragma: no-cover-if-gtk3
     default_display = Gdk.Display.get_default()
 if default_display is None:  # pragma: no cover
     raise RuntimeError(

--- a/gtk/src/toga_gtk/libs/gtk.py
+++ b/gtk/src/toga_gtk/libs/gtk.py
@@ -1,7 +1,10 @@
+import os
+
 import gi
 
-gi.require_version("Gdk", "3.0")
-gi.require_version("Gtk", "3.0")
+gtk_version = "4.0" if os.getenv("TOGA_GTK") == "4" else "3.0"
+gi.require_version("Gdk", gtk_version)
+gi.require_version("Gtk", gtk_version)
 
 from gi.events import GLibEventLoopPolicy  # noqa: E402, F401
 from gi.repository import (  # noqa: E402, F401
@@ -14,7 +17,17 @@ from gi.repository import (  # noqa: E402, F401
     Gtk,
 )
 
-if Gdk.Screen.get_default() is None:  # pragma: no cover
+GTK_VERSION: tuple[int, int, int] = (
+    Gtk.get_major_version(),
+    Gtk.get_minor_version(),
+    Gtk.get_micro_version(),
+)
+
+if GTK_VERSION < (4, 0, 0):
+    default_display = Gdk.Screen.get_default()
+else:
+    default_display = Gdk.Display.get_default()
+if default_display is None:  # pragma: no cover
     raise RuntimeError(
         "Cannot identify an active display. Is the `DISPLAY` "
         "environment variable set correctly?"

--- a/gtk/src/toga_gtk/libs/gtk.py
+++ b/gtk/src/toga_gtk/libs/gtk.py
@@ -38,14 +38,21 @@ IS_WAYLAND = not isinstance(Gdk.Display.get_default(), GdkX11.X11Display)
 # The following imports will fail if the underlying libraries or their API
 # wrappers aren't installed; handle failure gracefully (see
 # https://github.com/beeware/toga/issues/26)
-try:
+if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
     try:
-        gi.require_version("WebKit2", "4.1")
-    except ValueError:  # pragma: no cover
-        gi.require_version("WebKit2", "4.0")
-    from gi.repository import WebKit2  # noqa: F401
-except (ImportError, ValueError):  # pragma: no cover
-    WebKit2 = None
+        try:
+            gi.require_version("WebKit2", "4.1")
+        except ValueError:  # pragma: no cover
+            gi.require_version("WebKit2", "4.0")
+        from gi.repository import WebKit2  # noqa: F401
+    except (ImportError, ValueError):  # pragma: no cover
+        WebKit2 = None
+else:  # pragma: no-cover-if-gtk3
+    try:
+        gi.require_version("WebKit", "6.0")
+        from gi.repository import WebKit as WebKit2  # noqa: F401
+    except (ImportError, ValueError):  # pragma: no cover
+        WebKit2 = None
 
 try:
     gi.require_version("Pango", "1.0")

--- a/gtk/src/toga_gtk/libs/styles.py
+++ b/gtk/src/toga_gtk/libs/styles.py
@@ -1,17 +1,32 @@
 from toga.colors import TRANSPARENT
 from toga.fonts import SYSTEM_DEFAULT_FONT_SIZE
 
-TOGA_DEFAULT_STYLES = b"""
-.toga-detailed-list-floating-buttons {
-    min-width: 24px;
-    min-height: 24px;
-    color: white;
-    background: #000000;
-    border-style: none;
-    border-radius: 0;
-    opacity: 0.60;
-}
-"""
+from ..libs import GTK_VERSION
+
+if GTK_VERSION < (4, 0, 0):
+    TOGA_DEFAULT_STYLES = b"""
+    .toga-detailed-list-floating-buttons {
+        min-width: 24px;
+        min-height: 24px;
+        color: white;
+        background: #000000;
+        border-style: none;
+        border-radius: 0;
+        opacity: 0.60;
+    }
+    """
+else:
+    TOGA_DEFAULT_STYLES = """
+    .toga-detailed-list-floating-buttons {
+        min-width: 24px;
+        min-height: 24px;
+        color: white;
+        background: #000000;
+        border-style: none;
+        border-radius: 0;
+        opacity: 0.60;
+    }
+    """
 
 
 def get_color_css(value):

--- a/gtk/src/toga_gtk/libs/styles.py
+++ b/gtk/src/toga_gtk/libs/styles.py
@@ -3,7 +3,7 @@ from toga.fonts import SYSTEM_DEFAULT_FONT_SIZE
 
 from ..libs import GTK_VERSION
 
-if GTK_VERSION < (4, 0, 0):
+if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
     TOGA_DEFAULT_STYLES = b"""
     .toga-detailed-list-floating-buttons {
         min-width: 24px;
@@ -15,7 +15,7 @@ if GTK_VERSION < (4, 0, 0):
         opacity: 0.60;
     }
     """
-else:
+else:  # pragma: no-cover-if-gtk3
     TOGA_DEFAULT_STYLES = """
     .toga-detailed-list-floating-buttons {
         min-width: 24px;

--- a/gtk/src/toga_gtk/screens.py
+++ b/gtk/src/toga_gtk/screens.py
@@ -25,6 +25,9 @@ class Screen:
             geometry = self.native.get_geometry()
             return Position(geometry.x, geometry.y)
         else:  # pragma: no-cover-if-gtk3
+            self.interface.factory.not_implemented(
+                "Screen get_origin is not possible with GTK4"
+            )
             return Position(0, 0)
 
     def get_size(self) -> Size:

--- a/gtk/src/toga_gtk/screens.py
+++ b/gtk/src/toga_gtk/screens.py
@@ -21,10 +21,10 @@ class Screen:
         return self.native.get_model()
 
     def get_origin(self) -> Position:
-        if GTK_VERSION < (4, 0, 0):
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             geometry = self.native.get_geometry()
             return Position(geometry.x, geometry.y)
-        else:
+        else:  # pragma: no-cover-if-gtk3
             return Position(0, 0)
 
     def get_size(self) -> Size:

--- a/gtk/src/toga_gtk/screens.py
+++ b/gtk/src/toga_gtk/screens.py
@@ -1,7 +1,7 @@
 from toga.screens import Screen as ScreenInterface
 from toga.types import Position, Size
 
-from .libs import IS_WAYLAND, Gdk
+from .libs import GTK_VERSION, IS_WAYLAND, Gdk
 
 
 class Screen:
@@ -21,8 +21,11 @@ class Screen:
         return self.native.get_model()
 
     def get_origin(self) -> Position:
-        geometry = self.native.get_geometry()
-        return Position(geometry.x, geometry.y)
+        if GTK_VERSION < (4, 0, 0):
+            geometry = self.native.get_geometry()
+            return Position(geometry.x, geometry.y)
+        else:
+            return Position(0, 0)
 
     def get_size(self) -> Size:
         geometry = self.native.get_geometry()

--- a/gtk/src/toga_gtk/statusicons.py
+++ b/gtk/src/toga_gtk/statusicons.py
@@ -41,6 +41,8 @@ class SimpleStatusIcon(StatusIcon):
         super().create()
         if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             self.native.connect("activate", self.gtk_activate)
+        else:  # pragma: no-cover-if-gtk3
+            pass
 
     def gtk_activate(self, icon, button, time):
         self.interface.on_press()

--- a/gtk/src/toga_gtk/statusicons.py
+++ b/gtk/src/toga_gtk/statusicons.py
@@ -1,7 +1,7 @@
 import toga
 from toga.command import Group, Separator
 
-from .libs import Gtk, XApp
+from .libs import GTK_VERSION, Gtk, XApp
 
 
 class StatusIcon:
@@ -17,16 +17,19 @@ class StatusIcon:
             self.native.set_icon_name(path)
 
     def create(self):
-        if XApp is None:  # pragma: no cover
-            # Can't replicate this in testbed
-            raise RuntimeError(
-                "Unable to import XApp. Ensure that the system package "
-                "providing libxapp and its GTK bindings have been installed."
-            )
+        if GTK_VERSION < (4, 0, 0):
+            if XApp is None:  # pragma: no cover
+                # Can't replicate this in testbed
+                raise RuntimeError(
+                    "Unable to import XApp. Ensure that the system package "
+                    "providing libxapp and its GTK bindings have been installed."
+                )
 
-        self.native = XApp.StatusIcon.new()
-        self.native.set_tooltip_text(self.interface.text)
-        self.set_icon(self.interface.icon)
+            self.native = XApp.StatusIcon.new()
+            self.native.set_tooltip_text(self.interface.text)
+            self.set_icon(self.interface.icon)
+        else:
+            self.interface.factory.not_implemented("StatusIcon")
 
     def remove(self):
         del self.native
@@ -36,7 +39,8 @@ class StatusIcon:
 class SimpleStatusIcon(StatusIcon):
     def create(self):
         super().create()
-        self.native.connect("activate", self.gtk_activate)
+        if GTK_VERSION < (4, 0, 0):
+            self.native.connect("activate", self.gtk_activate)
 
     def gtk_activate(self, icon, button, time):
         self.interface.on_press()
@@ -71,42 +75,46 @@ class StatusIconSet:
         return submenu
 
     def create(self):
-        # Menu status icons are the only icons that have extra construction needs.
-        # Clear existing menus
-        for item in self.interface._menu_status_icons:
-            submenu = Gtk.Menu.new()
-            item._impl.native.set_primary_menu(submenu)
+        if GTK_VERSION < (4, 0, 0):
+            # Menu status icons are the only icons that have extra construction needs.
+            # Clear existing menus
+            for item in self.interface._menu_status_icons:
+                submenu = Gtk.Menu.new()
+                item._impl.native.set_primary_menu(submenu)
 
-        # Determine the primary status icon.
-        primary_group = self.interface._primary_menu_status_icon
-        if primary_group is None:  # pragma: no cover
-            # If there isn't at least one menu status icon, then there aren't any menus
-            # to populate. This can't be replicated in the testbed.
-            return
+            # Determine the primary status icon.
+            primary_group = self.interface._primary_menu_status_icon
+            if primary_group is None:  # pragma: no cover
+                # If there isn't at least one menu status icon, then there aren't any
+                # menus to populate. This can't be replicated in the testbed.
+                return
 
-        # Add the menu status items to the cache
-        group_cache = {
-            item: item._impl.native.get_primary_menu()
-            for item in self.interface._menu_status_icons
-        }
-        # Map the COMMANDS group to the primary status icon's menu.
-        group_cache[Group.COMMANDS] = primary_group._impl.native.get_primary_menu()
-        self._menu_items = {}
+            # Add the menu status items to the cache
+            group_cache = {
+                item: item._impl.native.get_primary_menu()
+                for item in self.interface._menu_status_icons
+            }
+            # Map the COMMANDS group to the primary status icon's menu.
+            group_cache[Group.COMMANDS] = primary_group._impl.native.get_primary_menu()
+            self._menu_items = {}
 
-        for cmd in self.interface.commands:
-            try:
-                submenu = self._submenu(cmd.group, group_cache)
-            except ValueError:
-                raise ValueError(
-                    f"Command {cmd.text!r} does not belong to "
-                    "a current status icon group."
-                )
-            else:
-                if isinstance(cmd, Separator):
-                    menu_item = Gtk.SeparatorMenuItem.new()
+            for cmd in self.interface.commands:
+                try:
+                    submenu = self._submenu(cmd.group, group_cache)
+                except ValueError:
+                    raise ValueError(
+                        f"Command {cmd.text!r} does not belong to "
+                        "a current status icon group."
+                    )
                 else:
-                    menu_item = Gtk.MenuItem.new_with_label(cmd.text)
-                    menu_item.connect("activate", cmd._impl.gtk_activate)
+                    if isinstance(cmd, Separator):
+                        menu_item = Gtk.SeparatorMenuItem.new()
+                    else:
+                        menu_item = Gtk.MenuItem.new_with_label(cmd.text)
+                        menu_item.connect("activate", cmd._impl.gtk_activate)
 
-                submenu.append(menu_item)
-                submenu.show_all()
+                    submenu.append(menu_item)
+                    submenu.show_all()
+
+        else:
+            self.interface.factory.not_implemented("StatusIconSet.create()")

--- a/gtk/src/toga_gtk/statusicons.py
+++ b/gtk/src/toga_gtk/statusicons.py
@@ -17,7 +17,7 @@ class StatusIcon:
             self.native.set_icon_name(path)
 
     def create(self):
-        if GTK_VERSION < (4, 0, 0):
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             if XApp is None:  # pragma: no cover
                 # Can't replicate this in testbed
                 raise RuntimeError(
@@ -28,7 +28,7 @@ class StatusIcon:
             self.native = XApp.StatusIcon.new()
             self.native.set_tooltip_text(self.interface.text)
             self.set_icon(self.interface.icon)
-        else:
+        else:  # pragma: no-cover-if-gtk3
             self.interface.factory.not_implemented("StatusIcon")
 
     def remove(self):
@@ -39,7 +39,7 @@ class StatusIcon:
 class SimpleStatusIcon(StatusIcon):
     def create(self):
         super().create()
-        if GTK_VERSION < (4, 0, 0):
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             self.native.connect("activate", self.gtk_activate)
 
     def gtk_activate(self, icon, button, time):
@@ -75,7 +75,7 @@ class StatusIconSet:
         return submenu
 
     def create(self):
-        if GTK_VERSION < (4, 0, 0):
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             # Menu status icons are the only icons that have extra construction needs.
             # Clear existing menus
             for item in self.interface._menu_status_icons:
@@ -116,5 +116,5 @@ class StatusIconSet:
                     submenu.append(menu_item)
                     submenu.show_all()
 
-        else:
+        else:  # pragma: no-cover-if-gtk3
             self.interface.factory.not_implemented("StatusIconSet.create()")

--- a/gtk/src/toga_gtk/widgets/activityindicator.py
+++ b/gtk/src/toga_gtk/widgets/activityindicator.py
@@ -28,3 +28,5 @@ class ActivityIndicator(Widget):
 
             self.interface.intrinsic.width = width[0]
             self.interface.intrinsic.height = height[0]
+        else:  # pragma: no-cover-if-gtk3
+            pass

--- a/gtk/src/toga_gtk/widgets/activityindicator.py
+++ b/gtk/src/toga_gtk/widgets/activityindicator.py
@@ -1,4 +1,4 @@
-from ..libs import Gtk
+from ..libs import GTK_VERSION, Gtk
 from .base import Widget
 
 
@@ -16,14 +16,15 @@ class ActivityIndicator(Widget):
         self.native.stop()
 
     def rehint(self):
-        # print(
-        #     "REHINT",
-        #     self,
-        #     self.native.get_preferred_width(),
-        #     self.native.get_preferred_height(),
-        # )
-        width = self.native.get_preferred_width()
-        height = self.native.get_preferred_height()
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            # print(
+            #     "REHINT",
+            #     self,
+            #     self.native.get_preferred_width(),
+            #     self.native.get_preferred_height(),
+            # )
+            width = self.native.get_preferred_width()
+            height = self.native.get_preferred_height()
 
-        self.interface.intrinsic.width = width[0]
-        self.interface.intrinsic.height = height[0]
+            self.interface.intrinsic.width = width[0]
+            self.interface.intrinsic.height = height[0]

--- a/gtk/src/toga_gtk/widgets/base.py
+++ b/gtk/src/toga_gtk/widgets/base.py
@@ -27,9 +27,9 @@ class Widget:
         # Ensure the native widget has GTK CSS style attributes; create() should
         # ensure any other widgets are also styled appropriately.
         self.native.set_name(f"toga-{self.interface.id}")
-        if GTK_VERSION < (4, 0, 0):
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             self.native.get_style_context().add_class("toga")
-        else:
+        else:  # pragma: no-cover-if-gtk3
             self.native.add_css_class("toga")
 
     @abstractmethod
@@ -61,10 +61,10 @@ class Widget:
         elif container:
             # setting container, adding self to container.native
             self._container = container
-            if GTK_VERSION < (4, 0, 0):
+            if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
                 self._container.add(self.native)
                 self.native.show_all()
-            else:
+            else:  # pragma: no-cover-if-gtk3
                 self._container.append(self.native)
 
         for child in self.interface.children:
@@ -80,9 +80,9 @@ class Widget:
 
     @property
     def has_focus(self):
-        if GTK_VERSION < (4, 0, 0):
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             return self.native.has_focus()
-        else:
+        else:  # pragma: no-cover-if-gtk3
             root = self.native.get_root()
             focus_widget = root.get_focus()
             if focus_widget:
@@ -204,7 +204,7 @@ class Widget:
 
     def rehint(self):
         # Perform the actual GTK rehint.
-        if GTK_VERSION < (4, 0, 0):
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             # print(
             #     "REHINT",
             #     self,
@@ -216,7 +216,7 @@ class Widget:
 
             self.interface.intrinsic.width = at_least(width[0])
             self.interface.intrinsic.height = at_least(height[0])
-        else:
+        else:  # pragma: no-cover-if-gtk3
             min_size, _ = self.native.get_preferred_size()
             # print("REHINT", self, f"{width_info[0]}x{height_info[0]}")
             self.interface.intrinsic.width = at_least(min_size.width)

--- a/gtk/src/toga_gtk/widgets/base.py
+++ b/gtk/src/toga_gtk/widgets/base.py
@@ -2,7 +2,13 @@ from abc import abstractmethod
 
 from travertino.size import at_least
 
-from ..libs import Gtk, get_background_color_css, get_color_css, get_font_css
+from ..libs import (
+    GTK_VERSION,
+    Gtk,
+    get_background_color_css,
+    get_color_css,
+    get_font_css,
+)
 
 
 class Widget:
@@ -21,7 +27,10 @@ class Widget:
         # Ensure the native widget has GTK CSS style attributes; create() should
         # ensure any other widgets are also styled appropriately.
         self.native.set_name(f"toga-{self.interface.id}")
-        self.native.get_style_context().add_class("toga")
+        if GTK_VERSION < (4, 0, 0):
+            self.native.get_style_context().add_class("toga")
+        else:
+            self.native.add_css_class("toga")
 
     @abstractmethod
     def create(self): ...
@@ -52,8 +61,11 @@ class Widget:
         elif container:
             # setting container, adding self to container.native
             self._container = container
-            self._container.add(self.native)
-            self.native.show_all()
+            if GTK_VERSION < (4, 0, 0):
+                self._container.add(self.native)
+                self.native.show_all()
+            else:
+                self._container.append(self.native)
 
         for child in self.interface.children:
             child._impl.container = container
@@ -68,7 +80,18 @@ class Widget:
 
     @property
     def has_focus(self):
-        return self.native.has_focus()
+        if GTK_VERSION < (4, 0, 0):
+            return self.native.has_focus()
+        else:
+            root = self.native.get_root()
+            focus_widget = root.get_focus()
+            if focus_widget:
+                if focus_widget == self.native:
+                    return self.native.has_focus()
+                else:
+                    return focus_widget.is_ancestor(self.native)
+            else:
+                return False
 
     def focus(self):
         if not self.has_focus:
@@ -181,14 +204,20 @@ class Widget:
 
     def rehint(self):
         # Perform the actual GTK rehint.
-        # print(
-        #     "REHINT",
-        #     self,
-        #     self.native.get_preferred_width(),
-        #     self.native.get_preferred_height(),
-        # )
-        width = self.native.get_preferred_width()
-        height = self.native.get_preferred_height()
+        if GTK_VERSION < (4, 0, 0):
+            # print(
+            #     "REHINT",
+            #     self,
+            #     self.native.get_preferred_width(),
+            #     self.native.get_preferred_height(),
+            # )
+            width = self.native.get_preferred_width()
+            height = self.native.get_preferred_height()
 
-        self.interface.intrinsic.width = at_least(width[0])
-        self.interface.intrinsic.height = at_least(height[0])
+            self.interface.intrinsic.width = at_least(width[0])
+            self.interface.intrinsic.height = at_least(height[0])
+        else:
+            min_size, _ = self.native.get_preferred_size()
+            # print("REHINT", self, f"{width_info[0]}x{height_info[0]}")
+            self.interface.intrinsic.width = at_least(min_size.width)
+            self.interface.intrinsic.height = at_least(min_size.height)

--- a/gtk/src/toga_gtk/widgets/button.py
+++ b/gtk/src/toga_gtk/widgets/button.py
@@ -52,17 +52,18 @@ class Button(Widget):
         super().set_background_color(None if color is TRANSPARENT else color)
 
     def rehint(self):
-        # print(
-        #     "REHINT",
-        #     self,
-        #     self.native.get_preferred_width(),
-        #     self.native.get_preferred_height(),
-        # )
-        width = self.native.get_preferred_width()
-        height = self.native.get_preferred_height()
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            # print(
+            #     "REHINT",
+            #     self,
+            #     self.native.get_preferred_width(),
+            #     self.native.get_preferred_height(),
+            # )
+            width = self.native.get_preferred_width()
+            height = self.native.get_preferred_height()
 
-        self.interface.intrinsic.width = at_least(width[0])
-        self.interface.intrinsic.height = height[1]
+            self.interface.intrinsic.width = at_least(width[0])
+            self.interface.intrinsic.height = height[1]
 
     def gtk_clicked(self, event):
         self.interface.on_press()

--- a/gtk/src/toga_gtk/widgets/button.py
+++ b/gtk/src/toga_gtk/widgets/button.py
@@ -64,6 +64,8 @@ class Button(Widget):
 
             self.interface.intrinsic.width = at_least(width[0])
             self.interface.intrinsic.height = height[1]
+        else:  # pragma: no-cover-if-gtk3
+            pass
 
     def gtk_clicked(self, event):
         self.interface.on_press()

--- a/gtk/src/toga_gtk/widgets/button.py
+++ b/gtk/src/toga_gtk/widgets/button.py
@@ -2,7 +2,7 @@ from travertino.size import at_least
 
 from toga.colors import TRANSPARENT
 
-from ..libs import Gtk
+from ..libs import GTK_VERSION, Gtk
 from .base import Widget
 
 
@@ -14,7 +14,10 @@ class Button(Widget):
         self._icon = None
 
     def get_text(self):
-        return self.native.get_label()
+        text = self.native.get_label()
+        if GTK_VERSION < (4, 0, 0):
+            return text
+        return text if text else ""
 
     def set_text(self, text):
         self.native.set_label(text)
@@ -24,12 +27,22 @@ class Button(Widget):
 
     def set_icon(self, icon):
         self._icon = icon
-        if icon:
-            self.native.set_image(Gtk.Image.new_from_pixbuf(icon._impl.native(32)))
-            self.native.set_always_show_image(True)
+        if GTK_VERSION < (4, 0, 0):
+            if icon:
+                self.native.set_image(Gtk.Image.new_from_pixbuf(icon._impl.native(32)))
+                self.native.set_always_show_image(True)
+            else:
+                self.native.set_image(None)
+                self.native.set_always_show_image(False)
         else:
-            self.native.set_image(None)
-            self.native.set_always_show_image(False)
+            if icon:
+                icon._impl.native.set_icon_size(Gtk.IconSize.LARGE)
+                self.native.set_child(icon._impl.native)
+            else:
+                text = self.native.get_label()
+                if text:
+                    self.native.set_label(text)
+                self.native.set_child(None)
 
     def set_enabled(self, value):
         self.native.set_sensitive(value)

--- a/gtk/src/toga_gtk/widgets/button.py
+++ b/gtk/src/toga_gtk/widgets/button.py
@@ -15,9 +15,9 @@ class Button(Widget):
 
     def get_text(self):
         text = self.native.get_label()
-        if GTK_VERSION < (4, 0, 0):
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             return text
-        return text if text else ""
+        return text if text else ""  # pragma: no-cover-if-gtk3
 
     def set_text(self, text):
         self.native.set_label(text)
@@ -27,14 +27,14 @@ class Button(Widget):
 
     def set_icon(self, icon):
         self._icon = icon
-        if GTK_VERSION < (4, 0, 0):
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             if icon:
                 self.native.set_image(Gtk.Image.new_from_pixbuf(icon._impl.native(32)))
                 self.native.set_always_show_image(True)
             else:
                 self.native.set_image(None)
                 self.native.set_always_show_image(False)
-        else:
+        else:  # pragma: no-cover-if-gtk3
             if icon:
                 icon._impl.native.set_icon_size(Gtk.IconSize.LARGE)
                 self.native.set_child(icon._impl.native)

--- a/gtk/src/toga_gtk/widgets/canvas.py
+++ b/gtk/src/toga_gtk/widgets/canvas.py
@@ -8,7 +8,7 @@ from toga import Font
 from toga.constants import Baseline, FillRule
 from toga.fonts import SYSTEM_DEFAULT_FONT_SIZE
 from toga_gtk.colors import native_color
-from toga_gtk.libs import Gdk, Gtk, Pango, PangoCairo, cairo
+from toga_gtk.libs import GTK_VERSION, Gdk, Gtk, Pango, PangoCairo, cairo
 
 from .base import Widget
 
@@ -23,16 +23,17 @@ class Canvas(Widget):
 
         self.native = Gtk.DrawingArea()
 
-        self.native.connect("draw", self.gtk_draw_callback)
-        self.native.connect("size-allocate", self.gtk_on_size_allocate)
-        self.native.connect("button-press-event", self.mouse_down)
-        self.native.connect("button-release-event", self.mouse_up)
-        self.native.connect("motion-notify-event", self.mouse_move)
-        self.native.set_events(
-            Gdk.EventMask.BUTTON_PRESS_MASK
-            | Gdk.EventMask.BUTTON_RELEASE_MASK
-            | Gdk.EventMask.BUTTON_MOTION_MASK
-        )
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            self.native.connect("draw", self.gtk_draw_callback)
+            self.native.connect("size-allocate", self.gtk_on_size_allocate)
+            self.native.connect("button-press-event", self.mouse_down)
+            self.native.connect("button-release-event", self.mouse_up)
+            self.native.connect("motion-notify-event", self.mouse_move)
+            self.native.set_events(
+                Gdk.EventMask.BUTTON_PRESS_MASK
+                | Gdk.EventMask.BUTTON_RELEASE_MASK
+                | Gdk.EventMask.BUTTON_MOTION_MASK
+            )
 
     def gtk_draw_callback(self, widget, cairo_context):
         """Creates a draw callback.

--- a/gtk/src/toga_gtk/widgets/canvas.py
+++ b/gtk/src/toga_gtk/widgets/canvas.py
@@ -34,6 +34,8 @@ class Canvas(Widget):
                 | Gdk.EventMask.BUTTON_RELEASE_MASK
                 | Gdk.EventMask.BUTTON_MOTION_MASK
             )
+        else:  # pragma: no-cover-if-gtk3
+            pass
 
     def gtk_draw_callback(self, widget, cairo_context):
         """Creates a draw callback.

--- a/gtk/src/toga_gtk/widgets/detailedlist.py
+++ b/gtk/src/toga_gtk/widgets/detailedlist.py
@@ -2,7 +2,7 @@ import html
 
 from travertino.size import at_least
 
-from toga_gtk.libs import Gdk, Gio, Gtk, Pango
+from toga_gtk.libs import GTK_VERSION, Gdk, Gio, Gtk, Pango
 
 from .base import Widget
 
@@ -18,8 +18,10 @@ class DetailedListRow(Gtk.ListBoxRow):
         # The row is a built as a stack, so that the action buttons can be pushed onto
         # the stack as required.
         self.stack = Gtk.Stack()
-        self.stack.set_homogeneous(True)
-        self.add(self.stack)
+
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            self.stack.set_homogeneous(True)
+            self.add(self.stack)
 
         self.content = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
 
@@ -28,20 +30,21 @@ class DetailedListRow(Gtk.ListBoxRow):
 
         self.text = Gtk.Label(xalign=0)
 
-        # The three line below are necessary for right to left text.
-        self.text.set_hexpand(True)
-        self.text.set_ellipsize(Pango.EllipsizeMode.END)
-        self.text.set_margin_end(12)
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            # The three line below are necessary for right to left text.
+            self.text.set_hexpand(True)
+            self.text.set_ellipsize(Pango.EllipsizeMode.END)
+            self.text.set_margin_end(12)
 
-        self.content.pack_end(self.text, True, True, 5)
+            self.content.pack_end(self.text, True, True, 5)
 
-        # Update the content for the row.
-        self.update(dl, row)
+            # Update the content for the row.
+            self.update(dl, row)
 
-        self.stack.add_named(self.content, "content")
+            self.stack.add_named(self.content, "content")
 
-        # Make sure the widgets have been made visible.
-        self.show_all()
+            # Make sure the widgets have been made visible.
+            self.show_all()
 
     def update(self, dl, row):
         """Update the contents of the rendered row, using data from `row`,
@@ -108,99 +111,109 @@ class DetailedList(Widget):
 
         # Main functional widget is a ListBox.
         self.native_detailedlist = Gtk.ListBox()
-        self.native_detailedlist.set_selection_mode(Gtk.SelectionMode.SINGLE)
-        self.native_detailedlist.connect("row-selected", self.gtk_on_row_selected)
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            self.native_detailedlist.set_selection_mode(Gtk.SelectionMode.SINGLE)
+            self.native_detailedlist.connect("row-selected", self.gtk_on_row_selected)
 
         self.store = Gio.ListStore()
-        # We need to provide a function that transforms whatever is in the store into a
-        # `Gtk.ListBoxRow`, but the items in the store already are `Gtk.ListBoxRow`, so
-        # this is the identity function.
-        self.native_detailedlist.bind_model(self.store, lambda a: a)
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            # We need to provide a function that transforms whatever is in the
+            # store into a `Gtk.ListBoxRow`, but the items in the store already
+            # are `Gtk.ListBoxRow`, so this is the identity function.
+            self.native_detailedlist.bind_model(self.store, lambda a: a)
 
-        # Put the ListBox into a vertically scrolling window.
+            # Put the ListBox into a vertically scrolling window.
         scrolled_window = Gtk.ScrolledWindow()
-        scrolled_window.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
-        scrolled_window.set_min_content_width(self.interface._MIN_WIDTH)
-        scrolled_window.set_min_content_height(self.interface._MIN_HEIGHT)
-        scrolled_window.add(self.native_detailedlist)
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            scrolled_window.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+            scrolled_window.set_min_content_width(self.interface._MIN_WIDTH)
+            scrolled_window.set_min_content_height(self.interface._MIN_HEIGHT)
+            scrolled_window.add(self.native_detailedlist)
 
         self.native_vadj = scrolled_window.get_vadjustment()
-        self.native_vadj.connect("value-changed", self.gtk_on_value_changed)
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            self.native_vadj.connect("value-changed", self.gtk_on_value_changed)
 
-        # Define a revealer widget that can be used to show/hide with a crossfade.
+            # Define a revealer widget that can be used to show/hide with a crossfade.
         self.native_revealer = Gtk.Revealer()
-        self.native_revealer.set_transition_type(Gtk.RevealerTransitionType.CROSSFADE)
-        self.native_revealer.set_valign(Gtk.Align.END)
-        self.native_revealer.set_halign(Gtk.Align.CENTER)
-        self.native_revealer.set_margin_bottom(12)
-        self.native_revealer.set_reveal_child(False)
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            self.native_revealer.set_transition_type(
+                Gtk.RevealerTransitionType.CROSSFADE
+            )
+            self.native_revealer.set_valign(Gtk.Align.END)
+            self.native_revealer.set_halign(Gtk.Align.CENTER)
+            self.native_revealer.set_margin_bottom(12)
+            self.native_revealer.set_reveal_child(False)
 
-        # Define a refresh button.
-        self.native_refresh_button = Gtk.Button.new_from_icon_name(
-            "view-refresh-symbolic", Gtk.IconSize.BUTTON
-        )
-        self.native_refresh_button.set_can_focus(False)
-        self.native_refresh_button.connect("clicked", self.gtk_on_refresh_clicked)
+            # Define a refresh button.
+            self.native_refresh_button = Gtk.Button.new_from_icon_name(
+                "view-refresh-symbolic", Gtk.IconSize.BUTTON
+            )
+            self.native_refresh_button.set_can_focus(False)
+            self.native_refresh_button.connect("clicked", self.gtk_on_refresh_clicked)
 
-        style_context = self.native_refresh_button.get_style_context()
-        style_context.add_class("osd")
-        style_context.add_class("toga-detailed-list-floating-buttons")
-        style_context.remove_class("button")
+            style_context = self.native_refresh_button.get_style_context()
+            style_context.add_class("osd")
+            style_context.add_class("toga-detailed-list-floating-buttons")
+            style_context.remove_class("button")
 
-        # Add the refresh button to the revealer
-        self.native_revealer.add(self.native_refresh_button)
+            # Add the refresh button to the revealer
+            self.native_revealer.add(self.native_refresh_button)
 
         # The actual native widget is an overlay, made up of the scrolled window, with
         # the revealer over the top.
         self.native = Gtk.Overlay()
-        self.native.add_overlay(scrolled_window)
-        self.native.add_overlay(self.native_revealer)
 
-        # Set up a gesture to capture right clicks.
-        self.gesture = Gtk.GestureMultiPress.new(self.native_detailedlist)
-        self.gesture.set_button(3)
-        self.gesture.set_propagation_phase(Gtk.PropagationPhase.BUBBLE)
-        self.gesture.connect("pressed", self.gtk_on_right_click)
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            self.native.add_overlay(scrolled_window)
+            self.native.add_overlay(self.native_revealer)
+            # Set up a gesture to capture right clicks.
+            self.gesture = Gtk.GestureMultiPress.new(self.native_detailedlist)
+            self.gesture.set_button(3)
+            self.gesture.set_propagation_phase(Gtk.PropagationPhase.BUBBLE)
+            self.gesture.connect("pressed", self.gtk_on_right_click)
 
-        # Set up a box that contains action buttons. This widget can be can be reused
-        # for any row when it is activated.
-        self.native_action_buttons = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
-        action_buttons_hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
+            # Set up a box that contains action buttons. This widget can be reused
+            # for any row when it is activated.
+            self.native_action_buttons = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+            action_buttons_hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
 
-        # TODO: Can we replace "magic words" like delete with an appropriate icon?
-        # self.native_primary_action_button = Gtk.Button.new_from_icon_name(
-        #     "user-trash-symbolic", Gtk.IconSize.BUTTON
-        # )
-        action_buttons_hbox.pack_start(Gtk.Box(), True, True, 0)
+            # TODO: Can we replace "magic words" like delete with an appropriate icon?
+            # self.native_primary_action_button = Gtk.Button.new_from_icon_name(
+            #     "user-trash-symbolic", Gtk.IconSize.BUTTON
+            # )
+            action_buttons_hbox.pack_start(Gtk.Box(), True, True, 0)
 
         self.native_primary_action_button = Gtk.Button.new_with_label(
             self.interface._primary_action
         )
-        self.native_primary_action_button.connect(
-            "clicked", self.gtk_on_primary_clicked
-        )
-        action_buttons_hbox.pack_start(
-            self.native_primary_action_button, False, False, 10
-        )
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            self.native_primary_action_button.connect(
+                "clicked", self.gtk_on_primary_clicked
+            )
+            action_buttons_hbox.pack_start(
+                self.native_primary_action_button, False, False, 10
+            )
 
-        # TODO: Can we replace "magic words" like delete with an appropriate icon?
-        # self.native_secondary_action_button = Gtk.Button.new_from_icon_name(
-        #     "user-trash-symbolic", Gtk.IconSize.BUTTON
-        # )
+            # TODO: Can we replace "magic words" like delete with an appropriate icon?
+            # self.native_secondary_action_button = Gtk.Button.new_from_icon_name(
+            #     "user-trash-symbolic", Gtk.IconSize.BUTTON
+            # )
         self.native_secondary_action_button = Gtk.Button.new_with_label(
             self.interface._secondary_action
         )
-        self.native_secondary_action_button.connect(
-            "clicked", self.gtk_on_secondary_clicked
-        )
-        action_buttons_hbox.pack_start(
-            self.native_secondary_action_button, False, False, 10
-        )
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            self.native_secondary_action_button.connect(
+                "clicked", self.gtk_on_secondary_clicked
+            )
+            action_buttons_hbox.pack_start(
+                self.native_secondary_action_button, False, False, 10
+            )
 
-        action_buttons_hbox.pack_start(Gtk.Box(), True, True, 0)
+            action_buttons_hbox.pack_start(Gtk.Box(), True, True, 0)
 
-        self.native_action_buttons.pack_start(action_buttons_hbox, True, False, 0)
-        self.native_action_buttons.show_all()
+            self.native_action_buttons.pack_start(action_buttons_hbox, True, False, 0)
+            self.native_action_buttons.show_all()
 
     def row_factory(self, item):
         return DetailedListRow(self.interface, item)

--- a/gtk/src/toga_gtk/widgets/detailedlist.py
+++ b/gtk/src/toga_gtk/widgets/detailedlist.py
@@ -22,6 +22,8 @@ class DetailedListRow(Gtk.ListBoxRow):
         if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             self.stack.set_homogeneous(True)
             self.add(self.stack)
+        else:  # pragma: no-cover-if-gtk3
+            pass
 
         self.content = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
 
@@ -45,6 +47,8 @@ class DetailedListRow(Gtk.ListBoxRow):
 
             # Make sure the widgets have been made visible.
             self.show_all()
+        else:  # pragma: no-cover-if-gtk3
+            pass
 
     def update(self, dl, row):
         """Update the contents of the rendered row, using data from `row`,
@@ -114,6 +118,8 @@ class DetailedList(Widget):
         if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             self.native_detailedlist.set_selection_mode(Gtk.SelectionMode.SINGLE)
             self.native_detailedlist.connect("row-selected", self.gtk_on_row_selected)
+        else:  # pragma: no-cover-if-gtk3
+            pass
 
         self.store = Gio.ListStore()
         if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
@@ -121,20 +127,26 @@ class DetailedList(Widget):
             # store into a `Gtk.ListBoxRow`, but the items in the store already
             # are `Gtk.ListBoxRow`, so this is the identity function.
             self.native_detailedlist.bind_model(self.store, lambda a: a)
+        else:  # pragma: no-cover-if-gtk3
+            pass
 
-            # Put the ListBox into a vertically scrolling window.
+        # Put the ListBox into a vertically scrolling window.
         scrolled_window = Gtk.ScrolledWindow()
         if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             scrolled_window.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
             scrolled_window.set_min_content_width(self.interface._MIN_WIDTH)
             scrolled_window.set_min_content_height(self.interface._MIN_HEIGHT)
             scrolled_window.add(self.native_detailedlist)
+        else:  # pragma: no-cover-if-gtk3
+            pass
 
         self.native_vadj = scrolled_window.get_vadjustment()
         if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             self.native_vadj.connect("value-changed", self.gtk_on_value_changed)
+        else:  # pragma: no-cover-if-gtk3
+            pass
 
-            # Define a revealer widget that can be used to show/hide with a crossfade.
+        # Define a revealer widget that can be used to show/hide with a crossfade.
         self.native_revealer = Gtk.Revealer()
         if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             self.native_revealer.set_transition_type(
@@ -159,6 +171,8 @@ class DetailedList(Widget):
 
             # Add the refresh button to the revealer
             self.native_revealer.add(self.native_refresh_button)
+        else:  # pragma: no-cover-if-gtk3
+            pass
 
         # The actual native widget is an overlay, made up of the scrolled window, with
         # the revealer over the top.
@@ -183,6 +197,8 @@ class DetailedList(Widget):
             #     "user-trash-symbolic", Gtk.IconSize.BUTTON
             # )
             action_buttons_hbox.pack_start(Gtk.Box(), True, True, 0)
+        else:  # pragma: no-cover-if-gtk3
+            pass
 
         self.native_primary_action_button = Gtk.Button.new_with_label(
             self.interface._primary_action
@@ -199,6 +215,8 @@ class DetailedList(Widget):
             # self.native_secondary_action_button = Gtk.Button.new_from_icon_name(
             #     "user-trash-symbolic", Gtk.IconSize.BUTTON
             # )
+        else:  # pragma: no-cover-if-gtk3
+            pass
         self.native_secondary_action_button = Gtk.Button.new_with_label(
             self.interface._secondary_action
         )
@@ -214,6 +232,8 @@ class DetailedList(Widget):
 
             self.native_action_buttons.pack_start(action_buttons_hbox, True, False, 0)
             self.native_action_buttons.show_all()
+        else:  # pragma: no-cover-if-gtk3
+            pass
 
     def row_factory(self, item):
         return DetailedListRow(self.interface, item)
@@ -342,3 +362,5 @@ class DetailedList(Widget):
         if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             self.interface.intrinsic.width = at_least(self.interface._MIN_WIDTH)
             self.interface.intrinsic.height = at_least(self.interface._MIN_HEIGHT)
+        else:  # pragma: no-cover-if-gtk3
+            pass

--- a/gtk/src/toga_gtk/widgets/detailedlist.py
+++ b/gtk/src/toga_gtk/widgets/detailedlist.py
@@ -339,5 +339,6 @@ class DetailedList(Widget):
         self.native_revealer.set_reveal_child(show_refresh)
 
     def rehint(self):
-        self.interface.intrinsic.width = at_least(self.interface._MIN_WIDTH)
-        self.interface.intrinsic.height = at_least(self.interface._MIN_HEIGHT)
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            self.interface.intrinsic.width = at_least(self.interface._MIN_WIDTH)
+            self.interface.intrinsic.height = at_least(self.interface._MIN_HEIGHT)

--- a/gtk/src/toga_gtk/widgets/divider.py
+++ b/gtk/src/toga_gtk/widgets/divider.py
@@ -1,6 +1,6 @@
 from travertino.size import at_least
 
-from ..libs import Gtk
+from ..libs import GTK_VERSION, Gtk
 from .base import Widget
 
 
@@ -9,15 +9,16 @@ class Divider(Widget):
         self.native = Gtk.Separator()
 
     def rehint(self):
-        width = self.native.get_preferred_width()
-        height = self.native.get_preferred_height()
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            width = self.native.get_preferred_width()
+            height = self.native.get_preferred_height()
 
-        if self.get_direction() == self.interface.VERTICAL:
-            self.interface.intrinsic.width = width[0]
-            self.interface.intrinsic.height = at_least(height[1])
-        else:
-            self.interface.intrinsic.width = at_least(width[0])
-            self.interface.intrinsic.height = height[1]
+            if self.get_direction() == self.interface.VERTICAL:
+                self.interface.intrinsic.width = width[0]
+                self.interface.intrinsic.height = at_least(height[1])
+            else:
+                self.interface.intrinsic.width = at_least(width[0])
+                self.interface.intrinsic.height = height[1]
 
     def get_direction(self):
         return (

--- a/gtk/src/toga_gtk/widgets/divider.py
+++ b/gtk/src/toga_gtk/widgets/divider.py
@@ -19,6 +19,8 @@ class Divider(Widget):
             else:
                 self.interface.intrinsic.width = at_least(width[0])
                 self.interface.intrinsic.height = height[1]
+        else:  # pragma: no-cover-if-gtk3
+            pass
 
     def get_direction(self):
         return (

--- a/gtk/src/toga_gtk/widgets/imageview.py
+++ b/gtk/src/toga_gtk/widgets/imageview.py
@@ -9,6 +9,8 @@ class ImageView(Widget):
         self.native = Gtk.Image()
         if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             self.native.connect("size-allocate", self.gtk_size_allocate)
+        else:  # pragma: no-cover-if-gtk3
+            pass
         self._aspect_ratio = None
 
     def set_image(self, image):
@@ -65,3 +67,5 @@ class ImageView(Widget):
             )
             self.interface.intrinsic.width = width
             self.interface.intrinsic.height = height
+        else:  # pragma: no-cover-if-gtk3
+            pass

--- a/gtk/src/toga_gtk/widgets/imageview.py
+++ b/gtk/src/toga_gtk/widgets/imageview.py
@@ -1,20 +1,24 @@
 from toga.widgets.imageview import rehint_imageview
 
-from ..libs import GdkPixbuf, Gtk
+from ..libs import GTK_VERSION, GdkPixbuf, Gtk
 from .base import Widget
 
 
 class ImageView(Widget):
     def create(self):
         self.native = Gtk.Image()
-        self.native.connect("size-allocate", self.gtk_size_allocate)
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            self.native.connect("size-allocate", self.gtk_size_allocate)
         self._aspect_ratio = None
 
     def set_image(self, image):
-        if image:
-            self.set_scaled_pixbuf(image._impl.native, self.native.get_allocation())
-        else:
-            self.native.set_from_pixbuf(None)
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            if image:
+                self.set_scaled_pixbuf(image._impl.native, self.native.get_allocation())
+            else:
+                self.native.set_from_pixbuf(None)
+        else:  # pragma: no-cover-if-gtk3
+            self.native.set_from_paintable()
 
     def gtk_size_allocate(self, widget, allocation):
         # GTK doesn't have any native image resizing; so, when the Gtk.Image

--- a/gtk/src/toga_gtk/widgets/imageview.py
+++ b/gtk/src/toga_gtk/widgets/imageview.py
@@ -58,9 +58,10 @@ class ImageView(Widget):
         self.native.set_from_pixbuf(scaled)
 
     def rehint(self):
-        width, height, self._aspect_ratio = rehint_imageview(
-            image=self.interface.image,
-            style=self.interface.style,
-        )
-        self.interface.intrinsic.width = width
-        self.interface.intrinsic.height = height
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            width, height, self._aspect_ratio = rehint_imageview(
+                image=self.interface.image,
+                style=self.interface.style,
+            )
+            self.interface.intrinsic.width = width
+            self.interface.intrinsic.height = height

--- a/gtk/src/toga_gtk/widgets/label.py
+++ b/gtk/src/toga_gtk/widgets/label.py
@@ -7,9 +7,9 @@ from .base import Widget
 class Label(Widget):
     def create(self):
         self.native = Gtk.Label()
-        if GTK_VERSION < (4, 0, 0):
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             self.native.set_line_wrap(False)
-        else:
+        else:  # pragma: no-cover-if-gtk3
             self.native.set_wrap(False)
 
     def set_text_align(self, value):
@@ -27,7 +27,7 @@ class Label(Widget):
         self.native.set_text(value)
 
     def rehint(self):
-        if GTK_VERSION < (4, 0, 0):
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             # print(
             #     "REHINT",
             #     self,
@@ -41,7 +41,7 @@ class Label(Widget):
 
             self.interface.intrinsic.width = at_least(width[0])
             self.interface.intrinsic.height = height[1]
-        else:
+        else:  # pragma: no-cover-if-gtk3
             # print(
             #     "REHINT",
             #     self,

--- a/gtk/src/toga_gtk/widgets/label.py
+++ b/gtk/src/toga_gtk/widgets/label.py
@@ -1,13 +1,16 @@
 from travertino.size import at_least
 
-from ..libs import Gtk, gtk_text_align
+from ..libs import GTK_VERSION, Gtk, gtk_text_align
 from .base import Widget
 
 
 class Label(Widget):
     def create(self):
         self.native = Gtk.Label()
-        self.native.set_line_wrap(False)
+        if GTK_VERSION < (4, 0, 0):
+            self.native.set_line_wrap(False)
+        else:
+            self.native.set_wrap(False)
 
     def set_text_align(self, value):
         xalign, justify = gtk_text_align(value)
@@ -24,16 +27,28 @@ class Label(Widget):
         self.native.set_text(value)
 
     def rehint(self):
-        # print(
-        #     "REHINT",
-        #     self,
-        #     self.native.get_preferred_width(),
-        #     self.native.get_preferred_height(),
-        #     getattr(self, "_fixed_height", False),
-        #     getattr(self, "_fixed_width", False),
-        # )
-        width = self.native.get_preferred_width()
-        height = self.native.get_preferred_height()
+        if GTK_VERSION < (4, 0, 0):
+            # print(
+            #     "REHINT",
+            #     self,
+            #     self.native.get_preferred_width(),
+            #     self.native.get_preferred_height(),
+            #     getattr(self, "_fixed_height", False),
+            #     getattr(self, "_fixed_width", False),
+            # )
+            width = self.native.get_preferred_width()
+            height = self.native.get_preferred_height()
 
-        self.interface.intrinsic.width = at_least(width[0])
-        self.interface.intrinsic.height = height[1]
+            self.interface.intrinsic.width = at_least(width[0])
+            self.interface.intrinsic.height = height[1]
+        else:
+            # print(
+            #     "REHINT",
+            #     self,
+            #     self.native.get_preferred_size()[0].width,
+            #     self.native.get_preferred_size()[0].height,
+            # )
+            min_size, size = self.native.get_preferred_size()
+
+            self.interface.intrinsic.width = at_least(min_size.width)
+            self.interface.intrinsic.height = size.height

--- a/gtk/src/toga_gtk/widgets/mapview.py
+++ b/gtk/src/toga_gtk/widgets/mapview.py
@@ -4,7 +4,7 @@ from travertino.size import at_least
 
 from toga.types import LatLng
 
-from ..libs import Gtk, WebKit2
+from ..libs import GTK_VERSION, Gtk, WebKit2
 from .base import Widget
 
 MAPVIEW_HTML_CONTENT = """<!DOCTYPE html>
@@ -68,6 +68,9 @@ class MapView(Widget):
     SUPPORTS_ON_SELECT = False
 
     def create(self):
+        if GTK_VERSION >= (4, 0, 0):  # pragma: no-cover-if-gtk3
+            raise RuntimeError("MapView isn't supported on GTK4 (yet!)")
+
         if WebKit2 is None:  # pragma: no cover
             raise RuntimeError(
                 "Unable to import WebKit2. Ensure that the system package providing "

--- a/gtk/src/toga_gtk/widgets/multilinetextinput.py
+++ b/gtk/src/toga_gtk/widgets/multilinetextinput.py
@@ -45,6 +45,8 @@ class MultilineTextInput(Widget):
             self.native_textview.connect("key-press-event", self.gtk_on_key_press)
 
             self.native.add(self.native_textview)
+        else:  # pragma: no-cover-if-gtk3
+            pass
 
     def set_color(self, color):
         self.apply_css(
@@ -151,6 +153,8 @@ class MultilineTextInput(Widget):
         if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             self.interface.intrinsic.width = at_least(self.interface._MIN_WIDTH)
             self.interface.intrinsic.height = at_least(self.interface._MIN_HEIGHT)
+        else:  # pragma: no-cover-if-gtk3
+            pass
 
     def scroll_to_bottom(self):
         self.buffer.place_cursor(self.buffer.get_end_iter())

--- a/gtk/src/toga_gtk/widgets/multilinetextinput.py
+++ b/gtk/src/toga_gtk/widgets/multilinetextinput.py
@@ -148,8 +148,9 @@ class MultilineTextInput(Widget):
         return False
 
     def rehint(self):
-        self.interface.intrinsic.width = at_least(self.interface._MIN_WIDTH)
-        self.interface.intrinsic.height = at_least(self.interface._MIN_HEIGHT)
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            self.interface.intrinsic.width = at_least(self.interface._MIN_WIDTH)
+            self.interface.intrinsic.height = at_least(self.interface._MIN_HEIGHT)
 
     def scroll_to_bottom(self):
         self.buffer.place_cursor(self.buffer.get_end_iter())

--- a/gtk/src/toga_gtk/widgets/multilinetextinput.py
+++ b/gtk/src/toga_gtk/widgets/multilinetextinput.py
@@ -1,6 +1,7 @@
 from travertino.size import at_least
 
 from ..libs import (
+    GTK_VERSION,
     Gtk,
     get_background_color_css,
     get_color_css,
@@ -34,15 +35,16 @@ class MultilineTextInput(Widget):
 
         self.native_textview = Gtk.TextView()
         self.native_textview.set_name(f"toga-{self.interface.id}-textview")
-        self.native_textview.get_style_context().add_class("toga")
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            self.native_textview.get_style_context().add_class("toga")
 
-        self.native_textview.set_buffer(self.placeholder)
-        self.native_textview.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
-        self.native_textview.connect("focus-in-event", self.gtk_on_focus_in)
-        self.native_textview.connect("focus-out-event", self.gtk_on_focus_out)
-        self.native_textview.connect("key-press-event", self.gtk_on_key_press)
+            self.native_textview.set_buffer(self.placeholder)
+            self.native_textview.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
+            self.native_textview.connect("focus-in-event", self.gtk_on_focus_in)
+            self.native_textview.connect("focus-out-event", self.gtk_on_focus_out)
+            self.native_textview.connect("key-press-event", self.gtk_on_key_press)
 
-        self.native.add(self.native_textview)
+            self.native.add(self.native_textview)
 
     def set_color(self, color):
         self.apply_css(

--- a/gtk/src/toga_gtk/widgets/numberinput.py
+++ b/gtk/src/toga_gtk/widgets/numberinput.py
@@ -5,7 +5,7 @@ from travertino.size import at_least
 
 from toga.widgets.numberinput import _clean_decimal
 
-from ..libs import Gtk, gtk_text_align
+from ..libs import GTK_VERSION, Gtk, gtk_text_align
 from .base import Widget
 
 
@@ -64,10 +64,11 @@ class NumberInput(Widget):
         self.native.set_alignment(xalign)
 
     def rehint(self):
-        width = self.native.get_preferred_width()
-        height = self.native.get_preferred_height()
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            width = self.native.get_preferred_width()
+            height = self.native.get_preferred_height()
 
-        self.interface.intrinsic.width = at_least(
-            max(self.interface._MIN_WIDTH, width[1])
-        )
-        self.interface.intrinsic.height = height[1]
+            self.interface.intrinsic.width = at_least(
+                max(self.interface._MIN_WIDTH, width[1])
+            )
+            self.interface.intrinsic.height = height[1]

--- a/gtk/src/toga_gtk/widgets/numberinput.py
+++ b/gtk/src/toga_gtk/widgets/numberinput.py
@@ -72,3 +72,5 @@ class NumberInput(Widget):
                 max(self.interface._MIN_WIDTH, width[1])
             )
             self.interface.intrinsic.height = height[1]
+        else:  # pragma: no-cover-if-gtk3
+            pass

--- a/gtk/src/toga_gtk/widgets/optioncontainer.py
+++ b/gtk/src/toga_gtk/widgets/optioncontainer.py
@@ -9,6 +9,9 @@ class OptionContainer(Widget):
     uses_icons = False
 
     def create(self):
+        if GTK_VERSION >= (4, 0, 0):  # pragma: no-cover-if-gtk3
+            raise RuntimeError("OptionContainer isn't supported on GTK4 (yet!)")
+
         self.native = Gtk.Notebook()
         self.native.connect("switch-page", self.gtk_on_switch_page)
         self.sub_containers = []

--- a/gtk/src/toga_gtk/widgets/optioncontainer.py
+++ b/gtk/src/toga_gtk/widgets/optioncontainer.py
@@ -33,6 +33,8 @@ class OptionContainer(Widget):
             # Tabs aren't visible by default;
             # tell the notebook to show all content.
             self.native.show_all()
+        else:  # pragma: no-cover-if-gtk3
+            pass
 
     def remove_option(self, index):
         self.native.remove_page(index)

--- a/gtk/src/toga_gtk/widgets/optioncontainer.py
+++ b/gtk/src/toga_gtk/widgets/optioncontainer.py
@@ -9,11 +9,11 @@ class OptionContainer(Widget):
     uses_icons = False
 
     def create(self):
-        if GTK_VERSION >= (4, 0, 0):  # pragma: no-cover-if-gtk3
-            raise RuntimeError("OptionContainer isn't supported on GTK4 (yet!)")
-
         self.native = Gtk.Notebook()
-        self.native.connect("switch-page", self.gtk_on_switch_page)
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            self.native.connect("switch-page", self.gtk_on_switch_page)
+        else:  # pragma: no-cover-if-gtk3
+            pass
         self.sub_containers = []
 
     def gtk_on_switch_page(self, widget, page, page_num):
@@ -27,12 +27,12 @@ class OptionContainer(Widget):
         asyncio.get_event_loop().call_soon(self.interface.on_select)
 
     def add_option(self, index, text, widget, icon):
-        sub_container = TogaContainer()
-        sub_container.content = widget
-
-        self.sub_containers.insert(index, sub_container)
-        self.native.insert_page(sub_container, Gtk.Label(label=text), index)
         if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            sub_container = TogaContainer()
+            sub_container.content = widget
+
+            self.sub_containers.insert(index, sub_container)
+            self.native.insert_page(sub_container, Gtk.Label(label=text), index)
             # Tabs aren't visible by default;
             # tell the notebook to show all content.
             self.native.show_all()
@@ -45,7 +45,10 @@ class OptionContainer(Widget):
         del self.sub_containers[index]
 
     def set_option_enabled(self, index, enabled):
-        self.sub_containers[index].set_visible(enabled)
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            self.sub_containers[index].set_visible(enabled)
+        else:  # pragma: no-cover-if-gtk3
+            pass
 
     def is_option_enabled(self, index):
         return self.sub_containers[index].get_visible()

--- a/gtk/src/toga_gtk/widgets/optioncontainer.py
+++ b/gtk/src/toga_gtk/widgets/optioncontainer.py
@@ -1,7 +1,7 @@
 import asyncio
 
 from ..container import TogaContainer
-from ..libs import Gtk
+from ..libs import GTK_VERSION, Gtk
 from .base import Widget
 
 
@@ -29,9 +29,10 @@ class OptionContainer(Widget):
 
         self.sub_containers.insert(index, sub_container)
         self.native.insert_page(sub_container, Gtk.Label(label=text), index)
-        # Tabs aren't visible by default;
-        # tell the notebook to show all content.
-        self.native.show_all()
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            # Tabs aren't visible by default;
+            # tell the notebook to show all content.
+            self.native.show_all()
 
     def remove_option(self, index):
         self.native.remove_page(index)

--- a/gtk/src/toga_gtk/widgets/progressbar.py
+++ b/gtk/src/toga_gtk/widgets/progressbar.py
@@ -103,3 +103,5 @@ class ProgressBar(Widget):
 
             self.interface.intrinsic.width = at_least(width[0])
             self.interface.intrinsic.height = height[0]
+        else:  # pragma: no-cover-if-gtk3
+            pass

--- a/gtk/src/toga_gtk/widgets/progressbar.py
+++ b/gtk/src/toga_gtk/widgets/progressbar.py
@@ -2,7 +2,7 @@ import asyncio
 
 from travertino.size import at_least
 
-from ..libs import Gtk
+from ..libs import GTK_VERSION, Gtk
 from .base import Widget
 
 # Implementation notes
@@ -91,14 +91,15 @@ class ProgressBar(Widget):
         self._stop_indeterminate()
 
     def rehint(self):
-        # print(
-        #     "REHINT",
-        #     self,
-        #     self.native.get_preferred_width(),
-        #     self.native.get_preferred_height(),
-        # )
-        width = self.native.get_preferred_width()
-        height = self.native.get_preferred_height()
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            # print(
+            #     "REHINT",
+            #     self,
+            #     self.native.get_preferred_width(),
+            #     self.native.get_preferred_height(),
+            # )
+            width = self.native.get_preferred_width()
+            height = self.native.get_preferred_height()
 
-        self.interface.intrinsic.width = at_least(width[0])
-        self.interface.intrinsic.height = height[0]
+            self.interface.intrinsic.width = at_least(width[0])
+            self.interface.intrinsic.height = height[0]

--- a/gtk/src/toga_gtk/widgets/scrollcontainer.py
+++ b/gtk/src/toga_gtk/widgets/scrollcontainer.py
@@ -23,6 +23,8 @@ class ScrollContainer(Widget):
         self.document_container = TogaContainer()
         if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             self.native.add(self.document_container)
+        else:  # pragma: no-cover-if-gtk3
+            pass
 
     def gtk_on_changed(self, *args):
         self.interface.on_scroll()
@@ -33,6 +35,8 @@ class ScrollContainer(Widget):
         if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             # Force the display of the new content
             self.native.show_all()
+        else:  # pragma: no-cover-if-gtk3
+            pass
 
     def set_app(self, app):
         self.interface.content.app = app
@@ -44,6 +48,8 @@ class ScrollContainer(Widget):
         if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             self.interface.intrinsic.width = at_least(self.interface._MIN_WIDTH)
             self.interface.intrinsic.height = at_least(self.interface._MIN_HEIGHT)
+        else:  # pragma: no-cover-if-gtk3
+            pass
 
     def get_horizontal(self):
         return self.native.get_policy()[0] == Gtk.PolicyType.AUTOMATIC

--- a/gtk/src/toga_gtk/widgets/scrollcontainer.py
+++ b/gtk/src/toga_gtk/widgets/scrollcontainer.py
@@ -41,8 +41,9 @@ class ScrollContainer(Widget):
         self.interface.content.window = window
 
     def rehint(self):
-        self.interface.intrinsic.width = at_least(self.interface._MIN_WIDTH)
-        self.interface.intrinsic.height = at_least(self.interface._MIN_HEIGHT)
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            self.interface.intrinsic.width = at_least(self.interface._MIN_WIDTH)
+            self.interface.intrinsic.height = at_least(self.interface._MIN_HEIGHT)
 
     def get_horizontal(self):
         return self.native.get_policy()[0] == Gtk.PolicyType.AUTOMATIC

--- a/gtk/src/toga_gtk/widgets/scrollcontainer.py
+++ b/gtk/src/toga_gtk/widgets/scrollcontainer.py
@@ -1,7 +1,7 @@
 from travertino.size import at_least
 
 from ..container import TogaContainer
-from ..libs import Gtk
+from ..libs import GTK_VERSION, Gtk
 from .base import Widget
 
 
@@ -21,7 +21,8 @@ class ScrollContainer(Widget):
         self.native.set_overlay_scrolling(True)
 
         self.document_container = TogaContainer()
-        self.native.add(self.document_container)
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            self.native.add(self.document_container)
 
     def gtk_on_changed(self, *args):
         self.interface.on_scroll()
@@ -29,8 +30,9 @@ class ScrollContainer(Widget):
     def set_content(self, widget):
         self.document_container.content = widget
 
-        # Force the display of the new content
-        self.native.show_all()
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            # Force the display of the new content
+            self.native.show_all()
 
     def set_app(self, app):
         self.interface.content.app = app

--- a/gtk/src/toga_gtk/widgets/selection.py
+++ b/gtk/src/toga_gtk/widgets/selection.py
@@ -8,9 +8,12 @@ from .base import Widget
 
 class Selection(Widget):
     def create(self):
-        self.native = Gtk.ComboBoxText.new()
-        self.native.connect("changed", self.gtk_on_changed)
-        self._send_notifications = True
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            self.native = Gtk.ComboBoxText.new()
+            self.native.connect("changed", self.gtk_on_changed)
+            self._send_notifications = True
+        else:  # pragma: no-cover-if-gtk3
+            self.native = Gtk.DropDown()
 
     @contextmanager
     def suspend_notifications(self):
@@ -57,12 +60,15 @@ class Selection(Widget):
         self.interface.refresh()
 
     def insert(self, index, item):
-        with self.suspend_notifications():
-            self.native.insert_text(index, self.interface._title_for_item(item))
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            with self.suspend_notifications():
+                self.native.insert_text(index, self.interface._title_for_item(item))
 
-        # If you're inserting the first item, make sure it's selected
-        if self.native.get_active() == -1:
-            self.native.set_active(0)
+            # If you're inserting the first item, make sure it's selected
+            if self.native.get_active() == -1:
+                self.native.set_active(0)
+        else:  # pragma: no-cover-if-gtk3
+            pass
 
     def remove(self, index, item):
         selection = self.native.get_active()
@@ -75,9 +81,12 @@ class Selection(Widget):
             self.native.set_active(0)
 
     def clear(self):
-        with self.suspend_notifications():
-            self.native.remove_all()
-        self.interface.on_change()
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            with self.suspend_notifications():
+                self.native.remove_all()
+            self.interface.on_change()
+        else:  # pragma: no-cover-if-gtk3
+            pass
 
     def select_item(self, index, item):
         self.native.set_active(index)

--- a/gtk/src/toga_gtk/widgets/selection.py
+++ b/gtk/src/toga_gtk/widgets/selection.py
@@ -104,3 +104,5 @@ class Selection(Widget):
                 max(self.interface._MIN_WIDTH, width[1])
             )
             self.interface.intrinsic.height = height[1]
+        else:  # pragma: no-cover-if-gtk3
+            pass

--- a/gtk/src/toga_gtk/widgets/selection.py
+++ b/gtk/src/toga_gtk/widgets/selection.py
@@ -2,7 +2,7 @@ from contextlib import contextmanager
 
 from travertino.size import at_least
 
-from ..libs import Gtk
+from ..libs import GTK_VERSION, Gtk
 from .base import Widget
 
 
@@ -89,17 +89,18 @@ class Selection(Widget):
         return index
 
     def rehint(self):
-        width = self.native.get_preferred_width()
-        height = self.native.get_preferred_height()
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            width = self.native.get_preferred_width()
+            height = self.native.get_preferred_height()
 
-        # FIXME: 2023-05-31 This will always provide a size that is big enough,
-        # but sometimes it will be *too* big. For example, if you set the font size
-        # large, then reduce it again, the widget *could* reduce in size. However,
-        # I can't find any way to prod GTK to perform a resize that will reduce
-        # it's minimum size. This is the reason the test probe has a `shrink_on_resize`
-        # property; if we can fix this resize issue, `shrink_on_resize` may not
-        # be necessary.
-        self.interface.intrinsic.width = at_least(
-            max(self.interface._MIN_WIDTH, width[1])
-        )
-        self.interface.intrinsic.height = height[1]
+            # FIXME: 2023-05-31 This will always provide a size that is big enough,
+            # but sometimes it will be *too* big. For example, if you set the font size
+            # large, then reduce it again, the widget *could* reduce in size. However,
+            # I can't find any way to prod GTK to perform a resize that will reduce
+            # it's minimum size. This is the reason the test probe has a
+            # `shrink_on_resize` property; if we can fix this resize issue,
+            # `shrink_on_resize` may not be necessary.
+            self.interface.intrinsic.width = at_least(
+                max(self.interface._MIN_WIDTH, width[1])
+            )
+            self.interface.intrinsic.height = height[1]

--- a/gtk/src/toga_gtk/widgets/slider.py
+++ b/gtk/src/toga_gtk/widgets/slider.py
@@ -21,25 +21,30 @@ class Slider(Widget, SliderImpl):
         self.adj = Gtk.Adjustment()
         self.native = Gtk.Scale.new(Gtk.Orientation.HORIZONTAL, self.adj)
 
-        self.native.connect(
-            "value-changed",
-            lambda native: self.interface.on_change(),
-        )
-        self.native.connect(
-            "button-press-event",
-            lambda native, event: self.interface.on_press(),
-        )
-        self.native.connect(
-            "button-release-event",
-            lambda native, event: self.interface.on_release(),
-        )
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            self.native.connect(
+                "value-changed",
+                lambda native: self.interface.on_change(),
+            )
+            self.native.connect(
+                "button-press-event",
+                lambda native, event: self.interface.on_press(),
+            )
+            self.native.connect(
+                "button-release-event",
+                lambda native, event: self.interface.on_release(),
+            )
 
-        # Despite what the set_digits documentation says, set_round_digits has no effect
-        # when set_draw_value is False, so we have to round the value manually. Disable
-        # automatic rounding anyway, in case this changes in the future.
-        self.native.set_round_digits(-1)
-        self.native.set_draw_value(False)
-        self.native.connect("change-value", self.gtk_change_value)
+            # Despite what the set_digits documentation says, set_round_digits has no
+            # effect when set_draw_value is False, so we have to round the value
+            # manually. Disable automatic rounding anyway, in case this changes in the
+            # future.
+            self.native.set_round_digits(-1)
+            self.native.set_draw_value(False)
+            self.native.connect("change-value", self.gtk_change_value)
+
+        else:  # pragma: no-cover-if-gtk3
+            pass
 
         # Dummy values used during initialization.
         self.tick_count = None

--- a/gtk/src/toga_gtk/widgets/slider.py
+++ b/gtk/src/toga_gtk/widgets/slider.py
@@ -95,3 +95,5 @@ class Slider(Widget, SliderImpl):
             self.interface.intrinsic.width = at_least(self.interface._MIN_WIDTH)
             # Set intrinsic height to the natural height
             self.interface.intrinsic.height = height[1]
+        else:  # pragma: no-cover-if-gtk3
+            pass

--- a/gtk/src/toga_gtk/widgets/slider.py
+++ b/gtk/src/toga_gtk/widgets/slider.py
@@ -2,7 +2,7 @@ from travertino.size import at_least
 
 from toga.widgets.slider import SliderImpl
 
-from ..libs import Gtk
+from ..libs import GTK_VERSION, Gtk
 from .base import Widget
 
 # Implementation notes
@@ -82,15 +82,16 @@ class Slider(Widget, SliderImpl):
         return self.tick_count
 
     def rehint(self):
-        # print(
-        #     "REHINT",
-        #     self,
-        #     self.native.get_preferred_width(),
-        #     self.native.get_preferred_height(),
-        # )
-        height = self.native.get_preferred_height()
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            # print(
+            #     "REHINT",
+            #     self,
+            #     self.native.get_preferred_width(),
+            #     self.native.get_preferred_height(),
+            # )
+            height = self.native.get_preferred_height()
 
-        # Set intrinsic width to at least the minimum width
-        self.interface.intrinsic.width = at_least(self.interface._MIN_WIDTH)
-        # Set intrinsic height to the natural height
-        self.interface.intrinsic.height = height[1]
+            # Set intrinsic width to at least the minimum width
+            self.interface.intrinsic.width = at_least(self.interface._MIN_WIDTH)
+            # Set intrinsic height to the natural height
+            self.interface.intrinsic.height = height[1]

--- a/gtk/src/toga_gtk/widgets/splitcontainer.py
+++ b/gtk/src/toga_gtk/widgets/splitcontainer.py
@@ -1,7 +1,7 @@
 from travertino.size import at_least
 
 from ..container import TogaContainer
-from ..libs import Gtk
+from ..libs import GTK_VERSION, Gtk
 from .base import Widget
 
 
@@ -97,5 +97,6 @@ class SplitContainer(Widget):
 
             min_width = max(min_width, self.interface._MIN_WIDTH) + SPLITTER_WIDTH
 
-        self.interface.intrinsic.width = at_least(min_width)
-        self.interface.intrinsic.height = at_least(min_height)
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            self.interface.intrinsic.width = at_least(min_width)
+            self.interface.intrinsic.height = at_least(min_height)

--- a/gtk/src/toga_gtk/widgets/splitcontainer.py
+++ b/gtk/src/toga_gtk/widgets/splitcontainer.py
@@ -100,3 +100,5 @@ class SplitContainer(Widget):
         if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             self.interface.intrinsic.width = at_least(min_width)
             self.interface.intrinsic.height = at_least(min_height)
+        else:  # pragma: no-cover-if-gtk3
+            pass

--- a/gtk/src/toga_gtk/widgets/splitcontainer.py
+++ b/gtk/src/toga_gtk/widgets/splitcontainer.py
@@ -11,8 +11,12 @@ class SplitContainer(Widget):
         self.native.set_wide_handle(True)
 
         self.sub_containers = [TogaContainer(), TogaContainer()]
-        self.native.pack1(self.sub_containers[0], True, False)
-        self.native.pack2(self.sub_containers[1], True, False)
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            self.native.pack1(self.sub_containers[0], True, False)
+            self.native.pack2(self.sub_containers[1], True, False)
+        else:  # pragma: no-cover-if-gtk3
+            self.native.set_start_child(self.sub_containers[0])
+            self.native.set_end_child(self.sub_containers[1])
 
         self._split_proportion = 0.5
 

--- a/gtk/src/toga_gtk/widgets/switch.py
+++ b/gtk/src/toga_gtk/widgets/switch.py
@@ -1,6 +1,6 @@
 from travertino.size import at_least
 
-from ..libs import Gtk, get_color_css, get_font_css
+from ..libs import GTK_VERSION, Gtk, get_color_css, get_font_css
 from .base import Widget
 
 
@@ -52,21 +52,22 @@ class Switch(Widget):
         self.apply_css("font", get_font_css(font), native=self.native_label)
 
     def rehint(self):
-        # print(
-        #     "REHINT",
-        #     self,
-        #     self.native.get_preferred_width(),
-        #     self.native.get_preferred_height(),
-        # )
-        label_width = self.native_label.get_preferred_width()
-        label_height = self.native_label.get_preferred_height()
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            # print(
+            #     "REHINT",
+            #     self,
+            #     self.native.get_preferred_width(),
+            #     self.native.get_preferred_height(),
+            # )
+            label_width = self.native_label.get_preferred_width()
+            label_height = self.native_label.get_preferred_height()
 
-        switch_width = self.native_switch.get_preferred_width()
-        switch_height = self.native_switch.get_preferred_height()
+            switch_width = self.native_switch.get_preferred_width()
+            switch_height = self.native_switch.get_preferred_height()
 
-        # Set intrinsic width to at least the minimum width
-        self.interface.intrinsic.width = at_least(
-            label_width[0] + self.SPACING + switch_width[0]
-        )
-        # Set intrinsic height to the natural height
-        self.interface.intrinsic.height = max(label_height[1], switch_height[1])
+            # Set intrinsic width to at least the minimum width
+            self.interface.intrinsic.width = at_least(
+                label_width[0] + self.SPACING + switch_width[0]
+            )
+            # Set intrinsic height to the natural height
+            self.interface.intrinsic.height = max(label_height[1], switch_height[1])

--- a/gtk/src/toga_gtk/widgets/switch.py
+++ b/gtk/src/toga_gtk/widgets/switch.py
@@ -11,17 +11,23 @@ class Switch(Widget):
         self.native = Gtk.Box(spacing=self.SPACING)
 
         self.native_label = Gtk.Label(xalign=0)
-        self.native_label.set_name(f"toga-{self.interface.id}-label")
-        self.native_label.get_style_context().add_class("toga")
-        self.native_label.set_line_wrap(False)
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            self.native_label.set_name(f"toga-{self.interface.id}-label")
+            self.native_label.get_style_context().add_class("toga")
+            self.native_label.set_line_wrap(False)
+        else:  # pragma: no-cover-if-gtk3
+            pass
 
         self.native_switch = Gtk.Switch()
-        self.native_switch.set_name(f"toga-{self.interface.id}-switch")
-        self.native_switch.get_style_context().add_class("toga")
-        self.native_switch.connect("notify::active", self.gtk_notify_active)
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            self.native_switch.set_name(f"toga-{self.interface.id}-switch")
+            self.native_switch.get_style_context().add_class("toga")
+            self.native_switch.connect("notify::active", self.gtk_notify_active)
 
-        self.native.pack_start(self.native_label, True, True, 0)
-        self.native.pack_start(self.native_switch, False, False, 0)
+            self.native.pack_start(self.native_label, True, True, 0)
+            self.native.pack_start(self.native_switch, False, False, 0)
+        else:  # pragma: no-cover-if-gtk3
+            pass
 
     def gtk_notify_active(self, widget, state):
         self.interface.on_change()

--- a/gtk/src/toga_gtk/widgets/switch.py
+++ b/gtk/src/toga_gtk/widgets/switch.py
@@ -71,3 +71,5 @@ class Switch(Widget):
             )
             # Set intrinsic height to the natural height
             self.interface.intrinsic.height = max(label_height[1], switch_height[1])
+        else:  # pragma: no-cover-if-gtk3
+            pass

--- a/gtk/src/toga_gtk/widgets/textinput.py
+++ b/gtk/src/toga_gtk/widgets/textinput.py
@@ -12,11 +12,11 @@ class TextInput(Widget):
         self.native = Gtk.Entry()
         self.native.connect("changed", self.gtk_on_change)
 
-        if GTK_VERSION < (4, 0, 0):
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             self.native.connect("focus-in-event", self.gtk_focus_in_event)
             self.native.connect("focus-out-event", self.gtk_focus_out_event)
             self.native.connect("key-press-event", self.gtk_key_press_event)
-        else:
+        else:  # pragma: no-cover-if-gtk3
             focus_controller = Gtk.EventControllerFocus()
             focus_controller.connect("enter", self.gtk_focus_in_event)
             focus_controller.connect("leave", self.gtk_focus_out_event)
@@ -28,15 +28,15 @@ class TextInput(Widget):
             self.native.add_controller(key_press_controller)
 
     def gtk_on_change(self, *_args):
-        if GTK_VERSION < (4, 0, 0):
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             self.interface._value_changed()
-        else:
+        else:  # pragma: no-cover-if-gtk3
             self.interface._value_changed(self.interface)
 
     def gtk_focus_in_event(self, *_args):
-        if GTK_VERSION < (4, 0, 0):
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             self.interface.on_gain_focus()
-        else:
+        else:  # pragma: no-cover-if-gtk3
             self.interface.on_gain_focus(self.interface)
 
     def gtk_focus_out_event(self, *_args):

--- a/gtk/src/toga_gtk/widgets/textinput.py
+++ b/gtk/src/toga_gtk/widgets/textinput.py
@@ -88,6 +88,8 @@ class TextInput(Widget):
                 max(self.interface._MIN_WIDTH, width[1])
             )
             self.interface.intrinsic.height = height[1]
+        else:  # pragma: no-cover-if-gtk3
+            pass
 
     def set_error(self, error_message):
         self.native.set_icon_from_icon_name(Gtk.EntryIconPosition.SECONDARY, "error")

--- a/gtk/src/toga_gtk/widgets/textinput.py
+++ b/gtk/src/toga_gtk/widgets/textinput.py
@@ -10,22 +10,14 @@ from .base import Widget
 class TextInput(Widget):
     def create(self):
         self.native = Gtk.Entry()
-        self.native.connect("changed", self.gtk_on_change)
 
         if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            self.native.connect("changed", self.gtk_on_change)
             self.native.connect("focus-in-event", self.gtk_focus_in_event)
             self.native.connect("focus-out-event", self.gtk_focus_out_event)
             self.native.connect("key-press-event", self.gtk_key_press_event)
         else:  # pragma: no-cover-if-gtk3
-            focus_controller = Gtk.EventControllerFocus()
-            focus_controller.connect("enter", self.gtk_focus_in_event)
-            focus_controller.connect("leave", self.gtk_focus_out_event)
-
-            key_press_controller = Gtk.EventControllerKey()
-            key_press_controller.connect("key-pressed", self.gtk_key_press_event)
-
-            self.native.add_controller(focus_controller)
-            self.native.add_controller(key_press_controller)
+            pass
 
     def gtk_on_change(self, *_args):
         if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4

--- a/gtk/src/toga_gtk/widgets/textinput.py
+++ b/gtk/src/toga_gtk/widgets/textinput.py
@@ -72,21 +72,22 @@ class TextInput(Widget):
         self.native.set_text(value)
 
     def rehint(self):
-        # print(
-        #     "REHINT",
-        #     self,
-        #     self._impl.get_preferred_width(),
-        #     self._impl.get_preferred_height(),
-        #     getattr(self, "_fixed_height", False),
-        #     getattr(self, "_fixed_width", False),
-        # )
-        width = self.native.get_preferred_width()
-        height = self.native.get_preferred_height()
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            # print(
+            #     "REHINT",
+            #     self,
+            #     self._impl.get_preferred_width(),
+            #     self._impl.get_preferred_height(),
+            #     getattr(self, "_fixed_height", False),
+            #     getattr(self, "_fixed_width", False),
+            # )
+            width = self.native.get_preferred_width()
+            height = self.native.get_preferred_height()
 
-        self.interface.intrinsic.width = at_least(
-            max(self.interface._MIN_WIDTH, width[1])
-        )
-        self.interface.intrinsic.height = height[1]
+            self.interface.intrinsic.width = at_least(
+                max(self.interface._MIN_WIDTH, width[1])
+            )
+            self.interface.intrinsic.height = height[1]
 
     def set_error(self, error_message):
         self.native.set_icon_from_icon_name(Gtk.EntryIconPosition.SECONDARY, "error")

--- a/gtk/src/toga_gtk/widgets/tree.py
+++ b/gtk/src/toga_gtk/widgets/tree.py
@@ -150,5 +150,6 @@ class Tree(Widget):
         self.change_source(self.interface.data)
 
     def rehint(self):
-        self.interface.intrinsic.width = at_least(self.interface._MIN_WIDTH)
-        self.interface.intrinsic.height = at_least(self.interface._MIN_HEIGHT)
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            self.interface.intrinsic.width = at_least(self.interface._MIN_WIDTH)
+            self.interface.intrinsic.height = at_least(self.interface._MIN_HEIGHT)

--- a/gtk/src/toga_gtk/widgets/tree.py
+++ b/gtk/src/toga_gtk/widgets/tree.py
@@ -23,6 +23,8 @@ class Tree(Widget):
             self.selection.connect("changed", self.gtk_on_select)
 
             self._create_columns()
+        else:  # pragma: no-cover-if-gtk3
+            pass
 
         self.native = Gtk.ScrolledWindow()
         if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
@@ -30,6 +32,8 @@ class Tree(Widget):
             self.native.add(self.native_tree)
             self.native.set_min_content_width(200)
             self.native.set_min_content_height(200)
+        else:  # pragma: no-cover-if-gtk3
+            pass
 
     def _create_columns(self):
         if self.interface.headings:
@@ -83,6 +87,8 @@ class Tree(Widget):
 
             self.native_tree.set_model(self.store)
             self.refresh()
+        else:  # pragma: no-cover-if-gtk3
+            pass
 
     def insert(self, parent, index, item):
         row = TogaRow(item)
@@ -153,3 +159,5 @@ class Tree(Widget):
         if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             self.interface.intrinsic.width = at_least(self.interface._MIN_WIDTH)
             self.interface.intrinsic.height = at_least(self.interface._MIN_HEIGHT)
+        else:  # pragma: no-cover-if-gtk3
+            pass

--- a/gtk/src/toga_gtk/widgets/tree.py
+++ b/gtk/src/toga_gtk/widgets/tree.py
@@ -1,6 +1,6 @@
 from travertino.size import at_least
 
-from ..libs import GdkPixbuf, Gtk
+from ..libs import GTK_VERSION, GdkPixbuf, Gtk
 from .base import Widget
 from .table import TogaRow
 
@@ -14,20 +14,22 @@ class Tree(Widget):
         self.native_tree = Gtk.TreeView(model=self.store)
         self.native_tree.connect("row-activated", self.gtk_on_row_activated)
 
-        self.selection = self.native_tree.get_selection()
-        if self.interface.multiple_select:
-            self.selection.set_mode(Gtk.SelectionMode.MULTIPLE)
-        else:
-            self.selection.set_mode(Gtk.SelectionMode.SINGLE)
-        self.selection.connect("changed", self.gtk_on_select)
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            self.selection = self.native_tree.get_selection()
+            if self.interface.multiple_select:
+                self.selection.set_mode(Gtk.SelectionMode.MULTIPLE)
+            else:
+                self.selection.set_mode(Gtk.SelectionMode.SINGLE)
+            self.selection.connect("changed", self.gtk_on_select)
 
-        self._create_columns()
+            self._create_columns()
 
         self.native = Gtk.ScrolledWindow()
-        self.native.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
-        self.native.add(self.native_tree)
-        self.native.set_min_content_width(200)
-        self.native.set_min_content_height(200)
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            self.native.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+            self.native.add(self.native_tree)
+            self.native.set_min_content_width(200)
+            self.native.set_min_content_height(200)
 
     def _create_columns(self):
         if self.interface.headings:
@@ -62,24 +64,25 @@ class Tree(Widget):
         self.interface.on_activate(node=node)
 
     def change_source(self, source):
-        # Temporarily disconnecting the TreeStore improves performance for large
-        # updates by deferring row rendering until the update is complete.
-        self.native_tree.set_model(None)
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            # Temporarily disconnecting the TreeStore improves performance for large
+            # updates by deferring row rendering until the update is complete.
+            self.native_tree.set_model(None)
 
-        for column in self.native_tree.get_columns():
-            self.native_tree.remove_column(column)
-        self._create_columns()
+            for column in self.native_tree.get_columns():
+                self.native_tree.remove_column(column)
+            self._create_columns()
 
-        types = [TogaRow]
-        for accessor in self.interface._accessors:
-            types.extend([GdkPixbuf.Pixbuf, str])
-        self.store = Gtk.TreeStore(*types)
+            types = [TogaRow]
+            for accessor in self.interface._accessors:
+                types.extend([GdkPixbuf.Pixbuf, str])
+            self.store = Gtk.TreeStore(*types)
 
-        for i, row in enumerate(self.interface.data):
-            self.insert(None, i, row)
+            for i, row in enumerate(self.interface.data):
+                self.insert(None, i, row)
 
-        self.native_tree.set_model(self.store)
-        self.refresh()
+            self.native_tree.set_model(self.store)
+            self.refresh()
 
     def insert(self, parent, index, item):
         row = TogaRow(item)

--- a/gtk/src/toga_gtk/widgets/webview.py
+++ b/gtk/src/toga_gtk/widgets/webview.py
@@ -4,7 +4,7 @@ from travertino.size import at_least
 
 from toga.widgets.webview import CookiesResult, JavaScriptResult
 
-from ..libs import GLib, WebKit2
+from ..libs import GTK_VERSION, GLib, WebKit2
 from .base import Widget
 
 
@@ -125,5 +125,6 @@ class WebView(Widget):
         return result
 
     def rehint(self):
-        self.interface.intrinsic.width = at_least(self.interface._MIN_WIDTH)
-        self.interface.intrinsic.height = at_least(self.interface._MIN_HEIGHT)
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            self.interface.intrinsic.width = at_least(self.interface._MIN_WIDTH)
+            self.interface.intrinsic.height = at_least(self.interface._MIN_HEIGHT)

--- a/gtk/src/toga_gtk/widgets/webview.py
+++ b/gtk/src/toga_gtk/widgets/webview.py
@@ -128,3 +128,5 @@ class WebView(Widget):
         if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             self.interface.intrinsic.width = at_least(self.interface._MIN_WIDTH)
             self.interface.intrinsic.height = at_least(self.interface._MIN_HEIGHT)
+        else:  # pragma: no-cover-if-gtk3
+            pass

--- a/gtk/src/toga_gtk/widgets/webview.py
+++ b/gtk/src/toga_gtk/widgets/webview.py
@@ -12,6 +12,9 @@ class WebView(Widget):
     """GTK WebView implementation."""
 
     def create(self):
+        if GTK_VERSION >= (4, 0, 0):  # pragma: no-cover-if-gtk3
+            raise RuntimeError("WebView isn't supported on GTK4 (yet!)")
+
         if WebKit2 is None:  # pragma: no cover
             raise RuntimeError(
                 "Unable to import WebKit2. Ensure that the system package providing "

--- a/gtk/src/toga_gtk/window.py
+++ b/gtk/src/toga_gtk/window.py
@@ -96,12 +96,13 @@ class Window:
     def gtk_window_state_event(self, widget, event):
         if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             previous_window_state_flags = self._window_state_flags
+            previous_state = self.get_window_state()
             # Get the window state flags
             self._window_state_flags = event.new_window_state
         else:  # pragma: no-cover-if-gtk3
             previous_window_state_flags = None
+            previous_state = self.get_window_state()
             self._window_state_flags = None
-        previous_state = self.get_window_state()
         current_state = self.get_window_state()
 
         # Window state flags are unreliable when window is hidden,

--- a/gtk/src/toga_gtk/window.py
+++ b/gtk/src/toga_gtk/window.py
@@ -26,21 +26,21 @@ class Window:
         self.create()
         self.native._impl = self
 
-        if GTK_VERSION < (4, 0, 0):
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             self._delete_handler = self.native.connect(
                 "delete-event",
                 self.gtk_delete_event,
             )
-        else:
+        else:  # pragma: no-cover-if-gtk3
             self._delete_handler = self.native.connect(
                 "close-request", self.gtk_delete_event
             )
 
         self.native.connect("show", self.gtk_show)
         self.native.connect("hide", self.gtk_hide)
-        if GTK_VERSION < (4, 0, 0):
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             self.native.connect("window-state-event", self.gtk_window_state_event)
-        else:
+        else:  # pragma: no-cover-if-gtk3
             self.native.connect("notify::fullscreened", self.gtk_window_state_event)
             self.native.connect("notify::maximized", self.gtk_window_state_event)
             self.native.connect("notify::minimized", self.gtk_window_state_event)
@@ -72,10 +72,10 @@ class Window:
         # Because expand and fill are True, the container will fill the available
         # space, and will get a size_allocate callback if the window is resized.
         self.container = TogaContainer()
-        if GTK_VERSION < (4, 0, 0):
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             self.layout.pack_end(self.container, expand=True, fill=True, padding=0)
             self.native.add(self.layout)
-        else:
+        else:  # pragma: no-cover-if-gtk3
             self.container.set_valign(Gtk.Align.FILL)
             self.container.set_vexpand(True)
             self.layout.append(self.container)
@@ -94,7 +94,7 @@ class Window:
         self.interface.on_hide()
 
     def gtk_window_state_event(self, widget, event):
-        if GTK_VERSION < (4, 0, 0):
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             previous_window_state_flags = self._window_state_flags
             previous_state = self.get_window_state()
             # Get the window state flags
@@ -196,15 +196,15 @@ class Window:
 
     def set_app(self, app):
         app.native.add_window(self.native)
-        if GTK_VERSION < (4, 0, 0):
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             self.native.set_icon(app.interface.icon._impl.native(72))
-        else:
+        else:  # pragma: no-cover-if-gtk3
             self.interface.factory.not_implemented("Window.set_app() icon")
 
     def show(self):
-        if GTK_VERSION < (4, 0, 0):
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             self.native.show_all()
-        else:
+        else:  # pragma: no-cover-if-gtk3
             self.native.present()
 
     ######################################################################
@@ -220,18 +220,18 @@ class Window:
     ######################################################################
 
     def get_size(self) -> Size:
-        if GTK_VERSION < (4, 0, 0):
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             width, height = self.native.get_default_size()
             size = self.native.get_size()
             return Size(size.width, size.height)
-        else:
+        else:  # pragma: no-cover-if-gtk3
             width, height = self.native.get_default_size()
             return Size(width, height)
 
     def set_size(self, size: SizeT):
-        if GTK_VERSION < (4, 0, 0):
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             self.native.resize(size[0], size[1])
-        else:
+        else:  # pragma: no-cover-if-gtk3
             self.native.set_default_size(size[0], size[1])
 
     ######################################################################
@@ -239,26 +239,26 @@ class Window:
     ######################################################################
 
     def get_current_screen(self):
-        if GTK_VERSION < (4, 0, 0):
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             display = Gdk.Display.get_default()
             monitor_native = display.get_monitor_at_window(self.native.get_window())
-        else:
+        else:  # pragma: no-cover-if-gtk3
             monitor_native = self.native.props.display
         return ScreenImpl(monitor_native)
 
     def get_position(self) -> Position:
-        if GTK_VERSION < (4, 0, 0):
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             pos = self.native.get_position()
             return Position(pos.root_x, pos.root_y)
-        else:
+        else:  # pragma: no-cover-if-gtk3
             # GTK4 no longer has an API to get position
             # since it isn't supported by Wayland
             return Position(0, 0)
 
     def set_position(self, position: PositionT):
-        if GTK_VERSION < (4, 0, 0):
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             self.native.move(position[0], position[1])
-        else:
+        else:  # pragma: no-cover-if-gtk3
             # GTK4 no longer has an API to set position
             # since it isn't supported by Wayland
             pass
@@ -271,9 +271,9 @@ class Window:
         return self.native.get_property("visible")
 
     def hide(self):
-        if GTK_VERSION < (4, 0, 0):
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             self.native.hide()
-        else:
+        else:  # pragma: no-cover-if-gtk3
             self.native.set_visible(False)
 
     ######################################################################
@@ -283,7 +283,7 @@ class Window:
     def get_window_state(self, in_progress_state=False):
         if in_progress_state and self._pending_state_transition:
             return self._pending_state_transition
-        if GTK_VERSION < (4, 0, 0):
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             window_state_flags = self._window_state_flags
             if window_state_flags:  # pragma: no branch
                 if window_state_flags & Gdk.WindowState.MAXIMIZED:
@@ -296,7 +296,7 @@ class Window:
                         if self._in_presentation
                         else WindowState.FULLSCREEN
                     )
-        else:
+        else:  # pragma: no-cover-if-gtk3
             if self.native.is_maximized():
                 return WindowState.MAXIMIZED
             if GTK_VERSION >= (4, 12) and self.native.is_suspended():
@@ -352,9 +352,9 @@ class Window:
             self.native.maximize()
 
         elif target_state == WindowState.MINIMIZED:  # pragma: no-cover-if-linux-wayland
-            if GTK_VERSION < (4, 0, 0):
+            if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
                 self.native.iconify()
-            else:
+            else:  # pragma: no-cover-if-gtk3
                 self.native.minimize()
 
         elif target_state == WindowState.FULLSCREEN:
@@ -397,7 +397,7 @@ class Window:
     ######################################################################
 
     def get_image_data(self):
-        if GTK_VERSION < (4, 0, 0):
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             display = self.native.get_display()
             display.flush()
 
@@ -426,14 +426,14 @@ class Window:
                 # This shouldn't ever happen, and it's difficult to manufacture
                 # in test conditions
                 raise ValueError(f"Unable to generate screenshot of {self}")
-        else:
+        else:  # pragma: no-cover-if-gtk3
             self.interface.factory.not_implemented("Window.get_image_data()")
 
 
 class MainWindow(Window):
     def create(self):
         self.native = Gtk.ApplicationWindow()
-        if GTK_VERSION < (4, 0, 0):
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             self.native.set_role("MainWindow")
 
             self.native_toolbar = Gtk.Toolbar()
@@ -446,7 +446,7 @@ class MainWindow(Window):
         pass
 
     def create_toolbar(self):
-        if GTK_VERSION < (4, 0, 0):
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             # If there's an existing toolbar, hide it until we know we need it.
             self.layout.remove(self.native_toolbar)
 
@@ -504,6 +504,6 @@ class MainWindow(Window):
                     padding=0,
                 )
                 self.native_toolbar.show_all()
-        else:
+        else:  # pragma: no-cover-if-gtk3
             # TODO: Implement toolbar commands in HeaderBar with #1931
             pass

--- a/gtk/src/toga_gtk/window.py
+++ b/gtk/src/toga_gtk/window.py
@@ -98,7 +98,7 @@ class Window:
             previous_window_state_flags = self._window_state_flags
             # Get the window state flags
             self._window_state_flags = event.new_window_state
-        else:
+        else:  # pragma: no-cover-if-gtk3
             previous_window_state_flags = None
             self._window_state_flags = None
         previous_state = self.get_window_state()
@@ -119,6 +119,8 @@ class Window:
                     if previous_window_state_flags & flag:
                         self._window_state_flags |= flag
                         break
+        else:  # pragma: no-cover-if-gtk3
+            pass
 
         # Trigger the appropriate visibility events
         # Wayland doesn't allow for the detection of MINIMIZED, so the
@@ -444,6 +446,8 @@ class MainWindow(Window):
             self.native_toolbar.set_style(Gtk.ToolbarStyle.BOTH)
             self.toolbar_items = {}
             self.toolbar_separators = set()
+        else:  # pragma: no-cover-if-gtk3
+            pass
 
     def create_menus(self):
         # GTK menus are handled at the app level

--- a/gtk/src/toga_gtk/window.py
+++ b/gtk/src/toga_gtk/window.py
@@ -290,23 +290,27 @@ class Window:
     def get_window_state(self, in_progress_state=False):
         if in_progress_state and self._pending_state_transition:
             return self._pending_state_transition
+
         if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
-            window_state_flags = self._window_state_flags
-            if window_state_flags:  # pragma: no branch
-                if window_state_flags & Gdk.WindowState.MAXIMIZED:
-                    return WindowState.MAXIMIZED
-                elif window_state_flags & Gdk.WindowState.ICONIFIED:
-                    return WindowState.MINIMIZED  # pragma: no-cover-if-linux-wayland
-                elif window_state_flags & Gdk.WindowState.FULLSCREEN:
-                    return (
-                        WindowState.PRESENTATION
-                        if self._in_presentation
-                        else WindowState.FULLSCREEN
-                    )
+            if not self._window_state_flags:
+                return WindowState.NORMAL
+
+            flags = self._window_state_flags
+            if flags & Gdk.WindowState.MAXIMIZED:
+                return WindowState.MAXIMIZED
+            elif flags & Gdk.WindowState.ICONIFIED:
+                return WindowState.MINIMIZED  # pragma: no-cover-if-linux-wayland
+            elif flags & Gdk.WindowState.FULLSCREEN:
+                return (
+                    WindowState.PRESENTATION
+                    if self._in_presentation
+                    else WindowState.FULLSCREEN
+                )
+
         else:  # pragma: no-cover-if-gtk3
             if self.native.is_maximized():
                 return WindowState.MAXIMIZED
-            if GTK_VERSION >= (4, 12) and self.native.is_suspended():
+            elif GTK_VERSION >= (4, 12) and self.native.is_suspended():
                 return WindowState.MINIMIZED
             elif self.native.is_fullscreen():
                 return (
@@ -314,6 +318,7 @@ class Window:
                     if self._in_presentation
                     else WindowState.FULLSCREEN
                 )
+
         return WindowState.NORMAL
 
     def set_window_state(self, state):

--- a/gtk/src/toga_gtk/window.py
+++ b/gtk/src/toga_gtk/window.py
@@ -9,7 +9,7 @@ from toga.types import Position, Size
 from toga.window import _initial_position
 
 from .container import TogaContainer
-from .libs import IS_WAYLAND, Gdk, GLib, Gtk
+from .libs import GTK_VERSION, IS_WAYLAND, Gdk, GLib, Gtk
 from .screens import Screen as ScreenImpl
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -26,13 +26,24 @@ class Window:
         self.create()
         self.native._impl = self
 
-        self._delete_handler = self.native.connect(
-            "delete-event",
-            self.gtk_delete_event,
-        )
+        if GTK_VERSION < (4, 0, 0):
+            self._delete_handler = self.native.connect(
+                "delete-event",
+                self.gtk_delete_event,
+            )
+        else:
+            self._delete_handler = self.native.connect(
+                "close-request", self.gtk_delete_event
+            )
+
         self.native.connect("show", self.gtk_show)
         self.native.connect("hide", self.gtk_hide)
-        self.native.connect("window-state-event", self.gtk_window_state_event)
+        if GTK_VERSION < (4, 0, 0):
+            self.native.connect("window-state-event", self.gtk_window_state_event)
+        else:
+            self.native.connect("notify::fullscreened", self.gtk_window_state_event)
+            self.native.connect("notify::maximized", self.gtk_window_state_event)
+            self.native.connect("notify::minimized", self.gtk_window_state_event)
         self.native.connect("focus-in-event", self.gtk_focus_in_event)
         self.native.connect("focus-out-event", self.gtk_focus_out_event)
 
@@ -61,9 +72,14 @@ class Window:
         # Because expand and fill are True, the container will fill the available
         # space, and will get a size_allocate callback if the window is resized.
         self.container = TogaContainer()
-        self.layout.pack_end(self.container, expand=True, fill=True, padding=0)
-
-        self.native.add(self.layout)
+        if GTK_VERSION < (4, 0, 0):
+            self.layout.pack_end(self.container, expand=True, fill=True, padding=0)
+            self.native.add(self.layout)
+        else:
+            self.container.set_valign(Gtk.Align.FILL)
+            self.container.set_vexpand(True)
+            self.layout.append(self.container)
+            self.native.set_child(self.layout)
 
     def create(self):
         self.native = Gtk.Window()
@@ -78,11 +94,12 @@ class Window:
         self.interface.on_hide()
 
     def gtk_window_state_event(self, widget, event):
-        previous_window_state_flags = self._window_state_flags
-        previous_state = self.get_window_state()
-        # Get the window state flags
-        self._window_state_flags = event.new_window_state
-        current_state = self.get_window_state()
+        if GTK_VERSION < (4, 0, 0):
+            previous_window_state_flags = self._window_state_flags
+            previous_state = self.get_window_state()
+            # Get the window state flags
+            self._window_state_flags = event.new_window_state
+            current_state = self.get_window_state()
 
         # Window state flags are unreliable when window is hidden,
         # so cache the previous window state flag on to the new
@@ -144,7 +161,7 @@ class Window:
                 else:  # pragma: no-cover-if-linux-wayland
                     self._apply_state(self._pending_state_transition)
 
-    def gtk_delete_event(self, widget, data):
+    def gtk_delete_event(self, *_):
         # Return value of the GTK on_close handler indicates whether the event has been
         # fully handled. Returning True indicates the event has been handled, so further
         # handling (including actually closing the window) shouldn't be performed. This
@@ -179,10 +196,16 @@ class Window:
 
     def set_app(self, app):
         app.native.add_window(self.native)
-        self.native.set_icon(app.interface.icon._impl.native(72))
+        if GTK_VERSION < (4, 0, 0):
+            self.native.set_icon(app.interface.icon._impl.native(72))
+        else:
+            self.interface.factory.not_implemented("Window.set_app() icon")
 
     def show(self):
-        self.native.show_all()
+        if GTK_VERSION < (4, 0, 0):
+            self.native.show_all()
+        else:
+            self.native.present()
 
     ######################################################################
     # Window content and resources
@@ -197,27 +220,48 @@ class Window:
     ######################################################################
 
     def get_size(self) -> Size:
-        size = self.native.get_size()
-        return Size(size.width, size.height)
+        if GTK_VERSION < (4, 0, 0):
+            width, height = self.native.get_default_size()
+            size = self.native.get_size()
+            return Size(size.width, size.height)
+        else:
+            width, height = self.native.get_default_size()
+            return Size(width, height)
 
     def set_size(self, size: SizeT):
-        self.native.resize(size[0], size[1])
+        if GTK_VERSION < (4, 0, 0):
+            self.native.resize(size[0], size[1])
+        else:
+            self.native.set_default_size(size[0], size[1])
 
     ######################################################################
     # Window position
     ######################################################################
 
     def get_current_screen(self):
-        display = Gdk.Display.get_default()
-        monitor_native = display.get_monitor_at_window(self.native.get_window())
+        if GTK_VERSION < (4, 0, 0):
+            display = Gdk.Display.get_default()
+            monitor_native = display.get_monitor_at_window(self.native.get_window())
+        else:
+            monitor_native = self.native.props.display
         return ScreenImpl(monitor_native)
 
     def get_position(self) -> Position:
-        pos = self.native.get_position()
-        return Position(pos.root_x, pos.root_y)
+        if GTK_VERSION < (4, 0, 0):
+            pos = self.native.get_position()
+            return Position(pos.root_x, pos.root_y)
+        else:
+            # GTK4 no longer has an API to get position
+            # since it isn't supported by Wayland
+            return Position(0, 0)
 
     def set_position(self, position: PositionT):
-        self.native.move(position[0], position[1])
+        if GTK_VERSION < (4, 0, 0):
+            self.native.move(position[0], position[1])
+        else:
+            # GTK4 no longer has an API to set position
+            # since it isn't supported by Wayland
+            pass
 
     ######################################################################
     # Window visibility
@@ -227,7 +271,10 @@ class Window:
         return self.native.get_property("visible")
 
     def hide(self):
-        self.native.hide()
+        if GTK_VERSION < (4, 0, 0):
+            self.native.hide()
+        else:
+            self.native.set_visible(False)
 
     ######################################################################
     # Window state
@@ -236,13 +283,25 @@ class Window:
     def get_window_state(self, in_progress_state=False):
         if in_progress_state and self._pending_state_transition:
             return self._pending_state_transition
-        window_state_flags = self._window_state_flags
-        if window_state_flags:  # pragma: no branch
-            if window_state_flags & Gdk.WindowState.MAXIMIZED:
+        if GTK_VERSION < (4, 0, 0):
+            window_state_flags = self._window_state_flags
+            if window_state_flags:  # pragma: no branch
+                if window_state_flags & Gdk.WindowState.MAXIMIZED:
+                    return WindowState.MAXIMIZED
+                elif window_state_flags & Gdk.WindowState.ICONIFIED:
+                    return WindowState.MINIMIZED  # pragma: no-cover-if-linux-wayland
+                elif window_state_flags & Gdk.WindowState.FULLSCREEN:
+                    return (
+                        WindowState.PRESENTATION
+                        if self._in_presentation
+                        else WindowState.FULLSCREEN
+                    )
+        else:
+            if self.native.is_maximized():
                 return WindowState.MAXIMIZED
-            elif window_state_flags & Gdk.WindowState.ICONIFIED:
-                return WindowState.MINIMIZED  # pragma: no-cover-if-linux-wayland
-            elif window_state_flags & Gdk.WindowState.FULLSCREEN:
+            if GTK_VERSION >= (4, 12) and self.native.is_suspended():
+                return WindowState.MINIMIZED
+            elif self.native.is_fullscreen():
                 return (
                     WindowState.PRESENTATION
                     if self._in_presentation
@@ -293,7 +352,10 @@ class Window:
             self.native.maximize()
 
         elif target_state == WindowState.MINIMIZED:  # pragma: no-cover-if-linux-wayland
-            self.native.iconify()
+            if GTK_VERSION < (4, 0, 0):
+                self.native.iconify()
+            else:
+                self.native.minimize()
 
         elif target_state == WindowState.FULLSCREEN:
             self.native.fullscreen()
@@ -335,105 +397,113 @@ class Window:
     ######################################################################
 
     def get_image_data(self):
-        display = self.native.get_display()
-        display.flush()
+        if GTK_VERSION < (4, 0, 0):
+            display = self.native.get_display()
+            display.flush()
 
-        # For some reason, converting the *window* to a pixbuf fails. But if you extract
-        # a *part* of the overall screen, that works. So - work out the origin of the
-        # window, then the allocation for the container relative to that window, and
-        # capture that rectangle.
-        window = self.native.get_window()
-        origin = window.get_origin()
-        allocation = self.container.get_allocation()
+            # For some reason, converting the *window* to a pixbuf fails. But if you
+            # extract a *part* of the overall screen, that works. So - work out the
+            # origin of the window, then the allocation for the container relative to
+            # that window, and capture that rectangle.
+            window = self.native.get_window()
+            origin = window.get_origin()
+            allocation = self.container.get_allocation()
 
-        screen = display.get_default_screen()
-        root_window = screen.get_root_window()
-        screenshot = Gdk.pixbuf_get_from_window(
-            root_window,
-            origin.x + allocation.x,
-            origin.y + allocation.y,
-            allocation.width,
-            allocation.height,
-        )
+            screen = display.get_default_screen()
+            root_window = screen.get_root_window()
+            screenshot = Gdk.pixbuf_get_from_window(
+                root_window,
+                origin.x + allocation.x,
+                origin.y + allocation.y,
+                allocation.width,
+                allocation.height,
+            )
 
-        success, buffer = screenshot.save_to_bufferv("png")
-        if success:
-            return buffer
-        else:  # pragma: nocover
-            # This shouldn't ever happen, and it's difficult to manufacture
-            # in test conditions
-            raise ValueError(f"Unable to generate screenshot of {self}")
+            success, buffer = screenshot.save_to_bufferv("png")
+            if success:
+                return buffer
+            else:  # pragma: nocover
+                # This shouldn't ever happen, and it's difficult to manufacture
+                # in test conditions
+                raise ValueError(f"Unable to generate screenshot of {self}")
+        else:
+            self.interface.factory.not_implemented("Window.get_image_data()")
 
 
 class MainWindow(Window):
     def create(self):
         self.native = Gtk.ApplicationWindow()
-        self.native.set_role("MainWindow")
+        if GTK_VERSION < (4, 0, 0):
+            self.native.set_role("MainWindow")
 
-        self.native_toolbar = Gtk.Toolbar()
-        self.native_toolbar.set_style(Gtk.ToolbarStyle.BOTH)
-        self.toolbar_items = {}
-        self.toolbar_separators = set()
+            self.native_toolbar = Gtk.Toolbar()
+            self.native_toolbar.set_style(Gtk.ToolbarStyle.BOTH)
+            self.toolbar_items = {}
+            self.toolbar_separators = set()
 
     def create_menus(self):
         # GTK menus are handled at the app level
         pass
 
     def create_toolbar(self):
-        # If there's an existing toolbar, hide it until we know we need it.
-        self.layout.remove(self.native_toolbar)
+        if GTK_VERSION < (4, 0, 0):
+            # If there's an existing toolbar, hide it until we know we need it.
+            self.layout.remove(self.native_toolbar)
 
-        # Deregister any toolbar buttons from their commands, and remove them
-        # from the toolbar
-        for cmd, item_impl in self.toolbar_items.items():
-            self.native_toolbar.remove(item_impl)
-            cmd._impl.native.remove(item_impl)
+            # Deregister any toolbar buttons from their commands, and remove them
+            # from the toolbar
+            for cmd, item_impl in self.toolbar_items.items():
+                self.native_toolbar.remove(item_impl)
+                cmd._impl.native.remove(item_impl)
 
-        # Remove any toolbar separators
-        for sep in self.toolbar_separators:
-            self.native_toolbar.remove(sep)
+            # Remove any toolbar separators
+            for sep in self.toolbar_separators:
+                self.native_toolbar.remove(sep)
 
-        # Create the new toolbar items
-        self.toolbar_items = {}
-        self.toolbar_separators = set()
-        prev_group = None
-        for cmd in self.interface.toolbar:
-            if isinstance(cmd, Separator):
-                item_impl = Gtk.SeparatorToolItem()
-                item_impl.set_draw(False)
-                self.toolbar_separators.add(item_impl)
-                prev_group = None
-            else:
-                # A change in group requires adding a toolbar separator
-                if prev_group is not None and prev_group != cmd.group:
-                    group_sep = Gtk.SeparatorToolItem()
-                    group_sep.set_draw(True)
-                    self.toolbar_separators.add(group_sep)
-                    self.native_toolbar.insert(group_sep, -1)
+            # Create the new toolbar items
+            self.toolbar_items = {}
+            self.toolbar_separators = set()
+            prev_group = None
+            for cmd in self.interface.toolbar:
+                if isinstance(cmd, Separator):
+                    item_impl = Gtk.SeparatorToolItem()
+                    item_impl.set_draw(False)
+                    self.toolbar_separators.add(item_impl)
                     prev_group = None
                 else:
-                    prev_group = cmd.group
+                    # A change in group requires adding a toolbar separator
+                    if prev_group is not None and prev_group != cmd.group:
+                        group_sep = Gtk.SeparatorToolItem()
+                        group_sep.set_draw(True)
+                        self.toolbar_separators.add(group_sep)
+                        self.native_toolbar.insert(group_sep, -1)
+                        prev_group = None
+                    else:
+                        prev_group = cmd.group
 
-                item_impl = Gtk.ToolButton()
-                if cmd.icon:
-                    item_impl.set_icon_widget(
-                        Gtk.Image.new_from_pixbuf(cmd.icon._impl.native(32))
-                    )
-                item_impl.set_label(cmd.text)
-                if cmd.tooltip:
-                    item_impl.set_tooltip_text(cmd.tooltip)
-                item_impl.connect("clicked", cmd._impl.gtk_clicked)
-                cmd._impl.native.append(item_impl)
-                self.toolbar_items[cmd] = item_impl
+                    item_impl = Gtk.ToolButton()
+                    if cmd.icon:
+                        item_impl.set_icon_widget(
+                            Gtk.Image.new_from_pixbuf(cmd.icon._impl.native(32))
+                        )
+                    item_impl.set_label(cmd.text)
+                    if cmd.tooltip:
+                        item_impl.set_tooltip_text(cmd.tooltip)
+                    item_impl.connect("clicked", cmd._impl.gtk_clicked)
+                    cmd._impl.native.append(item_impl)
+                    self.toolbar_items[cmd] = item_impl
 
-            self.native_toolbar.insert(item_impl, -1)
+                self.native_toolbar.insert(item_impl, -1)
 
-        if self.toolbar_items:
-            # We have toolbar items; add the toolbar to the top of the layout.
-            self.layout.pack_start(
-                self.native_toolbar,
-                expand=False,
-                fill=False,
-                padding=0,
-            )
-            self.native_toolbar.show_all()
+            if self.toolbar_items:
+                # We have toolbar items; add the toolbar to the top of the layout.
+                self.layout.pack_start(
+                    self.native_toolbar,
+                    expand=False,
+                    fill=False,
+                    padding=0,
+                )
+                self.native_toolbar.show_all()
+        else:
+            # TODO: Implement toolbar commands in HeaderBar with #1931
+            pass

--- a/gtk/tests_backend/app.py
+++ b/gtk/tests_backend/app.py
@@ -17,6 +17,10 @@ class AppProbe(BaseProbe, DialogsMixin):
     supports_key_mod3 = True
     # Gtk 3.24.41 ships with Ubuntu 24.04 where present() works on Wayland
     supports_current_window_assignment = not (IS_WAYLAND and GTK_VERSION < (3, 24, 41))
+    if GTK_VERSION < (4, 0, 0):
+        supports_save_dialog = True
+    else:
+        supports_save_dialog = False
 
     def __init__(self, app):
         super().__init__()
@@ -65,6 +69,8 @@ class AppProbe(BaseProbe, DialogsMixin):
                 assert mid_color == (149, 119, 73, 255)
 
     def assert_dialog_in_focus(self, dialog):
+        if GTK_VERSION >= (4, 0, 0):
+            pytest.skip("GTK4 doesn't support dialogs")
         # Gtk.Dialog's methods - is_active(), has_focus() both return False, even
         # when the dialog is in focus. Hence, they cannot be used to determine focus.
         assert dialog._impl.native.is_visible(), "The dialog is not in focus"
@@ -112,16 +118,24 @@ class AppProbe(BaseProbe, DialogsMixin):
         return item, action
 
     def _activate_menu_item(self, path):
+        if GTK_VERSION >= (4, 0, 0):
+            pytest.skip("GTK4 doesn't support system menus")
         _, action = self._menu_item(path)
         action.emit("activate", None)
 
     def activate_menu_exit(self):
+        if GTK_VERSION >= (4, 0, 0):
+            pytest.skip("GTK4 doesn't support system menus")
         self._activate_menu_item(["*", "Quit"])
 
     def activate_menu_about(self):
+        if GTK_VERSION >= (4, 0, 0):
+            pytest.skip("GTK4 doesn't support system menus")
         self._activate_menu_item(["Help", "About Toga Testbed"])
 
     async def close_about_dialog(self):
+        if GTK_VERSION >= (4, 0, 0):
+            pytest.skip("GTK4 doesn't support system menus")
         self.app._impl._close_about(self.app._impl.native_about_dialog)
 
     def activate_menu_visit_homepage(self):
@@ -129,6 +143,8 @@ class AppProbe(BaseProbe, DialogsMixin):
         pytest.xfail("GTK doesn't have a visit homepage menu item")
 
     def assert_system_menus(self):
+        if GTK_VERSION >= (4, 0, 0):
+            pytest.skip("GTK4 doesn't support system menus")
         self.assert_menu_item(["*", "Preferences"], enabled=False)
         self.assert_menu_item(["*", "Quit"], enabled=True)
 
@@ -152,10 +168,14 @@ class AppProbe(BaseProbe, DialogsMixin):
         pytest.xfail("GTK doesn't have a window management menu items")
 
     def assert_menu_item(self, path, enabled):
+        if GTK_VERSION >= (4, 0, 0):
+            pytest.skip("GTK4 doesn't support menu items")
         _, action = self._menu_item(path)
         assert action.get_enabled() == enabled
 
     def assert_menu_order(self, path, expected):
+        if GTK_VERSION >= (4, 0, 0):
+            pytest.skip("GTK4 doesn't support menu items")
         item, action = self._menu_item(path)
         menu = item[0].get_item_link(item[1], "submenu")
 
@@ -181,6 +201,8 @@ class AppProbe(BaseProbe, DialogsMixin):
         assert actual == expected
 
     def keystroke(self, combination):
+        if GTK_VERSION >= (4, 0, 0):
+            pytest.skip("GTK4 doesn't support keystroke")
         accel = gtk_accel(combination)
         state = 0
 
@@ -226,9 +248,13 @@ class AppProbe(BaseProbe, DialogsMixin):
         pytest.xfail("GTK doesn't support opening documents by drag")
 
     def has_status_icon(self, status_icon):
+        if GTK_VERSION >= (4, 0, 0):
+            pytest.skip("GTK4 doesn't support status icons")
         return status_icon._impl.native is not None
 
     def status_menu_items(self, status_icon):
+        if GTK_VERSION >= (4, 0, 0):
+            pytest.skip("GTK4 doesn't support status menu items")
         menu = status_icon._impl.native.get_primary_menu()
         if menu:
             return [
@@ -244,9 +270,13 @@ class AppProbe(BaseProbe, DialogsMixin):
             return None
 
     def activate_status_icon_button(self, item_id):
+        if GTK_VERSION >= (4, 0, 0):
+            pytest.skip("GTK4 doesn't support status icons")
         self.app.status_icons[item_id]._impl.native.emit("activate", 0, 0)
 
     def activate_status_menu_item(self, item_id, title):
+        if GTK_VERSION >= (4, 0, 0):
+            pytest.skip("GTK4 doesn't support status menu items")
         menu = self.app.status_icons[item_id]._impl.native.get_primary_menu()
         item = {child.get_label(): child for child in menu.get_children()}[title]
 

--- a/gtk/tests_backend/app.py
+++ b/gtk/tests_backend/app.py
@@ -6,7 +6,7 @@ import pytest
 
 import toga
 from toga_gtk.keys import gtk_accel, toga_key
-from toga_gtk.libs import IS_WAYLAND, Gdk, Gtk
+from toga_gtk.libs import GTK_VERSION, IS_WAYLAND, Gdk, Gtk
 
 from .dialogs import DialogsMixin
 from .probe import BaseProbe
@@ -16,9 +16,7 @@ class AppProbe(BaseProbe, DialogsMixin):
     supports_key = True
     supports_key_mod3 = True
     # Gtk 3.24.41 ships with Ubuntu 24.04 where present() works on Wayland
-    supports_current_window_assignment = not (
-        IS_WAYLAND and BaseProbe.GTK_VERSION < (3, 24, 41)
-    )
+    supports_current_window_assignment = not (IS_WAYLAND and GTK_VERSION < (3, 24, 41))
 
     def __init__(self, app):
         super().__init__()
@@ -47,6 +45,8 @@ class AppProbe(BaseProbe, DialogsMixin):
         pytest.skip("Cursor visibility not implemented on GTK")
 
     def assert_app_icon(self, icon):
+        if GTK_VERSION >= (4, 0, 0):
+            pytest.skip("Checking app icon not implemented in GTK4")
         for window in self.app.windows:
             # We have no real way to check we've got the right icon; use pixel peeping
             # as a guess. Construct a PIL image from the current icon.

--- a/gtk/tests_backend/app.py
+++ b/gtk/tests_backend/app.py
@@ -17,10 +17,6 @@ class AppProbe(BaseProbe, DialogsMixin):
     supports_key_mod3 = True
     # Gtk 3.24.41 ships with Ubuntu 24.04 where present() works on Wayland
     supports_current_window_assignment = not (IS_WAYLAND and GTK_VERSION < (3, 24, 41))
-    if GTK_VERSION < (4, 0, 0):
-        supports_save_dialog = True
-    else:
-        supports_save_dialog = False
 
     def __init__(self, app):
         super().__init__()

--- a/gtk/tests_backend/dialogs.py
+++ b/gtk/tests_backend/dialogs.py
@@ -196,4 +196,6 @@ class DialogsMixin:
             )
 
     def is_modal_dialog(self, dialog):
+        if GTK_VERSION >= (4, 0, 0):
+            pytest.xfail("Getting the modal of a dialog is not yet supported on GTK4")
         return dialog._impl.native.get_modal()

--- a/gtk/tests_backend/dialogs.py
+++ b/gtk/tests_backend/dialogs.py
@@ -3,7 +3,9 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from unittest.mock import Mock
 
-from toga_gtk.libs import Gtk
+import pytest
+
+from toga_gtk.libs import GTK_VERSION, Gtk
 
 
 class DialogsMixin:
@@ -25,6 +27,9 @@ class DialogsMixin:
     def _setup_dialog_result(
         self, dialog, gtk_result, close_handler=None, pre_close_test_method=None
     ):
+        if GTK_VERSION >= (4, 0, 0):
+            pytest.xfail("Setting up Dialogs not yet supported on GTK4")
+
         # Install an overridden show method that invokes the original,
         # but then closes the open dialog.
         orig_show = dialog._impl.show

--- a/gtk/tests_backend/icons.py
+++ b/gtk/tests_backend/icons.py
@@ -5,13 +5,16 @@ import pytest
 
 import toga
 import toga_gtk
-from toga_gtk.libs import GdkPixbuf
+from toga_gtk.libs import GTK_VERSION, GdkPixbuf
 
 from .probe import BaseProbe
 
 
 class IconProbe(BaseProbe):
     alternate_resource = "resources/icons/orange"
+
+    if GTK_VERSION >= (4, 0, 0):
+        pytest.skip("GTK4 doesn't support icons yet")
 
     def __init__(self, app, icon):
         super().__init__()

--- a/gtk/tests_backend/probe.py
+++ b/gtk/tests_backend/probe.py
@@ -1,20 +1,25 @@
 import asyncio
 
 import toga
-from toga_gtk.libs import Gtk
+from toga_gtk.libs import GTK_VERSION, GLib, Gtk
 
 
 class BaseProbe:
-    GTK_VERSION = Gtk.MAJOR_VERSION, Gtk.MINOR_VERSION, Gtk.MICRO_VERSION
 
     def repaint_needed(self):
-        return Gtk.events_pending()
+        if GTK_VERSION < (4, 0, 0):
+            return Gtk.events_pending()
+        else:
+            return GLib.main_context_default().pending()
 
     async def redraw(self, message=None, delay=0):
         """Request a redraw of the app, waiting until that redraw has completed."""
         # Force a repaint
         while self.repaint_needed():
-            Gtk.main_iteration_do(blocking=False)
+            if GTK_VERSION < (4, 0, 0):
+                Gtk.main_iteration_do(blocking=False)
+            else:
+                GLib.main_context_default().iteration(may_block=False)
 
         # If we're running slow, wait for a second
         if toga.App.app.run_slow:

--- a/gtk/tests_backend/widgets/base.py
+++ b/gtk/tests_backend/widgets/base.py
@@ -3,7 +3,7 @@ from threading import Event
 
 import pytest
 
-from toga_gtk.libs import Gdk, Gtk
+from toga_gtk.libs import GTK_VERSION, Gdk, Gtk
 
 from ..fonts import FontMixin
 from ..probe import BaseProbe
@@ -21,6 +21,9 @@ class SimpleProbe(BaseProbe, FontMixin):
 
         # Set the target for keypress events
         self._keypress_target = self.native
+
+        if GTK_VERSION >= (4, 0, 0):
+            pytest.skip("GTK4 only has minimal container support")
 
         # Ensure that the theme isn't using animations for the widget.
         settings = Gtk.Settings.get_for_screen(self.native.get_screen())

--- a/gtk/tests_backend/widgets/canvas.py
+++ b/gtk/tests_backend/widgets/canvas.py
@@ -1,14 +1,18 @@
 from io import BytesIO
 
+import pytest
 from PIL import Image
 
-from toga_gtk.libs import IS_WAYLAND, Gdk, Gtk
+from toga_gtk.libs import GTK_VERSION, IS_WAYLAND, Gdk, Gtk
 
 from .base import SimpleProbe
 
 
 class CanvasProbe(SimpleProbe):
     native_class = Gtk.DrawingArea
+
+    if GTK_VERSION >= (4, 0, 0):
+        pytest.skip("GTK4 doesn't support a canvas yet")
 
     def reference_variant(self, reference):
         if reference == "multiline_text":

--- a/gtk/tests_backend/widgets/detailedlist.py
+++ b/gtk/tests_backend/widgets/detailedlist.py
@@ -1,7 +1,9 @@
 import asyncio
 import html
 
-from toga_gtk.libs import GLib, Gtk
+import pytest
+
+from toga_gtk.libs import GTK_VERSION, GLib, Gtk
 
 from .base import SimpleProbe
 
@@ -16,6 +18,9 @@ class DetailedListProbe(SimpleProbe):
         self.native_detailedlist = widget._impl.native_detailedlist
         self.native_vadj = widget._impl.native_vadj
         assert isinstance(self.native_detailedlist, Gtk.ListBox)
+
+        if GTK_VERSION >= (4, 0, 0):
+            pytest.skip("GTK4 doesn't support a detailed list yet")
 
     @property
     def row_count(self):

--- a/gtk/tests_backend/widgets/divider.py
+++ b/gtk/tests_backend/widgets/divider.py
@@ -1,7 +1,12 @@
-from toga_gtk.libs import Gtk
+import pytest
+
+from toga_gtk.libs import GTK_VERSION, Gtk
 
 from .base import SimpleProbe
 
 
 class DividerProbe(SimpleProbe):
     native_class = Gtk.Separator
+
+    if GTK_VERSION >= (4, 0, 0):
+        pytest.skip("GTK4 doesn't support a divider yet")

--- a/gtk/tests_backend/widgets/imageview.py
+++ b/gtk/tests_backend/widgets/imageview.py
@@ -1,10 +1,15 @@
-from toga_gtk.libs import Gtk
+import pytest
+
+from toga_gtk.libs import GTK_VERSION, Gtk
 
 from .base import SimpleProbe
 
 
 class ImageViewProbe(SimpleProbe):
     native_class = Gtk.Image
+
+    if GTK_VERSION >= (4, 0, 0):
+        pytest.skip("GTK4 doesn't support image view yet")
 
     @property
     def preserve_aspect_ratio(self):

--- a/gtk/tests_backend/widgets/label.py
+++ b/gtk/tests_backend/widgets/label.py
@@ -1,10 +1,14 @@
-from toga_gtk.libs import Gtk
+import pytest
+
+from toga_gtk.libs import GTK_VERSION, Gtk
 
 from .base import SimpleProbe
 from .properties import toga_x_text_align, toga_y_text_align
 
 
 class LabelProbe(SimpleProbe):
+    if GTK_VERSION >= (4, 0, 0):
+        pytest.xfail("Labels are not yet supported on GTK4")
     native_class = Gtk.Label
 
     @property

--- a/gtk/tests_backend/widgets/mapview.py
+++ b/gtk/tests_backend/widgets/mapview.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pytest
 
-from toga_gtk.libs import WebKit2
+from toga_gtk.libs import GTK_VERSION, WebKit2
 
 from .base import SimpleProbe
 
@@ -18,6 +18,9 @@ def region_eq(r1, r2):
 
 class MapViewProbe(SimpleProbe):
     native_class = WebKit2.WebView
+
+    if GTK_VERSION >= (4, 0, 0):
+        pytest.skip("GTK4 doesn't support map view yet")
 
     @property
     def scale_height(self):

--- a/gtk/tests_backend/widgets/multilinetextinput.py
+++ b/gtk/tests_backend/widgets/multilinetextinput.py
@@ -1,6 +1,6 @@
 import pytest
 
-from toga_gtk.libs import Gtk
+from toga_gtk.libs import GTK_VERSION, Gtk
 
 from .base import SimpleProbe
 from .properties import toga_color, toga_text_align_from_justification
@@ -8,6 +8,9 @@ from .properties import toga_color, toga_text_align_from_justification
 
 class MultilineTextInputProbe(SimpleProbe):
     native_class = Gtk.ScrolledWindow
+
+    if GTK_VERSION >= (4, 0, 0):
+        pytest.skip("GTK4 doesn't support multiline text input yet")
 
     def __init__(self, widget):
         super().__init__(widget)

--- a/gtk/tests_backend/widgets/numberinput.py
+++ b/gtk/tests_backend/widgets/numberinput.py
@@ -1,7 +1,7 @@
 import pytest
 
 from toga.constants import JUSTIFY, LEFT
-from toga_gtk.libs import Gtk
+from toga_gtk.libs import GTK_VERSION, Gtk
 
 from .base import SimpleProbe
 from .properties import toga_x_text_align
@@ -12,6 +12,9 @@ class NumberInputProbe(SimpleProbe):
     allows_invalid_value = False
     allows_empty_value = False
     allows_extra_digits = False
+
+    if GTK_VERSION >= (4, 0, 0):
+        pytest.skip("GTK4 doesn't support number input yet")
 
     def clear_input(self):
         self.native.set_text("")

--- a/gtk/tests_backend/widgets/optioncontainer.py
+++ b/gtk/tests_backend/widgets/optioncontainer.py
@@ -1,4 +1,6 @@
-from toga_gtk.libs import Gtk
+import pytest
+
+from toga_gtk.libs import GTK_VERSION, Gtk
 
 from .base import SimpleProbe
 
@@ -7,6 +9,9 @@ class OptionContainerProbe(SimpleProbe):
     native_class = Gtk.Notebook
     max_tabs = None
     disabled_tab_selectable = False
+
+    if GTK_VERSION >= (4, 0, 0):
+        pytest.skip("GTK4 doesn't support option containers yet")
 
     def repaint_needed(self):
         return (

--- a/gtk/tests_backend/widgets/progressbar.py
+++ b/gtk/tests_backend/widgets/progressbar.py
@@ -1,12 +1,17 @@
 import asyncio
 
-from toga_gtk.libs import Gtk
+import pytest
+
+from toga_gtk.libs import GTK_VERSION, Gtk
 
 from .base import SimpleProbe
 
 
 class ProgressBarProbe(SimpleProbe):
     native_class = Gtk.ProgressBar
+
+    if GTK_VERSION >= (4, 0, 0):
+        pytest.skip("GTK4 doesn't support progress bars yet")
 
     @property
     def is_determinate(self):

--- a/gtk/tests_backend/widgets/scrollcontainer.py
+++ b/gtk/tests_backend/widgets/scrollcontainer.py
@@ -1,4 +1,6 @@
-from toga_gtk.libs import Gtk
+import pytest
+
+from toga_gtk.libs import GTK_VERSION, Gtk
 
 from .base import SimpleProbe
 
@@ -6,6 +8,9 @@ from .base import SimpleProbe
 class ScrollContainerProbe(SimpleProbe):
     native_class = Gtk.ScrolledWindow
     scrollbar_inset = 0
+
+    if GTK_VERSION >= (4, 0, 0):
+        pytest.skip("GTK4 doesn't support progress bars yet")
 
     @property
     def has_content(self):

--- a/gtk/tests_backend/widgets/selection.py
+++ b/gtk/tests_backend/widgets/selection.py
@@ -1,12 +1,16 @@
+import pytest
 from pytest import skip, xfail
 
-from toga_gtk.libs import Gtk
+from toga_gtk.libs import GTK_VERSION, Gtk
 
 from .base import SimpleProbe
 
 
 class SelectionProbe(SimpleProbe):
     native_class = Gtk.ComboBoxText
+
+    if GTK_VERSION >= (4, 0, 0):
+        pytest.skip("GTK4 doesn't support selection probes yet")
 
     def assert_resizes_on_content_change(self):
         pass

--- a/gtk/tests_backend/widgets/selection.py
+++ b/gtk/tests_backend/widgets/selection.py
@@ -7,9 +7,10 @@ from .base import SimpleProbe
 
 
 class SelectionProbe(SimpleProbe):
-    native_class = Gtk.ComboBoxText
-
-    if GTK_VERSION >= (4, 0, 0):
+    if GTK_VERSION < (4, 0, 0):
+        native_class = Gtk.ComboBoxText
+    else:
+        native_class = Gtk.DropDown
         pytest.skip("GTK4 doesn't support selection probes yet")
 
     def assert_resizes_on_content_change(self):

--- a/gtk/tests_backend/widgets/slider.py
+++ b/gtk/tests_backend/widgets/slider.py
@@ -1,10 +1,15 @@
-from toga_gtk.libs import Gdk, Gtk
+import pytest
+
+from toga_gtk.libs import GTK_VERSION, Gdk, Gtk
 
 from .base import SimpleProbe
 
 
 class SliderProbe(SimpleProbe):
     native_class = Gtk.Scale
+
+    if GTK_VERSION >= (4, 0, 0):
+        pytest.skip("GTK4 doesn't support sliders yet")
 
     @property
     def position(self):

--- a/gtk/tests_backend/widgets/splitcontainer.py
+++ b/gtk/tests_backend/widgets/splitcontainer.py
@@ -1,6 +1,8 @@
 import asyncio
 
-from toga_gtk.libs import Gtk
+import pytest
+
+from toga_gtk.libs import GTK_VERSION, Gtk
 
 from .base import SimpleProbe
 
@@ -9,6 +11,9 @@ class SplitContainerProbe(SimpleProbe):
     native_class = Gtk.Paned
     border_size = 0
     direction_change_preserves_position = False
+
+    if GTK_VERSION >= (4, 0, 0):
+        pytest.skip("GTK4 doesn't split containers yet")
 
     def move_split(self, position):
         self.native.set_position(position)

--- a/gtk/tests_backend/widgets/switch.py
+++ b/gtk/tests_backend/widgets/switch.py
@@ -1,4 +1,6 @@
-from toga_gtk.libs import Gtk
+import pytest
+
+from toga_gtk.libs import GTK_VERSION, Gtk
 
 from .base import SimpleProbe
 from .properties import toga_color
@@ -6,6 +8,9 @@ from .properties import toga_color
 
 class SwitchProbe(SimpleProbe):
     native_class = Gtk.Box
+
+    if GTK_VERSION >= (4, 0, 0):
+        pytest.skip("GTK4 doesn't support switches yet")
 
     def __init__(self, widget):
         super().__init__(widget)

--- a/gtk/tests_backend/widgets/table.py
+++ b/gtk/tests_backend/widgets/table.py
@@ -1,6 +1,6 @@
 import pytest
 
-from toga_gtk.libs import Gtk
+from toga_gtk.libs import GTK_VERSION, Gtk
 
 from .base import SimpleProbe
 
@@ -10,6 +10,9 @@ class TableProbe(SimpleProbe):
     supports_icons = 2  # All columns
     supports_keyboard_shortcuts = False
     supports_widgets = False
+
+    if GTK_VERSION >= (4, 0, 0):
+        pytest.skip("GTK4 doesn't support tables yet")
 
     def __init__(self, widget):
         super().__init__(widget)

--- a/gtk/tests_backend/widgets/textinput.py
+++ b/gtk/tests_backend/widgets/textinput.py
@@ -1,7 +1,7 @@
 import pytest
 
 from toga.constants import JUSTIFY, LEFT
-from toga_gtk.libs import Gtk
+from toga_gtk.libs import GTK_VERSION, Gtk
 
 from .base import SimpleProbe
 from .properties import toga_x_text_align
@@ -9,6 +9,9 @@ from .properties import toga_x_text_align
 
 class TextInputProbe(SimpleProbe):
     native_class = Gtk.Entry
+
+    if GTK_VERSION >= (4, 0, 0):
+        pytest.skip("GTK4 doesn't support text input yet")
 
     @property
     def value(self):

--- a/gtk/tests_backend/widgets/tree.py
+++ b/gtk/tests_backend/widgets/tree.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pytest
 
-from toga_gtk.libs import Gtk
+from toga_gtk.libs import GTK_VERSION, Gtk
 
 from .base import SimpleProbe
 
@@ -11,6 +11,9 @@ class TreeProbe(SimpleProbe):
     native_class = Gtk.ScrolledWindow
     supports_keyboard_shortcuts = False
     supports_widgets = False
+
+    if GTK_VERSION >= (4, 0, 0):
+        pytest.skip("GTK4 doesn't support trees yet")
 
     def __init__(self, widget):
         super().__init__(widget)

--- a/gtk/tests_backend/widgets/webview.py
+++ b/gtk/tests_backend/widgets/webview.py
@@ -1,8 +1,9 @@
 from http.cookiejar import CookieJar
 
+import pytest
 from pytest import skip
 
-from toga_gtk.libs import WebKit2
+from toga_gtk.libs import GTK_VERSION, WebKit2
 
 from .base import SimpleProbe
 
@@ -12,6 +13,9 @@ class WebViewProbe(SimpleProbe):
     content_supports_url = True
     javascript_supports_exception = True
     supports_on_load = True
+
+    if GTK_VERSION >= (4, 0, 0):
+        pytest.skip("GTK4 doesn't support trees yet")
 
     def extract_cookie(self, cookie_jar, name):
         assert isinstance(cookie_jar, CookieJar)

--- a/gtk/tests_backend/window.py
+++ b/gtk/tests_backend/window.py
@@ -16,9 +16,11 @@ class WindowProbe(BaseProbe, DialogsMixin):
     if GTK_VERSION < (4, 0, 0):
         supports_closable = True
         supports_as_image = True
+        supports_focus = True
     else:
         supports_closable = False
         supports_as_image = False
+        supports_focus = False
     supports_minimizable = False
     supports_move_while_hidden = False
     supports_unminimize = False

--- a/gtk/tests_backend/window.py
+++ b/gtk/tests_backend/window.py
@@ -1,7 +1,9 @@
 import asyncio
 
+import pytest
+
 from toga.constants import WindowState
-from toga_gtk.libs import IS_WAYLAND, Gdk, Gtk
+from toga_gtk.libs import GTK_VERSION, IS_WAYLAND, Gdk, Gtk
 
 from .dialogs import DialogsMixin
 from .probe import BaseProbe
@@ -11,13 +13,23 @@ class WindowProbe(BaseProbe, DialogsMixin):
     # GTK defers a lot of window behavior to the window manager, which means some
     # features either don't exist, or we can't guarantee they behave the way Toga would
     # like.
-    supports_closable = True
+    if GTK_VERSION < (4, 0, 0):
+        supports_closable = True
+        supports_as_image = True
+    else:
+        supports_closable = False
+        supports_as_image = False
     supports_minimizable = False
     supports_move_while_hidden = False
     supports_unminimize = False
-    # Wayland mostly prohibits interaction with the larger windowing environment
-    supports_minimize = not IS_WAYLAND
-    supports_placement = not IS_WAYLAND
+
+    if GTK_VERSION < (4, 0, 0):
+        # Wayland mostly prohibits interaction with the larger windowing environment
+        supports_minimize = not IS_WAYLAND
+        supports_placement = not IS_WAYLAND
+    else:
+        supports_minimize = False
+        supports_placement = False
 
     def __init__(self, app, window):
         super().__init__()
@@ -64,12 +76,20 @@ class WindowProbe(BaseProbe, DialogsMixin):
     def close(self):
         if self.is_closable:
             # Trigger the OS-level window close event.
-            self.native.emit("delete-event", None)
+            if GTK_VERSION < (4, 0, 0):
+                self.native.emit("delete-event", None)
+            else:
+                self.native.emit("close-request")
 
     @property
     def content_size(self):
-        content_allocation = self.impl.container.get_allocation()
-        return (content_allocation.width, content_allocation.height)
+        if GTK_VERSION < (4, 0, 0):
+            content_allocation = self.impl.container.get_allocation()
+            return content_allocation.width, content_allocation.height
+        else:
+            pytest.skip("Content size in GTK4 is not implemented")
+            content = self.impl.container
+            return content.width, content.height
 
     @property
     def is_resizable(self):
@@ -84,17 +104,25 @@ class WindowProbe(BaseProbe, DialogsMixin):
         return self.impl._window_state_flags & Gdk.WindowState.ICONIFIED
 
     def minimize(self):
-        self.native.iconify()
+        if GTK_VERSION < (4, 0, 0):
+            self.native.iconify()
+        else:
+            self.native.minimize()
 
     def unminimize(self):
-        self.native.deiconify()
+        if GTK_VERSION < (4, 0, 0):
+            self.native.deiconify()
+        else:
+            self.native.present()
 
     @property
     def instantaneous_state(self):
         return self.impl.get_window_state(in_progress_state=False)
 
     def has_toolbar(self):
-        return self.impl.native_toolbar.get_n_items() > 0
+        if GTK_VERSION < (4, 0, 0):
+            return self.impl.native_toolbar.get_n_items() > 0
+        pytest.skip("Toolbars not implemented on GTK4")
 
     def assert_is_toolbar_separator(self, index, section=False):
         item = self.impl.native_toolbar.get_nth_item(index)

--- a/iOS/tests_backend/window.py
+++ b/iOS/tests_backend/window.py
@@ -11,6 +11,7 @@ from .probe import BaseProbe
 class WindowProbe(BaseProbe, DialogsMixin):
     supports_fullscreen = False
     supports_presentation = False
+    supports_as_image = True
 
     def __init__(self, app, window):
         super().__init__()

--- a/iOS/tests_backend/window.py
+++ b/iOS/tests_backend/window.py
@@ -12,6 +12,7 @@ class WindowProbe(BaseProbe, DialogsMixin):
     supports_fullscreen = False
     supports_presentation = False
     supports_as_image = True
+    supports_focus = True
 
     def __init__(self, app, window):
         super().__init__()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ exclude_lines = [
 ]
 
 [tool.coverage.coverage_conditional_plugin.rules]
+# Additional testbed rules are configured in the testbed module
 no-cover-if-missing-setuptools_scm = "not is_installed('setuptools_scm')"
 no-cover-if-missing-PIL = "not is_installed('PIL')"
 no-cover-if-PIL-installed = "is_installed('PIL')"

--- a/testbed/tests/app/test_dialogs.py
+++ b/testbed/tests/app/test_dialogs.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 import toga
+from toga_gtk.libs import GTK_VERSION
 
 TESTS_DIR = Path(__file__).parent.parent
 
@@ -109,6 +110,8 @@ async def test_save_file_dialog(
     result,
 ):
     """An app-level file open dialog can be displayed and acknowledged."""
+    if GTK_VERSION >= (4, 0, 0):
+        pytest.xfail("Save dialog is not yet supported on GTK4")
     dialog = toga.SaveFileDialog(
         "Save file",
         suggested_filename=filename,
@@ -175,6 +178,8 @@ async def test_open_file_dialog(
     result,
 ):
     """An app-level file open dialog can be displayed and acknowledged."""
+    if GTK_VERSION >= (4, 0, 0):
+        pytest.xfail("Open dialog is not yet supported on GTK4")
     dialog = toga.OpenFileDialog(
         "Open file",
         initial_directory=initial_directory,
@@ -223,6 +228,8 @@ async def test_select_folder_dialog(
     result,
 ):
     """An app-level folder selection dialog can be displayed and acknowledged."""
+    if GTK_VERSION >= (4, 0, 0):
+        pytest.xfail("Open dialog is not yet supported on GTK4")
     dialog = toga.SelectFolderDialog(
         "Select folder",
         initial_directory=initial_directory,

--- a/testbed/tests/app/test_dialogs.py
+++ b/testbed/tests/app/test_dialogs.py
@@ -5,7 +5,6 @@ from pathlib import Path
 import pytest
 
 import toga
-from toga_gtk.libs import GTK_VERSION
 
 TESTS_DIR = Path(__file__).parent.parent
 
@@ -110,8 +109,6 @@ async def test_save_file_dialog(
     result,
 ):
     """An app-level file open dialog can be displayed and acknowledged."""
-    if GTK_VERSION >= (4, 0, 0):
-        pytest.xfail("Save dialog is not yet supported on GTK4")
     dialog = toga.SaveFileDialog(
         "Save file",
         suggested_filename=filename,
@@ -178,8 +175,6 @@ async def test_open_file_dialog(
     result,
 ):
     """An app-level file open dialog can be displayed and acknowledged."""
-    if GTK_VERSION >= (4, 0, 0):
-        pytest.xfail("Open dialog is not yet supported on GTK4")
     dialog = toga.OpenFileDialog(
         "Open file",
         initial_directory=initial_directory,
@@ -228,8 +223,6 @@ async def test_select_folder_dialog(
     result,
 ):
     """An app-level folder selection dialog can be displayed and acknowledged."""
-    if GTK_VERSION >= (4, 0, 0):
-        pytest.xfail("Open dialog is not yet supported on GTK4")
     dialog = toga.SelectFolderDialog(
         "Select folder",
         initial_directory=initial_directory,

--- a/testbed/tests/app/test_document_app.py
+++ b/testbed/tests/app/test_document_app.py
@@ -128,9 +128,6 @@ async def test_save_document(app, app_probe):
 async def test_save_as_document(monkeypatch, app, app_probe, tmp_path):
     """A document can be saved under a new filename."""
 
-    if not app_probe.supports_save_dialog:
-        pytest.xfail("This backend doesn't support save dialogs")
-
     # A document can be opened
     document_path = Path(__file__).parent / "docs/example.testbed"
     document = app.documents.open(document_path)

--- a/testbed/tests/app/test_document_app.py
+++ b/testbed/tests/app/test_document_app.py
@@ -128,6 +128,9 @@ async def test_save_document(app, app_probe):
 async def test_save_as_document(monkeypatch, app, app_probe, tmp_path):
     """A document can be saved under a new filename."""
 
+    if not app_probe.supports_save_dialog:
+        pytest.xfail("This backend doesn't support save dialogs")
+
     # A document can be opened
     document_path = Path(__file__).parent / "docs/example.testbed"
     document = app.documents.open(document_path)

--- a/testbed/tests/test_icons.py
+++ b/testbed/tests/test_icons.py
@@ -4,12 +4,9 @@ from importlib import import_module
 import pytest
 
 import toga
-from toga_gtk.libs import GTK_VERSION
 
 
 def icon_probe(app, image):
-    if GTK_VERSION >= (4, 0, 0):
-        pytest.xfail("Labels are not yet supported on GTK4")
     module = import_module("tests_backend.icons")
     return module.IconProbe(app, image)
 

--- a/testbed/tests/test_icons.py
+++ b/testbed/tests/test_icons.py
@@ -4,9 +4,12 @@ from importlib import import_module
 import pytest
 
 import toga
+from toga_gtk.libs import GTK_VERSION
 
 
 def icon_probe(app, image):
+    if GTK_VERSION >= (4, 0, 0):
+        pytest.xfail("Labels are not yet supported on GTK4")
     module = import_module("tests_backend.icons")
     return module.IconProbe(app, image)
 

--- a/testbed/tests/testbed.py
+++ b/testbed/tests/testbed.py
@@ -155,6 +155,8 @@ if __name__ == "__main__":
             "no-cover-if-linux-x": (
                 "os_environ.get('WAYLAND_DISPLAY', 'not-set') == 'not-set'"
             ),
+            "no-cover-if-gtk4": "os_environ.get('TOGA_GTK') == '4'",
+            "no-cover-if-gtk3": "os_environ.get('TOGA_GTK') != '4'",
         },
     )
     cov.start()

--- a/testbed/tests/testbed.py
+++ b/testbed/tests/testbed.py
@@ -105,7 +105,14 @@ def run_tests(app, cov, args, report_coverage, run_slow, running_in_ci):
                     show_missing=True,
                 )
                 if total < 100.0:
-                    print("Test coverage is incomplete")
+                    if os.getenv("TOGA_GTK", None) == "4":
+                        print("Incomplete test coverage is expected on GTK4 (for now!)")
+                    else:
+                        print("Test coverage is incomplete")
+                        app.returncode = 1
+                elif os.getenv("TOGA_GTK", None) == "4":
+                    print("Test coverage for GTK4 is unexpectedly complete!")
+                    print("Can we remove the special case in the testbed?")
                     app.returncode = 1
 
     except BaseException:

--- a/testbed/tests/testbed.py
+++ b/testbed/tests/testbed.py
@@ -155,8 +155,8 @@ if __name__ == "__main__":
             "no-cover-if-linux-x": (
                 "os_environ.get('WAYLAND_DISPLAY', 'not-set') == 'not-set'"
             ),
-            "no-cover-if-gtk4": "os_environ.get('TOGA_GTK') == '4'",
-            "no-cover-if-gtk3": "os_environ.get('TOGA_GTK') != '4'",
+            "no-cover-if-gtk4": "os_environ.get('TOGA_GTK', '') == '4'",
+            "no-cover-if-gtk3": "os_environ.get('TOGA_GTK', '3') == '3'",
         },
     )
     cov.start()

--- a/testbed/tests/widgets/conftest.py
+++ b/testbed/tests/widgets/conftest.py
@@ -1,8 +1,10 @@
 import gc
+import os
 import weakref
+from contextlib import contextmanager
 from unittest.mock import Mock
 
-from pytest import fixture
+import pytest
 
 import toga
 from toga.style.pack import TOP
@@ -11,12 +13,12 @@ from ..conftest import skip_on_platforms, xfail_on_platforms
 from .probe import get_probe
 
 
-@fixture
+@pytest.fixture
 async def widget():
     raise NotImplementedError("test modules must define a `widget` fixture")
 
 
-@fixture
+@pytest.fixture
 async def probe(main_window, widget):
     old_content = main_window.content
 
@@ -30,12 +32,12 @@ async def probe(main_window, widget):
     main_window.content = old_content
 
 
-@fixture
+@pytest.fixture
 async def container_probe(widget):
     return get_probe(widget.parent)
 
 
-@fixture
+@pytest.fixture
 async def other(widget):
     """A separate widget that can take focus"""
     other = toga.TextInput()
@@ -43,12 +45,12 @@ async def other(widget):
     return other
 
 
-@fixture
+@pytest.fixture
 async def other_probe(other):
     return get_probe(other)
 
 
-@fixture(params=[True, False])
+@pytest.fixture(params=[True, False])
 async def focused(request, widget, other):
     if request.param:
         widget.focus()
@@ -57,7 +59,7 @@ async def focused(request, widget, other):
     return request.param
 
 
-@fixture
+@pytest.fixture
 async def on_change(widget):
     on_change = Mock()
     widget.on_change = on_change
@@ -65,26 +67,59 @@ async def on_change(widget):
     return on_change
 
 
-@fixture
+@pytest.fixture
 def verify_font_sizes():
     """Whether the widget's width and height are affected by font size"""
     return True, True
 
 
-@fixture
+@pytest.fixture
 def verify_focus_handlers():
     """Whether the widget has on_gain_focus and on_lose_focus handlers"""
     return False
 
 
-@fixture
+@pytest.fixture
 def verify_vertical_text_align():
     """The widget's default vertical text alignment"""
     return TOP
 
 
+@contextmanager
+def safe_create():
+    """A context manager to protect against widgets that can't be instantiated.
+
+    Catches RuntimeErrors, and:
+    * skips if the exception message contains the content "isn't supported on"
+      (e.g., "WebView isn't supported on GTK4");
+    * xfails if running outside a CI environment (this likely indicates a
+      missing system requirement)
+    * re-raises if in CI environment (since the CI environment *should* have
+      all system requirements installed)
+    """
+    try:
+        yield
+    except RuntimeError as e:
+        msg = str(e)
+        if " isn't supported on " in msg:
+            # If the widget fails because the platform doesn't support it, we
+            # can skip the test.
+            pytest.skip(msg)
+        elif os.getenv("CI", None) is None:
+            # If we're on the user's machine (i.e., *not* in a CI environment),
+            # they might not have the required dependencies installed - in which
+            # case that's an expected failure.
+            pytest.xfail(msg)
+        else:
+            raise
+
+
 def build_cleanup_test(
-    widget_constructor, args=None, kwargs=None, skip_platforms=(), xfail_platforms=()
+    widget_constructor,
+    args=None,
+    kwargs=None,
+    skip_platforms=(),
+    xfail_platforms=(),
 ):
     async def test_cleanup():
         nonlocal args, kwargs
@@ -98,7 +133,9 @@ def build_cleanup_test(
         if kwargs is None:
             kwargs = {}
 
-        widget = widget_constructor(*args, **kwargs)
+        with safe_create():
+            widget = widget_constructor(*args, **kwargs)
+
         ref = weakref.ref(widget)
 
         # Args or kwargs may hold a backref to the widget itself, for example if they

--- a/testbed/tests/widgets/test_mapview.py
+++ b/testbed/tests/widgets/test_mapview.py
@@ -8,7 +8,7 @@ import pytest
 import toga
 from toga.style import Pack
 
-from .conftest import build_cleanup_test
+from .conftest import build_cleanup_test, safe_create
 from .properties import (  # noqa: F401
     test_flex_widget_size,
 )
@@ -32,7 +32,8 @@ async def on_select():
 
 @pytest.fixture
 async def widget(on_select):
-    widget = toga.MapView(style=Pack(flex=1), on_select=on_select)
+    with safe_create():
+        widget = toga.MapView(style=Pack(flex=1), on_select=on_select)
 
     # Some implementations of MapView are a WebView wearing a trenchcoat.
     # Ensure that the webview is fully configured before proceeding.

--- a/testbed/tests/widgets/test_optioncontainer.py
+++ b/testbed/tests/widgets/test_optioncontainer.py
@@ -6,7 +6,7 @@ import toga
 from toga.colors import CORNFLOWERBLUE, GOLDENROD, REBECCAPURPLE, SEAGREEN
 from toga.style.pack import Pack
 
-from .conftest import build_cleanup_test
+from .conftest import build_cleanup_test, safe_create
 from .probe import get_probe
 from .properties import (  # noqa: F401
     test_enable_noop,
@@ -61,15 +61,20 @@ async def on_select_handler():
 
 @pytest.fixture
 async def widget(content1, content2, content3, on_select_handler):
-    return toga.OptionContainer(
-        content=[
-            ("Tab 1", content1, "resources/tab-icon-1"),
-            toga.OptionItem("Tab 2", content2, icon=toga.Icon("resources/tab-icon-2")),
-            ("Tab 3", content3),
-        ],
-        style=Pack(flex=1),
-        on_select=on_select_handler,
-    )
+    with safe_create():
+        return toga.OptionContainer(
+            content=[
+                ("Tab 1", content1, "resources/tab-icon-1"),
+                toga.OptionItem(
+                    "Tab 2",
+                    content2,
+                    icon=toga.Icon("resources/tab-icon-2"),
+                ),
+                ("Tab 3", content3),
+            ],
+            style=Pack(flex=1),
+            on_select=on_select_handler,
+        )
 
 
 test_cleanup = build_cleanup_test(

--- a/testbed/tests/widgets/test_webview.py
+++ b/testbed/tests/widgets/test_webview.py
@@ -10,7 +10,7 @@ import pytest
 import toga
 from toga.style import Pack
 
-from .conftest import build_cleanup_test
+from .conftest import build_cleanup_test, safe_create
 from .properties import (  # noqa: F401
     test_flex_widget_size,
     test_focus,
@@ -80,7 +80,9 @@ async def on_load():
 
 @pytest.fixture
 async def widget(on_load):
-    widget = toga.WebView(style=Pack(flex=1), on_webview_load=on_load)
+    with safe_create():
+        widget = toga.WebView(style=Pack(flex=1), on_webview_load=on_load)
+
     # We shouldn't be able to get a callback until at least one tick of the event loop
     # has completed.
     on_load.assert_not_called()

--- a/testbed/tests/window/test_dialogs.py
+++ b/testbed/tests/window/test_dialogs.py
@@ -7,7 +7,6 @@ from time import time
 import pytest
 
 import toga
-from toga_gtk.libs import GTK_VERSION
 
 TESTS_DIR = Path(__file__).parent.parent
 
@@ -150,8 +149,6 @@ async def test_save_file_dialog(
     wait_for_dialog_to_close,
 ):
     """A file open dialog can be displayed and acknowledged."""
-    if GTK_VERSION >= (4, 0, 0):
-        pytest.xfail("Save dialog is not yet supported on GTK4")
     dialog = toga.SaveFileDialog(
         "Save file",
         suggested_filename=filename,
@@ -219,8 +216,6 @@ async def test_open_file_dialog(
     wait_for_dialog_to_close,
 ):
     """A file open dialog can be displayed and acknowledged."""
-    if GTK_VERSION >= (4, 0, 0):
-        pytest.xfail("Open dialog is not yet supported on GTK4")
     dialog = toga.OpenFileDialog(
         "Open file",
         initial_directory=initial_directory,
@@ -270,8 +265,6 @@ async def test_select_folder_dialog(
     wait_for_dialog_to_close,
 ):
     """A folder selection dialog can be displayed and acknowledged."""
-    if GTK_VERSION >= (4, 0, 0):
-        pytest.xfail("Open dialog is not yet supported on GTK4")
     dialog = toga.SelectFolderDialog(
         "Select folder",
         initial_directory=initial_directory,

--- a/testbed/tests/window/test_dialogs.py
+++ b/testbed/tests/window/test_dialogs.py
@@ -7,6 +7,7 @@ from time import time
 import pytest
 
 import toga
+from toga_gtk.libs import GTK_VERSION
 
 TESTS_DIR = Path(__file__).parent.parent
 
@@ -149,6 +150,8 @@ async def test_save_file_dialog(
     wait_for_dialog_to_close,
 ):
     """A file open dialog can be displayed and acknowledged."""
+    if GTK_VERSION >= (4, 0, 0):
+        pytest.xfail("Save dialog is not yet supported on GTK4")
     dialog = toga.SaveFileDialog(
         "Save file",
         suggested_filename=filename,
@@ -216,6 +219,8 @@ async def test_open_file_dialog(
     wait_for_dialog_to_close,
 ):
     """A file open dialog can be displayed and acknowledged."""
+    if GTK_VERSION >= (4, 0, 0):
+        pytest.xfail("Open dialog is not yet supported on GTK4")
     dialog = toga.OpenFileDialog(
         "Open file",
         initial_directory=initial_directory,
@@ -265,6 +270,8 @@ async def test_select_folder_dialog(
     wait_for_dialog_to_close,
 ):
     """A folder selection dialog can be displayed and acknowledged."""
+    if GTK_VERSION >= (4, 0, 0):
+        pytest.xfail("Open dialog is not yet supported on GTK4")
     dialog = toga.SelectFolderDialog(
         "Select folder",
         initial_directory=initial_directory,

--- a/testbed/tests/window/test_window.py
+++ b/testbed/tests/window/test_window.py
@@ -1012,6 +1012,9 @@ else:
     ):
         """The window can trigger on_gain_focus() and on_lose_focus()
         event handlers, when the window gains or loses input focus."""
+        if not main_window_probe.supports_focus:
+            pytest.skip("GTK4 doesn't yet support gain and lose focus.")
+
         main_window.on_gain_focus = Mock()
         main_window.on_lose_focus = Mock()
         second_window.content = toga.Box(style=Pack(background_color=CORNFLOWERBLUE))

--- a/testbed/tests/window/test_window.py
+++ b/testbed/tests/window/test_window.py
@@ -342,7 +342,8 @@ else:
         assert second_window.size == (640, 480)
         # Position should be cascaded; the exact position depends on the platform,
         # and how many windows have been created. As long as it's not at (100,100).
-        assert second_window.position != (100, 100)
+        if second_window_probe.supports_placement:
+            assert second_window.position != (100, 100)
 
         assert second_window_probe.is_resizable
         if second_window_probe.supports_closable:
@@ -1070,19 +1071,19 @@ else:
         """The window can be relocated to another screen, using both absolute and
         relative screen positions."""
 
+        if not second_window_probe.supports_placement:
+            pytest.xfail("This backend doesn't support window placement.")
         initial_position = second_window.position
 
         # Move the window using absolute position.
         second_window.position = (200, 200)
         await second_window_probe.wait_for_window("Secondary window has been moved")
-        if second_window_probe.supports_placement:
-            assert second_window.position != initial_position
+        assert second_window.position != initial_position
 
         # `position` and `screen_position` will be same as the window will be in
         # primary screen.
-        if second_window_probe.supports_placement:
-            assert second_window.position == (200, 200)
-            assert second_window.screen_position == (200, 200)
+        assert second_window.position == (200, 200)
+        assert second_window.screen_position == (200, 200)
 
         # Move the window between available screens and assert its `screen_position`
         for screen in second_window.app.screens:
@@ -1100,9 +1101,10 @@ else:
 async def test_as_image(main_window, main_window_probe):
     """The window can be captured as a screenshot"""
 
-    screenshot = main_window.as_image()
-    main_window_probe.assert_image_size(
-        screenshot.size,
-        main_window_probe.content_size,
-        screen=main_window.screen,
-    )
+    if main_window_probe.supports_as_image:
+        screenshot = main_window.as_image()
+        main_window_probe.assert_image_size(
+            screenshot.size,
+            main_window_probe.content_size,
+            screen=main_window.screen,
+        )

--- a/winforms/tests_backend/window.py
+++ b/winforms/tests_backend/window.py
@@ -28,6 +28,7 @@ class WindowProbe(BaseProbe, DialogsMixin):
     supports_minimize = True
     supports_placement = True
     supports_as_image = True
+    supports_focus = True
 
     def __init__(self, app, window):
         self.app = app

--- a/winforms/tests_backend/window.py
+++ b/winforms/tests_backend/window.py
@@ -27,6 +27,7 @@ class WindowProbe(BaseProbe, DialogsMixin):
     supports_unminimize = True
     supports_minimize = True
     supports_placement = True
+    supports_as_image = True
 
     def __init__(self, app, window):
         self.app = app


### PR DESCRIPTION
This PR is a first step for #3069 through:

- Add a switch to turn on using GTK4 by setting the environmental variable `TOGA_GTK=4`
- Make minimal changes to allow running a Hello World app using GTK4
- Add a new CI test backend for linux-wayland-gtk4

Future PRs would implement libadwaita support and changes for additional widgets until we have a complete backend and then GTK3 can be removed.

Things left to do:

- [x] Determine why I am getting a libxapp error when trying to run the test suite with `TOGA_GTK=4` set, maybe XApp is GTK3 only for Cinnamon, MATE and Xfce
- [x] Update tests / mark them xfail if not migrated yet
- [x] Fix my co-authored statements to give @MuhammadMuradG credit
- [x] Add changelog entry

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct

![image](https://github.com/user-attachments/assets/03f03a6d-2673-429b-91e1-ead220496faa)
