### PR TITLE
Move to a pinned, formally published version of setuptools-dynamic-dependencies

### DIFF
--- a/android/pyproject.toml
+++ b/android/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools==75.7.0",
     "setuptools_scm==8.1.0",
-    "setuptools_dynamic_dependencies @ git+https://github.com/beeware/setuptools_dynamic_dependencies",
+    "setuptools_dynamic_dependencies==1.0.0",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/changes/3089.misc.rst
+++ b/changes/3089.misc.rst
@@ -1,0 +1,1 @@
+Moved to a pinned version of setuptools_dynamic_dependencies.

--- a/cocoa/pyproject.toml
+++ b/cocoa/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools==75.7.0",
     "setuptools_scm==8.1.0",
-    "setuptools_dynamic_dependencies @ git+https://github.com/beeware/setuptools_dynamic_dependencies",
+    "setuptools_dynamic_dependencies==1.0.0",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools==75.7.0",
     "setuptools_scm==8.1.0",
-    "setuptools_dynamic_dependencies @ git+https://github.com/beeware/setuptools_dynamic_dependencies",
+    "setuptools_dynamic_dependencies==1.0.0",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/demo/pyproject.toml
+++ b/demo/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools==75.5.0",
     "setuptools_scm==8.1.0",
-    "setuptools_dynamic_dependencies @ git+https://github.com/beeware/setuptools_dynamic_dependencies",
+    "setuptools_dynamic_dependencies==1.0.0",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/dummy/pyproject.toml
+++ b/dummy/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools==75.5.0",
     "setuptools_scm==8.1.0",
-    "setuptools_dynamic_dependencies @ git+https://github.com/beeware/setuptools_dynamic_dependencies",
+    "setuptools_dynamic_dependencies==1.0.0",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/gtk/pyproject.toml
+++ b/gtk/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools==75.7.0",
     "setuptools_scm==8.1.0",
-    "setuptools_dynamic_dependencies @ git+https://github.com/beeware/setuptools_dynamic_dependencies",
+    "setuptools_dynamic_dependencies==1.0.0",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/iOS/pyproject.toml
+++ b/iOS/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools==75.7.0",
     "setuptools_scm==8.1.0",
-    "setuptools_dynamic_dependencies @ git+https://github.com/beeware/setuptools_dynamic_dependencies",
+    "setuptools_dynamic_dependencies==1.0.0",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/textual/pyproject.toml
+++ b/textual/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools==75.5.0",
     "setuptools_scm==8.1.0",
-    "setuptools_dynamic_dependencies @ git+https://github.com/beeware/setuptools_dynamic_dependencies",
+    "setuptools_dynamic_dependencies==1.0.0",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/toga/pyproject.toml
+++ b/toga/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools==75.7.0",
     "setuptools_scm==8.1.0",
-    "setuptools_dynamic_dependencies @ git+https://github.com/beeware/setuptools_dynamic_dependencies",
+    "setuptools_dynamic_dependencies==1.0.0",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/web/pyproject.toml
+++ b/web/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools==75.7.0",
     "setuptools_scm==8.1.0",
-    "setuptools_dynamic_dependencies @ git+https://github.com/beeware/setuptools_dynamic_dependencies",
+    "setuptools_dynamic_dependencies==1.0.0",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/winforms/pyproject.toml
+++ b/winforms/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools==75.7.0",
     "setuptools_scm==8.1.0",
-    "setuptools_dynamic_dependencies @ git+https://github.com/beeware/setuptools_dynamic_dependencies",
+    "setuptools_dynamic_dependencies==1.0.0",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
Fixes #3089.

Moves to a pinned, formally published version of setuptools-dynamic-dependencies. This should slightly speed up builds.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
