### PR TITLE
Disable hiding window while in `MINIMIZED`, `FULLSCREEN` or `PRESENTATION` state and ignore no-op visibility requests

### DIFF
--- a/android/src/toga_android/window.py
+++ b/android/src/toga_android/window.py
@@ -82,7 +82,10 @@ class Window(Container):
         )
         self.set_title(self._initial_title)
 
-    def show(self):
+    def show(self):  # pragma: no cover
+        # The Window on Android is shown by default when the app starts.
+        # Requesting show() on an already shown window is a no-op and is
+        # ignored at the core level. So this method will never be reached.
         pass
 
     ######################################################################

--- a/changes/3109.removal.rst
+++ b/changes/3109.removal.rst
@@ -1,1 +1,1 @@
-Hiding of a window while in `MINIMIZED`, `FULLSCREEN` or `PRESENTATION` state is now disabled, in order to keep the API behavior consistent on all platforms.
+The `show()` and `hide()` APIs can no longer be used on a window while it is in a `MINIMIZED`, `FULLSCREEN` or `PRESENTATION` state.

--- a/changes/3109.removal.rst
+++ b/changes/3109.removal.rst
@@ -1,0 +1,1 @@
+Hiding of a window while in `MINIMIZED`, `FULLSCREEN` or `PRESENTATION` state is now disabled, in order to keep the API behavior consistent on all platforms.

--- a/core/src/toga/window.py
+++ b/core/src/toga/window.py
@@ -440,7 +440,7 @@ class Window:
         effect.
 
         :raises ValueError: If the window is currently in a minimized, full screen or
-        presentation state.
+            presentation state.
         """
         if self.state in {
             WindowState.MINIMIZED,

--- a/core/src/toga/window.py
+++ b/core/src/toga/window.py
@@ -437,13 +437,17 @@ class Window:
 
     def hide(self) -> None:
         """Hide the window. If the window is already hidden, this method has no
-        effect."""
+        effect.
+
+        :raises ValueError: If the window is currently in a minimized, fullscreen or
+        presentation state.
+        """
         if self.state in {
             WindowState.MINIMIZED,
             WindowState.FULLSCREEN,
             WindowState.PRESENTATION,
         }:
-            raise ValueError(f"A window in {self.state} cannot be set to hidden.")
+            raise ValueError(f"A window in {self.state} state cannot be hidden.")
         else:
             if self.visible:
                 self._impl.hide()

--- a/core/src/toga/window.py
+++ b/core/src/toga/window.py
@@ -312,7 +312,8 @@ class Window:
     def show(self) -> None:
         """Show the window. If the window is already visible, this method has no
         effect."""
-        self._impl.show()
+        if not self.visible:
+            self._impl.show()
 
     ######################################################################
     # Window content and resources
@@ -444,7 +445,8 @@ class Window:
         }:
             raise ValueError(f"A window in {self.state} cannot be set to hidden.")
         else:
-            self._impl.hide()
+            if self.visible:
+                self._impl.hide()
 
     @property
     def visible(self) -> bool:

--- a/core/src/toga/window.py
+++ b/core/src/toga/window.py
@@ -311,9 +311,20 @@ class Window:
 
     def show(self) -> None:
         """Show the window. If the window is already visible, this method has no
-        effect."""
+        effect.
+
+        :raises ValueError: If the window is currently in a minimized, full screen or
+            presentation state.
+        """
         if not self.visible:
-            self._impl.show()
+            if self.state in {
+                WindowState.MINIMIZED,
+                WindowState.FULLSCREEN,
+                WindowState.PRESENTATION,
+            }:
+                raise ValueError(f"A window in {self.state} state cannot be shown.")
+            else:
+                self._impl.show()
 
     ######################################################################
     # Window content and resources
@@ -442,14 +453,14 @@ class Window:
         :raises ValueError: If the window is currently in a minimized, full screen or
             presentation state.
         """
-        if self.state in {
-            WindowState.MINIMIZED,
-            WindowState.FULLSCREEN,
-            WindowState.PRESENTATION,
-        }:
-            raise ValueError(f"A window in {self.state} state cannot be hidden.")
-        else:
-            if self.visible:
+        if self.visible:
+            if self.state in {
+                WindowState.MINIMIZED,
+                WindowState.FULLSCREEN,
+                WindowState.PRESENTATION,
+            }:
+                raise ValueError(f"A window in {self.state} state cannot be hidden.")
+            else:
                 self._impl.hide()
 
     @property

--- a/core/src/toga/window.py
+++ b/core/src/toga/window.py
@@ -439,7 +439,7 @@ class Window:
         """Hide the window. If the window is already hidden, this method has no
         effect.
 
-        :raises ValueError: If the window is currently in a minimized, fullscreen or
+        :raises ValueError: If the window is currently in a minimized, full screen or
         presentation state.
         """
         if self.state in {

--- a/core/src/toga/window.py
+++ b/core/src/toga/window.py
@@ -437,7 +437,14 @@ class Window:
     def hide(self) -> None:
         """Hide the window. If the window is already hidden, this method has no
         effect."""
-        self._impl.hide()
+        if self.state in {
+            WindowState.MINIMIZED,
+            WindowState.FULLSCREEN,
+            WindowState.PRESENTATION,
+        }:
+            raise ValueError(f"A window in {self.state} cannot be set to hidden.")
+        else:
+            self._impl.hide()
 
     @property
     def visible(self) -> bool:

--- a/core/tests/window/test_window.py
+++ b/core/tests/window/test_window.py
@@ -305,6 +305,38 @@ def test_visibility(window, app):
 
 
 @pytest.mark.parametrize(
+    "state",
+    [
+        WindowState.MINIMIZED,
+        WindowState.FULLSCREEN,
+        WindowState.PRESENTATION,
+    ],
+)
+def test_hide_disallowed_on_window_state(window, app, state):
+    """A window in MINIMIZED, FULLSCREEN or PRESENTATION state cannot be
+    set to hidden."""
+    window.show()
+
+    window.state = state
+    assert window.state == state
+    assert window.visible is True
+
+    with pytest.raises(
+        ValueError,
+        match=f"A window in {state} cannot be set to hidden.",
+    ):
+        window.hide()
+        assert_action_not_performed(window, "hide")
+
+    with pytest.raises(
+        ValueError,
+        match=f"A window in {state} cannot be set to hidden.",
+    ):
+        window.visible = False
+        assert_action_not_performed(window, "hide")
+
+
+@pytest.mark.parametrize(
     "initial_state, final_state",
     [
         # Direct switch from NORMAL:

--- a/core/tests/window/test_window.py
+++ b/core/tests/window/test_window.py
@@ -264,6 +264,7 @@ def test_show_hide(window, app):
 
 def test_hide_show(window, app):
     """The window can be hidden then shown."""
+    window.show()
     assert window.app == app
     window.hide()
 
@@ -302,6 +303,37 @@ def test_visibility(window, app):
     assert window in app.windows
     assert_action_performed(window, "hide")
     assert not window.visible
+
+
+def test_visibility_no_op(window, app):
+    """Changing visibility when already in that visibility state is a no-op."""
+    # Show the window
+    window.show()
+    assert window.visible
+    assert_action_performed(window, "show")
+    EventLog.reset()
+
+    window.show()
+    assert window.visible
+    assert_action_not_performed(window, "show")
+
+    window.visible = True
+    assert window.visible
+    assert_action_not_performed(window, "show")
+
+    # Hide the window
+    window.hide()
+    assert not window.visible
+    assert_action_performed(window, "hide")
+    EventLog.reset()
+
+    window.hide()
+    assert not window.visible
+    assert_action_not_performed(window, "hide")
+
+    window.visible = False
+    assert not window.visible
+    assert_action_not_performed(window, "hide")
 
 
 @pytest.mark.parametrize(

--- a/core/tests/window/test_window.py
+++ b/core/tests/window/test_window.py
@@ -355,14 +355,14 @@ def test_hide_disallowed_on_window_state(window, app, state):
 
     with pytest.raises(
         ValueError,
-        match=f"A window in {state} cannot be set to hidden.",
+        match=f"A window in {state} state cannot be hidden.",
     ):
         window.hide()
         assert_action_not_performed(window, "hide")
 
     with pytest.raises(
         ValueError,
-        match=f"A window in {state} cannot be set to hidden.",
+        match=f"A window in {state} state cannot be hidden.",
     ):
         window.visible = False
         assert_action_not_performed(window, "hide")

--- a/core/tests/window/test_window.py
+++ b/core/tests/window/test_window.py
@@ -242,46 +242,59 @@ def test_set_size_with_content(window):
 
 
 def test_show_hide(window, app):
-    """The window can be shown and hidden."""
+    """The window can be shown & hidden, but requesting visibility change when
+    the window is already in that requested visibility state is a no-op."""
+    # Window is assigned to the app, but is not visible
     assert window.app == app
+    assert window in app.windows
+    assert not window.visible
+
+    # Show the window
     window.show()
 
     # The window has been assigned to the app, and is visible
     assert window.app == app
     assert window in app.windows
-    assert_action_performed(window, "show")
     assert window.visible
+    assert_action_performed(window, "show")
+    EventLog.reset()
 
-    # Hide with an explicit call
+    # The window is already shown, so this call will be a no-op
+    window.show()
+
+    # The window is still assigned to the app, and is visible
+    assert window.app == app
+    assert window in app.windows
+    assert window.visible
+    assert_action_not_performed(window, "show")
+
+    # Hide the window
     window.hide()
 
     # Window is still assigned to the app, but is not visible
     assert window.app == app
     assert window in app.windows
-    assert_action_performed(window, "hide")
     assert not window.visible
+    assert_action_performed(window, "hide")
+    EventLog.reset()
 
-
-def test_hide_show(window, app):
-    """The window can be hidden then shown."""
-    window.show()
-    assert window.app == app
+    # The window is already hidden, so this call will be a no-op
     window.hide()
-
-    # The window has been assigned to the app, and is not visible
-    assert window.app == app
-    assert window in app.windows
-    assert_action_performed(window, "hide")
-    assert not window.visible
-
-    # Show with an explicit call
-    window.show()
 
     # Window is still assigned to the app, but is not visible
     assert window.app == app
     assert window in app.windows
-    assert_action_performed(window, "show")
+    assert not window.visible
+    assert_action_not_performed(window, "hide")
+
+    # Show the window
+    window.show()
+
+    # The window is still assigned to the app, and is visible
+    assert window.app == app
+    assert window in app.windows
     assert window.visible
+    assert_action_performed(window, "show")
 
 
 def test_visibility(window, app):
@@ -303,37 +316,6 @@ def test_visibility(window, app):
     assert window in app.windows
     assert_action_performed(window, "hide")
     assert not window.visible
-
-
-def test_visibility_no_op(window, app):
-    """Changing visibility when already in that visibility state is a no-op."""
-    # Show the window
-    window.show()
-    assert window.visible
-    assert_action_performed(window, "show")
-    EventLog.reset()
-
-    window.show()
-    assert window.visible
-    assert_action_not_performed(window, "show")
-
-    window.visible = True
-    assert window.visible
-    assert_action_not_performed(window, "show")
-
-    # Hide the window
-    window.hide()
-    assert not window.visible
-    assert_action_performed(window, "hide")
-    EventLog.reset()
-
-    window.hide()
-    assert not window.visible
-    assert_action_not_performed(window, "hide")
-
-    window.visible = False
-    assert not window.visible
-    assert_action_not_performed(window, "hide")
 
 
 @pytest.mark.parametrize(

--- a/dummy/src/toga_dummy/window.py
+++ b/dummy/src/toga_dummy/window.py
@@ -58,6 +58,7 @@ class Window(LoggedObject):
         self.set_size(size)
 
         self._state = WindowState.NORMAL
+        self._visible = False
 
     ######################################################################
     # Window properties
@@ -82,7 +83,7 @@ class Window(LoggedObject):
 
     def show(self):
         self._action("show")
-        self._set_value("visible", True)
+        self._visible = True
 
     ######################################################################
     # Window content and resources
@@ -122,11 +123,14 @@ class Window(LoggedObject):
     ######################################################################
 
     def get_visible(self):
-        return self._get_value("visible", False)
+        # We cannot store the visibility value on the EventLog, since the value
+        # would be cleared on EventLog.reset(), thereby preventing us from
+        # testing no-op condition of requesting the same visibility as current.
+        return self._visible
 
     def hide(self):
         self._action("hide")
-        self._set_value("visible", False)
+        self._visible = False
 
     ######################################################################
     # Window state

--- a/iOS/src/toga_iOS/window.py
+++ b/iOS/src/toga_iOS/window.py
@@ -132,8 +132,12 @@ class Window:
     ######################################################################
 
     def get_visible(self):
-        # The window is always visible
-        return True
+        # The window is hidden as default by the system, unless makeKeyAndVisible
+        # has been called on the UIWindow. Requesting the same visibility as the
+        # current visibility state is a no-op and is ignored at the core level.
+        # So, always check if the window is currently hidden or not, to ensure that
+        # the other APIs that are dependent on get_visible() work correctly.
+        return not bool(self.native.isHidden())
 
     def hide(self):
         # A no-op, as the window cannot be hidden.

--- a/testbed/tests/window/test_window.py
+++ b/testbed/tests/window/test_window.py
@@ -55,6 +55,7 @@ if toga.platform.current_platform in {"iOS", "android"}:
 
     async def test_visibility(main_window, main_window_probe):
         """Hide and close are no-ops on mobile"""
+        main_window.show()
         assert main_window.visible
 
         main_window.hide()

--- a/testbed/tests/window/test_window.py
+++ b/testbed/tests/window/test_window.py
@@ -55,7 +55,6 @@ if toga.platform.current_platform in {"iOS", "android"}:
 
     async def test_visibility(main_window, main_window_probe):
         """Hide and close are no-ops on mobile"""
-        main_window.show()
         assert main_window.visible
 
         main_window.hide()

--- a/testbed/tests/window/test_window.py
+++ b/testbed/tests/window/test_window.py
@@ -917,10 +917,9 @@ else:
         "state",
         [
             WindowState.NORMAL,
-            WindowState.MINIMIZED,
             WindowState.MAXIMIZED,
-            WindowState.FULLSCREEN,
-            WindowState.PRESENTATION,
+            # Window cannot be hidden while in MINIMIZED, FULLSCREEN or
+            # PRESENTATION. So, those states are excluded from this test.
         ],
     )
     @pytest.mark.parametrize(


### PR DESCRIPTION
<!--- Describe your changes in detail -->
As identified in #2096, the behavior of hiding a window while in MINIMIZED, FULLSCREEN or PRESENTATION state, is inconsistent on macOS:

|From state|Result on calling `window.hide()`|Result of then calling `window.show()`|
|--|--|--|
|`NORMAL`|Window is not visible and window icon is not visible in the dock|Window becomes visible and window icon becomes visible in the dock|
|`MINIMIZED`|Window is not visible and window icon is not visible in the dock|Window becomes visible & un-minimized, and window icon becomes visible in the dock|
|`MAXIMIZED`|Window is not visible and window icon is not visible in the dock|Window becomes visible and window icon becomes visible in the dock|
|`FULLSCREEN`|Screen becomes black|Window becomes visible in fullscreen like before|
|`PRESENTATION`|window content is still visible on the screen, but `NSWindow.isVisible` reports `False`|window content is still visible on the screen, but `NSWindow.isVisible` reports `True`|

This behavior is also inconsistent when compared to other platforms. Therefore, to keep the behavior consistent on all platforms and to be able to implement a stable API on #2096, the hiding of window while in MINIMIZED, FULLSCREEN or PRESENTATION state is disabled.
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Context:
* https://github.com/beeware/toga/pull/2096#issuecomment-2593642551
* https://github.com/beeware/toga/pull/2096#issuecomment-2594594061
## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
