### PR TITLE
Allow style properties to be accessed directly on the widget

### DIFF
--- a/changes/3011.feature.rst
+++ b/changes/3011.feature.rst
@@ -1,0 +1,1 @@
+Style properties can now be passed directly to a widget's constructor, or accessed as attributes, without explicitly using a ``style`` object.

--- a/core/src/toga/style/mixin.py
+++ b/core/src/toga/style/mixin.py
@@ -1,0 +1,28 @@
+class StyleProperty:
+    def __set_name__(self, mixin_cls, name):
+        self.name = name
+
+    def __get__(self, widget, mixin_cls):
+        return self if widget is None else getattr(widget.style, self.name)
+
+    def __set__(self, widget, value):
+        setattr(widget.style, self.name, value)
+
+    def __delete__(self, widget):
+        delattr(widget.style, self.name)
+
+
+def style_mixin(style_cls):
+    mixin_dict = {
+        "__doc__": f"""
+            Allows accessing the {style_cls.__name__} {style_cls._doc_link} directly on
+            the widget. For example, instead of ``widget.style.color``, you can simply
+            write ``widget.color``.
+            """
+    }
+
+    for name in dir(style_cls):
+        if not name.startswith("_") and isinstance(getattr(style_cls, name), property):
+            mixin_dict[name] = StyleProperty()
+
+    return type(style_cls.__name__ + "Mixin", (), mixin_dict)

--- a/core/src/toga/style/pack.py
+++ b/core/src/toga/style/pack.py
@@ -91,6 +91,8 @@ FONT_SIZE_CHOICES = Choices(integer=True)
 
 
 class Pack(BaseStyle):
+    _doc_link = ":doc:`style properties </reference/style/pack>`"
+
     class Box(BaseBox):
         pass
 

--- a/core/src/toga/widgets/activityindicator.py
+++ b/core/src/toga/widgets/activityindicator.py
@@ -11,6 +11,7 @@ class ActivityIndicator(Widget):
         id: str | None = None,
         style: StyleT | None = None,
         running: bool = False,
+        **kwargs,
     ):
         """Create a new ActivityIndicator widget.
 
@@ -19,8 +20,9 @@ class ActivityIndicator(Widget):
             will be applied to the widget.
         :param running: Describes whether the indicator is running at the
             time it is created.
+        :param kwargs: Initial style properties.
         """
-        super().__init__(id=id, style=style)
+        super().__init__(id, style, **kwargs)
 
         if running:
             self.start()

--- a/core/src/toga/widgets/base.py
+++ b/core/src/toga/widgets/base.py
@@ -9,15 +9,17 @@ from travertino.node import Node
 
 from toga.platform import get_platform_factory
 from toga.style import Pack, TogaApplicator
+from toga.style.mixin import style_mixin
 
 if TYPE_CHECKING:
     from toga.app import App
     from toga.window import Window
 
 StyleT = TypeVar("StyleT", bound=BaseStyle)
+PackMixin = style_mixin(Pack)
 
 
-class Widget(Node):
+class Widget(Node, PackMixin):
     _MIN_WIDTH = 100
     _MIN_HEIGHT = 100
 
@@ -25,6 +27,7 @@ class Widget(Node):
         self,
         id: str | None = None,
         style: StyleT | None = None,
+        **kwargs,
     ):
         """Create a base Toga widget.
 
@@ -33,8 +36,14 @@ class Widget(Node):
         :param id: The ID for the widget.
         :param style: A style object. If no style is provided, a default style
             will be applied to the widget.
+        :param kwargs: Initial style properties.
         """
-        super().__init__(style=style if style is not None else Pack())
+        if style is None:
+            style = Pack(**kwargs)
+        elif kwargs:
+            style = style.copy()
+            style.update(**kwargs)
+        super().__init__(style)
 
         self._id = str(id if id else identifier(self))
         self._window: Window | None = None

--- a/core/src/toga/widgets/box.py
+++ b/core/src/toga/widgets/box.py
@@ -14,6 +14,7 @@ class Box(Widget):
         id: str | None = None,
         style: StyleT | None = None,
         children: Iterable[Widget] | None = None,
+        **kwargs,
     ):
         """Create a new Box container widget.
 
@@ -21,8 +22,9 @@ class Box(Widget):
         :param style: A style object. If no style is provided, a default style
             will be applied to the widget.
         :param children: An optional list of children for to add to the Box.
+        :param kwargs: Initial style properties.
         """
-        super().__init__(id=id, style=style)
+        super().__init__(id, style, **kwargs)
 
         # Children need to be added *after* the impl has been created.
         self._children: list[Widget] = []

--- a/core/src/toga/widgets/button.py
+++ b/core/src/toga/widgets/button.py
@@ -29,6 +29,7 @@ class Button(Widget):
         style: StyleT | None = None,
         on_press: toga.widgets.button.OnPressHandler | None = None,
         enabled: bool = True,
+        **kwargs,
     ):
         """Create a new button widget.
 
@@ -41,8 +42,9 @@ class Button(Widget):
         :param on_press: A handler that will be invoked when the button is pressed.
         :param enabled: Is the button enabled (i.e., can it be pressed?). Optional; by
             default, buttons are created in an enabled state.
+        :param kwargs: Initial style properties.
         """
-        super().__init__(id=id, style=style)
+        super().__init__(id, style, **kwargs)
 
         # Set a dummy handler before installing the actual on_press, because we do not
         # want on_press triggered by the initial value being set

--- a/core/src/toga/widgets/canvas/canvas.py
+++ b/core/src/toga/widgets/canvas/canvas.py
@@ -68,6 +68,7 @@ class Canvas(Widget):
         on_alt_press: OnTouchHandler | None = None,
         on_alt_release: OnTouchHandler | None = None,
         on_alt_drag: OnTouchHandler | None = None,
+        **kwargs,
     ):
         """Create a new Canvas widget.
 
@@ -84,10 +85,11 @@ class Canvas(Widget):
         :param on_alt_press: Initial :any:`on_alt_press` handler.
         :param on_alt_release: Initial :any:`on_alt_release` handler.
         :param on_alt_drag: Initial :any:`on_alt_drag` handler.
+        :param kwargs: Initial style properties.
         """
         self._context = Context(canvas=self)
 
-        super().__init__(id=id, style=style)
+        super().__init__(id, style, **kwargs)
 
         # Set all the properties
         self.on_resize = on_resize

--- a/core/src/toga/widgets/dateinput.py
+++ b/core/src/toga/widgets/dateinput.py
@@ -36,6 +36,7 @@ class DateInput(Widget):
         min: datetime.date | None = None,
         max: datetime.date | None = None,
         on_change: toga.widgets.dateinput.OnChangeHandler | None = None,
+        **kwargs,
     ):
         """Create a new DateInput widget.
 
@@ -47,8 +48,9 @@ class DateInput(Widget):
         :param min: The earliest date (inclusive) that can be selected.
         :param max: The latest date (inclusive) that can be selected.
         :param on_change: A handler that will be invoked when the value changes.
+        :param kwargs: Initial style properties.
         """
-        super().__init__(id=id, style=style)
+        super().__init__(id, style, **kwargs)
 
         self.on_change = None
         self.min = min

--- a/core/src/toga/widgets/detailedlist.py
+++ b/core/src/toga/widgets/detailedlist.py
@@ -64,6 +64,7 @@ class DetailedList(Widget):
         on_secondary_action: OnSecondaryActionHandler | None = None,
         on_refresh: OnRefreshHandler | None = None,
         on_select: toga.widgets.detailedlist.OnSelectHandler | None = None,
+        **kwargs,
     ):
         """Create a new DetailedList widget.
 
@@ -81,6 +82,7 @@ class DetailedList(Widget):
         :param secondary_action: The name for the secondary action.
         :param on_secondary_action: Initial :any:`on_secondary_action` handler.
         :param on_refresh: Initial :any:`on_refresh` handler.
+        :param kwargs: Initial style properties.
         """
         # Prime the attributes and handlers that need to exist when the widget is
         # created.
@@ -92,7 +94,7 @@ class DetailedList(Widget):
 
         self._data: SourceT | ListSource = None
 
-        super().__init__(id=id, style=style)
+        super().__init__(id, style, **kwargs)
 
         self.data = data
         self.on_primary_action = on_primary_action

--- a/core/src/toga/widgets/divider.py
+++ b/core/src/toga/widgets/divider.py
@@ -16,6 +16,7 @@ class Divider(Widget):
         id: str | None = None,
         style: StyleT | None = None,
         direction: Direction = HORIZONTAL,
+        **kwargs,
     ):
         """Create a new divider line.
 
@@ -26,8 +27,9 @@ class Divider(Widget):
             :attr:`~toga.constants.Direction.HORIZONTAL` or
             :attr:`~toga.constants.Direction.VERTICAL`; defaults to
             :attr:`~toga.constants.Direction.HORIZONTAL`
+        :param kwargs: Initial style properties.
         """
-        super().__init__(id=id, style=style)
+        super().__init__(id, style, **kwargs)
 
         self.direction = direction
 

--- a/core/src/toga/widgets/imageview.py
+++ b/core/src/toga/widgets/imageview.py
@@ -73,20 +73,21 @@ class ImageView(Widget):
         image: ImageContentT | None = None,
         id: str | None = None,
         style: StyleT | None = None,
+        **kwargs,
     ):
-        """
-        Create a new image view.
+        """Create a new image view.
 
         :param image: The image to display. Can be any valid :any:`image content
             <ImageContentT>` type; or :any:`None` to display no image.
         :param id: The ID for the widget.
         :param style: A style object. If no style is provided, a default style will be
             applied to the widget.
+        :param kwargs: Initial style properties.
         """
         # Prime the image attribute
         self._image = None
 
-        super().__init__(id=id, style=style)
+        super().__init__(id, style, **kwargs)
 
         self.image = image
 

--- a/core/src/toga/widgets/label.py
+++ b/core/src/toga/widgets/label.py
@@ -11,6 +11,7 @@ class Label(Widget):
         text: str,
         id: str | None = None,
         style: StyleT | None = None,
+        **kwargs,
     ):
         """Create a new text label.
 
@@ -18,8 +19,9 @@ class Label(Widget):
         :param id: The ID for the widget.
         :param style: A style object. If no style is provided, a default style
             will be applied to the widget.
+        :param kwargs: Initial style properties.
         """
-        super().__init__(id=id, style=style)
+        super().__init__(id, style, **kwargs)
 
         self.text = text
 

--- a/core/src/toga/widgets/mapview.py
+++ b/core/src/toga/widgets/mapview.py
@@ -139,6 +139,7 @@ class MapView(Widget):
         zoom: int = 11,
         pins: Iterable[MapPin] | None = None,
         on_select: toga.widgets.mapview.OnSelectHandler | None = None,
+        **kwargs,
     ):
         """Create a new MapView widget.
 
@@ -152,8 +153,9 @@ class MapView(Widget):
         :param pins: The initial pins to display on the map.
         :param on_select: A handler that will be invoked when the user selects a map
             pin.
+        :param kwargs: Initial style properties.
         """
-        super().__init__(id=id, style=style)
+        super().__init__(id, style, **kwargs)
 
         self._pins = MapPinSet(self, pins)
 

--- a/core/src/toga/widgets/multilinetextinput.py
+++ b/core/src/toga/widgets/multilinetextinput.py
@@ -26,6 +26,7 @@ class MultilineTextInput(Widget):
         readonly: bool = False,
         placeholder: str | None = None,
         on_change: toga.widgets.multilinetextinput.OnChangeHandler | None = None,
+        **kwargs,
     ):
         """Create a new multi-line text input widget.
 
@@ -38,8 +39,9 @@ class MultilineTextInput(Widget):
             there is no user content to display.
         :param on_change: A handler that will be invoked when the value of
             the widget changes.
+        :param kwargs: Initial style properties.
         """
-        super().__init__(id=id, style=style)
+        super().__init__(id, style, **kwargs)
 
         # Set a dummy handler before installing the actual on_change, because we do not
         # want on_change triggered by the initial value being set

--- a/core/src/toga/widgets/numberinput.py
+++ b/core/src/toga/widgets/numberinput.py
@@ -91,6 +91,7 @@ class NumberInput(Widget):
         value: NumberInputT | None = None,
         readonly: bool = False,
         on_change: toga.widgets.numberinput.OnChangeHandler | None = None,
+        **kwargs,
     ):
         """Create a new number input widget.
 
@@ -107,6 +108,7 @@ class NumberInput(Widget):
         :param readonly: Can the value of the widget be modified by the user?
         :param on_change: A handler that will be invoked when the value of the widget
             changes.
+        :param kwargs: Initial style properties.
         """
         # The initial setting of min requires calling get_value(),
         # which in turn interrogates min. Prime those values with
@@ -116,7 +118,7 @@ class NumberInput(Widget):
 
         self.on_change = None
 
-        super().__init__(id=id, style=style)
+        super().__init__(id, style, **kwargs)
 
         self.readonly = readonly
         self.step = step

--- a/core/src/toga/widgets/optioncontainer.py
+++ b/core/src/toga/widgets/optioncontainer.py
@@ -383,6 +383,7 @@ class OptionContainer(Widget):
         style: StyleT | None = None,
         content: Iterable[OptionContainerContentT] | None = None,
         on_select: toga.widgets.optioncontainer.OnSelectHandler | None = None,
+        **kwargs,
     ):
         """Create a new OptionContainer.
 
@@ -392,11 +393,12 @@ class OptionContainer(Widget):
         :param content: The initial :any:`OptionContainer content
             <OptionContainerContentT>` to display in the OptionContainer.
         :param on_select: Initial :any:`on_select` handler.
+        :param kwargs: Initial style properties.
         """
         self._content = OptionList(self)
         self.on_select = None
 
-        super().__init__(id=id, style=style)
+        super().__init__(id, style, **kwargs)
 
         if content is not None:
             for item in content:

--- a/core/src/toga/widgets/progressbar.py
+++ b/core/src/toga/widgets/progressbar.py
@@ -15,6 +15,7 @@ class ProgressBar(Widget):
         max: str | SupportsFloat = 1.0,
         value: str | SupportsFloat = 0.0,
         running: bool = False,
+        **kwargs,
     ):
         """Create a new Progress Bar widget.
 
@@ -29,8 +30,9 @@ class ProgressBar(Widget):
             clipped. Defaults to 0.0.
         :param running: Describes whether the indicator is running at the time
             it is created. Default is False.
+        :param kwargs: Initial style properties.
         """
-        super().__init__(id=id, style=style)
+        super().__init__(id, style, **kwargs)
 
         self.max = max
         self.value = value

--- a/core/src/toga/widgets/scrollcontainer.py
+++ b/core/src/toga/widgets/scrollcontainer.py
@@ -29,6 +29,7 @@ class ScrollContainer(Widget):
         vertical: bool = True,
         on_scroll: OnScrollHandler | None = None,
         content: Widget | None = None,
+        **kwargs,
     ):
         """Create a new Scroll Container.
 
@@ -39,12 +40,13 @@ class ScrollContainer(Widget):
         :param vertical: Should horizontal scrolling be permitted?
         :param on_scroll: Initial :any:`on_scroll` handler.
         :param content: The content to display in the scroll window.
+        :param kwargs: Initial style properties.
         """
 
         self._content: Widget | None = None
         self.on_scroll = None
 
-        super().__init__(id=id, style=style)
+        super().__init__(id, style, **kwargs)
 
         # Set all attributes
         self.vertical = vertical

--- a/core/src/toga/widgets/selection.py
+++ b/core/src/toga/widgets/selection.py
@@ -31,6 +31,7 @@ class Selection(Widget):
         value: object | None = None,
         on_change: toga.widgets.selection.OnChangeHandler | None = None,
         enabled: bool = True,
+        **kwargs,
     ):
         """Create a new Selection widget.
 
@@ -45,6 +46,7 @@ class Selection(Widget):
             ``items`` will be selected.
         :param on_change: Initial :any:`on_change` handler.
         :param enabled: Whether the user can interact with the widget.
+        :param kwargs: Initial style properties.
         """
 
         self._items: SourceT | ListSource
@@ -52,7 +54,7 @@ class Selection(Widget):
         self.on_change = None  # needed for _impl initialization
 
         self._accessor = accessor
-        super().__init__(id=id, style=style)
+        super().__init__(id, style, **kwargs)
 
         self.items = items
         if value:

--- a/core/src/toga/widgets/slider.py
+++ b/core/src/toga/widgets/slider.py
@@ -52,6 +52,7 @@ class Slider(Widget):
         on_press: toga.widgets.slider.OnPressHandler | None = None,
         on_release: OnReleaseHandler | None = None,
         enabled: bool = True,
+        **kwargs,
     ):
         """Create a new Slider widget.
 
@@ -68,8 +69,9 @@ class Slider(Widget):
         :param on_press: Initial :any:`on_press` handler.
         :param on_release: Initial :any:`on_release` handler.
         :param enabled: Whether the user can interact with the widget.
+        :param kwargs: Initial style properties.
         """
-        super().__init__(id=id, style=style)
+        super().__init__(id, style, **kwargs)
 
         # Set a dummy handler before installing the actual on_change, because we do not
         # want on_change triggered by the initial value being set

--- a/core/src/toga/widgets/splitcontainer.py
+++ b/core/src/toga/widgets/splitcontainer.py
@@ -29,6 +29,7 @@ class SplitContainer(Widget):
         style: StyleT | None = None,
         direction: Direction = Direction.VERTICAL,
         content: Sequence[SplitContainerContentT] | None = None,
+        **kwargs,
     ):
         """Create a new SplitContainer.
 
@@ -41,9 +42,10 @@ class SplitContainer(Widget):
             :attr:`~toga.constants.Direction.VERTICAL`
         :param content: Initial :any:`SplitContainer content <SplitContainerContentT>`
             of the container. Defaults to both panels being empty.
+        :param kwargs: Initial style properties.
         """
         self._content: list[SplitContainerContentT] = [None, None]
-        super().__init__(id=id, style=style)
+        super().__init__(id, style, **kwargs)
 
         if content:
             self.content = content

--- a/core/src/toga/widgets/switch.py
+++ b/core/src/toga/widgets/switch.py
@@ -26,6 +26,7 @@ class Switch(Widget):
         on_change: toga.widgets.switch.OnChangeHandler | None = None,
         value: bool = False,
         enabled: bool = True,
+        **kwargs,
     ):
         """Create a new Switch widget.
 
@@ -38,8 +39,9 @@ class Switch(Widget):
             value.
         :param enabled: Is the switch enabled (i.e., can it be pressed?).
             Optional; by default, switches are created in an enabled state.
+        :param kwargs: Initial style properties.
         """
-        super().__init__(id=id, style=style)
+        super().__init__(id, style, **kwargs)
 
         self.text = text
 

--- a/core/src/toga/widgets/table.py
+++ b/core/src/toga/widgets/table.py
@@ -44,6 +44,7 @@ class Table(Widget):
         on_select: toga.widgets.table.OnSelectHandler | None = None,
         on_activate: toga.widgets.table.OnActivateHandler | None = None,
         missing_value: str = "",
+        **kwargs,
     ):
         """Create a new Table widget.
 
@@ -74,6 +75,7 @@ class Table(Widget):
         :param missing_value: The string that will be used to populate a cell when the
             value provided by its accessor is :any:`None`, or the accessor isn't
             defined.
+        :param kwargs: Initial style properties.
         """
         self._headings: list[str] | None
         self._accessors: list[str]
@@ -98,7 +100,7 @@ class Table(Widget):
         self.on_activate = None
         self._data = None
 
-        super().__init__(id=id, style=style)
+        super().__init__(id, style, **kwargs)
 
         self.data = data
 

--- a/core/src/toga/widgets/textinput.py
+++ b/core/src/toga/widgets/textinput.py
@@ -46,8 +46,6 @@ class OnLoseFocusHandler(Protocol):
 
 
 class TextInput(Widget):
-    """Create a new single-line text input widget."""
-
     def __init__(
         self,
         id: str | None = None,
@@ -60,8 +58,10 @@ class TextInput(Widget):
         on_gain_focus: OnGainFocusHandler | None = None,
         on_lose_focus: OnLoseFocusHandler | None = None,
         validators: Iterable[Callable[[str], bool]] | None = None,
+        **kwargs,
     ):
-        """
+        """Create a new single-line text input widget.
+
         :param id: The ID for the widget.
         :param style: A style object. If no style is provided, a default style will be
             applied to the widget.
@@ -78,8 +78,9 @@ class TextInput(Widget):
         :param on_lose_focus: A handler that will be invoked when the widget loses
             input focus.
         :param validators: A list of validators to run on the value of the input.
+        :param kwargs: Initial style properties.
         """
-        super().__init__(id=id, style=style)
+        super().__init__(id, style, **kwargs)
 
         self.placeholder = placeholder
         self.readonly = readonly

--- a/core/src/toga/widgets/timeinput.py
+++ b/core/src/toga/widgets/timeinput.py
@@ -27,6 +27,7 @@ class TimeInput(Widget):
         min: datetime.time | None = None,
         max: datetime.time | None = None,
         on_change: toga.widgets.timeinput.OnChangeHandler | None = None,
+        **kwargs,
     ):
         """Create a new TimeInput widget.
 
@@ -38,8 +39,9 @@ class TimeInput(Widget):
         :param min: The earliest time (inclusive) that can be selected.
         :param max: The latest time (inclusive) that can be selected.
         :param on_change: A handler that will be invoked when the value changes.
+        :param kwargs: Initial style properties.
         """
-        super().__init__(id=id, style=style)
+        super().__init__(id, style, **kwargs)
 
         self.on_change = None
         self.min = min

--- a/core/src/toga/widgets/tree.py
+++ b/core/src/toga/widgets/tree.py
@@ -44,6 +44,7 @@ class Tree(Widget):
         on_select: toga.widgets.tree.OnSelectHandler | None = None,
         on_activate: toga.widgets.tree.OnActivateHandler | None = None,
         missing_value: str = "",
+        **kwargs,
     ):
         """Create a new Tree widget.
 
@@ -74,6 +75,7 @@ class Tree(Widget):
         :param missing_value: The string that will be used to populate a cell when the
             value provided by its accessor is :any:`None`, or the accessor isn't
             defined.
+        :param kwargs: Initial style properties.
         """
         self._headings: list[str] | None
         self._data: SourceT | TreeSource
@@ -96,7 +98,7 @@ class Tree(Widget):
         self.on_activate = None
         self._data = None
 
-        super().__init__(id=id, style=style)
+        super().__init__(id, style, **kwargs)
 
         self.data = data
 

--- a/core/src/toga/widgets/webview.py
+++ b/core/src/toga/widgets/webview.py
@@ -33,6 +33,7 @@ class WebView(Widget):
         url: str | None = None,
         user_agent: str | None = None,
         on_webview_load: OnWebViewLoadHandler | None = None,
+        **kwargs,
     ):
         """Create a new WebView widget.
 
@@ -45,8 +46,9 @@ class WebView(Widget):
             provided, the default user agent for the platform will be used.
         :param on_webview_load: A handler that will be invoked when the web view
             finishes loading.
+        :param kwargs: Initial style properties.
         """
-        super().__init__(id=id, style=style)
+        super().__init__(id, style, **kwargs)
 
         self.user_agent = user_agent
 

--- a/core/tests/style/test_mixin.py
+++ b/core/tests/style/test_mixin.py
@@ -1,0 +1,58 @@
+from pytest import raises
+
+from toga.style import Pack
+
+from ..utils import ExampleWidget
+
+
+def test_constructor():
+    """Style properties can be set with widget constructor kwargs."""
+    widget = ExampleWidget()
+    assert widget.id.isdigit()
+    assert widget.style.flex == 0
+    assert widget.style.display == "pack"
+
+    widget = ExampleWidget(id="my-id", flex=1, display="none")
+    assert widget.id == "my-id"
+    assert widget.style.flex == 1
+    assert widget.style.display == "none"
+
+    with raises(NameError, match="Unknown style 'nonexistent'"):
+        ExampleWidget(nonexistent=None)
+
+
+def test_constructor_style():
+    """If both a style object and kwargs are passed, the kwargs should take priority,
+    and the style object should not be modified."""
+    style = Pack(display="none", flex=1)
+    widget = ExampleWidget(style=style, flex=2)
+    assert widget.style.display == "none"
+    assert widget.style.flex == 2
+    assert style.flex == 1
+
+
+def test_attribute():
+    """Style properties can be accessed as widget properties."""
+    widget = ExampleWidget()
+    assert widget.flex == 0
+
+    widget.flex = 1
+    assert widget.flex == 1
+
+    del widget.flex
+    assert widget.flex == 0
+
+    # Check regular attributes still work correctly
+    with raises(AttributeError):
+        widget.my_attr
+    widget.my_attr = 42
+    assert widget.my_attr == 42
+    del widget.my_attr
+    with raises(AttributeError):
+        widget.my_attr
+
+
+def test_class_attribute():
+    """Getting a style attribute from the class should return a property object."""
+    prop = ExampleWidget.flex
+    assert type(prop).__name__ == "StyleProperty"

--- a/core/tests/style/test_mixin.py
+++ b/core/tests/style/test_mixin.py
@@ -35,12 +35,23 @@ def test_attribute():
     """Style properties can be accessed as widget properties."""
     widget = ExampleWidget()
     assert widget.flex == 0
+    assert widget.style.flex == 0
 
     widget.flex = 1
     assert widget.flex == 1
+    assert widget.style.flex == 1
 
     del widget.flex
     assert widget.flex == 0
+    assert widget.style.flex == 0
+
+    widget.style.flex = 2
+    assert widget.flex == 2
+    assert widget.style.flex == 2
+
+    del widget.flex
+    assert widget.flex == 0
+    assert widget.style.flex == 0
 
     # Check regular attributes still work correctly
     with raises(AttributeError):

--- a/core/tests/widgets/test_activityindicator.py
+++ b/core/tests/widgets/test_activityindicator.py
@@ -20,6 +20,24 @@ def test_widget_created(activity_indicator):
     assert_action_performed(activity_indicator, "create ActivityIndicator")
 
 
+def test_widget_create_with_values():
+    """An activity indicator can be created with initial values."""
+    activity_indicator = toga.ActivityIndicator(
+        id="foobar",
+        running=True,
+        # A style property
+        width=256,
+    )
+
+    # Round trip the impl/interface
+    assert activity_indicator._impl.interface == activity_indicator
+    assert_action_performed(activity_indicator, "create ActivityIndicator")
+
+    assert activity_indicator.id == "foobar"
+    assert activity_indicator.is_running
+    assert activity_indicator.style.width == 256
+
+
 def test_disable_no_op(activity_indicator):
     """ActivityIndicator doesn't have a disabled state."""
     # Enabled by default

--- a/core/tests/widgets/test_box.py
+++ b/core/tests/widgets/test_box.py
@@ -20,7 +20,12 @@ def test_create_box_with_children():
     """A Box can be created with children."""
     child1 = toga.Box()
     child2 = toga.Box()
-    box = toga.Box(children=[child1, child2])
+    box = toga.Box(
+        id="foobar",
+        children=[child1, child2],
+        # A style property
+        width=256,
+    )
 
     # Round trip the impl/interface
     assert box._impl.interface == box
@@ -31,6 +36,10 @@ def test_create_box_with_children():
 
     # But the box will have children.
     assert box.children == [child1, child2]
+
+    # Other properties are preserved
+    assert box.id == "foobar"
+    assert box.style.width == 256
 
 
 def test_disable_no_op():

--- a/core/tests/widgets/test_button.py
+++ b/core/tests/widgets/test_button.py
@@ -45,6 +45,30 @@ def test_button_created(value, expected):
     assert button.icon is None
 
 
+def test_button_created_with_values():
+    """A button can be created with initial values."""
+    on_press_handler = Mock()
+    button = toga.Button(
+        id="foobar",
+        text="Button text",
+        on_press=on_press_handler,
+        enabled=False,
+        # A style property
+        width=256,
+    )
+
+    # Round trip the impl/interface
+    assert button._impl.interface == button
+
+    assert_action_performed(button, "create Button")
+    assert button.id == "foobar"
+    assert button.text == "Button text"
+    assert button.icon is None
+    assert button.on_press._raw == on_press_handler
+    assert not button.enabled
+    assert button.style.width == 256
+
+
 def test_icon_button_created(button, sample_icon):
     """A button can be created."""
     button = toga.Button(icon=sample_icon)

--- a/core/tests/widgets/test_dateinput.py
+++ b/core/tests/widgets/test_dateinput.py
@@ -36,18 +36,23 @@ def test_widget_created_with_values(on_change_handler):
     """A DateInput can be created with initial values."""
     # Round trip the impl/interface
     widget = toga.DateInput(
+        id="foobar",
         value=date(2015, 6, 15),
         min=date(2013, 5, 14),
         max=date(2017, 7, 16),
         on_change=on_change_handler,
+        # A style property
+        width=256,
     )
     assert widget._impl.interface == widget
     assert_action_performed(widget, "create DateInput")
 
+    assert widget.id == "foobar"
     assert widget.value == date(2015, 6, 15)
     assert widget.min == date(2013, 5, 14)
     assert widget.max == date(2017, 7, 16)
     assert widget.on_change._raw == on_change_handler
+    assert widget.style.width == 256
 
     # The change handler isn't invoked at construction.
     on_change_handler.assert_not_called()

--- a/core/tests/widgets/test_detailedlist.py
+++ b/core/tests/widgets/test_detailedlist.py
@@ -93,6 +93,7 @@ def test_create_with_values(
 ):
     """A DetailedList can be created with initial values."""
     detailedlist = toga.DetailedList(
+        id="foobar",
         data=source,
         accessors=("key", "value", "icon"),
         missing_value="Boo!",
@@ -102,10 +103,13 @@ def test_create_with_values(
         on_primary_action=on_primary_action_handler,
         secondary_action="Secondary",
         on_secondary_action=on_secondary_action_handler,
+        # A style property
+        width=256,
     )
     assert detailedlist._impl.interface == detailedlist
     assert_action_performed(detailedlist, "create DetailedList")
 
+    assert detailedlist.id == "foobar"
     assert len(detailedlist.data) == 3
     assert detailedlist.accessors == ("key", "value", "icon")
     assert detailedlist.missing_value == "Boo!"
@@ -115,6 +119,7 @@ def test_create_with_values(
     assert detailedlist.on_secondary_action._raw == on_secondary_action_handler
     assert detailedlist._primary_action == "Primary"
     assert detailedlist._secondary_action == "Secondary"
+    assert detailedlist.style.width == 256
 
     assert_action_performed_with(detailedlist, "refresh enabled", enabled=True)
     assert_action_performed_with(detailedlist, "primary action enabled", enabled=True)

--- a/core/tests/widgets/test_divider.py
+++ b/core/tests/widgets/test_divider.py
@@ -23,7 +23,12 @@ def test_divider_created():
 @pytest.mark.parametrize("direction", [toga.Divider.HORIZONTAL, toga.Divider.VERTICAL])
 def test_divider_created_explicit(direction):
     """A divider can be created."""
-    divider = toga.Divider(direction=direction)
+    divider = toga.Divider(
+        id="foobar",
+        direction=direction,
+        # A style property
+        width=256,
+    )
 
     # Round trip the impl/interface
     assert divider._impl.interface == divider
@@ -31,6 +36,9 @@ def test_divider_created_explicit(direction):
 
     # Default direction is honored
     assert divider.direction == direction
+
+    assert divider.id == "foobar"
+    assert divider.style.width == 256
 
 
 def test_disable_no_op():

--- a/core/tests/widgets/test_imageview.py
+++ b/core/tests/widgets/test_imageview.py
@@ -37,7 +37,12 @@ ABSOLUTE_FILE_PATH = Path(__file__).parent.parent / "resources/toga.png"
 def test_create_from_toga_image(app):
     """An ImageView can be created from a Toga image."""
     image = toga.Image(ABSOLUTE_FILE_PATH)
-    widget = toga.ImageView(image=image)
+    widget = toga.ImageView(
+        id="foobar",
+        image=image,
+        # A style property
+        width=256,
+    )
 
     # Interface/impl round trips
     assert widget._impl.interface is widget
@@ -45,8 +50,10 @@ def test_create_from_toga_image(app):
     assert_action_performed_with(widget, "set image", image=image)
     assert_action_performed(widget, "refresh")
 
-    # Image attribute is set
+    # Image attributes are set
+    assert widget.id == "foobar"
     assert widget.image == image
+    assert widget.style.width == 256
 
 
 def test_create_from_pil():

--- a/core/tests/widgets/test_label.py
+++ b/core/tests/widgets/test_label.py
@@ -21,6 +21,23 @@ def test_label_created(label):
     assert_action_performed(label, "create Label")
 
 
+def test_label_create_with_values():
+    """A label can be created with initial values."""
+    label = toga.Label(
+        "Test Label",
+        id="foobar",
+        # A style property
+        width=256,
+    )
+    # Round trip the impl/interface
+    assert label._impl.interface == label
+    assert_action_performed(label, "create Label")
+
+    assert label.id == "foobar"
+    assert label.text == "Test Label"
+    assert label.style.width == 256
+
+
 @pytest.mark.parametrize(
     "value, expected",
     [

--- a/core/tests/widgets/test_mapview.py
+++ b/core/tests/widgets/test_mapview.py
@@ -49,16 +49,26 @@ def test_create_with_values(pins):
     """A MapView can be created with all available arguments"""
     on_select = Mock()
 
-    widget = toga.MapView(location=(37.0, 42.0), zoom=4, pins=pins, on_select=on_select)
+    widget = toga.MapView(
+        id="foobar",
+        location=(37.0, 42.0),
+        zoom=4,
+        pins=pins,
+        on_select=on_select,
+        # A style property
+        width=256,
+    )
 
     assert widget._impl.interface == widget
     assert_action_performed(widget, "create MapView")
 
+    assert widget.id == "foobar"
     assert widget.location == toga.LatLng(37.0, 42.0)
     assert widget.zoom == 4
     assert set(widget.pins) == set(pins)
     assert repr(widget.pins) == "<MapPinSet (2 pins)>"
     assert widget._on_select._raw == on_select
+    assert widget.style.width == 256
 
 
 def test_latlng_properties():

--- a/core/tests/widgets/test_multilinetextinput.py
+++ b/core/tests/widgets/test_multilinetextinput.py
@@ -26,18 +26,23 @@ def test_create_with_values():
     """A multiline text input can be created with initial values."""
     on_change = Mock()
     widget = toga.MultilineTextInput(
+        id="foobar",
         value="Some text",
         placeholder="A placeholder",
         readonly=True,
         on_change=on_change,
+        # A style property
+        width=256,
     )
     assert widget._impl.interface == widget
     assert_action_performed(widget, "create MultilineTextInput")
 
+    assert widget.id == "foobar"
     assert widget.readonly
     assert widget.placeholder == "A placeholder"
     assert widget.value == "Some text"
     assert widget._on_change._raw == on_change
+    assert widget.style.width == 256
 
     # Change handler hasn't been invoked
     on_change.assert_not_called()

--- a/core/tests/widgets/test_numberinput.py
+++ b/core/tests/widgets/test_numberinput.py
@@ -37,22 +37,27 @@ def test_create_with_values():
     on_change = Mock()
 
     widget = toga.NumberInput(
+        id="foobar",
         value=Decimal("2.71828"),
         step=0.001,
         min=-42,
         max=420,
         readonly=True,
         on_change=on_change,
+        # A style property
+        width=256,
     )
     assert widget._impl.interface == widget
     assert_action_performed(widget, "create NumberInput")
 
+    assert widget.id == "foobar"
     assert widget.readonly
     assert widget.value == Decimal("2.718")
     assert widget.step == Decimal("0.001")
     assert widget.min == Decimal("-42")
     assert widget.max == Decimal("420")
     assert widget._on_change._raw == on_change
+    assert widget.style.width == 256
 
     # Change handler hasn't been invoked
     on_change.assert_not_called()

--- a/core/tests/widgets/test_optioncontainer.py
+++ b/core/tests/widgets/test_optioncontainer.py
@@ -78,7 +78,6 @@ def test_widget_create():
 
 
 def test_widget_create_with_args(
-    optioncontainer,
     content1,
     content2,
     content3,
@@ -87,15 +86,30 @@ def test_widget_create_with_args(
     tab_icon,
 ):
     """An option container can be created with arguments."""
+    optioncontainer = toga.OptionContainer(
+        id="foobar",
+        content=[
+            ("Item 1", content1),
+            ("Item 2", content2, "other-icon"),
+            ("Item 3", content3, tab_icon, False),
+            toga.OptionItem("Item 4", content4),
+        ],
+        on_select=on_select_handler,
+        # A style property
+        width=256,
+    )
+
     assert optioncontainer._impl.interface == optioncontainer
     assert_action_performed(optioncontainer, "create OptionContainer")
 
+    assert optioncontainer.id == "foobar"
     assert len(optioncontainer.content) == 4
     assert optioncontainer.current_tab.text == "Item 1"
     assert optioncontainer.current_tab.icon is None
     assert optioncontainer.current_tab.enabled
     assert optioncontainer.current_tab.content == content1
     assert optioncontainer.on_select._raw == on_select_handler
+    assert optioncontainer.style.width == 256
 
     assert optioncontainer.content[1].text == "Item 2"
     assert optioncontainer.content[1].icon.path.name == "other-icon"

--- a/core/tests/widgets/test_passwordinput.py
+++ b/core/tests/widgets/test_passwordinput.py
@@ -30,6 +30,7 @@ def test_create_with_values():
     validator2 = Mock(return_value=None)
 
     widget = toga.PasswordInput(
+        id="foobar",
         value="Some text",
         placeholder="A placeholder",
         readonly=True,
@@ -38,10 +39,13 @@ def test_create_with_values():
         on_gain_focus=on_gain_focus,
         on_lose_focus=on_lose_focus,
         validators=[validator1, validator2],
+        # A style property
+        width=256,
     )
     assert widget._impl.interface == widget
     assert_action_performed(widget, "create PasswordInput")
 
+    assert widget.id == "foobar"
     assert widget.readonly
     assert widget.placeholder == "A placeholder"
     assert widget.value == "Some text"
@@ -50,6 +54,7 @@ def test_create_with_values():
     assert widget._on_gain_focus._raw == on_gain_focus
     assert widget._on_lose_focus._raw == on_lose_focus
     assert widget.validators == [validator1, validator2]
+    assert widget.style.width == 256
 
     # Validators have been invoked with the initial text
     validator1.assert_called_once_with("Some text")

--- a/core/tests/widgets/test_progressbar.py
+++ b/core/tests/widgets/test_progressbar.py
@@ -29,6 +29,30 @@ def test_progressbar_created(progressbar):
     assert not progressbar.is_running
 
 
+def test_progressbar_create_with_values():
+    """A progressbar can be created with initial values."""
+    progressbar = toga.ProgressBar(
+        id="foobar",
+        max=42.0,
+        value=37.0,
+        running=True,
+        # A style property
+        width=256,
+    )
+
+    # Round trip the impl/interface
+    assert progressbar._impl.interface == progressbar
+    assert_action_performed(progressbar, "create ProgressBar")
+
+    # Assert the state of the progress bar.
+    assert progressbar.id == "foobar"
+    assert progressbar.max == pytest.approx(42.0)
+    assert progressbar.value == pytest.approx(37.0)
+    assert progressbar.is_determinate
+    assert progressbar.is_running
+    assert progressbar.style.width == 256
+
+
 @pytest.mark.parametrize(
     "value, actual",
     [

--- a/core/tests/widgets/test_scrollcontainer.py
+++ b/core/tests/widgets/test_scrollcontainer.py
@@ -47,18 +47,23 @@ def test_widget_created():
 def test_widget_created_with_values(content, on_scroll_handler):
     """A scroll container can be created with arguments."""
     scroll_container = toga.ScrollContainer(
+        id="foobar",
         content=content,
         on_scroll=on_scroll_handler,
         vertical=False,
         horizontal=False,
+        # A style property
+        width=256,
     )
     assert scroll_container._impl.interface == scroll_container
     assert_action_performed(scroll_container, "create ScrollContainer")
 
+    assert scroll_container.id == "foobar"
     assert scroll_container.content == content
     assert not scroll_container.vertical
     assert not scroll_container.horizontal
     assert scroll_container.on_scroll._raw == on_scroll_handler
+    assert scroll_container.style.width == 256
 
     # The content has been assigned to the widget
     assert_action_performed_with(

--- a/core/tests/widgets/test_selection.py
+++ b/core/tests/widgets/test_selection.py
@@ -57,19 +57,24 @@ def test_create_with_value():
     on_change = Mock()
 
     widget = toga.Selection(
+        id="foobar",
         items=["first", "second", "third"],
         value="second",
         on_change=on_change,
         enabled=False,
+        # A style property
+        width=256,
     )
     assert widget._impl.interface == widget
     assert_action_performed(widget, "create Selection")
 
+    assert widget.id == "foobar"
     assert len(widget.items) == 3
     assert widget._accessor is None
     assert widget.value == "second"
     assert widget.on_change._raw == on_change
     assert not widget.enabled
+    assert widget.style.width == 256
 
 
 @pytest.mark.parametrize(

--- a/core/tests/widgets/test_slider.py
+++ b/core/tests/widgets/test_slider.py
@@ -31,9 +31,44 @@ def slider(on_change):
     )
 
 
-def test_widget_created(slider, on_change):
+def test_widget_create(slider, on_change):
+    """A slider widget can be created."""
     assert slider._impl.interface == slider
     assert_action_performed(slider, "create Slider")
+
+
+def test_widget_create_initial_values(on_change):
+    """A slider widget can be created."""
+    on_press = Mock()
+    on_release = Mock()
+
+    slider = toga.Slider(
+        id="foobar",
+        value=37.0,
+        min=-42.0,
+        max=42.0,
+        tick_count=1234,
+        on_change=on_change,
+        on_press=on_press,
+        on_release=on_release,
+        enabled=False,
+        # A style property
+        width=256,
+    )
+
+    assert slider._impl.interface == slider
+    assert_action_performed(slider, "create Slider")
+
+    assert slider.id == "foobar"
+    assert slider.value == pytest.approx(37.0, abs=0.1)
+    assert slider.min == pytest.approx(-42.0)
+    assert slider.max == pytest.approx(42.0)
+    assert slider.tick_count == 1234
+    assert slider.on_change._raw == on_change
+    assert slider.on_press._raw == on_press
+    assert slider.on_release._raw == on_release
+    assert not slider.enabled
+    assert slider.style.width == 256
 
 
 @pytest.mark.parametrize(

--- a/core/tests/widgets/test_splitcontainer.py
+++ b/core/tests/widgets/test_splitcontainer.py
@@ -46,14 +46,19 @@ def test_widget_created():
 def test_widget_created_with_values(content1, content2):
     """A split container can be created with arguments."""
     splitcontainer = toga.SplitContainer(
+        id="foobar",
         content=[content1, content2],
         direction=toga.SplitContainer.HORIZONTAL,
+        # A style property
+        width=256,
     )
     assert splitcontainer._impl.interface == splitcontainer
     assert_action_performed(splitcontainer, "create SplitContainer")
 
+    assert splitcontainer.id == "foobar"
     assert splitcontainer.content == [content1, content2]
     assert splitcontainer.direction == toga.SplitContainer.HORIZONTAL
+    assert splitcontainer.style.width == 256
 
     # The content has been assigned to the widget
     assert_action_performed_with(

--- a/core/tests/widgets/test_switch.py
+++ b/core/tests/widgets/test_switch.py
@@ -35,14 +35,19 @@ def test_widget_created_explicit(switch):
 
     switch = toga.Switch(
         "Explicit Switch",
+        id="foobar",
         value=True,
         enabled=False,
         on_change=change_handler,
+        # A style property
+        width=256,
     )
 
+    assert switch.id == "foobar"
     assert switch.text == "Explicit Switch"
     assert switch.on_change._raw == change_handler
     assert not switch.enabled
+    assert switch.style.width == 256
 
 
 @pytest.mark.parametrize(

--- a/core/tests/widgets/test_table.py
+++ b/core/tests/widgets/test_table.py
@@ -63,16 +63,20 @@ def test_create_with_values(source, on_select_handler, on_activate_handler):
     """A Table can be created with initial values."""
     table = toga.Table(
         ["First", "Second"],
+        id="foobar",
         data=source,
         accessors=["primus", "secondus"],
         multiple_select=True,
         on_select=on_select_handler,
         on_activate=on_activate_handler,
         missing_value="Boo!",
+        # A style property
+        width=256,
     )
     assert table._impl.interface == table
     assert_action_performed(table, "create Table")
 
+    assert table.id == "foobar"
     assert len(table.data) == 3
     assert table.headings == ["First", "Second"]
     assert table.accessors == ["primus", "secondus"]
@@ -80,6 +84,7 @@ def test_create_with_values(source, on_select_handler, on_activate_handler):
     assert table.missing_value == "Boo!"
     assert table.on_select._raw == on_select_handler
     assert table.on_activate._raw == on_activate_handler
+    assert table.style.width == 256
 
 
 def test_create_with_accessor_overrides():

--- a/core/tests/widgets/test_textinput.py
+++ b/core/tests/widgets/test_textinput.py
@@ -49,6 +49,7 @@ def test_create_with_values():
     validator2 = Mock(return_value=None)
 
     widget = toga.TextInput(
+        id="foobar",
         value="Some text",
         placeholder="A placeholder",
         readonly=True,
@@ -57,10 +58,13 @@ def test_create_with_values():
         on_gain_focus=on_gain_focus,
         on_lose_focus=on_lose_focus,
         validators=[validator1, validator2],
+        # A style property
+        width=256,
     )
     assert widget._impl.interface == widget
     assert_action_performed(widget, "create TextInput")
 
+    assert widget.id == "foobar"
     assert widget.readonly
     assert widget.placeholder == "A placeholder"
     assert widget.value == "Some text"
@@ -69,6 +73,7 @@ def test_create_with_values():
     assert widget._on_gain_focus._raw == on_gain_focus
     assert widget._on_lose_focus._raw == on_lose_focus
     assert widget.validators == [validator1, validator2]
+    assert widget.style.width == 256
 
     # Validators have been invoked with the initial text
     validator1.assert_called_once_with("Some text")

--- a/core/tests/widgets/test_timeinput.py
+++ b/core/tests/widgets/test_timeinput.py
@@ -34,18 +34,23 @@ def test_widget_created_with_values(on_change_handler):
     """A TimeInput can be created with initial values."""
     # Round trip the impl/interface
     widget = toga.TimeInput(
+        id="foobar",
         value=time(13, 37, 42),
         min=time(6, 1, 2),
         max=time(18, 58, 59),
         on_change=on_change_handler,
+        # A style property
+        width=256,
     )
     assert widget._impl.interface == widget
     assert_action_performed(widget, "create TimeInput")
 
+    assert widget.id == "foobar"
     assert widget.value == time(13, 37, 42)
     assert widget.min == time(6, 1, 2)
     assert widget.max == time(18, 58, 59)
     assert widget.on_change._raw == on_change_handler
+    assert widget.style.width == 256
 
     # The change handler isn't invoked at construction.
     on_change_handler.assert_not_called()

--- a/core/tests/widgets/test_tree.py
+++ b/core/tests/widgets/test_tree.py
@@ -95,16 +95,20 @@ def test_create_with_values(source, on_select_handler, on_activate_handler):
     """A Tree can be created with initial values."""
     tree = toga.Tree(
         ["First", "Second"],
+        id="foobar",
         data=source,
         accessors=["primus", "secondus"],
         multiple_select=True,
         on_select=on_select_handler,
         on_activate=on_activate_handler,
         missing_value="Boo!",
+        # A style property
+        width=256,
     )
     assert tree._impl.interface == tree
     assert_action_performed(tree, "create Tree")
 
+    assert tree.id == "foobar"
     assert len(tree.data) == 2
     assert tree.headings == ["First", "Second"]
     assert tree.accessors == ["primus", "secondus"]
@@ -112,6 +116,7 @@ def test_create_with_values(source, on_select_handler, on_activate_handler):
     assert tree.missing_value == "Boo!"
     assert tree.on_select._raw == on_select_handler
     assert tree.on_activate._raw == on_activate_handler
+    assert tree.style.width == 256
 
 
 def test_create_with_accessor_overrides():

--- a/core/tests/widgets/test_webview.py
+++ b/core/tests/widgets/test_webview.py
@@ -36,16 +36,21 @@ def test_create_with_values():
     on_webview_load = Mock()
 
     widget = toga.WebView(
+        id="foobar",
         url="https://beeware.org",
         user_agent="Custom agent",
         on_webview_load=on_webview_load,
+        # A style property
+        width=256,
     )
     assert widget._impl.interface == widget
     assert_action_performed(widget, "create WebView")
 
+    assert widget.id == "foobar"
     assert widget.url == "https://beeware.org"
     assert widget.user_agent == "Custom agent"
     assert widget.on_webview_load._raw == on_webview_load
+    assert widget.style.width == 256
 
 
 def test_webview_load_disabled(monkeypatch):

--- a/docs/reference/api/widgets/widget.rst
+++ b/docs/reference/api/widgets/widget.rst
@@ -15,4 +15,7 @@ Reference
 ---------
 
 .. autoclass:: toga.Widget
-   :inherited-members:
+   :inherited-members: object, PackMixin
+
+.. autoclass:: toga.widgets.base.PackMixin
+   :no-members:

--- a/examples/layout/layout/app.py
+++ b/examples/layout/layout/app.py
@@ -1,6 +1,5 @@
 import toga
 from toga.constants import CENTER, COLUMN, HIDDEN, ROW, VISIBLE
-from toga.style import Pack
 
 
 class ExampleLayoutApp(toga.App):
@@ -20,10 +19,10 @@ class ExampleLayoutApp(toga.App):
             text="Add new label", on_press=self.add_label
         )
 
-        self.content_box = toga.Box(children=[], style=Pack(direction=COLUMN, gap=4))
+        self.content_box = toga.Box(children=[], direction=COLUMN, gap=4)
 
         image = toga.Image("resources/tiberius.png")
-        self.image_view = toga.ImageView(image, style=Pack(width=60, height=60))
+        self.image_view = toga.ImageView(image, width=60, height=60)
 
         # this tests adding children during init, before we have an implementation
         self.button_box = toga.Box(
@@ -35,18 +34,18 @@ class ExampleLayoutApp(toga.App):
                 self.button_remove,
                 self.button_add_to_scroll,
             ],
-            style=Pack(direction=COLUMN, width=120, gap=20),
+            direction=COLUMN,
+            width=120,
+            gap=20,
         )
 
         self.box = toga.Box(
             children=[],
-            style=Pack(
-                direction=ROW,
-                margin=20,
-                gap=20,
-                align_items=CENTER,
-                justify_content=CENTER,
-            ),
+            direction=ROW,
+            margin=20,
+            gap=20,
+            align_items=CENTER,
+            justify_content=CENTER,
         )
 
         # this tests adding children when we already have an impl but no window or app
@@ -63,11 +62,11 @@ class ExampleLayoutApp(toga.App):
         self.main_window.show()
 
     def hide_label(self, sender):
-        if self.labels[0].style.visibility == HIDDEN:
-            self.labels[0].style.visibility = VISIBLE
+        if self.labels[0].visibility == HIDDEN:
+            self.labels[0].visibility = VISIBLE
             self.button_hide.text = "Hide label"
         else:
-            self.labels[0].style.visibility = HIDDEN
+            self.labels[0].visibility = HIDDEN
             self.button_hide.text = "Show label"
 
     def add_image(self, sender):

--- a/examples/resize/resize/app.py
+++ b/examples/resize/resize/app.py
@@ -1,5 +1,4 @@
 import toga
-from toga.style import Pack
 from toga.style.pack import COLUMN, ROW
 
 
@@ -18,70 +17,72 @@ class SizeButton(toga.Button):
 class SizePanel(toga.Box):
     def __init__(self, title, *, on_change):
         self.on_change = on_change
-        self.width, self.height = (
+        self.width_button, self.height_button = (
             SizeButton(text, value=1, max=6, on_press=self.on_press)
             for text in ["W", "H"]
         )
-        self.flex = SizeButton("F", value=0, max=3, on_press=self.on_press)
+        self.flex_button = SizeButton("F", value=0, max=3, on_press=self.on_press)
         super().__init__(
-            style=Pack(direction=COLUMN, align_items="center"),
+            direction=COLUMN,
+            align_items="center",
             children=[
-                toga.Label(title.upper(), style=Pack(font_weight="bold")),
+                toga.Label(title.upper(), font_weight="bold"),
                 toga.Box(
-                    style=Pack(direction=ROW),
-                    children=[self.width, self.height, self.flex],
+                    direction=ROW,
+                    children=[self.width_button, self.height_button, self.flex_button],
                 ),
             ],
         )
         self.on_press(None)
 
     def on_press(self, button):
-        self.on_change(self, self.width.value, self.height.value, self.flex.value)
+        self.on_change(
+            self,
+            self.width_button.value,
+            self.height_button.value,
+            self.flex_button.value,
+        )
 
 
 class Resize(toga.App):
     def startup(self):
         self.text_label, self.style_label = (
-            toga.Label("", style=Pack(background_color="cyan")) for i in range(2)
+            toga.Label("", background_color="cyan") for i in range(2)
         )
         main_box = toga.Box(
-            style=Pack(direction=COLUMN),
+            direction=COLUMN,
             children=[
                 toga.Box(
-                    style=Pack(direction=ROW),
+                    direction=ROW,
                     children=[
                         SizePanel("Text", on_change=self.on_change_text),
-                        toga.Box(style=Pack(flex=1)),
+                        toga.Box(flex=1),
                         SizePanel("Style", on_change=self.on_change_style),
                     ],
                 ),
                 toga.Box(
-                    style=Pack(direction=ROW),
+                    direction=ROW,
                     children=[
                         self.text_label,
                         toga.Label(
                             "Left",
-                            style=Pack(
-                                text_align="left",
-                                background_color="pink",
-                                height=50,
-                                flex=1,
-                            ),
+                            text_align="left",
+                            background_color="pink",
+                            height=50,
+                            flex=1,
                         ),
                         toga.Label(
                             "Center",
-                            style=Pack(
-                                text_align="center",
-                                background_color="yellow",
-                                height=50,
-                                flex=1,
-                            ),
+                            text_align="center",
+                            background_color="yellow",
+                            height=50,
+                            flex=1,
                         ),
                         self.style_label,
                     ],
                 ),
-                toga.Box(style=Pack(background_color="pink", flex=1)),
-                toga.Box(style=Pack(background_color="yellow", flex=1)),
+                toga.Box(background_color="pink", flex=1),
+                toga.Box(background_color="yellow", flex=1),
             ],
         )
 
@@ -98,9 +99,9 @@ class Resize(toga.App):
         # Increment should be large enough that the minimum window width can be
         # determined by either the buttons or the labels, depending on the labels' size.
         INCREMENT = 70
-        setattr_if_changed(self.style_label.style, "width", width * INCREMENT)
-        setattr_if_changed(self.style_label.style, "height", height * INCREMENT)
-        setattr_if_changed(self.style_label.style, "flex", flex)
+        setattr_if_changed(self.style_label, "width", width * INCREMENT)
+        setattr_if_changed(self.style_label, "height", height * INCREMENT)
+        setattr_if_changed(self.style_label, "flex", flex)
 
 
 def setattr_if_changed(obj, name, value):


### PR DESCRIPTION
Closes #3011. 

See design discussion starting at https://github.com/beeware/toga/issues/3011#issuecomment-2588355948.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
