### PR TITLE
Add a retry for setting the cookie in webview tests.

### DIFF
--- a/changes/3103.misc.rst
+++ b/changes/3103.misc.rst
@@ -1,0 +1,1 @@
+A retry strategy was added to webview cookie tests.


### PR DESCRIPTION
#3068 added an API to retrieve cookies from WebView; however, the test for this feature has been flaky on iOS and macOS. This appears to be due to a race condition in the testbed - the `on_load` signal isn't a 100% reliable mechanism to prove that the webview is fully initialised and ready to accept Javascript calls. 

You can overcome this by adding a short delay before setting the cookie. This PR adds a retry strategy to setting the cookie so that the delay is as short as is practical.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
