### PR TITLE
Bump codespell from v2.3.0 to v2.4.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.0
     hooks:
     - id: codespell
       # remove toml extra once Python 3.10 is no longer supported

--- a/changes/3133.misc.rst
+++ b/changes/3133.misc.rst
@@ -1,0 +1,1 @@
+The ``pre-commit`` hook for ``codespell`` was updated to its latest version.

--- a/core/tests/window/test_window.py
+++ b/core/tests/window/test_window.py
@@ -803,7 +803,7 @@ def test_widget_id_reusablity(window, app):
     try:
         new_label_widget = toga.Label(text="New Label", id=LABEL_WIDGET_ID)
     except KeyError:
-        pytest.fail("Widget IDs that aren't part of a layout can be re-used.")
+        pytest.fail("Widget IDs that aren't part of a layout can be reused.")
 
     # Create 2 new visible windows
     second_window = toga.Window()
@@ -827,7 +827,7 @@ def test_widget_id_reusablity(window, app):
     assert CONTENT_WIDGET_ID not in third_window.widgets
     assert LABEL_WIDGET_ID not in third_window.widgets
 
-    # Adding content that has a child with a re-used ID should raise an error
+    # Adding content that has a child with a reused ID should raise an error
     with pytest.raises(
         KeyError,
         match=r"There is already a widget with the id 'sample_label'",
@@ -836,7 +836,7 @@ def test_widget_id_reusablity(window, app):
     assert CONTENT_WIDGET_ID not in third_window.widgets
     assert LABEL_WIDGET_ID not in third_window.widgets
 
-    # Adding a child with a re-used ID should raise an error.
+    # Adding a child with a reused ID should raise an error.
     third_window.content = third_window_content
     with pytest.raises(
         KeyError,
@@ -850,13 +850,13 @@ def test_widget_id_reusablity(window, app):
     try:
         another_label_widget = toga.Label(text="Another Label", id=LABEL_WIDGET_ID)
     except KeyError:
-        pytest.fail("Widget IDs that aren't part of a layout can be re-used.")
+        pytest.fail("Widget IDs that aren't part of a layout can be reused.")
 
-    # If a widget using an ID is being *replaced*, the ID can be re-used.
+    # If a widget using an ID is being *replaced*, the ID can be reused.
     try:
         second_window.content = another_label_widget
     except KeyError:
-        pytest.fail("Widget IDs that are replaced can be re-used.")
+        pytest.fail("Widget IDs that are replaced can be reused.")
 
     # Close Window 2
     second_window.close()
@@ -867,7 +867,7 @@ def test_widget_id_reusablity(window, app):
     try:
         third_window_content.add(new_label_widget)
     except KeyError:
-        pytest.fail("Widget IDs that are replaced can be re-used.")
+        pytest.fail("Widget IDs that are replaced can be reused.")
 
     third_window.close()
 

--- a/gtk/src/toga_gtk/widgets/detailedlist.py
+++ b/gtk/src/toga_gtk/widgets/detailedlist.py
@@ -162,7 +162,7 @@ class DetailedList(Widget):
         self.gesture.set_propagation_phase(Gtk.PropagationPhase.BUBBLE)
         self.gesture.connect("pressed", self.gtk_on_right_click)
 
-        # Set up a box that contains action buttons. This widget can be can be re-used
+        # Set up a box that contains action buttons. This widget can be can be reused
         # for any row when it is activated.
         self.native_action_buttons = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         action_buttons_hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)


### PR DESCRIPTION
Bumps `pre-commit` hook for `codespell` from v2.3.0 to v2.4.0 and ran the update against the repo.