### PR TITLE
Fix #3009 (iOS default widget background color)

### DIFF
--- a/changes/3104.misc.rst
+++ b/changes/3104.misc.rst
@@ -1,0 +1,1 @@
+The default background color of `toga.Label` on iOS now correctly displays a transparent background, instead of a black background.

--- a/iOS/src/toga_iOS/widgets/base.py
+++ b/iOS/src/toga_iOS/widgets/base.py
@@ -13,6 +13,10 @@ class Widget:
         self.native = None
         self.create()
 
+        # Override this attribute to set a different default background
+        # color for a given widget.
+        self._default_background_color = self.native.backgroundColor
+
     @abstractmethod
     def create(self): ...
 
@@ -87,7 +91,9 @@ class Widget:
         pass
 
     def set_background_color(self, color):
-        self.native.backgroundColor = None if color is None else native_color(color)
+        self.native.backgroundColor = (
+            self._default_background_color if color is None else native_color(color)
+        )
 
     # INTERFACE
     def add_child(self, child):


### PR DESCRIPTION
<!--- Describe your changes in detail -->
A bug has slipped past me in #3009. The current implementation sets `backgroundColor = None` as the default background color. The docs also mentions that `None` or `nil` gets the default background color, which is the transparent background color: https://developer.apple.com/documentation/uikit/uiview/backgroundcolor?language=objc:
>Changes to this property can be animated. The default value is nil, which results in a transparent background color.

However, contrary to the docs, when `backgroundColor = None` is set as the default background color for `UILabel`, then it displays a black background color instead:
<img src="https://github.com/user-attachments/assets/605b7d2e-d1e5-41a7-a6a4-12095653ac26" width=25%>

On further testing, I have found that the default background color(default value of `native.backgroundColor`) which the system assigns to `UILabel` on initialization is not `None`/`nil` or even `UIColor.clearColor`, but rather `UIExtendedGrayColorSpace 0 0`. 

I couldn't find any official docs for `UIExtendedGrayColorSpace 0 0`, the best I could get was: https://stackoverflow.com/a/45491411, which suggests that:
>UIExtendedGrayColorSpace 0 0 is "clear"

So, it seems contrary to the docs, setting `backgroundColor` to `nil` doesn't always set it to the widget's system assigned default background color. So, the best option is to cache the system assigned widget default background color during the widget initialization and use that as the default reset background color, in order to avoid any similar background color bugs.

I have tested this PR with both light mode and dark mode, and it works correctly even when the system theme is changed while the app is running:
||||
|--|--|--|
|Light Mode to Dark Mode|![Screenshot 2025-01-13 at 10 06 01 AM](https://github.com/user-attachments/assets/4087b0b3-daf1-4b16-9f1b-880191c3aca0)|![Screenshot 2025-01-13 at 10 08 11 AM](https://github.com/user-attachments/assets/a680fda7-1de5-4573-b4c5-d0347bf5a1e6)
|Dark Mode to Light Mode|![Screenshot 2025-01-13 at 10 09 12 AM](https://github.com/user-attachments/assets/9b5c62fd-b84b-4bcb-9c3e-9319a0c4ffb8)|![Screenshot 2025-01-13 at 10 10 09 AM](https://github.com/user-attachments/assets/364eca0f-c669-4286-a60c-026e8710b226)
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
