### PR TITLE
Remove value parameter from style's apply() method

### DIFF
--- a/core/src/toga/style/pack.py
+++ b/core/src/toga/style/pack.py
@@ -259,23 +259,26 @@ class Pack(BaseStyle):
     # End backwards compatibility
     ######################################################################
 
-    def apply(self, prop: str, value: object) -> None:
+    def apply(self, name: str) -> None:
         if self._applicator:
-            if prop == "text_align":
-                if value is None:
+            if name == "text_align":
+                if (value := self.text_align) is None:
                     if self.text_direction == RTL:
                         value = RIGHT
                     else:
                         value = LEFT
                 self._applicator.set_text_align(value)
-            elif prop == "text_direction":
+            elif name == "text_direction":
                 if self.text_align is None:
-                    self._applicator.set_text_align(RIGHT if value == RTL else LEFT)
-            elif prop == "color":
-                self._applicator.set_color(value)
-            elif prop == "background_color":
-                self._applicator.set_background_color(value)
-            elif prop == "visibility":
+                    self._applicator.set_text_align(
+                        RIGHT if self.text_direction == RTL else LEFT
+                    )
+            elif name == "color":
+                self._applicator.set_color(self.color)
+            elif name == "background_color":
+                self._applicator.set_background_color(self.background_color)
+            elif name == "visibility":
+                value = self.visibility
                 if value == VISIBLE:
                     # If visibility is being set to VISIBLE, look up the chain to see if
                     # an ancestor is hidden.
@@ -286,7 +289,7 @@ class Pack(BaseStyle):
                             break
 
                 self._applicator.set_hidden(value == HIDDEN)
-            elif prop in (
+            elif name in (
                 "font_family",
                 "font_size",
                 "font_style",

--- a/core/src/toga/style/pack.py
+++ b/core/src/toga/style/pack.py
@@ -51,6 +51,8 @@ from toga.fonts import (
 # Make sure deprecation warnings are shown by default
 warnings.filterwarnings("default", category=DeprecationWarning)
 
+NOT_PROVIDED = object()
+
 PACK = "pack"
 
 # Used in backwards compatibility section below
@@ -259,7 +261,25 @@ class Pack(BaseStyle):
     # End backwards compatibility
     ######################################################################
 
-    def apply(self, name: str) -> None:
+    def apply(self, name: str, value: object = NOT_PROVIDED) -> None:
+        ######################################################################
+        # 2025-01: Backwards compatibility for Toga <= 0.4.8
+        ######################################################################
+
+        if value is not NOT_PROVIDED:
+            warnings.warn(
+                (
+                    "The value parameter to Pack.apply() is deprecated. The instance "
+                    "will use its own current value for the property named."
+                ),
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        ######################################################################
+        # End backwards compatibility
+        ######################################################################
+
         if self._applicator:
             if name == "text_align":
                 if (value := self.text_align) is None:

--- a/core/tests/style/pack/test_apply.py
+++ b/core/tests/style/pack/test_apply.py
@@ -1,5 +1,7 @@
 from unittest.mock import call
 
+import pytest
+
 from toga.colors import rgb
 from toga.fonts import Font
 from toga.style.pack import (
@@ -7,6 +9,7 @@ from toga.style.pack import (
     HIDDEN,
     LEFT,
     RIGHT,
+    ROW,
     RTL,
     VISIBLE,
     Pack,
@@ -118,3 +121,10 @@ def test_set_visibility_inherited():
     # Show grandparent again; the other two should reappear.
     grandparent.style.visibility = VISIBLE
     assert_hidden_called(False, False, False)
+
+
+def test_apply_deprecated_signature():
+    """Calling apply() with a second argument raises a DeprecationWarning."""
+    style = Pack()
+    with pytest.warns(DeprecationWarning):
+        style.apply("direction", ROW)

--- a/travertino/src/travertino/declaration.py
+++ b/travertino/src/travertino/declaration.py
@@ -160,11 +160,11 @@ class validated_property:
             # to the initial value.
             setattr(obj, f"_{self.name}", value)
             if value != self.initial:
-                obj.apply(self.name, value)
+                obj.apply(self.name)
 
         elif value != current:
             setattr(obj, f"_{self.name}", value)
-            obj.apply(self.name, value)
+            obj.apply(self.name)
 
     def __delete__(self, obj):
         try:
@@ -172,7 +172,7 @@ class validated_property:
         except AttributeError:
             pass
         else:
-            obj.apply(self.name, self.initial)
+            obj.apply(self.name)
 
     @property
     def _name_if_set(self):
@@ -332,7 +332,7 @@ class BaseStyle:
 
     def reapply(self):
         for name in self._PROPERTIES:
-            self.apply(name, self[name])
+            self.apply(name)
 
     def copy(self, applicator=None):
         """Create a duplicate of this style declaration."""
@@ -362,7 +362,7 @@ class BaseStyle:
     # Interface that style declarations must define
     ######################################################################
 
-    def apply(self, property, value):
+    def apply(self, name):
         raise NotImplementedError(
             "Style must define an apply method"
         )  # pragma: no cover

--- a/travertino/tests/test_choices.py
+++ b/travertino/tests/test_choices.py
@@ -66,7 +66,7 @@ with catch_warnings():
 def assert_property(obj, name, value):
     assert getattr(obj, name) == value
 
-    obj.apply.assert_called_once_with(name, value)
+    obj.apply.assert_called_once_with(name)
     obj.apply.reset_mock()
 
 

--- a/travertino/tests/test_declaration.py
+++ b/travertino/tests/test_declaration.py
@@ -149,14 +149,14 @@ def test_reapply(StyleClass):
     style.reapply()
     style.apply.assert_has_calls(
         [
-            call("explicit_const", VALUE2),
-            call("explicit_value", 0),
-            call("explicit_none", None),
-            call("implicit", VALUE3),
-            call("thing_left", 0),
-            call("thing_top", 0),
-            call("thing_right", 0),
-            call("thing_bottom", 0),
+            call("explicit_const"),
+            call("explicit_value"),
+            call("explicit_none"),
+            call("implicit"),
+            call("thing_left"),
+            call("thing_top"),
+            call("thing_right"),
+            call("thing_bottom"),
         ],
         any_order=True,
     )
@@ -174,7 +174,7 @@ def test_property_with_explicit_const(StyleClass):
     style.explicit_const = 10
 
     assert style.explicit_const == 10
-    style.apply.assert_called_once_with("explicit_const", 10)
+    style.apply.assert_called_once_with("explicit_const")
 
     # Clear the applicator mock
     style.apply.reset_mock()
@@ -189,7 +189,7 @@ def test_property_with_explicit_const(StyleClass):
     # A dirty notification is set.
     style.explicit_const = 20
     assert style.explicit_const == 20
-    style.apply.assert_called_once_with("explicit_const", 20)
+    style.apply.assert_called_once_with("explicit_const")
 
     # Clear the applicator mock
     style.apply.reset_mock()
@@ -197,7 +197,7 @@ def test_property_with_explicit_const(StyleClass):
     # Clear the property
     del style.explicit_const
     assert style.explicit_const is VALUE1
-    style.apply.assert_called_once_with("explicit_const", VALUE1)
+    style.apply.assert_called_once_with("explicit_const")
 
     # Clear the applicator mock
     style.apply.reset_mock()
@@ -222,7 +222,7 @@ def test_property_with_explicit_value(StyleClass):
     style.explicit_value = 10
 
     assert style.explicit_value == 10
-    style.apply.assert_called_once_with("explicit_value", 10)
+    style.apply.assert_called_once_with("explicit_value")
 
     # Clear the applicator mock
     style.apply.reset_mock()
@@ -237,7 +237,7 @@ def test_property_with_explicit_value(StyleClass):
     # A dirty notification is set.
     style.explicit_value = 20
     assert style.explicit_value == 20
-    style.apply.assert_called_once_with("explicit_value", 20)
+    style.apply.assert_called_once_with("explicit_value")
 
     # Clear the applicator mock
     style.apply.reset_mock()
@@ -245,7 +245,7 @@ def test_property_with_explicit_value(StyleClass):
     # Clear the property
     del style.explicit_value
     assert style.explicit_value == 0
-    style.apply.assert_called_once_with("explicit_value", 0)
+    style.apply.assert_called_once_with("explicit_value")
 
 
 @pytest.mark.parametrize("StyleClass", [Style, DeprecatedStyle])
@@ -260,7 +260,7 @@ def test_property_with_explicit_none(StyleClass):
     style.explicit_none = 10
 
     assert style.explicit_none == 10
-    style.apply.assert_called_once_with("explicit_none", 10)
+    style.apply.assert_called_once_with("explicit_none")
 
     # Clear the applicator mock
     style.apply.reset_mock()
@@ -275,7 +275,7 @@ def test_property_with_explicit_none(StyleClass):
     # A dirty notification is set.
     style.explicit_none = 20
     assert style.explicit_none == 20
-    style.apply.assert_called_once_with("explicit_none", 20)
+    style.apply.assert_called_once_with("explicit_none")
 
     # Clear the applicator mock
     style.apply.reset_mock()
@@ -283,7 +283,7 @@ def test_property_with_explicit_none(StyleClass):
     # Clear the property
     del style.explicit_none
     assert style.explicit_none is None
-    style.apply.assert_called_once_with("explicit_none", None)
+    style.apply.assert_called_once_with("explicit_none")
 
 
 @pytest.mark.parametrize("StyleClass", [Style, DeprecatedStyle])
@@ -298,7 +298,7 @@ def test_property_with_implicit_default(StyleClass):
     style.implicit = 10
 
     assert style.implicit == 10
-    style.apply.assert_called_once_with("implicit", 10)
+    style.apply.assert_called_once_with("implicit")
 
     # Clear the applicator mock
     style.apply.reset_mock()
@@ -313,7 +313,7 @@ def test_property_with_implicit_default(StyleClass):
     # A dirty notification is set.
     style.implicit = 20
     assert style.implicit == 20
-    style.apply.assert_called_once_with("implicit", 20)
+    style.apply.assert_called_once_with("implicit")
 
     # Clear the applicator mock
     style.apply.reset_mock()
@@ -321,7 +321,7 @@ def test_property_with_implicit_default(StyleClass):
     # Clear the property
     del style.implicit
     assert style.implicit is None
-    style.apply.assert_called_once_with("implicit", None)
+    style.apply.assert_called_once_with("implicit")
 
 
 @pytest.mark.parametrize("StyleClass", [Style, DeprecatedStyle])
@@ -355,7 +355,7 @@ def test_directional_property(StyleClass):
     assert style.thing_right == 0
     assert style.thing_bottom == 0
     assert style.thing_left == 0
-    style.apply.assert_called_once_with("thing_top", 10)
+    style.apply.assert_called_once_with("thing_top")
 
     # Clear the applicator mock
     style.apply.reset_mock()
@@ -370,9 +370,9 @@ def test_directional_property(StyleClass):
     assert style.thing_left == 10
     style.apply.assert_has_calls(
         [
-            call("thing_right", 10),
-            call("thing_bottom", 10),
-            call("thing_left", 10),
+            call("thing_right"),
+            call("thing_bottom"),
+            call("thing_left"),
         ]
     )
 
@@ -389,10 +389,10 @@ def test_directional_property(StyleClass):
     assert style.thing_left == 30
     style.apply.assert_has_calls(
         [
-            call("thing_top", 30),
-            call("thing_right", 30),
-            call("thing_bottom", 30),
-            call("thing_left", 30),
+            call("thing_top"),
+            call("thing_right"),
+            call("thing_bottom"),
+            call("thing_left"),
         ]
     )
 
@@ -409,10 +409,10 @@ def test_directional_property(StyleClass):
     assert style.thing_left == 20
     style.apply.assert_has_calls(
         [
-            call("thing_top", 10),
-            call("thing_right", 20),
-            call("thing_bottom", 10),
-            call("thing_left", 20),
+            call("thing_top"),
+            call("thing_right"),
+            call("thing_bottom"),
+            call("thing_left"),
         ]
     )
 
@@ -427,7 +427,7 @@ def test_directional_property(StyleClass):
     assert style.thing_right == 20
     assert style.thing_bottom == 30
     assert style.thing_left == 20
-    style.apply.assert_called_once_with("thing_bottom", 30)
+    style.apply.assert_called_once_with("thing_bottom")
 
     # Clear the applicator mock
     style.apply.reset_mock()
@@ -440,7 +440,7 @@ def test_directional_property(StyleClass):
     assert style.thing_right == 20
     assert style.thing_bottom == 30
     assert style.thing_left == 40
-    style.apply.assert_called_once_with("thing_left", 40)
+    style.apply.assert_called_once_with("thing_left")
 
     # Set a value directly with an invalid number of values
     with pytest.raises(ValueError):
@@ -460,7 +460,7 @@ def test_directional_property(StyleClass):
     assert style.thing_right == 20
     assert style.thing_bottom == 30
     assert style.thing_left == 40
-    style.apply.assert_called_once_with("thing_top", 0)
+    style.apply.assert_called_once_with("thing_top")
 
     # Restore the top thing
     style.thing_top = 10
@@ -478,9 +478,9 @@ def test_directional_property(StyleClass):
     assert style.thing_left == 0
     style.apply.assert_has_calls(
         [
-            call("thing_right", 0),
-            call("thing_bottom", 0),
-            call("thing_left", 0),
+            call("thing_right"),
+            call("thing_bottom"),
+            call("thing_left"),
         ]
     )
 
@@ -628,8 +628,8 @@ def test_set_multiple_properties(StyleClass):
     assert style.explicit_value == 20
     style.apply.assert_has_calls(
         [
-            call("explicit_value", 20),
-            call("explicit_none", 10),
+            call("explicit_value"),
+            call("explicit_none"),
         ],
         any_order=True,
     )
@@ -642,8 +642,8 @@ def test_set_multiple_properties(StyleClass):
     assert style.explicit_none == 10
     style.apply.assert_has_calls(
         [
-            call("explicit_const", VALUE2),
-            call("explicit_value", 30),
+            call("explicit_const"),
+            call("explicit_value"),
         ],
         any_order=True,
     )


### PR DESCRIPTION
`BaseStyle.apply()` / `Pack.apply()` currently accepts two parameters, a name and a value for the property to apply. However, the correct value to pass is always the the value of that property on the style object in question. Thus I propose removing the `value` parameter.

I've also renamed the other parameter from `property` to `name`, in line with the consistent naming scheme I've been using in Travertino to distinguish between styles, properties, property names, and property values.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
