### PR TITLE
Consistently handle style properties that are explicitly set to initial value

### DIFF
--- a/changes/3151.bugfix.rst
+++ b/changes/3151.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug concerning inconsistent handling of whether explicitly assigning a style property a value equal to its initial value counts as having been set.

--- a/changes/3151.bugfix.rst
+++ b/changes/3151.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed a bug concerning inconsistent handling of whether explicitly assigning a style property a value equal to its initial value counts as having been set.

--- a/changes/3151.misc.rst
+++ b/changes/3151.misc.rst
@@ -1,0 +1,1 @@
+Style properties are now consistently counted as having been set, even when they are explicitly set to their default initial value.

--- a/core/src/toga/compat/collections/abc.py
+++ b/core/src/toga/compat/collections/abc.py
@@ -43,6 +43,9 @@ class _SubscriptWrapper:
     def __getitem__(self, key):
         return self.abc_cls
 
+    def register(self, cls):
+        pass
+
 
 for cls_name in __all__:
     globals()[cls_name] = _SubscriptWrapper(type(cls_name, (object,), {}))

--- a/travertino/src/travertino/declaration.py
+++ b/travertino/src/travertino/declaration.py
@@ -120,7 +120,8 @@ class validated_property:
         :param integer: Are integers allowed as values?
         :param number: Are numbers allowed as values?
         :param color: Are colors allowed as values?
-        :param initial: The initial value for the property.
+        :param initial: The initial value for the property. If the property has not been
+            explicitly set, this is what is returned when it's accessed.
         """
         self.choices = Choices(
             *constants, string=string, integer=integer, number=number, color=color
@@ -154,6 +155,9 @@ class validated_property:
         value = self.validate(value)
 
         if (current := getattr(obj, f"_{self.name}", None)) is None:
+            # If the value has not been explicitly set already, then we always want to
+            # assign to the attribute -- even if the value being assigned is identical
+            # to the initial value.
             setattr(obj, f"_{self.name}", value)
             if value != self.initial:
                 obj.apply(self.name, value)

--- a/travertino/src/travertino/declaration.py
+++ b/travertino/src/travertino/declaration.py
@@ -402,7 +402,7 @@ class BaseStyle:
             raise KeyError(name)
 
     def keys(self):
-        return {*self}
+        return {name for name in self}
 
     def items(self):
         return [(name, self[name]) for name in self]

--- a/travertino/src/travertino/declaration.py
+++ b/travertino/src/travertino/declaration.py
@@ -340,7 +340,7 @@ class BaseStyle:
         dup.update(**self)
 
         ######################################################################
-        # 10-24: Backwards compatibility for Toga <= 0.4.8
+        # 10-2024: Backwards compatibility for Toga <= 0.4.8
         ######################################################################
 
         if applicator is not None:

--- a/travertino/src/travertino/declaration.py
+++ b/travertino/src/travertino/declaration.py
@@ -153,7 +153,12 @@ class validated_property:
 
         value = self.validate(value)
 
-        if value != getattr(obj, f"_{self.name}", self.initial):
+        if (current := getattr(obj, f"_{self.name}", None)) is None:
+            setattr(obj, f"_{self.name}", value)
+            if value != self.initial:
+                obj.apply(self.name, value)
+
+        elif value != current:
             setattr(obj, f"_{self.name}", value)
             obj.apply(self.name, value)
 

--- a/travertino/tests/test_declaration.py
+++ b/travertino/tests/test_declaration.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from unittest.mock import call
 from warnings import catch_warnings, filterwarnings
 
@@ -605,6 +606,14 @@ def test_list_property_list_like():
     for _ in prop:
         count += 1
     assert count == 4
+
+    assert [*reversed(prop)] == [VALUE2, 3, 2, 1]
+
+    assert prop.index(3) == 2
+
+    assert prop.count(VALUE2) == 1
+
+    assert isinstance(prop, Sequence)
 
 
 @pytest.mark.parametrize("StyleClass", [Style, DeprecatedStyle])

--- a/travertino/tests/test_declaration.py
+++ b/travertino/tests/test_declaration.py
@@ -764,6 +764,33 @@ def test_dict(StyleClass):
 
 
 @pytest.mark.parametrize("StyleClass", [Style, DeprecatedStyle])
+def test_set_to_initial(StyleClass):
+    """A property set to its initial value is distinct from an unset property."""
+    style = StyleClass()
+
+    # explicit_const's initial value is VALUE1.
+    assert style.explicit_const == VALUE1
+    assert "explicit_const" not in style
+
+    # The unset property shouldn't affect the value when overlaid over a style with
+    # that property set.
+    non_initial_style = StyleClass(explicit_const=VALUE2)
+    union = non_initial_style | style
+    assert union.explicit_const == VALUE2
+    assert "explicit_const" in union
+
+    # The property should count as set, even when set to the same initial value.
+    style.explicit_const = VALUE1
+    assert style.explicit_const == VALUE1
+    assert "explicit_const" in style
+
+    # The property should now overwrite.
+    union = non_initial_style | style
+    assert union.explicit_const == VALUE1
+    assert "explicit_const" in union
+
+
+@pytest.mark.parametrize("StyleClass", [Style, DeprecatedStyle])
 @pytest.mark.parametrize("instantiate", [True, False])
 def test_union_operators(StyleClass, instantiate):
     """Styles support | and |= with dicts and with their own class."""


### PR DESCRIPTION
Ran into a moderately scruffy yak. My main motivation for adding the union operators to BaseStyle was to be able to compose styles, and I just realized one thing currently works very counterintuitively for that.

This works as expected:

```python
>>> p = Pack(gap=1) | Pack()
>>> p.gap
1
```

But I'd call this a bug:

```python
>>> p = Pack(gap=1) | Pack(gap=0)
>>> p.gap
1
```

Especially since this behaves differently:

```python
>>> other_p = Pack(gap=1)
>>> other_p.gap = 0
>>> p = Pack(gap=1) | other_p
>>> p.gap
0
```

The root cause is that explicitly setting a property to its initial value does nothing — in other words, doesn't assign to the underscore attribute — if the property is currently not set. On the other hand, setting it to something else first and *then* to its initial value *does* assign the value to the hidden attribute, and then things behave as expected. (This also affects `__contains__` checks.)

This PR alters the behavior so that set and unset properties are handled consistently, even when the value is the same as the initial. It also includes some minor cleanups and some additions to `ImmutableList`, all of which I imagine are pretty self-explanatory.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
