### PR TITLE
Modify handling of travertino dependency in example apps, CI and testbed.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
         # perform. We don't *explicitly* install the Travertino wheel; we provide the
         # dist dir as a source of wheels, and rely on pip to resolve the explicit
         # version match to the Travertino wheel in that folder.
-        export TOGA_INSTALL_COMMAND="python -m pip install --find-links ./dist ../$(ls dist/toga_core-*.whl)[dev] ../$(ls dist/toga_dummy-*.whl)"
+        export TOGA_INSTALL_COMMAND="python -m pip install --find-links ../dist ../$(ls dist/toga_core-*.whl)[dev] ../$(ls dist/toga_dummy-*.whl)"
         tox -e py-cov${{ matrix.tox-suffix }}
         tox -qe coverage$(tr -dc "0-9" <<< "${{ matrix.python-version }}")${{ matrix.tox-suffix }}
         mv ${{ matrix.package }}/.coverage ${{ matrix.package }}/.coverage.${{ matrix.platform }}.${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,7 +309,7 @@ jobs:
           pre-command: |
             sudo apt update -y
             sudo apt install -y --no-install-recommends \
-              blackbox pkg-config python3-dev libgirepository1.0-dev libcairo2-dev \
+              blackbox pkg-config python3-dev libgirepository-2.0-dev libcairo2-dev \
               gir1.2-webkit2-4.1 gir1.2-xapp-1.0 gir1.2-geoclue-2.0 gir1.2-flatpak-1.0
 
             # Start Virtual X Server
@@ -333,7 +333,7 @@ jobs:
           pre-command: |
             sudo apt update -y
             sudo apt install -y --no-install-recommends \
-              mutter pkg-config python3-dev libgirepository1.0-dev libcairo2-dev \
+              mutter pkg-config python3-dev libgirepository-2.0-dev libcairo2-dev \
               gir1.2-webkit2-4.1 gir1.2-xapp-1.0 gir1.2-geoclue-2.0 gir1.2-flatpak-1.0
 
             # Start Virtual X Server
@@ -362,7 +362,7 @@ jobs:
           pre-command: |
             sudo apt update -y
             sudo apt install -y --no-install-recommends \
-              mutter pkg-config python3-dev libgirepository1.0-dev libcairo2-dev \
+              mutter pkg-config python3-dev libgirepository-2.0-dev libcairo2-dev \
               gir1.2-webkit-6.0 gir1.2-xapp-1.0 gir1.2-geoclue-2.0 gir1.2-flatpak-1.0 \
               gir1.2-gtk-4.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,9 +119,12 @@ jobs:
 
     - name: Test
       run: |
-        # The $(ls ...) shell expansion is done in the Github environment;
-        # the value of TOGA_INSTALL_COMMAND will be a literal string without any shell expansions to perform
-        TOGA_INSTALL_COMMAND="python -m pip install ../$(ls dist/toga_core-*.whl)[dev] ../$(ls dist/toga_dummy-*.whl) ../$(ls dist/travertino-*.whl)"
+        # The $(ls ...) shell expansion is done in the Github environment; the value of
+        # TOGA_INSTALL_COMMAND will be a literal string without any shell expansions to
+        # perform. We don't *explicitly* install the Travertino wheel; we provide the
+        # dist dir as a source of wheels, and rely on pip to resolve the explicit
+        # version match to the travertino wheel in that folder.
+        TOGA_INSTALL_COMMAND="python -m pip install --find-wheels ./dist ../$(ls dist/toga_core-*.whl)[dev] ../$(ls dist/toga_dummy-*.whl)"
         tox -e py-cov${{ matrix.tox-suffix }}
         tox -qe coverage$(tr -dc "0-9" <<< "${{ matrix.python-version }}")${{ matrix.tox-suffix }}
         mv ${{ matrix.package }}/.coverage ${{ matrix.package }}/.coverage.${{ matrix.platform }}.${{ matrix.python-version }}
@@ -184,7 +187,11 @@ jobs:
 
       - name: Test
         run: |
-          pip install dist/toga_core-*.whl dist/travertino-*.whl
+          # We don't *explicitly* install the Travertino wheel; we provide the dist dir
+          # as a source of wheels, and rely on pip to resolve the explicit version match
+          # to the travertino wheel in that folder.
+          pip install --find-wheels ./dist dist/toga_core-*.whl
+
           site_packages=$(python -c '
           import sys
           print([path for path in sys.path if "site-packages" in path][0])
@@ -373,7 +380,7 @@ jobs:
           platform: "linux"
           runs-on: "ubuntu-latest"
           setup-python: false  # Use the system Python packages
-          briefcase-run-args: --config 'requires=["../core","../textual", "../travertino"]' --config 'console_app=true'
+          briefcase-run-args: --config 'requires=["../core", "../textual", "../travertino"]' --config 'console_app=true'
           app-user-data-path: "$HOME/.local/share/testbed"
           # install the meta-package build-essential since Briefcase explicitly checks for it
           pre-command: sudo apt update -y && sudo apt install -y build-essential
@@ -381,13 +388,13 @@ jobs:
         - backend: "textual-macOS"
           platform: "macOS"
           runs-on: "macos-latest"
-          briefcase-run-args: --config 'requires=["../core","../textual", "../travertino"]' --config 'console_app=true'
+          briefcase-run-args: --config 'requires=["../core", "../textual", "../travertino"]' --config 'console_app=true'
           app-user-data-path: "$HOME/Library/Application Support/org.beeware.toga.testbed"
 
         - backend: "textual-windows"
           platform: "windows"
           runs-on: "windows-latest"
-          briefcase-run-args: --config 'requires=["../core","../textual", "../travertino"]' --config 'console_app=true'
+          briefcase-run-args: --config 'requires=["../core", "../textual", "../travertino"]' --config 'console_app=true'
           app-user-data-path: '$HOME\AppData\Local\Tiberius Yak\Toga Testbed\Data'
 
         - backend: "windows"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,13 +34,19 @@ jobs:
     name: Pre-commit checks
     uses: beeware/.github/.github/workflows/pre-commit-run.yml@main
     with:
-      pre-commit-source: "./core[dev]"
+      # FIXME: This *should* be ./core[dev]; however, core is dependent on
+      # a dynamic version of Travertino, and the package that will match
+      # won't be built until *after* pre-commit is run.
+      # pre-commit-source: "./core[dev]"
+      pre-commit-source: "pre-commit"
 
   towncrier:
     name: Check towncrier
     uses: beeware/.github/.github/workflows/towncrier-run.yml@main
     with:
-      tox-source: "./core[dev]"
+      # FIXME: See pre-commit config
+      # tox-source: "./core[dev]"
+      tox-source: "tox"
 
   package:
     name: Package Toga

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,7 +307,7 @@ jobs:
           pre-command: |
             sudo apt update -y
             sudo apt install -y --no-install-recommends \
-              blackbox pkg-config python3-dev libgirepository-2.0-dev libcairo2-dev \
+              blackbox pkg-config python3-dev libgirepository1.0-dev libcairo2-dev \
               gir1.2-webkit2-4.1 gir1.2-xapp-1.0 gir1.2-geoclue-2.0 gir1.2-flatpak-1.0
 
             # Start Virtual X Server
@@ -331,7 +331,7 @@ jobs:
           pre-command: |
             sudo apt update -y
             sudo apt install -y --no-install-recommends \
-              mutter pkg-config python3-dev libgirepository-2.0-dev libcairo2-dev \
+              mutter pkg-config python3-dev libgirepository1.0-dev libcairo2-dev \
               gir1.2-webkit2-4.1 gir1.2-xapp-1.0 gir1.2-geoclue-2.0 gir1.2-flatpak-1.0
 
             # Start Virtual X Server
@@ -360,7 +360,7 @@ jobs:
           pre-command: |
             sudo apt update -y
             sudo apt install -y --no-install-recommends \
-              mutter pkg-config python3-dev libgirepository-2.0-dev libcairo2-dev \
+              mutter pkg-config python3-dev libgirepository1.0-dev libcairo2-dev \
               gir1.2-webkit-6.0 gir1.2-xapp-1.0 gir1.2-geoclue-2.0 gir1.2-flatpak-1.0 \
               gir1.2-gtk-4.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,19 +34,17 @@ jobs:
     name: Pre-commit checks
     uses: beeware/.github/.github/workflows/pre-commit-run.yml@main
     with:
-      # FIXME: This *should* be ./core[dev]; however, core is dependent on
-      # a dynamic version of Travertino, and the package that will match
-      # won't be built until *after* pre-commit is run.
-      # pre-commit-source: "./core[dev]"
-      pre-commit-source: "pre-commit"
+      # Although we only want to install the dev dependencies, we have to install the
+      # core, which means we need travertino as well.
+      pre-commit-source: "./travertino ./core[dev]"
 
   towncrier:
     name: Check towncrier
     uses: beeware/.github/.github/workflows/towncrier-run.yml@main
     with:
-      # FIXME: See pre-commit config
-      # tox-source: "./core[dev]"
-      tox-source: "tox"
+      # Although we only want to install the dev dependencies, we have to install the
+      # core, which means we need travertino as well.
+      tox-source: "./travertino ./core[dev]"
 
   package:
     name: Package Toga

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,7 +254,7 @@ jobs:
 
   testbed:
     name: Testbed
-    needs: core-and-travertino
+    needs: [ package, core-and-travertino ]
     runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
@@ -380,7 +380,7 @@ jobs:
           platform: "linux"
           runs-on: "ubuntu-latest"
           setup-python: false  # Use the system Python packages
-          briefcase-run-args: --config 'requires=["../core", "../textual", "../travertino"]' --config 'console_app=true'
+          briefcase-run-args: --config 'requires=["toga-core", "toga-textual"]' --config 'console_app=true'
           app-user-data-path: "$HOME/.local/share/testbed"
           # install the meta-package build-essential since Briefcase explicitly checks for it
           pre-command: sudo apt update -y && sudo apt install -y build-essential
@@ -388,13 +388,13 @@ jobs:
         - backend: "textual-macOS"
           platform: "macOS"
           runs-on: "macos-latest"
-          briefcase-run-args: --config 'requires=["../core", "../textual", "../travertino"]' --config 'console_app=true'
+          briefcase-run-args: --config 'requires=["toga-core", "toga-textual"]' --config 'console_app=true'
           app-user-data-path: "$HOME/Library/Application Support/org.beeware.toga.testbed"
 
         - backend: "textual-windows"
           platform: "windows"
           runs-on: "windows-latest"
-          briefcase-run-args: --config 'requires=["../core", "../textual", "../travertino"]' --config 'console_app=true'
+          briefcase-run-args: --config 'requires=["toga-core", "toga-textual"]' --config 'console_app=true'
           app-user-data-path: '$HOME\AppData\Local\Tiberius Yak\Toga Testbed\Data'
 
         - backend: "windows"
@@ -450,6 +450,13 @@ jobs:
         # Use the development version of Briefcase
         python -m pip install -U pip
         python -m pip install git+https://github.com/beeware/briefcase.git
+
+    - name: Get Packages
+      uses: actions/download-artifact@v4.1.8
+      with:
+        pattern: ${{ format('{0}-*', needs.package.outputs.artifact-basename) }}
+        merge-multiple: true
+        path: dist
 
     - name: Test App
       working-directory: testbed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
         # perform. We don't *explicitly* install the Travertino wheel; we provide the
         # dist dir as a source of wheels, and rely on pip to resolve the explicit
         # version match to the Travertino wheel in that folder.
-        TOGA_INSTALL_COMMAND="python -m pip install --find-links ./dist ../$(ls dist/toga_core-*.whl)[dev] ../$(ls dist/toga_dummy-*.whl)"
+        export TOGA_INSTALL_COMMAND="python -m pip install --find-links ./dist ../$(ls dist/toga_core-*.whl)[dev] ../$(ls dist/toga_dummy-*.whl)"
         tox -e py-cov${{ matrix.tox-suffix }}
         tox -qe coverage$(tr -dc "0-9" <<< "${{ matrix.python-version }}")${{ matrix.tox-suffix }}
         mv ${{ matrix.package }}/.coverage ${{ matrix.package }}/.coverage.${{ matrix.platform }}.${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,8 +123,8 @@ jobs:
         # TOGA_INSTALL_COMMAND will be a literal string without any shell expansions to
         # perform. We don't *explicitly* install the Travertino wheel; we provide the
         # dist dir as a source of wheels, and rely on pip to resolve the explicit
-        # version match to the travertino wheel in that folder.
-        TOGA_INSTALL_COMMAND="python -m pip install --find-wheels ./dist ../$(ls dist/toga_core-*.whl)[dev] ../$(ls dist/toga_dummy-*.whl)"
+        # version match to the Travertino wheel in that folder.
+        TOGA_INSTALL_COMMAND="python -m pip install --find-links ./dist ../$(ls dist/toga_core-*.whl)[dev] ../$(ls dist/toga_dummy-*.whl)"
         tox -e py-cov${{ matrix.tox-suffix }}
         tox -qe coverage$(tr -dc "0-9" <<< "${{ matrix.python-version }}")${{ matrix.tox-suffix }}
         mv ${{ matrix.package }}/.coverage ${{ matrix.package }}/.coverage.${{ matrix.platform }}.${{ matrix.python-version }}
@@ -190,7 +190,7 @@ jobs:
           # We don't *explicitly* install the Travertino wheel; we provide the dist dir
           # as a source of wheels, and rely on pip to resolve the explicit version match
           # to the travertino wheel in that folder.
-          pip install --find-wheels ./dist dist/toga_core-*.whl
+          pip install --find-links ./dist dist/toga_core-*.whl
 
           site_packages=$(python -c '
           import sys

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -27,13 +27,13 @@ sphinx:
 formats:
    - pdf
 
-# Install extras for build - dev is needed to run tox
+# Install extras for build. Order is significant; each entry is a separate call to
+# `pip`, and we need Travertino to exist before core is installed.
 python:
   install:
   - method: pip
+    path: travertino
+  - method: pip
     path: core
     extra_requirements:
-      - dev
       - docs
-  - method: pip
-    path: travertino

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -28,7 +28,8 @@ formats:
    - pdf
 
 # Install extras for build. Order is significant; each entry is a separate call to
-# `pip`, and we need Travertino to exist before core is installed.
+# `pip`, and we need Travertino to exist before core is installed. core[dev] is needed
+# to run `tox -e docs-lint` as a pre-build step.
 python:
   install:
   - method: pip
@@ -36,4 +37,5 @@ python:
   - method: pip
     path: core
     extra_requirements:
+      - dev
       - docs

--- a/changes/3154.misc.rst
+++ b/changes/3154.misc.rst
@@ -1,0 +1,1 @@
+The handling of the Travertino dependency in examples, CI and testbed was modified.

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [project]
-dynamic = ["version"]
+dynamic = ["version", "dependencies"]
 name = "toga-core"
 description = "A Python native, OS native GUI toolkit."
 readme = "README.rst"

--- a/core/src/toga/platform.py
+++ b/core/src/toga/platform.py
@@ -10,9 +10,9 @@ from types import ModuleType
 
 # Emulate the Python 3.10+ entry_points API on older Python versions.
 def entry_points(*, group):
-    if sys.version_info < (3, 10):
+    if sys.version_info < (3, 10):  # pragma: no-cover-if-gte-py310
         return metadata.entry_points()[group]
-    else:
+    else:  # pragma: no-cover-if-lt-py310
         return metadata.entry_points(group=group)
 
 

--- a/demo/pyproject.toml
+++ b/demo/pyproject.toml
@@ -83,33 +83,17 @@ author_email = "tiberius@beeware.org"
 formal_name = "Toga Demo"
 description = "A demonstration of the capabilities of the Toga widget toolkit."
 sources = ["toga_demo"]
-requires = ["../core"]
 
 [tool.briefcase.app.toga-demo.macOS]
-requires = [
-    "../cocoa",
-]
 
 [tool.briefcase.app.toga-demo.linux]
-requires = [
-    "../gtk",
-]
 
 [tool.briefcase.app.toga-demo.windows]
-requires = [
-    "../winforms",
-]
 
 # Mobile deployments
 [tool.briefcase.app.toga-demo.iOS]
-requires = [
-    "../iOS",
-]
 
 [tool.briefcase.app.toga-demo.android]
-requires = [
-    "../android",
-]
 
 base_theme = "Theme.MaterialComponents.Light.DarkActionBar"
 

--- a/examples/activityindicator/pyproject.toml
+++ b/examples/activityindicator/pyproject.toml
@@ -16,6 +16,7 @@ description = "A testing app"
 sources = ["activityindicator"]
 requires = [
     "../../core",
+    "../../travertino",
 ]
 
 

--- a/examples/beeliza/pyproject.toml
+++ b/examples/beeliza/pyproject.toml
@@ -16,6 +16,7 @@ description = "A testing app"
 sources = ["beeliza"]
 requires = [
     "../../core",
+    "../../travertino",
 ]
 
 

--- a/examples/box/pyproject.toml
+++ b/examples/box/pyproject.toml
@@ -16,6 +16,7 @@ description = "A testing app"
 sources = ["box"]
 requires = [
     "../../core",
+    "../../travertino",
 ]
 
 

--- a/examples/button/pyproject.toml
+++ b/examples/button/pyproject.toml
@@ -16,6 +16,7 @@ description = "A testing app"
 sources = ["button"]
 requires = [
     "../../core",
+    "../../travertino",
 ]
 
 

--- a/examples/canvas/pyproject.toml
+++ b/examples/canvas/pyproject.toml
@@ -16,6 +16,7 @@ description = "A testing app"
 sources = ["canvas"]
 requires = [
     "../../core",
+    "../../travertino",
 ]
 
 

--- a/examples/colors/pyproject.toml
+++ b/examples/colors/pyproject.toml
@@ -16,6 +16,7 @@ description = "A testing app"
 sources = ["colors"]
 requires = [
     "../../core",
+    "../../travertino",
 ]
 
 

--- a/examples/command/pyproject.toml
+++ b/examples/command/pyproject.toml
@@ -16,6 +16,7 @@ description = "A testing app"
 sources = ["command"]
 requires = [
     "../../core",
+    "../../travertino",
 ]
 
 

--- a/examples/date_and_time/pyproject.toml
+++ b/examples/date_and_time/pyproject.toml
@@ -16,6 +16,7 @@ description = "A testing app"
 sources = ["date_and_time"]
 requires = [
     "../../core",
+    "../../travertino",
 ]
 
 

--- a/examples/detailedlist/pyproject.toml
+++ b/examples/detailedlist/pyproject.toml
@@ -16,6 +16,7 @@ description = "A testing app"
 sources = ["detailedlist"]
 requires = [
     "../../core",
+    "../../travertino",
 ]
 
 

--- a/examples/dialogs/pyproject.toml
+++ b/examples/dialogs/pyproject.toml
@@ -16,6 +16,7 @@ description = "A testing app"
 sources = ["dialogs"]
 requires = [
     "../../core",
+    "../../travertino",
 ]
 
 

--- a/examples/divider/pyproject.toml
+++ b/examples/divider/pyproject.toml
@@ -16,6 +16,7 @@ description = "A testing app"
 sources = ["divider"]
 requires = [
     "../../core",
+    "../../travertino",
 ]
 
 

--- a/examples/documentapp/pyproject.toml
+++ b/examples/documentapp/pyproject.toml
@@ -16,6 +16,7 @@ description = "A testing app"
 sources = ["documentapp"]
 requires = [
     "../../core",
+    "../../travertino",
 ]
 
 

--- a/examples/examples_overview/pyproject.toml
+++ b/examples/examples_overview/pyproject.toml
@@ -16,6 +16,7 @@ description = "A testing app"
 sources = ["examples_overview"]
 requires = [
     "../../core",
+    "../../travertino",
 ]
 
 

--- a/examples/focus/pyproject.toml
+++ b/examples/focus/pyproject.toml
@@ -16,6 +16,7 @@ description = "A testing app"
 sources = ["focus"]
 requires = [
     "../../core",
+    "../../travertino",
 ]
 
 

--- a/examples/font/pyproject.toml
+++ b/examples/font/pyproject.toml
@@ -16,6 +16,7 @@ description = "A testing app"
 sources = ["font"]
 requires = [
     "../../core",
+    "../../travertino",
 ]
 
 

--- a/examples/font_size/pyproject.toml
+++ b/examples/font_size/pyproject.toml
@@ -16,6 +16,7 @@ description = "A testing app"
 sources = ["font_size"]
 requires = [
     "../../core",
+    "../../travertino",
 ]
 
 [tool.briefcase.app.font_size.macOS]

--- a/examples/handlers/pyproject.toml
+++ b/examples/handlers/pyproject.toml
@@ -16,6 +16,7 @@ description = "A testing app"
 sources = ["handlers"]
 requires = [
     "../../core",
+    "../../travertino",
     "httpx",
 ]
 

--- a/examples/imageview/pyproject.toml
+++ b/examples/imageview/pyproject.toml
@@ -16,6 +16,7 @@ description = "A testing app"
 sources = ["imageview"]
 requires = [
     "../../core",
+    "../../travertino",
 ]
 
 

--- a/examples/layout/pyproject.toml
+++ b/examples/layout/pyproject.toml
@@ -16,6 +16,7 @@ description = "A testing app"
 sources = ["layout"]
 requires = [
     "../../core",
+    "../../travertino",
 ]
 
 

--- a/examples/multilinetextinput/pyproject.toml
+++ b/examples/multilinetextinput/pyproject.toml
@@ -16,6 +16,7 @@ description = "A testing app"
 sources = ["multilinetextinput"]
 requires = [
     "../../core",
+    "../../travertino",
 ]
 
 

--- a/examples/numberinput/pyproject.toml
+++ b/examples/numberinput/pyproject.toml
@@ -16,6 +16,7 @@ description = "A testing app"
 sources = ["numberinput"]
 requires = [
     "../../core",
+    "../../travertino",
 ]
 
 

--- a/examples/optioncontainer/pyproject.toml
+++ b/examples/optioncontainer/pyproject.toml
@@ -16,6 +16,7 @@ description = "A testing app"
 sources = ["optioncontainer"]
 requires = [
     "../../core",
+    "../../travertino",
 ]
 
 

--- a/examples/positron-django/pyproject.toml
+++ b/examples/positron-django/pyproject.toml
@@ -17,6 +17,7 @@ icon = "src/positron/resources/positron"
 sources = ["src/positron", "src/webapp"]
 requires = [
     "../../core",
+    "../../travertino",
     "django~=4.1",
 ]
 

--- a/examples/positron-static/pyproject.toml
+++ b/examples/positron-static/pyproject.toml
@@ -17,6 +17,7 @@ icon = "src/positron/resources/positron"
 sources = ["src/positron"]
 requires = [
     "../../core",
+    "../../travertino",
 ]
 
 

--- a/examples/progressbar/pyproject.toml
+++ b/examples/progressbar/pyproject.toml
@@ -16,6 +16,7 @@ description = "A testing app"
 sources = ["progressbar"]
 requires = [
     "../../core",
+    "../../travertino",
 ]
 
 

--- a/examples/resize/pyproject.toml
+++ b/examples/resize/pyproject.toml
@@ -16,6 +16,7 @@ description = "A testing app"
 sources = ["resize"]
 requires = [
     "../../core",
+    "../../travertino",
 ]
 
 

--- a/examples/screenshot/pyproject.toml
+++ b/examples/screenshot/pyproject.toml
@@ -16,6 +16,7 @@ description = "A testing app"
 sources = ["screenshot"]
 requires = [
     "../../core",
+    "../../travertino",
     "pillow",
 ]
 

--- a/examples/scrollcontainer/pyproject.toml
+++ b/examples/scrollcontainer/pyproject.toml
@@ -16,6 +16,7 @@ description = "A testing app"
 sources = ["scrollcontainer"]
 requires = [
     "../../core",
+    "../../travertino",
 ]
 
 

--- a/examples/selection/pyproject.toml
+++ b/examples/selection/pyproject.toml
@@ -16,6 +16,7 @@ description = "A testing app"
 sources = ["selection"]
 requires = [
     "../../core",
+    "../../travertino",
 ]
 
 

--- a/examples/slider/pyproject.toml
+++ b/examples/slider/pyproject.toml
@@ -16,6 +16,7 @@ description = "A testing app"
 sources = ["slider"]
 requires = [
     "../../core",
+    "../../travertino",
 ]
 
 

--- a/examples/splitcontainer/pyproject.toml
+++ b/examples/splitcontainer/pyproject.toml
@@ -16,6 +16,7 @@ description = "A testing app"
 sources = ["splitcontainer"]
 requires = [
     "../../core",
+    "../../travertino",
 ]
 
 

--- a/examples/switch_demo/pyproject.toml
+++ b/examples/switch_demo/pyproject.toml
@@ -16,6 +16,7 @@ description = "A testing app"
 sources = ["switch_demo"]
 requires = [
     "../../core",
+    "../../travertino",
 ]
 
 

--- a/examples/table/pyproject.toml
+++ b/examples/table/pyproject.toml
@@ -16,6 +16,7 @@ description = "A testing app"
 sources = ["table"]
 requires = [
     "../../core",
+    "../../travertino",
 ]
 
 [tool.briefcase.app.table.macOS]

--- a/examples/table_source/pyproject.toml
+++ b/examples/table_source/pyproject.toml
@@ -16,6 +16,7 @@ description = "A testing app"
 sources = ["table_source"]
 requires = [
     "../../core",
+    "../../travertino",
 ]
 
 

--- a/examples/textinput/pyproject.toml
+++ b/examples/textinput/pyproject.toml
@@ -16,6 +16,7 @@ description = "A testing app"
 sources = ["textinput"]
 requires = [
     "../../core",
+    "../../travertino",
 ]
 
 

--- a/examples/tree/pyproject.toml
+++ b/examples/tree/pyproject.toml
@@ -16,6 +16,7 @@ description = "A testing app"
 sources = ["tree"]
 requires = [
     "../../core",
+    "../../travertino",
 ]
 
 

--- a/examples/tree_source/pyproject.toml
+++ b/examples/tree_source/pyproject.toml
@@ -16,6 +16,7 @@ description = "A testing app"
 sources = ["tree_source"]
 requires = [
     "../../core",
+    "../../travertino",
 ]
 
 

--- a/examples/tutorial0/pyproject.toml
+++ b/examples/tutorial0/pyproject.toml
@@ -16,6 +16,7 @@ description = "A testing app"
 sources = ["tutorial"]
 requires = [
     "../../core",
+    "../../travertino",
 ]
 
 

--- a/examples/tutorial1/pyproject.toml
+++ b/examples/tutorial1/pyproject.toml
@@ -16,6 +16,7 @@ description = "A testing app"
 sources = ["tutorial"]
 requires = [
     "../../core",
+    "../../travertino",
 ]
 
 

--- a/examples/tutorial2/pyproject.toml
+++ b/examples/tutorial2/pyproject.toml
@@ -16,6 +16,7 @@ description = "A testing app"
 sources = ["tutorial"]
 requires = [
     "../../core",
+    "../../travertino",
 ]
 
 

--- a/examples/tutorial3/pyproject.toml
+++ b/examples/tutorial3/pyproject.toml
@@ -16,6 +16,7 @@ description = "A testing app"
 sources = ["tutorial"]
 requires = [
     "../../core",
+    "../../travertino",
 ]
 
 

--- a/examples/tutorial4/pyproject.toml
+++ b/examples/tutorial4/pyproject.toml
@@ -16,6 +16,7 @@ description = "A testing app"
 sources = ["tutorial"]
 requires = [
     "../../core",
+    "../../travertino",
 ]
 
 

--- a/examples/webview/pyproject.toml
+++ b/examples/webview/pyproject.toml
@@ -16,6 +16,7 @@ description = "A demo app using all WebView features"
 sources = ["webview"]
 requires = [
     "../../core",
+    "../../travertino",
 ]
 
 [tool.briefcase.app.webview.macOS]

--- a/examples/window/pyproject.toml
+++ b/examples/window/pyproject.toml
@@ -16,6 +16,7 @@ description = "A testing app"
 sources = ["window"]
 requires = [
     "../../core",
+    "../../travertino",
 ]
 
 

--- a/gtk/pyproject.toml
+++ b/gtk/pyproject.toml
@@ -64,7 +64,7 @@ root = ".."
 [tool.setuptools_dynamic_dependencies]
 dependencies = [
     "pycairo >= 1.17.0",
-    "pygobject >= 3.50.0",
+    "pygobject == 3.50.0",
     "toga-core == {version}",
 ]
 

--- a/gtk/pyproject.toml
+++ b/gtk/pyproject.toml
@@ -64,6 +64,13 @@ root = ".."
 [tool.setuptools_dynamic_dependencies]
 dependencies = [
     "pycairo >= 1.17.0",
+    # TODO: PyGObject 3.50.0 is the first version with native GTK asyncio integration;
+    # PyGObject 3.51.0 will introduce a dependency on libgirepository-2.0, which isn't
+    # available on Ubuntu 22.04 and earlier. We need to make a bunch of other CI and
+    # documentation changes to accommodate this. Preemptively protect against the future
+    # release of 3.51.0, and the 3.51.0.dev0 pre-release that has been published to
+    # PyPI, but has inconsistent metadata and can't be installed with pip. See #3143.
+    # "pygobject >= 3.50.0",
     "pygobject == 3.50.0",
     "toga-core == {version}",
 ]

--- a/testbed/pyproject.toml
+++ b/testbed/pyproject.toml
@@ -40,7 +40,7 @@ requires = [
 # Look for pre-release wheels in the dist folder of the parent repo.
 requirement_installer_args=[
     "--pre",
-    "--find-wheels", "../dist",
+    "--find-links", "../dist",
 ]
 
 permission.camera = "The testbed needs to exercise Camera APIs"

--- a/testbed/pyproject.toml
+++ b/testbed/pyproject.toml
@@ -37,7 +37,12 @@ requires = [
     "../core",
     "../travertino",
 ]
-# Look for pre-release wheels in the dist folder of the parent repo.
+
+# Some CI configurations (e.g., Textual) manually override `requires` to specify
+# installation via the wheels built as part of the CI run. Adding `--find-links` allows
+# those wheels to be found. However, in most CI builds, these wheels will be .devX
+# wheels, so we need to add `--pre` to ensure they are found as solutions to pip's
+# solver.
 requirement_installer_args=[
     "--pre",
     "--find-links", "../dist",

--- a/testbed/pyproject.toml
+++ b/testbed/pyproject.toml
@@ -37,6 +37,11 @@ requires = [
     "../core",
     "../travertino",
 ]
+# Look for pre-release wheels in the dist folder of the parent repo.
+requirement_installer_args=[
+    "--pre",
+    "--find-wheels", "../dist",
+]
 
 permission.camera = "The testbed needs to exercise Camera APIs"
 permission.fine_location = "The testbed needs to exercise fine-grained geolocation services."

--- a/tox.ini
+++ b/tox.ini
@@ -60,9 +60,6 @@ base_python =
     coverage311: py311
     coverage312: py312
     coverage313: py313
-deps =
-    !trav: {tox_root}{/}core[dev]
-    trav: {tox_root}{/}travertino[dev]
 setenv =
     keep: COMBINE_KEEP = --keep
     fail: REPORT_FAIL_COND = --fail-under=100
@@ -73,6 +70,8 @@ setenv =
     {platform}: COVERAGE_EXCLUDE_PYTHON_VERSION=disable
 commands_pre = python --version
 commands =
+    # TOGA_INSTALL_COMMAND is set to a bash command by the CI workflow
+    {env:TOGA_INSTALL_COMMAND:python -m pip install {tox_root}{/}core[dev] {tox_root}{/}travertino}
     -python -m coverage combine {env:PACKAGE_RCFILE} {env:COMBINE_KEEP}
     html: python -m coverage html {env:PROJECT_RCFILE} --skip-covered --skip-empty
     python -m coverage report {env:PROJECT_RCFILE} {env:REPORT_FAIL_COND}

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ skip_missing_interpreters = True
 [testenv:pre-commit]
 skip_install = True
 deps =
+    {tox_root}{/}travertino
     {tox_root}{/}core[dev]
 commands = pre-commit run --all-files --show-diff-on-failure --color=always
 
@@ -80,7 +81,6 @@ commands =
 skip_install = True
 deps =
     towncrier==24.8.0
-    {tox_root}{/}core
 commands =
     check  : python -m towncrier.check --compare-with origin/main
     !check : python -m towncrier {posargs}


### PR DESCRIPTION
* Modifies the CI configuration so that Travertino is installed by pip finding the wheel in the dist folder, rather than by explicitly installing the package from the source directory.
* Modifies the testbed to look in the `dist` folder for prerelease wheels, but *doesn't* modify the platform configurations to use those wheels. This is so that local testing continues to work. However, the Textual backend *will* use the `dist` folder to install packages, so there is at least *some* testing of wheel usage by Briefcase.
* Updates all the examples and the demo app to include an explicit install of Travertino.
* Includes a hard version pin of PyGObject 3.50.0 to work around #3143.
* Includes a conditional coverage tweak that I noticed being reported on each of the standalone core test runs. This wasn't an issue for overall coverage, but it helps to keep local single-Python version test results clean.

Fixes #3154.
Refs #3143.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
