### PR TITLE
Deprecate use of generators as handlers.

### DIFF
--- a/changes/2721.removal.rst
+++ b/changes/2721.removal.rst
@@ -1,1 +1,1 @@
-The use of a generators as event handlers has been deprecated. Any generator-based event handler can be converted into an asynchronous co-routine by converting the handler to ``async def``, and using ``await asyncio.sleep(t)`` in place of ``yield t`` (for some sleep interval ``t``).
+The use of generators as event handlers has been deprecated. Any generator-based event handler can be converted into an asynchronous co-routine by converting the handler to ``async def``, and using ``await asyncio.sleep(t)`` in place of ``yield t`` (for some sleep interval ``t``).

--- a/changes/2721.removal.rst
+++ b/changes/2721.removal.rst
@@ -1,0 +1,1 @@
+The use of a generators as event handlers has been deprecated. Any generator-based event handler can be converted into an asynchronous co-routine by converting the handler to ``async def``, and using ``await asyncio.sleep(t)`` in place of ``yield t`` (for some sleep interval ``t``).

--- a/core/src/toga/handlers.py
+++ b/core/src/toga/handlers.py
@@ -48,7 +48,7 @@ async def long_running_task(
     ######################################################################
     warnings.warn(
         "Use of generators for async handlers has been deprecated; convert "
-        "the handler to an async co-routine that uses `asycio.sleep()`.",
+        "the handler to an async co-routine that uses `asyncio.sleep()`.",
         DeprecationWarning,
     )
     try:

--- a/core/src/toga/handlers.py
+++ b/core/src/toga/handlers.py
@@ -39,7 +39,18 @@ async def long_running_task(
     generator: HandlerGeneratorReturnT[object],
     cleanup: HandlerSyncT | None,
 ) -> object | None:
-    """Run a generator as an asynchronous coroutine."""
+    """Run a generator as an asynchronous coroutine.
+
+    **DEPRECATED** - use async co-routines instead of generators.
+    """
+    ######################################################################
+    # 2025-02: Deprecated in 0.5.0
+    ######################################################################
+    warnings.warn(
+        "Use of generators for async handlers has been deprecated; convert "
+        "the handler to an async co-routine that uses `asycio.sleep()`.",
+        DeprecationWarning,
+    )
     try:
         try:
             while True:

--- a/core/tests/test_handlers.py
+++ b/core/tests/test_handlers.py
@@ -180,7 +180,7 @@ def test_function_handler_with_cleanup_error(capsys):
 
 
 ######################################################################
-# 2025-02: Handlers deprecated in 0.5.0
+# 2025-02: Generator handlers deprecated in 0.5.0
 ######################################################################
 
 

--- a/core/tests/test_handlers.py
+++ b/core/tests/test_handlers.py
@@ -179,6 +179,182 @@ def test_function_handler_with_cleanup_error(capsys):
     )
 
 
+######################################################################
+# 2025-02: Handlers deprecated in 0.5.0
+######################################################################
+
+
+def test_generator_handler(event_loop):
+    """A generator can be used as a handler."""
+    obj = Mock()
+    handler_call = {}
+
+    def handler(*args, **kwargs):
+        handler_call["args"] = args
+        handler_call["kwargs"] = kwargs
+        yield 0.01  # A short sleep
+        handler_call["slept"] = True
+        yield  # A yield without a sleep
+        handler_call["done"] = True
+        return 42
+
+    wrapped = wrapped_handler(obj, handler)
+
+    # Raw handler is the original generator
+    assert wrapped._raw == handler
+
+    # Invoke the handler, and run until it is complete. Raises a deprecation warning.
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"Use of generators for async handlers has been deprecated;",
+    ):
+        assert (
+            event_loop.run_until_complete(wrapped("arg1", "arg2", kwarg1=3, kwarg2=4))
+            == 42
+        )
+
+    # Handler arguments are as expected.
+    assert handler_call == {
+        "args": (obj, "arg1", "arg2"),
+        "kwargs": {"kwarg1": 3, "kwarg2": 4},
+        "slept": True,
+        "done": True,
+    }
+
+
+def test_generator_handler_error(event_loop, capsys):
+    """A generator can raise an error."""
+    obj = Mock()
+    handler_call = {}
+
+    def handler(*args, **kwargs):
+        handler_call["args"] = args
+        handler_call["kwargs"] = kwargs
+        yield 0.01  # A short sleep
+        raise Exception("Problem in handler")
+
+    wrapped = wrapped_handler(obj, handler)
+
+    # Raw handler is the original generator
+    assert wrapped._raw == handler
+
+    # Invoke the handler; raises a deprecation warning, return value is None due to
+    # exception.
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"Use of generators for async handlers has been deprecated;",
+    ):
+        assert (
+            event_loop.run_until_complete(wrapped("arg1", "arg2", kwarg1=3, kwarg2=4))
+            is None
+        )
+
+    # Handler arguments are as expected.
+    assert handler_call == {
+        "args": (obj, "arg1", "arg2"),
+        "kwargs": {"kwarg1": 3, "kwarg2": 4},
+    }
+
+    # Evidence of the handler cleanup error is in the log.
+    assert (
+        "Error in long running handler: Problem in handler\n"
+        "Traceback (most recent call last):\n" in capsys.readouterr().err
+    )
+
+
+def test_generator_handler_with_cleanup(event_loop):
+    """A generator can have cleanup."""
+    obj = Mock()
+    cleanup = Mock()
+    handler_call = {}
+
+    def handler(*args, **kwargs):
+        handler_call["args"] = args
+        handler_call["kwargs"] = kwargs
+        yield 0.01  # A short sleep
+        handler_call["slept"] = True
+        yield  # A yield without a sleep
+        handler_call["done"] = True
+        return 42
+
+    wrapped = wrapped_handler(obj, handler, cleanup=cleanup)
+
+    # Raw handler is the original generator
+    assert wrapped._raw == handler
+
+    # Invoke the handler; raises a deprecation warning
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"Use of generators for async handlers has been deprecated;",
+    ):
+        assert (
+            event_loop.run_until_complete(wrapped("arg1", "arg2", kwarg1=3, kwarg2=4))
+            == 42
+        )
+
+    # Handler arguments are as expected.
+    assert handler_call == {
+        "args": (obj, "arg1", "arg2"),
+        "kwargs": {"kwarg1": 3, "kwarg2": 4},
+        "slept": True,
+        "done": True,
+    }
+
+    # Cleanup method was invoked
+    cleanup.assert_called_once_with(obj, 42)
+
+
+def test_generator_handler_with_cleanup_error(event_loop, capsys):
+    """A generator can raise an error during cleanup."""
+    obj = Mock()
+    cleanup = Mock(side_effect=Exception("Problem in cleanup"))
+    handler_call = {}
+
+    def handler(*args, **kwargs):
+        handler_call["args"] = args
+        handler_call["kwargs"] = kwargs
+        yield 0.01  # A short sleep
+        handler_call["slept"] = True
+        yield  # A yield without a sleep
+        handler_call["done"] = True
+        return 42
+
+    wrapped = wrapped_handler(obj, handler, cleanup=cleanup)
+
+    # Raw handler is the original generator
+    assert wrapped._raw == handler
+
+    # Invoke the handler; raises a deprecation warning, error in cleanup is swallowed
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"Use of generators for async handlers has been deprecated;",
+    ):
+        assert (
+            event_loop.run_until_complete(wrapped("arg1", "arg2", kwarg1=3, kwarg2=4))
+            == 42
+        )
+
+    # Handler arguments are as expected.
+    assert handler_call == {
+        "args": (obj, "arg1", "arg2"),
+        "kwargs": {"kwarg1": 3, "kwarg2": 4},
+        "slept": True,
+        "done": True,
+    }
+
+    # Cleanup method was invoked
+    cleanup.assert_called_once_with(obj, 42)
+
+    # Evidence of the handler cleanup error is in the log.
+    assert (
+        "Error in long running handler cleanup: Problem in cleanup\n"
+        "Traceback (most recent call last):\n" in capsys.readouterr().err
+    )
+
+
+######################################################################
+
+
 def test_coroutine_handler(event_loop):
     """A coroutine can be used as a handler."""
     obj = Mock()
@@ -566,176 +742,3 @@ def test_async_exception_cancelled_sync(event_loop):
 
     # The callback wasn't called
     on_result.assert_not_called()
-
-
-######################################################################
-# 2025-02: Handlers deprecated in 0.5.0
-######################################################################
-
-
-def test_generator_handler(event_loop):
-    """A generator can be used as a handler."""
-    obj = Mock()
-    handler_call = {}
-
-    def handler(*args, **kwargs):
-        handler_call["args"] = args
-        handler_call["kwargs"] = kwargs
-        yield 0.01  # A short sleep
-        handler_call["slept"] = True
-        yield  # A yield without a sleep
-        handler_call["done"] = True
-        return 42
-
-    wrapped = wrapped_handler(obj, handler)
-
-    # Raw handler is the original generator
-    assert wrapped._raw == handler
-
-    # Invoke the handler, and run until it is complete. Raises a deprecation warning.
-    with pytest.warns(
-        DeprecationWarning,
-        match=r"Use of generators for async handlers has been deprecated;",
-    ):
-        assert (
-            event_loop.run_until_complete(wrapped("arg1", "arg2", kwarg1=3, kwarg2=4))
-            == 42
-        )
-
-    # Handler arguments are as expected.
-    assert handler_call == {
-        "args": (obj, "arg1", "arg2"),
-        "kwargs": {"kwarg1": 3, "kwarg2": 4},
-        "slept": True,
-        "done": True,
-    }
-
-
-def test_generator_handler_error(event_loop, capsys):
-    """A generator can raise an error."""
-    obj = Mock()
-    handler_call = {}
-
-    def handler(*args, **kwargs):
-        handler_call["args"] = args
-        handler_call["kwargs"] = kwargs
-        yield 0.01  # A short sleep
-        raise Exception("Problem in handler")
-
-    wrapped = wrapped_handler(obj, handler)
-
-    # Raw handler is the original generator
-    assert wrapped._raw == handler
-
-    # Invoke the handler; raises a deprecation warning, return value is None due to
-    # exception.
-    with pytest.warns(
-        DeprecationWarning,
-        match=r"Use of generators for async handlers has been deprecated;",
-    ):
-        assert (
-            event_loop.run_until_complete(wrapped("arg1", "arg2", kwarg1=3, kwarg2=4))
-            is None
-        )
-
-    # Handler arguments are as expected.
-    assert handler_call == {
-        "args": (obj, "arg1", "arg2"),
-        "kwargs": {"kwarg1": 3, "kwarg2": 4},
-    }
-
-    # Evidence of the handler cleanup error is in the log.
-    assert (
-        "Error in long running handler: Problem in handler\n"
-        "Traceback (most recent call last):\n" in capsys.readouterr().err
-    )
-
-
-def test_generator_handler_with_cleanup(event_loop):
-    """A generator can have cleanup."""
-    obj = Mock()
-    cleanup = Mock()
-    handler_call = {}
-
-    def handler(*args, **kwargs):
-        handler_call["args"] = args
-        handler_call["kwargs"] = kwargs
-        yield 0.01  # A short sleep
-        handler_call["slept"] = True
-        yield  # A yield without a sleep
-        handler_call["done"] = True
-        return 42
-
-    wrapped = wrapped_handler(obj, handler, cleanup=cleanup)
-
-    # Raw handler is the original generator
-    assert wrapped._raw == handler
-
-    # Invoke the handler; raises a deprecation warning
-    with pytest.warns(
-        DeprecationWarning,
-        match=r"Use of generators for async handlers has been deprecated;",
-    ):
-        assert (
-            event_loop.run_until_complete(wrapped("arg1", "arg2", kwarg1=3, kwarg2=4))
-            == 42
-        )
-
-    # Handler arguments are as expected.
-    assert handler_call == {
-        "args": (obj, "arg1", "arg2"),
-        "kwargs": {"kwarg1": 3, "kwarg2": 4},
-        "slept": True,
-        "done": True,
-    }
-
-    # Cleanup method was invoked
-    cleanup.assert_called_once_with(obj, 42)
-
-
-def test_generator_handler_with_cleanup_error(event_loop, capsys):
-    """A generator can raise an error during cleanup."""
-    obj = Mock()
-    cleanup = Mock(side_effect=Exception("Problem in cleanup"))
-    handler_call = {}
-
-    def handler(*args, **kwargs):
-        handler_call["args"] = args
-        handler_call["kwargs"] = kwargs
-        yield 0.01  # A short sleep
-        handler_call["slept"] = True
-        yield  # A yield without a sleep
-        handler_call["done"] = True
-        return 42
-
-    wrapped = wrapped_handler(obj, handler, cleanup=cleanup)
-
-    # Raw handler is the original generator
-    assert wrapped._raw == handler
-
-    # Invoke the handler; raises a deprecation warning, error in cleanup is swallowed
-    with pytest.warns(
-        DeprecationWarning,
-        match=r"Use of generators for async handlers has been deprecated;",
-    ):
-        assert (
-            event_loop.run_until_complete(wrapped("arg1", "arg2", kwarg1=3, kwarg2=4))
-            == 42
-        )
-
-    # Handler arguments are as expected.
-    assert handler_call == {
-        "args": (obj, "arg1", "arg2"),
-        "kwargs": {"kwarg1": 3, "kwarg2": 4},
-        "slept": True,
-        "done": True,
-    }
-
-    # Cleanup method was invoked
-    cleanup.assert_called_once_with(obj, 42)
-
-    # Evidence of the handler cleanup error is in the log.
-    assert (
-        "Error in long running handler cleanup: Problem in cleanup\n"
-        "Traceback (most recent call last):\n" in capsys.readouterr().err
-    )

--- a/demo/toga_demo/app.py
+++ b/demo/toga_demo/app.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import toga
 from toga.constants import COLUMN
 from toga.style import Pack
@@ -82,10 +84,10 @@ class TogaDemo(toga.App):
         # Show the main window
         self.main_window.show()
 
-    def button_handler(self, widget):
+    async def button_handler(self, widget):
         print("button press")
         for i in range(0, 10):
-            yield 1
+            await asyncio.sleep(1)
             print("still running... (iteration %s)" % i)
 
     def action1(self, widget):

--- a/examples/handlers/handlers/app.py
+++ b/examples/handlers/handlers/app.py
@@ -15,7 +15,6 @@ class HandlerApp(toga.App):
         self.on_running_label.text = "Ready."
         self.background_label.text = "Ready."
         self.function_label.text = "Ready."
-        self.generator_label.text = "Ready."
         self.async_label.text = "Ready."
 
     def do_function(self, widget, **kwargs):
@@ -24,17 +23,6 @@ class HandlerApp(toga.App):
         self.function_label.text = "Here's a random number: {}".format(
             random.randint(0, 100)
         )
-
-    def do_generator(self, widget, **kwargs):
-        """A generator-based handler."""
-        # The generator yields a number; that number is the number of seconds
-        # to yield to the main event loop before processing is resumed.
-        widget.enabled = False
-        for i in range(1, 10):
-            self.generator_label.text = f"Iteration {i}"
-            yield 1
-        self.generator_label.text = "Ready."
-        widget.enabled = True
 
     async def do_async(self, widget, **kwargs):
         """An async handler."""
@@ -81,7 +69,6 @@ class HandlerApp(toga.App):
         self.on_running_label = toga.Label("Ready.", style=Pack(margin=10))
         self.background_label = toga.Label("Ready.", style=Pack(margin=10))
         self.function_label = toga.Label("Ready.", style=Pack(margin=10))
-        self.generator_label = toga.Label("Ready.", style=Pack(margin=10))
         self.async_label = toga.Label("Ready.", style=Pack(margin=10))
         self.web_label = toga.Label("Ready.", style=Pack(margin=10))
 
@@ -93,9 +80,6 @@ class HandlerApp(toga.App):
         btn_style = Pack(flex=1)
         btn_function = toga.Button(
             "Function callback", on_press=self.do_function, style=btn_style
-        )
-        btn_generator = toga.Button(
-            "Generator callback", on_press=self.do_generator, style=btn_style
         )
         btn_async = toga.Button(
             "Async callback", on_press=self.do_async, style=btn_style
@@ -112,8 +96,6 @@ class HandlerApp(toga.App):
                 self.background_label,
                 btn_function,
                 self.function_label,
-                btn_generator,
-                self.generator_label,
                 btn_async,
                 self.async_label,
                 btn_web,

--- a/examples/textinput/textinput/app.py
+++ b/examples/textinput/textinput/app.py
@@ -1,3 +1,4 @@
+import asyncio
 from string import ascii_lowercase, ascii_uppercase, digits
 
 import toga
@@ -10,7 +11,7 @@ EMPTY_PASSWORD = "Empty password"
 
 class TextInputApp(toga.App):
     # Button callback functions
-    def do_extract_values(self, widget, **kwargs):
+    async def do_extract_values(self, widget, **kwargs):
         # Disable all the text inputs
         for input in self.inputs:
             input.enabled = False
@@ -38,7 +39,7 @@ class TextInputApp(toga.App):
         # Wait a few seconds
         for i in range(2, 0, -1):
             self.label.text = f"Counting down from {i}..."
-            yield 1
+            await asyncio.sleep(1)
         self.label.text = "Enter some values and press extract."
 
         # Re-enable the inputs again.

--- a/examples/tutorial2/tutorial/app.py
+++ b/examples/tutorial2/tutorial/app.py
@@ -1,12 +1,14 @@
+import asyncio
+
 import toga
 from toga.style.pack import COLUMN, Pack
 
 
-def button_handler(widget):
+async def button_handler(widget):
     print("button handler")
     for i in range(0, 10):
         print("hello", i)
-        yield 1
+        await asyncio.sleep(1)
     print("done", i)
 
 

--- a/examples/window/window/app.py
+++ b/examples/window/window/app.py
@@ -86,11 +86,11 @@ class WindowDemoApp(toga.App):
     def do_window_state_maximize(self, widget, **kwargs):
         self.main_window.state = WindowState.MAXIMIZED
 
-    def do_window_state_minimize(self, widget, **kwargs):
+    async def do_window_state_minimize(self, widget, **kwargs):
         self.main_window.state = WindowState.MINIMIZED
         for i in range(5, 0, -1):
             print(f"Back in {i}...")
-            yield 1
+            await asyncio.sleep(1)
         self.main_window.state = WindowState.NORMAL
 
     def do_window_state_full_screen(self, widget, **kwargs):


### PR DESCRIPTION
Fixes #2721.

Deprecates the use of generators as event handlers.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
