### PR TITLE
Bump isort from 5.13.2 to 6.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
       - id: pyupgrade
         args: [--py39-plus]
   - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
+    rev: 6.0.0
     hooks:
       # isort for Travertino
       - id: isort

--- a/changes/3148.misc.rst
+++ b/changes/3148.misc.rst
@@ -1,0 +1,1 @@
+The ``pre-commit`` hook for ``isort`` was updated to its latest version.


### PR DESCRIPTION
Bumps `pre-commit` hook for `isort` from 5.13.2 to 6.0.0 and ran the update against the repo.