### PR TITLE
Ignore no-op window resize requests

### DIFF
--- a/changes/3131.removal.rst
+++ b/changes/3131.removal.rst
@@ -1,1 +1,1 @@
-Requests for resizing window to the same size as current, are now ignored.
+If window size is unchanged as a result of a resize request, a layout of window content is no longer triggered.

--- a/changes/3131.removal.rst
+++ b/changes/3131.removal.rst
@@ -1,0 +1,1 @@
+Requests for resizing window to the same size as current, are now ignored.

--- a/core/src/toga/window.py
+++ b/core/src/toga/window.py
@@ -443,9 +443,10 @@ class Window:
     def size(self, size: SizeT) -> None:
         if self.state in {WindowState.FULLSCREEN, WindowState.PRESENTATION}:
             raise RuntimeError(f"Cannot resize window while in {self.state}")
-        self._impl.set_size(size)
-        if self.content:
-            self.content.refresh()
+        elif self.size != size:
+            self._impl.set_size(size)
+            if self.content:
+                self.content.refresh()
 
     ######################################################################
     # Window position

--- a/core/tests/window/test_window.py
+++ b/core/tests/window/test_window.py
@@ -232,9 +232,18 @@ def test_position_cascade(app):
 
 def test_set_size(window):
     """The size of the window can be set."""
+    # Request for resizing to a new window size.
     window.size = (123, 456)
 
     assert window.size == toga.Size(123, 456)
+    assert_action_performed(window, "set size")
+    EventLog.reset()
+
+    # Again request for resizing to the same window size.
+    window.size = (123, 456)
+
+    assert window.size == toga.Size(123, 456)
+    assert_action_not_performed(window, "set size")
 
 
 def test_set_size_with_content(window):
@@ -242,10 +251,20 @@ def test_set_size_with_content(window):
     content = toga.Box()
     window.content = content
 
+    # Request for resizing to a new window size.
     window.size = (123, 456)
 
     assert window.size == toga.Size(123, 456)
+    assert_action_performed(window, "set size")
     assert_action_performed(content, "refresh")
+    EventLog.reset()
+
+    # Again request for resizing to the same window size.
+    window.size = (123, 456)
+
+    assert window.size == toga.Size(123, 456)
+    assert_action_not_performed(window, "set size")
+    assert_action_not_performed(content, "refresh")
 
 
 def test_show_hide(window, app):

--- a/dummy/src/toga_dummy/window.py
+++ b/dummy/src/toga_dummy/window.py
@@ -55,8 +55,11 @@ class Window(LoggedObject):
 
         self.set_title(title)
         self.set_position(position if position is not None else _initial_position())
-        self.set_size(size)
 
+        # We cannot store the following values on the EventLog, since they
+        # would be cleared on EventLog.reset(), thereby preventing us from
+        # testing no-op condition of requesting the same value as current.
+        self._size = size if size else Size(640, 480)
         self._state = WindowState.NORMAL
         self._visible = False
 
@@ -100,10 +103,11 @@ class Window(LoggedObject):
     ######################################################################
 
     def get_size(self) -> Size:
-        return self._get_value("size", Size(640, 480))
+        return self._size
 
     def set_size(self, size):
-        self._set_value("size", size)
+        self._action("set size")
+        self._size = size
 
     ######################################################################
     # Window position
@@ -124,9 +128,6 @@ class Window(LoggedObject):
     ######################################################################
 
     def get_visible(self):
-        # We cannot store the visibility value on the EventLog, since the value
-        # would be cleared on EventLog.reset(), thereby preventing us from
-        # testing no-op condition of requesting the same visibility as current.
         return self._visible
 
     def hide(self):
@@ -145,9 +146,6 @@ class Window(LoggedObject):
         previous_state = self._state
 
         self._action(f"set window state to {state}", state=state)
-        # We cannot store the state value on the EventLog, since the state
-        # value would be cleared on EventLog.reset(), thereby preventing us
-        # from testing no-op condition of assigning same state as current.
         self._state = state
         current_state = self._state
         if previous_state != current_state:


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Related PR: #2364 

Currently, all resize requests are passed down to the `impl` layers, even when the same window size as the current size is requested. Although this is a no-op on most backends, but on some backends(like on gtk), this results in firing of window resize events at wrong times. 

Hence, this PR ignores such no-op window resize requests at the core, preventing them from being transmitted to the `impl` layer.

<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
