### PR TITLE
Cache decoded toga color on gtk

### DIFF
--- a/changes/3117.misc.rst
+++ b/changes/3117.misc.rst
@@ -1,0 +1,1 @@
+On gtk, the decoded toga color is now cached for faster lookup.

--- a/changes/3117.misc.rst
+++ b/changes/3117.misc.rst
@@ -1,1 +1,1 @@
-On gtk, the decoded toga color is now cached for faster lookup.
+On GTK, native colors representations are now cached.

--- a/gtk/src/toga_gtk/colors.py
+++ b/gtk/src/toga_gtk/colors.py
@@ -6,5 +6,6 @@ def native_color(c):
         color = CACHE[c]
     except KeyError:
         color = (c.rgba.r / 255, c.rgba.g / 255, c.rgba.b / 255, c.rgba.a)
+        CACHE[c] = color
 
     return color

--- a/gtk/src/toga_gtk/widgets/button.py
+++ b/gtk/src/toga_gtk/widgets/button.py
@@ -36,9 +36,7 @@ class Button(Widget):
 
     def set_background_color(self, color):
         # Buttons interpret TRANSPARENT backgrounds as a reset
-        if color == TRANSPARENT:
-            color = None
-        super().set_background_color(color)
+        super().set_background_color(None if color is TRANSPARENT else color)
 
     def rehint(self):
         # print(


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Originally identified in #2484. However, since these changes are not directly related to #2484, so I have separated these changes from that PR.

This PR caches the decoded toga color on gtk, and also includes a minor cleanup.
## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
