### PR TITLE
Remove erroneous note about `_default_background_color` override behavior on iOS

### DIFF
--- a/changes/3125.misc.rst
+++ b/changes/3125.misc.rst
@@ -1,0 +1,1 @@
+On iOS, widgets without a specified default background color now use the system-assigned default background color.

--- a/changes/3125.misc.rst
+++ b/changes/3125.misc.rst
@@ -1,1 +1,1 @@
-On iOS, widgets without a specified default background color now use the system-assigned default background color.
+On iOS, an erroneous note stating that widgets can override their system-assigned default background color, has now been removed.

--- a/iOS/src/toga_iOS/widgets/base.py
+++ b/iOS/src/toga_iOS/widgets/base.py
@@ -13,19 +13,7 @@ class Widget:
         self.native = None
         self.create()
 
-        # Widgets that need to set a different default background_color should override
-        # the _default_background_color attribute.
-        # On iOS, _default_background_color is set in the form of native UIColor.
-        #
-        # Currently, on iOS there is no widget that specifies a custom default
-        # background color, so the else branch would never be reached.
-        if (
-            getattr(self, "_default_background_color", None) is None
-        ):  # pragma: no branch
-            # If a widget hasn't specifically defined a default background color then
-            # set the system assigned background color as the default background color
-            # of the widget.
-            self._default_background_color = self.native.backgroundColor
+        self._default_background_color = self.native.backgroundColor
 
     @abstractmethod
     def create(self): ...

--- a/iOS/src/toga_iOS/widgets/base.py
+++ b/iOS/src/toga_iOS/widgets/base.py
@@ -13,9 +13,19 @@ class Widget:
         self.native = None
         self.create()
 
-        # Override this attribute to set a different default background
-        # color for a given widget.
-        self._default_background_color = self.native.backgroundColor
+        # Widgets that need to set a different default background_color should override
+        # the _default_background_color attribute.
+        # On iOS, _default_background_color is set in the form of native UIColor.
+        #
+        # Currently, on iOS there is no widget that specifies a custom default
+        # background color, so the else branch would never be reached.
+        if (
+            getattr(self, "_default_background_color", None) is None
+        ):  # pragma: no branch
+            # If a widget hasn't specifically defined a default background color then
+            # set the system assigned background color as the default background color
+            # of the widget.
+            self._default_background_color = self.native.backgroundColor
 
     @abstractmethod
     def create(self): ...

--- a/iOS/src/toga_iOS/widgets/base.py
+++ b/iOS/src/toga_iOS/widgets/base.py
@@ -13,6 +13,13 @@ class Widget:
         self.native = None
         self.create()
 
+        # Many widgets have a "transparent" background; however, some widgets use
+        # UIColor.ClearColor, and some use UIExtendedGrayColorSpace 0 0, which has
+        # slightly different color mixing characteristics. Widgets like TextInput use
+        # `None` as their initial background color, so that always adapts to light/dark
+        # mode. Preserve the initial background color on the freshly created widget so
+        # that we can reset back to that color when background_color is set to None. See
+        # #3104 for details.
         self._default_background_color = self.native.backgroundColor
 
     @abstractmethod


### PR DESCRIPTION
<!--- Describe your changes in detail -->
While working on #2484, I noticed that the setting of `_default_background_color` attribute on iOS is not correct:
https://github.com/beeware/toga/blob/25891f05aba1b25a7a81e056ced24a0be76f7818/iOS/src/toga_iOS/widgets/base.py#L8-L18

Although, currently no widget on iOS is setting a different `_default_background_color`, but if any widget did override it, then `_default_background_color` would be overridden during the `create()` call. 

But we are unconditionally setting the `_default_background_color ` on line 18, which would discard any custom `_default_background_color` that may be specified by a widget. 

This PR was fixing this behavior by:
https://github.com/beeware/toga/blob/29d0fd553c27ffe59cf9efa34e22d8b1d0b82fc6/iOS/src/toga_iOS/widgets/base.py#L8-L19

However, since no widget is specifying a custom default background color, so the erroneous note was removed instead.
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
