### PR TITLE
Proposal: Change to validated property API

### DIFF
--- a/changes/3115.misc.rst
+++ b/changes/3115.misc.rst
@@ -1,0 +1,1 @@
+Travertino's new dataclass-based syntax for creating validated properties now directly accepts the arguments to pass along to its internal Choices object.

--- a/core/src/toga/style/pack.py
+++ b/core/src/toga/style/pack.py
@@ -56,44 +56,11 @@ from toga.fonts import (
 # Make sure deprecation warnings are shown by default
 warnings.filterwarnings("default", category=DeprecationWarning)
 
-######################################################################
-# Display
-######################################################################
-
 PACK = "pack"
-
-######################################################################
-# Declaration choices
-######################################################################
 
 # Used in backwards compatibility section below
 ALIGNMENT = "alignment"
 ALIGN_ITEMS = "align_items"
-
-DISPLAY_CHOICES = Choices(PACK, NONE)
-VISIBILITY_CHOICES = Choices(VISIBLE, HIDDEN)
-DIRECTION_CHOICES = Choices(ROW, COLUMN)
-ALIGN_ITEMS_CHOICES = Choices(START, CENTER, END)
-ALIGNMENT_CHOICES = Choices(LEFT, RIGHT, TOP, BOTTOM, CENTER)  # Deprecated
-JUSTIFY_CONTENT_CHOICES = Choices(START, CENTER, END)
-GAP_CHOICES = Choices(integer=True)
-
-SIZE_CHOICES = Choices(NONE, integer=True)
-FLEX_CHOICES = Choices(number=True)
-
-MARGIN_CHOICES = Choices(integer=True)
-
-TEXT_ALIGN_CHOICES = Choices(LEFT, RIGHT, CENTER, JUSTIFY)
-TEXT_DIRECTION_CHOICES = Choices(RTL, LTR)
-
-COLOR_CHOICES = Choices(color=True)
-BACKGROUND_COLOR_CHOICES = Choices(TRANSPARENT, color=True)
-
-FONT_FAMILY_CHOICES = Choices(*SYSTEM_DEFAULT_FONTS, string=True)
-FONT_STYLE_CHOICES = Choices(*FONT_STYLES)
-FONT_VARIANT_CHOICES = Choices(*FONT_VARIANTS)
-FONT_WEIGHT_CHOICES = Choices(*FONT_WEIGHTS)
-FONT_SIZE_CHOICES = Choices(integer=True)
 
 
 class Pack(BaseStyle):
@@ -107,42 +74,44 @@ class Pack(BaseStyle):
 
     _depth = -1
 
-    display: str = validated_property(choices=DISPLAY_CHOICES, initial=PACK)
-    visibility: str = validated_property(choices=VISIBILITY_CHOICES, initial=VISIBLE)
-    direction: str = validated_property(choices=DIRECTION_CHOICES, initial=ROW)
-    align_items: str | None = validated_property(choices=ALIGN_ITEMS_CHOICES)
-    alignment: str | None = validated_property(choices=ALIGNMENT_CHOICES)  # Deprecated
+    display: str = validated_property(Choices(PACK, NONE), initial=PACK)
+    visibility: str = validated_property(Choices(VISIBLE, HIDDEN), initial=VISIBLE)
+    direction: str = validated_property(Choices(ROW, COLUMN), initial=ROW)
+    align_items: str | None = validated_property(Choices(START, CENTER, END))
+    alignment: str | None = validated_property(
+        Choices(LEFT, RIGHT, TOP, BOTTOM, CENTER)
+    )  # Deprecated
     justify_content: str | None = validated_property(
-        choices=JUSTIFY_CONTENT_CHOICES, initial=START
+        Choices(START, CENTER, END), initial=START
     )
-    gap: int = validated_property(choices=GAP_CHOICES, initial=0)
+    gap: int = validated_property(Choices(integer=True), initial=0)
 
-    width: str | int = validated_property(choices=SIZE_CHOICES, initial=NONE)
-    height: str | int = validated_property(choices=SIZE_CHOICES, initial=NONE)
-    flex: float = validated_property(choices=FLEX_CHOICES, initial=0)
+    width: str | int = validated_property(Choices(NONE, integer=True), initial=NONE)
+    height: str | int = validated_property(Choices(NONE, integer=True), initial=NONE)
+    flex: float = validated_property(Choices(number=True), initial=0)
 
     margin: int | tuple[int] = directional_property("margin{}")
-    margin_top: int = validated_property(choices=MARGIN_CHOICES, initial=0)
-    margin_right: int = validated_property(choices=MARGIN_CHOICES, initial=0)
-    margin_bottom: int = validated_property(choices=MARGIN_CHOICES, initial=0)
-    margin_left: int = validated_property(choices=MARGIN_CHOICES, initial=0)
+    margin_top: int = validated_property(choices=Choices(integer=True), initial=0)
+    margin_right: int = validated_property(choices=Choices(integer=True), initial=0)
+    margin_bottom: int = validated_property(choices=Choices(integer=True), initial=0)
+    margin_left: int = validated_property(choices=Choices(integer=True), initial=0)
 
-    color: rgb | hsl | str | None = validated_property(choices=COLOR_CHOICES)
+    color: rgb | hsl | str | None = validated_property(Choices(color=True))
     background_color: rgb | hsl | str | None = validated_property(
-        choices=BACKGROUND_COLOR_CHOICES
+        Choices(TRANSPARENT, color=True)
     )
 
-    text_align: str | None = validated_property(choices=TEXT_ALIGN_CHOICES)
-    text_direction: str | None = validated_property(
-        choices=TEXT_DIRECTION_CHOICES, initial=LTR
-    )
+    text_align: str | None = validated_property(Choices(LEFT, RIGHT, CENTER, JUSTIFY))
+    text_direction: str | None = validated_property(Choices(RTL, LTR), initial=LTR)
 
-    font_family: str = validated_property(choices=FONT_FAMILY_CHOICES, initial=SYSTEM)
-    font_style: str = validated_property(choices=FONT_STYLE_CHOICES, initial=NORMAL)
-    font_variant: str = validated_property(choices=FONT_VARIANT_CHOICES, initial=NORMAL)
-    font_weight: str = validated_property(choices=FONT_WEIGHT_CHOICES, initial=NORMAL)
+    font_family: str = validated_property(
+        Choices(*SYSTEM_DEFAULT_FONTS, string=True), initial=SYSTEM
+    )
+    font_style: str = validated_property(Choices(*FONT_STYLES), initial=NORMAL)
+    font_variant: str = validated_property(Choices(*FONT_VARIANTS), initial=NORMAL)
+    font_weight: str = validated_property(Choices(*FONT_WEIGHTS), initial=NORMAL)
     font_size: int = validated_property(
-        choices=FONT_SIZE_CHOICES, initial=SYSTEM_DEFAULT_FONT_SIZE
+        Choices(integer=True), initial=SYSTEM_DEFAULT_FONT_SIZE
     )
 
     @classmethod

--- a/core/src/toga/style/pack.py
+++ b/core/src/toga/style/pack.py
@@ -35,12 +35,7 @@ from travertino.constants import (  # noqa: F401
     TRANSPARENT,
     VISIBLE,
 )
-from travertino.declaration import (
-    BaseStyle,
-    Choices,
-    directional_property,
-    validated_property,
-)
+from travertino.declaration import BaseStyle, directional_property, validated_property
 from travertino.layout import BaseBox
 from travertino.size import BaseIntrinsicSize
 
@@ -74,45 +69,41 @@ class Pack(BaseStyle):
 
     _depth = -1
 
-    display: str = validated_property(Choices(PACK, NONE), initial=PACK)
-    visibility: str = validated_property(Choices(VISIBLE, HIDDEN), initial=VISIBLE)
-    direction: str = validated_property(Choices(ROW, COLUMN), initial=ROW)
-    align_items: str | None = validated_property(Choices(START, CENTER, END))
+    display: str = validated_property(PACK, NONE, initial=PACK)
+    visibility: str = validated_property(VISIBLE, HIDDEN, initial=VISIBLE)
+    direction: str = validated_property(ROW, COLUMN, initial=ROW)
+    align_items: str | None = validated_property(START, CENTER, END)
     alignment: str | None = validated_property(
-        Choices(LEFT, RIGHT, TOP, BOTTOM, CENTER)
+        LEFT, RIGHT, TOP, BOTTOM, CENTER
     )  # Deprecated
-    justify_content: str | None = validated_property(
-        Choices(START, CENTER, END), initial=START
-    )
-    gap: int = validated_property(Choices(integer=True), initial=0)
+    justify_content: str | None = validated_property(START, CENTER, END, initial=START)
+    gap: int = validated_property(integer=True, initial=0)
 
-    width: str | int = validated_property(Choices(NONE, integer=True), initial=NONE)
-    height: str | int = validated_property(Choices(NONE, integer=True), initial=NONE)
-    flex: float = validated_property(Choices(number=True), initial=0)
+    width: str | int = validated_property(NONE, integer=True, initial=NONE)
+    height: str | int = validated_property(NONE, integer=True, initial=NONE)
+    flex: float = validated_property(number=True, initial=0)
 
     margin: int | tuple[int] = directional_property("margin{}")
-    margin_top: int = validated_property(choices=Choices(integer=True), initial=0)
-    margin_right: int = validated_property(choices=Choices(integer=True), initial=0)
-    margin_bottom: int = validated_property(choices=Choices(integer=True), initial=0)
-    margin_left: int = validated_property(choices=Choices(integer=True), initial=0)
+    margin_top: int = validated_property(integer=True, initial=0)
+    margin_right: int = validated_property(integer=True, initial=0)
+    margin_bottom: int = validated_property(integer=True, initial=0)
+    margin_left: int = validated_property(integer=True, initial=0)
 
-    color: rgb | hsl | str | None = validated_property(Choices(color=True))
+    color: rgb | hsl | str | None = validated_property(color=True)
     background_color: rgb | hsl | str | None = validated_property(
-        Choices(TRANSPARENT, color=True)
+        TRANSPARENT, color=True
     )
 
-    text_align: str | None = validated_property(Choices(LEFT, RIGHT, CENTER, JUSTIFY))
-    text_direction: str | None = validated_property(Choices(RTL, LTR), initial=LTR)
+    text_align: str | None = validated_property(LEFT, RIGHT, CENTER, JUSTIFY)
+    text_direction: str | None = validated_property(RTL, LTR, initial=LTR)
 
     font_family: str = validated_property(
-        Choices(*SYSTEM_DEFAULT_FONTS, string=True), initial=SYSTEM
+        *SYSTEM_DEFAULT_FONTS, string=True, initial=SYSTEM
     )
-    font_style: str = validated_property(Choices(*FONT_STYLES), initial=NORMAL)
-    font_variant: str = validated_property(Choices(*FONT_VARIANTS), initial=NORMAL)
-    font_weight: str = validated_property(Choices(*FONT_WEIGHTS), initial=NORMAL)
-    font_size: int = validated_property(
-        Choices(integer=True), initial=SYSTEM_DEFAULT_FONT_SIZE
-    )
+    font_style: str = validated_property(*FONT_STYLES, initial=NORMAL)
+    font_variant: str = validated_property(*FONT_VARIANTS, initial=NORMAL)
+    font_weight: str = validated_property(*FONT_WEIGHTS, initial=NORMAL)
+    font_size: int = validated_property(integer=True, initial=SYSTEM_DEFAULT_FONT_SIZE)
 
     @classmethod
     def _debug(cls, *args: str) -> None:  # pragma: no cover

--- a/travertino/src/travertino/declaration.py
+++ b/travertino/src/travertino/declaration.py
@@ -101,13 +101,27 @@ class Choices:
 
 
 class validated_property:
-    def __init__(self, choices, initial=None):
+    def __init__(
+        self,
+        *constants,
+        string=False,
+        integer=False,
+        number=False,
+        color=False,
+        initial=None,
+    ):
         """Define a simple validated property attribute.
 
-        :param choices: The available choices.
+        :param constants: Explicitly allowable values.
+        :param string: Are strings allowed as values?
+        :param integer: Are integers allowed as values?
+        :param number: Are numbers allowed as values?
+        :param color: Are colors allowed as values?
         :param initial: The initial value for the property.
         """
-        self.choices = choices
+        self.choices = Choices(
+            *constants, string=string, integer=integer, number=number, color=color
+        )
         self.initial = None
 
         try:
@@ -119,7 +133,7 @@ class validated_property:
             # Unfortunately, __set_name__ hasn't been called yet, so we don't know the
             # property's name.
             raise ValueError(
-                f"Invalid initial value {initial!r}. Available choices: {choices}"
+                f"Invalid initial value {initial!r}. Available choices: {self.choices}"
             )
 
     def __set_name__(self, owner, name):
@@ -444,7 +458,14 @@ class BaseStyle:
             DeprecationWarning,
             stacklevel=2,
         )
-        prop = validated_property(choices, initial)
+        prop = validated_property(
+            *choices.constants,
+            string=choices.string,
+            integer=choices.integer,
+            number=choices.number,
+            color=choices.color,
+            initial=initial,
+        )
         setattr(cls, name, prop)
         prop.__set_name__(cls, name)
 

--- a/travertino/tests/test_choices.py
+++ b/travertino/tests/test_choices.py
@@ -13,21 +13,21 @@ from .utils import mock_attr, prep_style_class
 
 @prep_style_class
 class Style(BaseStyle):
-    none: str = validated_property(choices=Choices(NONE, REBECCAPURPLE), initial=NONE)
-    allow_string: str = validated_property(
-        choices=Choices(string=True), initial="start"
-    )
-    allow_integer: int = validated_property(choices=Choices(integer=True), initial=0)
-    allow_number: float = validated_property(choices=Choices(number=True), initial=0)
-    allow_color: str = validated_property(
-        choices=Choices(color=True), initial="goldenrod"
-    )
-    values: str = validated_property(choices=Choices("a", "b", NONE), initial="a")
+    none: str = validated_property(NONE, REBECCAPURPLE, initial=NONE)
+    allow_string: str = validated_property(string=True, initial="start")
+    allow_integer: int = validated_property(integer=True, initial=0)
+    allow_number: float = validated_property(number=True, initial=0)
+    allow_color: str = validated_property(color=True, initial="goldenrod")
+    values: str = validated_property("a", "b", NONE, initial="a")
     multiple_choices: str | float = validated_property(
-        choices=Choices("a", "b", NONE, number=True, color=True),
+        "a",
+        "b",
+        NONE,
+        number=True,
+        color=True,
         initial=None,
     )
-    string_symbol: str = validated_property(choices=Choices(TOP, NONE))
+    string_symbol: str = validated_property(TOP, NONE)
 
 
 with catch_warnings():

--- a/travertino/tests/test_node.py
+++ b/travertino/tests/test_node.py
@@ -3,7 +3,7 @@ from warnings import catch_warnings, filterwarnings
 
 import pytest
 
-from travertino.declaration import BaseStyle, Choices, validated_property
+from travertino.declaration import BaseStyle, validated_property
 from travertino.layout import BaseBox, Viewport
 from travertino.node import Node
 from travertino.size import BaseIntrinsicSize
@@ -14,7 +14,7 @@ from .utils import mock_attr, prep_style_class
 @prep_style_class
 @mock_attr("reapply")
 class Style(BaseStyle):
-    int_prop: int = validated_property(Choices(integer=True))
+    int_prop: int = validated_property(integer=True)
 
     class IntrinsicSize(BaseIntrinsicSize):
         pass


### PR DESCRIPTION
While we're switching over to the dataclass-based Pack properties — and haven't put out a release yet with them — I'd like to propose a tweak to how they're instantiated.

The [first commit](https://github.com/beeware/toga/pull/3115/commits/8535a03e93f7ea7e1438eac1644cbdbf68dc80a6) is a stylistic one; I'm not sure if there was a particular reason for defining all the Choices objects at the top in #311; I suspect it was because the actual property creation had to be buried way down at the bottom of the file, due to the class method implementation? I've inlined them into the property definitions. It makes for a little bit of repetition in some of them, but the information's all in one place.

```python
SIZE_CHOICES = Choices(NONE, integer=True)
...
width: str | int = validated_property(choices=SIZE_CHOICES, initial=NONE)
```
to

```python
width: str | int = validated_property(Choices(NONE, integer=True), initial=NONE))
```

The [second](https://github.com/beeware/toga/pull/3115/commits/8cdb31ebe68e43ba05baa981d1386acfe57a7da9) is a change to the (as-yet-unreleased) new Travertino API. We don't use Choices anywhere except in validated_property, and there's no reason to define a validated_property without a Choices — so why not treat Choices as an internal component, and supply the parameters directly to the property? The only other parameter is `initial`.

```python
width: str | int = validated_property(NONE, integer=True, initial=NONE)
```

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
