### PR TITLE
Fix gtk `window.state` getter when window is hidden

### DIFF
--- a/changes/3105.bugfix.rst
+++ b/changes/3105.bugfix.rst
@@ -1,0 +1,1 @@
+On GTK, when a window is hidden, the `window.state` getter now correctly continues to report the same state as it did when the window was last visible.

--- a/gtk/src/toga_gtk/window.py
+++ b/gtk/src/toga_gtk/window.py
@@ -36,6 +36,7 @@ class Window:
         self._in_presentation = False
         # Pending Window state transition variable:
         self._pending_state_transition = None
+        self._previous_state = WindowState.NORMAL
 
         self.native.set_default_size(size[0], size[1])
 
@@ -73,6 +74,8 @@ class Window:
         self._window_state_flags = event.new_window_state
         current_state = self.get_window_state()
 
+        # Window state flags are unreliable when window is hidden, so cache the
+        # previous window state when it was visible.
         if self.get_visible():
             self._previous_state = current_state
 

--- a/gtk/src/toga_gtk/window.py
+++ b/gtk/src/toga_gtk/window.py
@@ -71,9 +71,12 @@ class Window:
     def gtk_window_state_event(self, widget, event):
         # Get the window state flags
         self._window_state_flags = event.new_window_state
+        current_state = self.get_window_state()
+
+        if self.get_visible():
+            self._previous_state = current_state
 
         if self._pending_state_transition:
-            current_state = self.get_window_state()
             if current_state != WindowState.NORMAL:
                 if self._pending_state_transition != current_state:
                     # Add a 10ms delay to wait for the native window state
@@ -191,7 +194,9 @@ class Window:
             return self._pending_state_transition
         window_state_flags = self._window_state_flags
         if window_state_flags:  # pragma: no branch
-            if window_state_flags & Gdk.WindowState.MAXIMIZED:
+            if window_state_flags & Gdk.WindowState.WITHDRAWN or not self.get_visible():
+                return self._previous_state
+            elif window_state_flags & Gdk.WindowState.MAXIMIZED:
                 return WindowState.MAXIMIZED
             elif window_state_flags & Gdk.WindowState.ICONIFIED:
                 return WindowState.MINIMIZED  # pragma: no-cover-if-linux-wayland

--- a/gtk/src/toga_gtk/window.py
+++ b/gtk/src/toga_gtk/window.py
@@ -36,6 +36,8 @@ class Window:
         self._in_presentation = False
         # Pending Window state transition variable:
         self._pending_state_transition = None
+        # Window state flags are unreliable when window is hidden, so cache the
+        # previous window state
         self._previous_state = WindowState.NORMAL
 
         self.native.set_default_size(size[0], size[1])
@@ -74,10 +76,7 @@ class Window:
         self._window_state_flags = event.new_window_state
         current_state = self.get_window_state()
 
-        # Window state flags are unreliable when window is hidden, so cache the
-        # previous window state when it was visible.
-        if self.get_visible():
-            self._previous_state = current_state
+        self._previous_state = current_state
 
         if self._pending_state_transition:
             if current_state != WindowState.NORMAL:

--- a/testbed/tests/window/test_window.py
+++ b/testbed/tests/window/test_window.py
@@ -914,6 +914,51 @@ else:
         assert second_window_probe.content_size == initial_content_size
 
     @pytest.mark.parametrize(
+        "state",
+        [
+            WindowState.NORMAL,
+            WindowState.MINIMIZED,
+            WindowState.MAXIMIZED,
+            WindowState.FULLSCREEN,
+            WindowState.PRESENTATION,
+        ],
+    )
+    @pytest.mark.parametrize(
+        "second_window_class, second_window_kwargs",
+        [
+            (
+                toga.Window,
+                dict(title="Secondary Window", position=(200, 150)),
+            )
+        ],
+    )
+    async def test_window_state_when_window_hidden(
+        second_window, second_window_probe, state
+    ):
+        """When a window is hidden using hide(), the window.state getter should
+        continue to report the same state as it did when the window was last visible."""
+        if state == WindowState.MINIMIZED and not second_window_probe.supports_minimize:
+            pytest.xfail(
+                "This backend doesn't reliably support minimized window state."
+            )
+        second_window.content = toga.Box(style=Pack(background_color=CORNFLOWERBLUE))
+        second_window.show()
+        # Wait for window animation before assertion.
+        await second_window_probe.wait_for_window("Secondary window is shown")
+
+        second_window.state = state
+        # Wait for window animation before assertion.
+        await second_window_probe.wait_for_window(
+            f"Secondary window is in {state}", state=state
+        )
+        assert second_window_probe.instantaneous_state == state
+        window_state_before_hidden = second_window.state
+
+        second_window.hide()
+        await second_window_probe.wait_for_window("Secondary window is hidden")
+        assert second_window.state == window_state_before_hidden
+
+    @pytest.mark.parametrize(
         "second_window_class, second_window_kwargs",
         [
             (


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Currently, on all platforms except on gtk, when the window is hidden using `hide()`, the `window.state` getter continues to report the same state as it did when the window was last visible. But on gtk, when the window is hidden, `window.state` getter always reports it as `WindowState.NORMAL`. This PR fixes the bug on gtk. 

This bug was identified in #2096. Since, it would take some time to accommodate the other inconsistencies identified on gtk for implementation of visibility events(i.e., `on_show` and `on_hide`), I have created this fix as a separate PR, independent of the other PRs.
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
