### PR TITLE
Replace reapply() with bare apply()

### DIFF
--- a/changes/3160.removal.rst
+++ b/changes/3160.removal.rst
@@ -1,0 +1,1 @@
+``Basestyle.reapply()`` / ``Pack.reapply()`` has been renamed to ``apply_all()``. This method is normally only used internally, but any user code that calls the old name directly will cause a ``DeprecationWarning``.

--- a/changes/3160.removal.rst
+++ b/changes/3160.removal.rst
@@ -1,1 +1,0 @@
-``Basestyle.reapply()`` / ``Pack.reapply()`` has been renamed to ``apply_all()``. This method is normally only used internally, but any user code that calls the old name directly will cause a ``DeprecationWarning``.

--- a/changes/3160.removal.rst
+++ b/changes/3160.removal.rst
@@ -1,0 +1,1 @@
+Travertino's ``BaseStyle.reapply()`` (and thus Toga's ``Pack.reapply()``) has been deprecated; the correct usage is now to call `.apply()` with no arguments. User code is unlikely to ever call this method, but Toga <= 0.4.8 calls it extensively, so users who update Travertino but not Toga will receive DeprecationWarnings.

--- a/core/src/toga/style/pack.py
+++ b/core/src/toga/style/pack.py
@@ -132,13 +132,6 @@ class Pack(BaseStyle):
         }
         super().update(**properties)
 
-    # Pack.alignment is still an actual property, despite being deprecated, so we need
-    # to suppress deprecation warnings when reapply is called.
-    # def reapply(self, *args, **kwargs):
-    #     with warnings.catch_warnings():
-    #         warnings.filterwarnings("ignore", category=DeprecationWarning)
-    #         super().apply(*args, **kwargs)
-
     _DEPRECATED_PROPERTIES = {
         # Map each deprecated property name to its replacement.
         # alignment / align_items is handled separately.

--- a/core/src/toga/style/pack.py
+++ b/core/src/toga/style/pack.py
@@ -258,6 +258,18 @@ class Pack(BaseStyle):
         super().__delitem__(self._update_property_name(name.replace("-", "_")))
 
     ######################################################################
+    # 2025-02: Backwards compatibility for Toga <= 0.4.8
+    ######################################################################
+
+    def reapply(self):
+        warnings.warn(
+            ("Pack.reapply() is deprecated; use Pack.apply_all() instead."),
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self.apply_all()
+
+    ######################################################################
     # End backwards compatibility
     ######################################################################
 

--- a/core/src/toga/style/pack.py
+++ b/core/src/toga/style/pack.py
@@ -134,10 +134,10 @@ class Pack(BaseStyle):
 
     # Pack.alignment is still an actual property, despite being deprecated, so we need
     # to suppress deprecation warnings when reapply is called.
-    def reapply(self, *args, **kwargs):
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=DeprecationWarning)
-            super().reapply(*args, **kwargs)
+    # def reapply(self, *args, **kwargs):
+    #     with warnings.catch_warnings():
+    #         warnings.filterwarnings("ignore", category=DeprecationWarning)
+    #         super().apply(*args, **kwargs)
 
     _DEPRECATED_PROPERTIES = {
         # Map each deprecated property name to its replacement.
@@ -261,74 +261,57 @@ class Pack(BaseStyle):
     # End backwards compatibility
     ######################################################################
 
-    def apply(self, name: str, value: object = NOT_PROVIDED) -> None:
-        ######################################################################
-        # 2025-02: Backwards compatibility for Toga < 0.5.0
-        ######################################################################
-
-        if value is not NOT_PROVIDED:
-            warnings.warn(
-                (
-                    "The value parameter to Pack.apply() is deprecated. The instance "
-                    "will use its own current value for the property named."
-                ),
-                DeprecationWarning,
-                stacklevel=2,
-            )
-
-        ######################################################################
-        # End backwards compatibility
-        ######################################################################
-
+    def apply(self, *names: list[str]) -> None:
         if self._applicator:
-            if name == "text_align":
-                if (value := self.text_align) is None:
-                    if self.text_direction == RTL:
-                        value = RIGHT
-                    else:
-                        value = LEFT
-                self._applicator.set_text_align(value)
-            elif name == "text_direction":
-                if self.text_align is None:
-                    self._applicator.set_text_align(
-                        RIGHT if self.text_direction == RTL else LEFT
-                    )
-            elif name == "color":
-                self._applicator.set_color(self.color)
-            elif name == "background_color":
-                self._applicator.set_background_color(self.background_color)
-            elif name == "visibility":
-                value = self.visibility
-                if value == VISIBLE:
-                    # If visibility is being set to VISIBLE, look up the chain to see if
-                    # an ancestor is hidden.
-                    widget = self._applicator.widget
-                    while widget := widget.parent:
-                        if widget.style._hidden:
-                            value = HIDDEN
-                            break
+            for name in names or self._PROPERTIES:
+                if name == "text_align":
+                    if (value := self.text_align) is None:
+                        if self.text_direction == RTL:
+                            value = RIGHT
+                        else:
+                            value = LEFT
+                    self._applicator.set_text_align(value)
+                elif name == "text_direction":
+                    if self.text_align is None:
+                        self._applicator.set_text_align(
+                            RIGHT if self.text_direction == RTL else LEFT
+                        )
+                elif name == "color":
+                    self._applicator.set_color(self.color)
+                elif name == "background_color":
+                    self._applicator.set_background_color(self.background_color)
+                elif name == "visibility":
+                    value = self.visibility
+                    if value == VISIBLE:
+                        # If visibility is being set to VISIBLE, look up the chain to
+                        # see if an ancestor is hidden.
+                        widget = self._applicator.widget
+                        while widget := widget.parent:
+                            if widget.style._hidden:
+                                value = HIDDEN
+                                break
 
-                self._applicator.set_hidden(value == HIDDEN)
-            elif name in (
-                "font_family",
-                "font_size",
-                "font_style",
-                "font_variant",
-                "font_weight",
-            ):
-                self._applicator.set_font(
-                    Font(
-                        self.font_family,
-                        self.font_size,
-                        style=self.font_style,
-                        variant=self.font_variant,
-                        weight=self.font_weight,
+                    self._applicator.set_hidden(value == HIDDEN)
+                elif name in (
+                    "font_family",
+                    "font_size",
+                    "font_style",
+                    "font_variant",
+                    "font_weight",
+                ):
+                    self._applicator.set_font(
+                        Font(
+                            self.font_family,
+                            self.font_size,
+                            style=self.font_style,
+                            variant=self.font_variant,
+                            weight=self.font_weight,
+                        )
                     )
-                )
-            else:
-                # Any other style change will cause a change in layout geometry,
-                # so perform a refresh.
-                self._applicator.refresh()
+                else:
+                    # Any other style change will cause a change in layout geometry, so
+                    # perform a refresh.
+                    self._applicator.refresh()
 
     def layout(self, viewport: Any) -> None:
         # self._debug("=" * 80)

--- a/core/src/toga/style/pack.py
+++ b/core/src/toga/style/pack.py
@@ -133,11 +133,11 @@ class Pack(BaseStyle):
         super().update(**properties)
 
     # Pack.alignment is still an actual property, despite being deprecated, so we need
-    # to suppress deprecation warnings when apply_all is called.
-    def apply_all(self, *args, **kwargs):
+    # to suppress deprecation warnings when reapply is called.
+    def reapply(self, *args, **kwargs):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=DeprecationWarning)
-            super().apply_all(*args, **kwargs)
+            super().reapply(*args, **kwargs)
 
     _DEPRECATED_PROPERTIES = {
         # Map each deprecated property name to its replacement.
@@ -256,18 +256,6 @@ class Pack(BaseStyle):
 
     def __delitem__(self, name):
         super().__delitem__(self._update_property_name(name.replace("-", "_")))
-
-    ######################################################################
-    # 2025-02: Backwards compatibility for Toga <= 0.4.8
-    ######################################################################
-
-    def reapply(self):
-        warnings.warn(
-            ("Pack.reapply() is deprecated; use Pack.apply_all() instead."),
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        self.apply_all()
 
     ######################################################################
     # End backwards compatibility

--- a/core/src/toga/style/pack.py
+++ b/core/src/toga/style/pack.py
@@ -133,11 +133,11 @@ class Pack(BaseStyle):
         super().update(**properties)
 
     # Pack.alignment is still an actual property, despite being deprecated, so we need
-    # to suppress deprecation warnings when reapply is called.
-    def reapply(self, *args, **kwargs):
+    # to suppress deprecation warnings when apply_all is called.
+    def apply_all(self, *args, **kwargs):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=DeprecationWarning)
-            super().reapply(*args, **kwargs)
+            super().apply_all(*args, **kwargs)
 
     _DEPRECATED_PROPERTIES = {
         # Map each deprecated property name to its replacement.

--- a/core/tests/style/pack/test_apply.py
+++ b/core/tests/style/pack/test_apply.py
@@ -20,7 +20,7 @@ from .utils import ExampleNode, ExampleParentNode
 
 def test_set_default_right_textalign_when_rtl():
     root = ExampleNode("app", style=Pack(text_direction=RTL))
-    root.style.reapply()
+    root.style.apply_all()
     # Two calls; one caused by text_align, one because text_direction
     # implies a change to text alignment.
     assert root._impl.set_text_align.mock_calls == [call(RIGHT), call(RIGHT)]
@@ -28,7 +28,7 @@ def test_set_default_right_textalign_when_rtl():
 
 def test_set_default_left_textalign_when_no_rtl():
     root = ExampleNode("app", style=Pack())
-    root.style.reapply()
+    root.style.apply_all()
     # Two calls; one caused by text_align, one because text_direction
     # implies a change to text alignment.
     assert root._impl.set_text_align.mock_calls == [call(LEFT), call(LEFT)]
@@ -36,21 +36,21 @@ def test_set_default_left_textalign_when_no_rtl():
 
 def test_set_center_text_align():
     root = ExampleNode("app", style=Pack(text_align="center"))
-    root.style.reapply()
+    root.style.apply_all()
     root._impl.set_text_align.assert_called_once_with(CENTER)
 
 
 def test_set_color():
     color = "#ffffff"
     root = ExampleNode("app", style=Pack(color=color))
-    root.style.reapply()
+    root.style.apply_all()
     root._impl.set_color.assert_called_once_with(rgb(255, 255, 255))
 
 
 def test_set_background_color():
     color = "#ffffff"
     root = ExampleNode("app", style=Pack(background_color=color))
-    root.style.reapply()
+    root.style.apply_all()
     root._impl.set_background_color.assert_called_once_with(rgb(255, 255, 255))
 
 
@@ -65,7 +65,7 @@ def test_set_font():
             font_weight="bold",
         ),
     )
-    root.style.reapply()
+    root.style.apply_all()
     root._impl.set_font.assert_called_with(
         Font("Roboto", 12, style="normal", variant="small-caps", weight="bold")
     )
@@ -74,7 +74,7 @@ def test_set_font():
 
 def test_set_visibility_hidden():
     root = ExampleNode("app", style=Pack(visibility=HIDDEN))
-    root.style.reapply()
+    root.style.apply_all()
     root._impl.set_hidden.assert_called_once_with(True)
 
 

--- a/core/tests/style/pack/test_apply.py
+++ b/core/tests/style/pack/test_apply.py
@@ -1,4 +1,4 @@
-from unittest.mock import call
+from unittest.mock import Mock, call
 
 import pytest
 
@@ -128,3 +128,12 @@ def test_apply_deprecated_signature():
     style = Pack()
     with pytest.warns(DeprecationWarning):
         style.apply("direction", ROW)
+
+
+def test_reapply_deprecated_name():
+    """Callying reapply instead of apply_all raises a DeprecationWarning."""
+    style = Pack()
+    style.apply_all = Mock()
+    with pytest.warns(DeprecationWarning):
+        style.reapply()
+    style.apply_all.assert_called_once()

--- a/core/tests/style/pack/test_apply.py
+++ b/core/tests/style/pack/test_apply.py
@@ -1,7 +1,5 @@
 from unittest.mock import call
 
-import pytest
-
 from toga.colors import rgb
 from toga.fonts import Font
 from toga.style.pack import (
@@ -9,7 +7,6 @@ from toga.style.pack import (
     HIDDEN,
     LEFT,
     RIGHT,
-    ROW,
     RTL,
     VISIBLE,
     Pack,
@@ -20,7 +17,7 @@ from .utils import ExampleNode, ExampleParentNode
 
 def test_set_default_right_textalign_when_rtl():
     root = ExampleNode("app", style=Pack(text_direction=RTL))
-    root.style.reapply()
+    root.style.apply()
     # Two calls; one caused by text_align, one because text_direction
     # implies a change to text alignment.
     assert root._impl.set_text_align.mock_calls == [call(RIGHT), call(RIGHT)]
@@ -28,7 +25,7 @@ def test_set_default_right_textalign_when_rtl():
 
 def test_set_default_left_textalign_when_no_rtl():
     root = ExampleNode("app", style=Pack())
-    root.style.reapply()
+    root.style.apply()
     # Two calls; one caused by text_align, one because text_direction
     # implies a change to text alignment.
     assert root._impl.set_text_align.mock_calls == [call(LEFT), call(LEFT)]
@@ -36,21 +33,21 @@ def test_set_default_left_textalign_when_no_rtl():
 
 def test_set_center_text_align():
     root = ExampleNode("app", style=Pack(text_align="center"))
-    root.style.reapply()
+    root.style.apply()
     root._impl.set_text_align.assert_called_once_with(CENTER)
 
 
 def test_set_color():
     color = "#ffffff"
     root = ExampleNode("app", style=Pack(color=color))
-    root.style.reapply()
+    root.style.apply()
     root._impl.set_color.assert_called_once_with(rgb(255, 255, 255))
 
 
 def test_set_background_color():
     color = "#ffffff"
     root = ExampleNode("app", style=Pack(background_color=color))
-    root.style.reapply()
+    root.style.apply()
     root._impl.set_background_color.assert_called_once_with(rgb(255, 255, 255))
 
 
@@ -65,7 +62,7 @@ def test_set_font():
             font_weight="bold",
         ),
     )
-    root.style.reapply()
+    root.style.apply()
     root._impl.set_font.assert_called_with(
         Font("Roboto", 12, style="normal", variant="small-caps", weight="bold")
     )
@@ -74,7 +71,7 @@ def test_set_font():
 
 def test_set_visibility_hidden():
     root = ExampleNode("app", style=Pack(visibility=HIDDEN))
-    root.style.reapply()
+    root.style.apply()
     root._impl.set_hidden.assert_called_once_with(True)
 
 
@@ -121,10 +118,3 @@ def test_set_visibility_inherited():
     # Show grandparent again; the other two should reappear.
     grandparent.style.visibility = VISIBLE
     assert_hidden_called(False, False, False)
-
-
-def test_apply_deprecated_signature():
-    """Calling apply() with a second argument raises a DeprecationWarning."""
-    style = Pack()
-    with pytest.warns(DeprecationWarning):
-        style.apply("direction", ROW)

--- a/core/tests/style/pack/test_apply.py
+++ b/core/tests/style/pack/test_apply.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, call
+from unittest.mock import call
 
 import pytest
 
@@ -20,7 +20,7 @@ from .utils import ExampleNode, ExampleParentNode
 
 def test_set_default_right_textalign_when_rtl():
     root = ExampleNode("app", style=Pack(text_direction=RTL))
-    root.style.apply_all()
+    root.style.reapply()
     # Two calls; one caused by text_align, one because text_direction
     # implies a change to text alignment.
     assert root._impl.set_text_align.mock_calls == [call(RIGHT), call(RIGHT)]
@@ -28,7 +28,7 @@ def test_set_default_right_textalign_when_rtl():
 
 def test_set_default_left_textalign_when_no_rtl():
     root = ExampleNode("app", style=Pack())
-    root.style.apply_all()
+    root.style.reapply()
     # Two calls; one caused by text_align, one because text_direction
     # implies a change to text alignment.
     assert root._impl.set_text_align.mock_calls == [call(LEFT), call(LEFT)]
@@ -36,21 +36,21 @@ def test_set_default_left_textalign_when_no_rtl():
 
 def test_set_center_text_align():
     root = ExampleNode("app", style=Pack(text_align="center"))
-    root.style.apply_all()
+    root.style.reapply()
     root._impl.set_text_align.assert_called_once_with(CENTER)
 
 
 def test_set_color():
     color = "#ffffff"
     root = ExampleNode("app", style=Pack(color=color))
-    root.style.apply_all()
+    root.style.reapply()
     root._impl.set_color.assert_called_once_with(rgb(255, 255, 255))
 
 
 def test_set_background_color():
     color = "#ffffff"
     root = ExampleNode("app", style=Pack(background_color=color))
-    root.style.apply_all()
+    root.style.reapply()
     root._impl.set_background_color.assert_called_once_with(rgb(255, 255, 255))
 
 
@@ -65,7 +65,7 @@ def test_set_font():
             font_weight="bold",
         ),
     )
-    root.style.apply_all()
+    root.style.reapply()
     root._impl.set_font.assert_called_with(
         Font("Roboto", 12, style="normal", variant="small-caps", weight="bold")
     )
@@ -74,7 +74,7 @@ def test_set_font():
 
 def test_set_visibility_hidden():
     root = ExampleNode("app", style=Pack(visibility=HIDDEN))
-    root.style.apply_all()
+    root.style.reapply()
     root._impl.set_hidden.assert_called_once_with(True)
 
 
@@ -128,12 +128,3 @@ def test_apply_deprecated_signature():
     style = Pack()
     with pytest.warns(DeprecationWarning):
         style.apply("direction", ROW)
-
-
-def test_reapply_deprecated_name():
-    """Callying reapply instead of apply_all raises a DeprecationWarning."""
-    style = Pack()
-    style.apply_all = Mock()
-    with pytest.warns(DeprecationWarning):
-        style.reapply()
-    style.apply_all.assert_called_once()

--- a/core/tests/widgets/test_base.py
+++ b/core/tests/widgets/test_base.py
@@ -1244,14 +1244,14 @@ def test_tab_index(widget):
     assert attribute_value(widget, "tab_index") == tab_index
 
 
-def test_one_apply_all_during_init():
-    """Style's apply_all should be called exactly once during widget initialization."""
+def test_one_reapply_during_init():
+    """Style's reapply() should be called exactly once during widget initialization."""
 
     class MockedPack(Pack):
-        apply_all = Mock()
+        reapply = Mock()
 
     ExampleWidget(style=MockedPack())
-    MockedPack.apply_all.assert_called_once()
+    MockedPack.reapply.assert_called_once()
 
 
 def test_widget_with_no_create():

--- a/core/tests/widgets/test_base.py
+++ b/core/tests/widgets/test_base.py
@@ -1244,14 +1244,14 @@ def test_tab_index(widget):
     assert attribute_value(widget, "tab_index") == tab_index
 
 
-def test_one_reapply_during_init():
-    """Style's reapply() should be called exactly once during widget initialization."""
+def test_one_apply_all_during_init():
+    """Style's apply_all should be called exactly once during widget initialization."""
 
     class MockedPack(Pack):
-        reapply = Mock()
+        apply_all = Mock()
 
     ExampleWidget(style=MockedPack())
-    MockedPack.reapply.assert_called_once()
+    MockedPack.apply_all.assert_called_once()
 
 
 def test_widget_with_no_create():

--- a/core/tests/widgets/test_base.py
+++ b/core/tests/widgets/test_base.py
@@ -1244,14 +1244,15 @@ def test_tab_index(widget):
     assert attribute_value(widget, "tab_index") == tab_index
 
 
-def test_one_reapply_during_init():
-    """Style's reapply() should be called exactly once during widget initialization."""
+def test_one_apply_during_init():
+    """Style's apply() should be called exactly once during widget initialization."""
 
     class MockedPack(Pack):
-        reapply = Mock()
+        apply = Mock()
 
     ExampleWidget(style=MockedPack())
-    MockedPack.reapply.assert_called_once()
+    # Make sure it was called with no arguments, to apply all properties.
+    MockedPack.apply.assert_called_once_with()
 
 
 def test_widget_with_no_create():

--- a/travertino/src/travertino/declaration.py
+++ b/travertino/src/travertino/declaration.py
@@ -316,7 +316,7 @@ class BaseStyle:
 
         if value is not None:
             try:
-                self.apply_all()
+                self.reapply()
             # This is backwards compatibility for Toga, which (at least as of
             # 0.4.8), assigns style and applicator before the widget's
             # implementation is available.
@@ -330,7 +330,7 @@ class BaseStyle:
                     stacklevel=2,
                 )
 
-    def apply_all(self):
+    def reapply(self):
         for name in self._PROPERTIES:
             self.apply(name)
 

--- a/travertino/src/travertino/declaration.py
+++ b/travertino/src/travertino/declaration.py
@@ -339,7 +339,7 @@ class BaseStyle:
         dup.update(**self)
 
         ######################################################################
-        # 10-2024: Backwards compatibility for Toga <= 0.5.0
+        # 10-2024: Backwards compatibility for Toga < 0.5.0
         ######################################################################
 
         if applicator is not None:

--- a/travertino/src/travertino/declaration.py
+++ b/travertino/src/travertino/declaration.py
@@ -316,12 +316,10 @@ class BaseStyle:
 
         if value is not None:
             try:
-                print("Going to call apply now")
                 self.apply()
-                print("After calling apply")
-            # This is backwards compatibility for Toga, which (at least as of
-            # 0.4.8), assigns style and applicator before the widget's
-            # implementation is available.
+            ######################################################################
+            # 10-2024: Backwards compatibility for Toga <= 0.5.0
+            ######################################################################
             except Exception:
                 warn(
                     "Failed to apply style when assigning applicator, or when "
@@ -331,6 +329,9 @@ class BaseStyle:
                     RuntimeWarning,
                     stacklevel=2,
                 )
+            ######################################################################
+            # End backwards compatibility
+            ######################################################################
 
     def copy(self, applicator=None):
         """Create a duplicate of this style declaration."""
@@ -338,7 +339,7 @@ class BaseStyle:
         dup.update(**self)
 
         ######################################################################
-        # 10-2024: Backwards compatibility for Toga <= 0.4.8
+        # 10-2024: Backwards compatibility for Toga <= 0.5.0
         ######################################################################
 
         if applicator is not None:

--- a/travertino/src/travertino/declaration.py
+++ b/travertino/src/travertino/declaration.py
@@ -318,7 +318,7 @@ class BaseStyle:
             try:
                 self.apply()
             ######################################################################
-            # 10-2024: Backwards compatibility for Toga <= 0.5.0
+            # 10-2024: Backwards compatibility for Toga < 0.5.0
             ######################################################################
             except Exception:
                 warn(

--- a/travertino/src/travertino/declaration.py
+++ b/travertino/src/travertino/declaration.py
@@ -325,7 +325,10 @@ class BaseStyle:
                     "Failed to apply style when assigning applicator, or when "
                     "assigning a new style once applicator is present. Node should be "
                     "sufficiently initialized to apply its style before it is assigned "
-                    "an applicator. This will be an exception in a future version.",
+                    "an applicator. This will be an exception in a future version.\n"
+                    "This error probably means you've updated Travertino to 0.5.0 but "
+                    "are still using Toga <= 0.4.8; to fix, either update Toga to "
+                    ">= 0.5.0, or pin Travertino to 0.3.0.",
                     RuntimeWarning,
                     stacklevel=2,
                 )
@@ -345,7 +348,10 @@ class BaseStyle:
         if applicator is not None:
             warn(
                 "Providing an applicator to BaseStyle.copy() is deprecated. Set "
-                "applicator afterward on the returned copy.",
+                "applicator afterward on the returned copy.\n"
+                "This error probably means you've updated Travertino to 0.5.0 but are "
+                "still using Toga <= 0.4.8; to fix, either update Toga to >= 0.5.0, or "
+                "pin Travertino to 0.3.0.",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -457,9 +463,10 @@ class BaseStyle:
 
     def reapply(self):
         warn(
-            "BaseStyle.reapply() is deprecated; call .apply with no arguments instead."
-            "This is probably because you've updated Travertino to 0.5.0 but are still "
-            "using Toga <= 0.4.8; to fix, either update Toga to >= 0.5.0, or pin "
+            "BaseStyle.reapply() is deprecated; call .apply with no arguments "
+            "instead.\n"
+            "This error probably means you've updated Travertino to 0.5.0 but are "
+            "still using Toga <= 0.4.8; to fix, either update Toga to >= 0.5.0, or pin "
             "Travertino to 0.3.0.",
             DeprecationWarning,
             stacklevel=2,
@@ -470,7 +477,10 @@ class BaseStyle:
     def validated_property(cls, name, choices, initial=None):
         warn(
             "Defining style properties with class methods is deprecated; use class "
-            "attributes instead.",
+            "attributes instead.\n"
+            "This error probably means you've updated Travertino to 0.5.0 but are "
+            "still using Toga <= 0.4.8; to fix, either update Toga to >= 0.5.0, or pin "
+            "Travertino to 0.3.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -489,7 +499,10 @@ class BaseStyle:
     def directional_property(cls, name):
         warn(
             "Defining style properties with class methods is deprecated; use class "
-            "attributes instead.",
+            "attributes instead.\n"
+            "This error probably means you've updated Travertino to 0.5.0 but are "
+            "still using Toga <= 0.4.8; to fix, either update Toga to >= 0.5.0, or pin "
+            "Travertino to 0.3.0.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/travertino/src/travertino/declaration.py
+++ b/travertino/src/travertino/declaration.py
@@ -361,7 +361,6 @@ class BaseStyle:
     ######################################################################
 
     def apply(self, name):
-        print("Calling base style somehow?")
         raise NotImplementedError(
             "Style must define an apply method"
         )  # pragma: no cover

--- a/travertino/src/travertino/declaration.py
+++ b/travertino/src/travertino/declaration.py
@@ -316,7 +316,9 @@ class BaseStyle:
 
         if value is not None:
             try:
-                self.reapply()
+                print("Going to call apply now")
+                self.apply()
+                print("After calling apply")
             # This is backwards compatibility for Toga, which (at least as of
             # 0.4.8), assigns style and applicator before the widget's
             # implementation is available.
@@ -329,10 +331,6 @@ class BaseStyle:
                     RuntimeWarning,
                     stacklevel=2,
                 )
-
-    def reapply(self):
-        for name in self._PROPERTIES:
-            self.apply(name)
 
     def copy(self, applicator=None):
         """Create a duplicate of this style declaration."""
@@ -363,6 +361,7 @@ class BaseStyle:
     ######################################################################
 
     def apply(self, name):
+        print("Calling base style somehow?")
         raise NotImplementedError(
             "Style must define an apply method"
         )  # pragma: no cover
@@ -455,6 +454,17 @@ class BaseStyle:
     ######################################################################
     # Backwards compatibility
     ######################################################################
+
+    def reapply(self):
+        warn(
+            "BaseStyle.reapply() is deprecated; call .apply with no arguments instead."
+            "This is probably because you've updated Travertino to 0.5.0 but are still "
+            "using Toga <= 0.4.8; to fix, either update Toga to >= 0.5.0, or pin "
+            "Travertino to 0.3.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self.apply()
 
     @classmethod
     def validated_property(cls, name, choices, initial=None):

--- a/travertino/src/travertino/declaration.py
+++ b/travertino/src/travertino/declaration.py
@@ -316,7 +316,7 @@ class BaseStyle:
 
         if value is not None:
             try:
-                self.reapply()
+                self.apply_all()
             # This is backwards compatibility for Toga, which (at least as of
             # 0.4.8), assigns style and applicator before the widget's
             # implementation is available.
@@ -330,7 +330,7 @@ class BaseStyle:
                     stacklevel=2,
                 )
 
-    def reapply(self):
+    def apply_all(self):
         for name in self._PROPERTIES:
             self.apply(name)
 

--- a/travertino/src/travertino/node.py
+++ b/travertino/src/travertino/node.py
@@ -53,13 +53,13 @@ class Node:
 
         if applicator:
             # This needs to happen *before* assigning the applicator to the style,
-            # below, because as part of receiving the applicator, the style will
-            # reapply itself. How this happens will vary with applicator
-            # implementation, but will probably need access to the node.
+            # below, because as part of receiving the applicator, the style will apply
+            # itself. How this happens will vary with applicator implementation, but
+            # will probably need access to the node.
             applicator.node = self
 
         self._applicator = applicator
-        # This triggers style.reapply():
+        # This triggers style.apply():
         self.style._applicator = applicator
 
     @property

--- a/travertino/src/travertino/node.py
+++ b/travertino/src/travertino/node.py
@@ -54,12 +54,12 @@ class Node:
         if applicator:
             # This needs to happen *before* assigning the applicator to the style,
             # below, because as part of receiving the applicator, the style will
-            # reapply itself. How this happens will vary with applicator
-            # implementation, but will probably need access to the node.
+            # apply itself. How this happens will vary with applicator implementation,
+            # but will probably need access to the node.
             applicator.node = self
 
         self._applicator = applicator
-        # This triggers style.reapply():
+        # This triggers style.apply_all():
         self.style._applicator = applicator
 
     @property

--- a/travertino/src/travertino/node.py
+++ b/travertino/src/travertino/node.py
@@ -54,12 +54,12 @@ class Node:
         if applicator:
             # This needs to happen *before* assigning the applicator to the style,
             # below, because as part of receiving the applicator, the style will
-            # apply itself. How this happens will vary with applicator implementation,
-            # but will probably need access to the node.
+            # reapply itself. How this happens will vary with applicator
+            # implementation, but will probably need access to the node.
             applicator.node = self
 
         self._applicator = applicator
-        # This triggers style.apply_all():
+        # This triggers style.reapply():
         self.style._applicator = applicator
 
     @property

--- a/travertino/tests/test_choices.py
+++ b/travertino/tests/test_choices.py
@@ -67,8 +67,8 @@ with catch_warnings():
 def assert_property(obj, name, value):
     assert getattr(obj, name) == value
 
-    obj._apply_names.assert_called_once_with(name)
-    obj._reset_mocks()
+    obj.apply.assert_called_once_with(name)
+    obj.apply.reset_mock()
 
 
 @pytest.mark.parametrize("StyleClass", [Style, DeprecatedStyle])

--- a/travertino/tests/test_choices.py
+++ b/travertino/tests/test_choices.py
@@ -67,8 +67,8 @@ with catch_warnings():
 def assert_property(obj, name, value):
     assert getattr(obj, name) == value
 
-    obj.apply.assert_called_once_with(name)
-    obj.apply.reset_mock()
+    obj._apply_names.assert_called_once_with(name)
+    obj._reset_mocks()
 
 
 @pytest.mark.parametrize("StyleClass", [Style, DeprecatedStyle])

--- a/travertino/tests/test_choices.py
+++ b/travertino/tests/test_choices.py
@@ -12,6 +12,7 @@ from .utils import mock_attr, prep_style_class
 
 
 @prep_style_class
+@mock_attr("apply")
 class Style(BaseStyle):
     none: str = validated_property(NONE, REBECCAPURPLE, initial=NONE)
     allow_string: str = validated_property(string=True, initial="start")

--- a/travertino/tests/test_choices.py
+++ b/travertino/tests/test_choices.py
@@ -8,11 +8,11 @@ from travertino.colors import NAMED_COLOR, rgb
 from travertino.constants import GOLDENROD, NONE, REBECCAPURPLE, TOP
 from travertino.declaration import BaseStyle, Choices, validated_property
 
-from .utils import mock_attr, prep_style_class
+from .utils import apply_dataclass, mock_apply
 
 
-@prep_style_class
-@mock_attr("apply")
+@mock_apply
+@apply_dataclass
 class Style(BaseStyle):
     none: str = validated_property(NONE, REBECCAPURPLE, initial=NONE)
     allow_string: str = validated_property(string=True, initial="start")
@@ -34,7 +34,7 @@ class Style(BaseStyle):
 with catch_warnings():
     filterwarnings("ignore", category=DeprecationWarning)
 
-    @mock_attr("apply")
+    @mock_apply
     class DeprecatedStyle(BaseStyle):
         pass
 

--- a/travertino/tests/test_declaration.py
+++ b/travertino/tests/test_declaration.py
@@ -98,8 +98,8 @@ class Sibling(BaseStyle):
 
 
 @prep_style_class
-@mock_attr("apply_all")
-class MockedApplyAllStyle(BaseStyle):
+@mock_attr("reapply")
+class MockedReapplyStyle(BaseStyle):
     pass
 
 
@@ -134,19 +134,19 @@ def test_create_and_copy(StyleClass):
 
 
 def test_deprecated_copy():
-    style = MockedApplyAllStyle()
+    style = MockedReapplyStyle()
 
     with pytest.warns(DeprecationWarning):
         style_copy = style.copy(applicator=object())
 
-    style_copy.apply_all.assert_called_once()
+    style_copy.reapply.assert_called_once()
 
 
 @pytest.mark.parametrize("StyleClass", [Style, DeprecatedStyle])
-def test_apply_all(StyleClass):
+def test_reapply(StyleClass):
     style = StyleClass(explicit_const=VALUE2, implicit=VALUE3)
 
-    style.apply_all()
+    style.reapply()
     style.apply.assert_has_calls(
         [
             call("explicit_const"),

--- a/travertino/tests/test_declaration.py
+++ b/travertino/tests/test_declaration.py
@@ -146,7 +146,7 @@ def test_deprecated_copy():
 @pytest.mark.parametrize("StyleClass", [Style, DeprecatedStyle])
 def test_apply(StyleClass):
     style = StyleClass(explicit_const=VALUE2, implicit=VALUE3)
-    style.apply.mock_calls = [call("explicit_const"), call("implicit")]
+    assert style.apply.mock_calls == [call("explicit_const"), call("implicit")]
     style.apply.reset_mock()
 
     style.apply()

--- a/travertino/tests/test_declaration.py
+++ b/travertino/tests/test_declaration.py
@@ -140,17 +140,17 @@ def test_deprecated_copy():
     with pytest.warns(DeprecationWarning):
         style_copy = style.copy(applicator=object())
 
-    style_copy._apply_all.assert_called_once()
+    style_copy.apply.assert_called_once_with()
 
 
 @pytest.mark.parametrize("StyleClass", [Style, DeprecatedStyle])
 def test_apply(StyleClass):
     style = StyleClass(explicit_const=VALUE2, implicit=VALUE3)
-    style._apply_names.assert_has_calls([call("explicit_const"), call("implicit")])
-    style._reset_mocks()
+    style.apply.assert_has_calls([call("explicit_const"), call("implicit")])
+    style.apply.reset_mock()
 
     style.apply()
-    style._apply_all.assert_called_once()
+    style.apply.assert_called_once_with()
 
 
 @pytest.mark.parametrize("StyleClass", [Style, DeprecatedStyle])
@@ -159,46 +159,46 @@ def test_property_with_explicit_const(StyleClass):
 
     # Default value is VALUE1
     assert style.explicit_const is VALUE1
-    style._apply_names.assert_not_called()
+    style.apply.assert_not_called()
 
     # Modify the value
     style.explicit_const = 10
 
     assert style.explicit_const == 10
-    style._apply_names.assert_called_once_with("explicit_const")
+    style.apply.assert_called_once_with("explicit_const")
 
     # Clear the applicator mock
-    style._reset_mocks()
+    style.apply.reset_mock()
 
     # Set the value to the same value.
     # No dirty notification is sent
     style.explicit_const = 10
     assert style.explicit_const == 10
-    style._apply_names.assert_not_called()
+    style.apply.assert_not_called()
 
     # Set the value to something new
     # A dirty notification is set.
     style.explicit_const = 20
     assert style.explicit_const == 20
-    style._apply_names.assert_called_once_with("explicit_const")
+    style.apply.assert_called_once_with("explicit_const")
 
     # Clear the applicator mock
-    style._reset_mocks()
+    style.apply.reset_mock()
 
     # Clear the property
     del style.explicit_const
     assert style.explicit_const is VALUE1
-    style._apply_names.assert_called_once_with("explicit_const")
+    style.apply.assert_called_once_with("explicit_const")
 
-    # Clear the applicator mocks
-    style._reset_mocks()
+    # Clear the applicator mock
+    style.apply.reset_mock()
 
     # Clear the property again.
     # The underlying attribute won't exist, so this
     # should be a no-op.
     del style.explicit_const
     assert style.explicit_const is VALUE1
-    style._apply_names.assert_not_called()
+    style.apply.assert_not_called()
 
 
 @pytest.mark.parametrize("StyleClass", [Style, DeprecatedStyle])
@@ -207,36 +207,36 @@ def test_property_with_explicit_value(StyleClass):
 
     # Default value is 0
     assert style.explicit_value == 0
-    style._apply_names.assert_not_called()
+    style.apply.assert_not_called()
 
     # Modify the value
     style.explicit_value = 10
 
     assert style.explicit_value == 10
-    style._apply_names.assert_called_once_with("explicit_value")
+    style.apply.assert_called_once_with("explicit_value")
 
     # Clear the applicator mock
-    style._apply_names.reset_mock()
+    style.apply.reset_mock()
 
     # Set the value to the same value.
     # No dirty notification is sent
     style.explicit_value = 10
     assert style.explicit_value == 10
-    style._apply_names.assert_not_called()
+    style.apply.assert_not_called()
 
     # Set the value to something new
     # A dirty notification is set.
     style.explicit_value = 20
     assert style.explicit_value == 20
-    style._apply_names.assert_called_once_with("explicit_value")
+    style.apply.assert_called_once_with("explicit_value")
 
     # Clear the applicator mock
-    style._reset_mocks()
+    style.apply.reset_mock()
 
     # Clear the property
     del style.explicit_value
     assert style.explicit_value == 0
-    style._apply_names.assert_called_once_with("explicit_value")
+    style.apply.assert_called_once_with("explicit_value")
 
 
 @pytest.mark.parametrize("StyleClass", [Style, DeprecatedStyle])
@@ -245,36 +245,36 @@ def test_property_with_explicit_none(StyleClass):
 
     # Default value is None
     assert style.explicit_none is None
-    style._apply_names.assert_not_called()
+    style.apply.assert_not_called()
 
     # Modify the value
     style.explicit_none = 10
 
     assert style.explicit_none == 10
-    style._apply_names.assert_called_once_with("explicit_none")
+    style.apply.assert_called_once_with("explicit_none")
 
     # Clear the applicator mock
-    style._reset_mocks()
+    style.apply.reset_mock()
 
     # Set the property to the same value.
     # No dirty notification is sent
     style.explicit_none = 10
     assert style.explicit_none == 10
-    style._apply_names.assert_not_called()
+    style.apply.assert_not_called()
 
     # Set the property to something new
     # A dirty notification is set.
     style.explicit_none = 20
     assert style.explicit_none == 20
-    style._apply_names.assert_called_once_with("explicit_none")
+    style.apply.assert_called_once_with("explicit_none")
 
     # Clear the applicator mock
-    style._reset_mocks()
+    style.apply.reset_mock()
 
     # Clear the property
     del style.explicit_none
     assert style.explicit_none is None
-    style._apply_names.assert_called_once_with("explicit_none")
+    style.apply.assert_called_once_with("explicit_none")
 
 
 @pytest.mark.parametrize("StyleClass", [Style, DeprecatedStyle])
@@ -283,36 +283,36 @@ def test_property_with_implicit_default(StyleClass):
 
     # Default value is None
     assert style.implicit is None
-    style._apply_names.assert_not_called()
+    style.apply.assert_not_called()
 
     # Modify the value
     style.implicit = 10
 
     assert style.implicit == 10
-    style._apply_names.assert_called_once_with("implicit")
+    style.apply.assert_called_once_with("implicit")
 
     # Clear the applicator mock
-    style._reset_mocks()
+    style.apply.reset_mock()
 
     # Set the value to the same value.
     # No dirty notification is sent
     style.implicit = 10
     assert style.implicit == 10
-    style._apply_names.assert_not_called()
+    style.apply.assert_not_called()
 
     # Set the value to something new
     # A dirty notification is set.
     style.implicit = 20
     assert style.implicit == 20
-    style._apply_names.assert_called_once_with("implicit")
+    style.apply.assert_called_once_with("implicit")
 
     # Clear the applicator mock
-    style._reset_mocks()
+    style.apply.reset_mock()
 
     # Clear the property
     del style.implicit
     assert style.implicit is None
-    style._apply_names.assert_called_once_with("implicit")
+    style.apply.assert_called_once_with("implicit")
 
 
 @pytest.mark.parametrize("StyleClass", [Style, DeprecatedStyle])
@@ -323,7 +323,7 @@ def test_set_initial_no_apply(StyleClass):
     # 0 is the initial value
     style.explicit_value = 0
 
-    style._apply_names.assert_not_called()
+    style.apply.assert_not_called()
 
 
 @pytest.mark.parametrize("StyleClass", [Style, DeprecatedStyle])
@@ -336,7 +336,7 @@ def test_directional_property(StyleClass):
     assert style.thing_right == 0
     assert style.thing_bottom == 0
     assert style.thing_left == 0
-    style._apply_names.assert_not_called()
+    style.apply.assert_not_called()
 
     # Set a value in one axis
     style.thing_top = 10
@@ -346,10 +346,10 @@ def test_directional_property(StyleClass):
     assert style.thing_right == 0
     assert style.thing_bottom == 0
     assert style.thing_left == 0
-    style._apply_names.assert_called_once_with("thing_top")
+    style.apply.assert_called_once_with("thing_top")
 
     # Clear the applicator mock
-    style._reset_mocks()
+    style.apply.reset_mock()
 
     # Set a value directly with a single item
     style.thing = (10,)
@@ -359,7 +359,7 @@ def test_directional_property(StyleClass):
     assert style.thing_right == 10
     assert style.thing_bottom == 10
     assert style.thing_left == 10
-    style._apply_names.assert_has_calls(
+    style.apply.assert_has_calls(
         [
             call("thing_right"),
             call("thing_bottom"),
@@ -368,7 +368,7 @@ def test_directional_property(StyleClass):
     )
 
     # Clear the applicator mock
-    style._reset_mocks()
+    style.apply.reset_mock()
 
     # Set a value directly with a single item
     style.thing = 30
@@ -378,7 +378,7 @@ def test_directional_property(StyleClass):
     assert style.thing_right == 30
     assert style.thing_bottom == 30
     assert style.thing_left == 30
-    style._apply_names.assert_has_calls(
+    style.apply.assert_has_calls(
         [
             call("thing_top"),
             call("thing_right"),
@@ -388,7 +388,7 @@ def test_directional_property(StyleClass):
     )
 
     # Clear the applicator mock
-    style._reset_mocks()
+    style.apply.reset_mock()
 
     # Set a value directly with a 2 values
     style.thing = (10, 20)
@@ -398,7 +398,7 @@ def test_directional_property(StyleClass):
     assert style.thing_right == 20
     assert style.thing_bottom == 10
     assert style.thing_left == 20
-    style._apply_names.assert_has_calls(
+    style.apply.assert_has_calls(
         [
             call("thing_top"),
             call("thing_right"),
@@ -408,7 +408,7 @@ def test_directional_property(StyleClass):
     )
 
     # Clear the applicator mock
-    style._reset_mocks()
+    style.apply.reset_mock()
 
     # Set a value directly with a 3 values
     style.thing = (10, 20, 30)
@@ -418,10 +418,10 @@ def test_directional_property(StyleClass):
     assert style.thing_right == 20
     assert style.thing_bottom == 30
     assert style.thing_left == 20
-    style._apply_names.assert_called_once_with("thing_bottom")
+    style.apply.assert_called_once_with("thing_bottom")
 
     # Clear the applicator mock
-    style._reset_mocks()
+    style.apply.reset_mock()
 
     # Set a value directly with a 4 values
     style.thing = (10, 20, 30, 40)
@@ -431,7 +431,7 @@ def test_directional_property(StyleClass):
     assert style.thing_right == 20
     assert style.thing_bottom == 30
     assert style.thing_left == 40
-    style._apply_names.assert_called_once_with("thing_left")
+    style.apply.assert_called_once_with("thing_left")
 
     # Set a value directly with an invalid number of values
     with pytest.raises(ValueError):
@@ -441,7 +441,7 @@ def test_directional_property(StyleClass):
         style.thing = (10, 20, 30, 40, 50)
 
     # Clear the applicator mock
-    style._reset_mocks()
+    style.apply.reset_mock()
 
     # Clear a value on one axis
     del style.thing_top
@@ -451,13 +451,13 @@ def test_directional_property(StyleClass):
     assert style.thing_right == 20
     assert style.thing_bottom == 30
     assert style.thing_left == 40
-    style._apply_names.assert_called_once_with("thing_top")
+    style.apply.assert_called_once_with("thing_top")
 
     # Restore the top thing
     style.thing_top = 10
 
     # Clear the applicator mock
-    style._reset_mocks()
+    style.apply.reset_mock()
 
     # Clear a value directly
     del style.thing
@@ -467,7 +467,7 @@ def test_directional_property(StyleClass):
     assert style.thing_right == 0
     assert style.thing_bottom == 0
     assert style.thing_left == 0
-    style._apply_names.assert_has_calls(
+    style.apply.assert_has_calls(
         [
             call("thing_right"),
             call("thing_bottom"),
@@ -617,7 +617,7 @@ def test_set_multiple_properties(StyleClass):
     assert style.explicit_const is VALUE1
     assert style.explicit_none == 10
     assert style.explicit_value == 20
-    style._apply_names.assert_has_calls(
+    style.apply.assert_has_calls(
         [
             call("explicit_value"),
             call("explicit_none"),
@@ -631,7 +631,7 @@ def test_set_multiple_properties(StyleClass):
     assert style.explicit_const is VALUE2
     assert style.explicit_value == 30
     assert style.explicit_none == 10
-    style._apply_names.assert_has_calls(
+    style.apply.assert_has_calls(
         [
             call("explicit_const"),
             call("explicit_value"),
@@ -640,13 +640,13 @@ def test_set_multiple_properties(StyleClass):
     )
 
     # Clear the applicator mock
-    style._reset_mocks()
+    style.apply.reset_mock()
 
     # Setting a non-property
     with pytest.raises(NameError):
         style.update(not_a_property=10)
 
-    style._apply_names.assert_not_called()
+    style.apply.assert_not_called()
 
 
 @pytest.mark.parametrize("StyleClass", [Style, DeprecatedStyle])
@@ -883,4 +883,4 @@ def test_deprecated_reapply():
     with pytest.warns(DeprecationWarning):
         style.reapply()
 
-    style._apply_all.assert_called_once()
+    style.apply.assert_called_once_with()

--- a/travertino/tests/test_declaration.py
+++ b/travertino/tests/test_declaration.py
@@ -140,17 +140,17 @@ def test_deprecated_copy():
     with pytest.warns(DeprecationWarning):
         style_copy = style.copy(applicator=object())
 
-    style_copy.apply.assert_called_once_with()
+    style_copy._apply_all.assert_called_once()
 
 
 @pytest.mark.parametrize("StyleClass", [Style, DeprecatedStyle])
 def test_apply(StyleClass):
     style = StyleClass(explicit_const=VALUE2, implicit=VALUE3)
-    style.apply.assert_has_calls([call("explicit_const"), call("implicit")])
-    style.apply.reset_mock()
+    style._apply_names.assert_has_calls([call("explicit_const"), call("implicit")])
+    style._reset_mocks()
 
     style.apply()
-    style.apply.assert_called_once_with()
+    style._apply_all.assert_called_once()
 
 
 @pytest.mark.parametrize("StyleClass", [Style, DeprecatedStyle])
@@ -159,46 +159,46 @@ def test_property_with_explicit_const(StyleClass):
 
     # Default value is VALUE1
     assert style.explicit_const is VALUE1
-    style.apply.assert_not_called()
+    style._apply_names.assert_not_called()
 
     # Modify the value
     style.explicit_const = 10
 
     assert style.explicit_const == 10
-    style.apply.assert_called_once_with("explicit_const")
+    style._apply_names.assert_called_once_with("explicit_const")
 
     # Clear the applicator mock
-    style.apply.reset_mock()
+    style._reset_mocks()
 
     # Set the value to the same value.
     # No dirty notification is sent
     style.explicit_const = 10
     assert style.explicit_const == 10
-    style.apply.assert_not_called()
+    style._apply_names.assert_not_called()
 
     # Set the value to something new
     # A dirty notification is set.
     style.explicit_const = 20
     assert style.explicit_const == 20
-    style.apply.assert_called_once_with("explicit_const")
+    style._apply_names.assert_called_once_with("explicit_const")
 
     # Clear the applicator mock
-    style.apply.reset_mock()
+    style._reset_mocks()
 
     # Clear the property
     del style.explicit_const
     assert style.explicit_const is VALUE1
-    style.apply.assert_called_once_with("explicit_const")
+    style._apply_names.assert_called_once_with("explicit_const")
 
-    # Clear the applicator mock
-    style.apply.reset_mock()
+    # Clear the applicator mocks
+    style._reset_mocks()
 
     # Clear the property again.
     # The underlying attribute won't exist, so this
     # should be a no-op.
     del style.explicit_const
     assert style.explicit_const is VALUE1
-    style.apply.assert_not_called()
+    style._apply_names.assert_not_called()
 
 
 @pytest.mark.parametrize("StyleClass", [Style, DeprecatedStyle])
@@ -207,36 +207,36 @@ def test_property_with_explicit_value(StyleClass):
 
     # Default value is 0
     assert style.explicit_value == 0
-    style.apply.assert_not_called()
+    style._apply_names.assert_not_called()
 
     # Modify the value
     style.explicit_value = 10
 
     assert style.explicit_value == 10
-    style.apply.assert_called_once_with("explicit_value")
+    style._apply_names.assert_called_once_with("explicit_value")
 
     # Clear the applicator mock
-    style.apply.reset_mock()
+    style._apply_names.reset_mock()
 
     # Set the value to the same value.
     # No dirty notification is sent
     style.explicit_value = 10
     assert style.explicit_value == 10
-    style.apply.assert_not_called()
+    style._apply_names.assert_not_called()
 
     # Set the value to something new
     # A dirty notification is set.
     style.explicit_value = 20
     assert style.explicit_value == 20
-    style.apply.assert_called_once_with("explicit_value")
+    style._apply_names.assert_called_once_with("explicit_value")
 
     # Clear the applicator mock
-    style.apply.reset_mock()
+    style._reset_mocks()
 
     # Clear the property
     del style.explicit_value
     assert style.explicit_value == 0
-    style.apply.assert_called_once_with("explicit_value")
+    style._apply_names.assert_called_once_with("explicit_value")
 
 
 @pytest.mark.parametrize("StyleClass", [Style, DeprecatedStyle])
@@ -245,36 +245,36 @@ def test_property_with_explicit_none(StyleClass):
 
     # Default value is None
     assert style.explicit_none is None
-    style.apply.assert_not_called()
+    style._apply_names.assert_not_called()
 
     # Modify the value
     style.explicit_none = 10
 
     assert style.explicit_none == 10
-    style.apply.assert_called_once_with("explicit_none")
+    style._apply_names.assert_called_once_with("explicit_none")
 
     # Clear the applicator mock
-    style.apply.reset_mock()
+    style._reset_mocks()
 
     # Set the property to the same value.
     # No dirty notification is sent
     style.explicit_none = 10
     assert style.explicit_none == 10
-    style.apply.assert_not_called()
+    style._apply_names.assert_not_called()
 
     # Set the property to something new
     # A dirty notification is set.
     style.explicit_none = 20
     assert style.explicit_none == 20
-    style.apply.assert_called_once_with("explicit_none")
+    style._apply_names.assert_called_once_with("explicit_none")
 
     # Clear the applicator mock
-    style.apply.reset_mock()
+    style._reset_mocks()
 
     # Clear the property
     del style.explicit_none
     assert style.explicit_none is None
-    style.apply.assert_called_once_with("explicit_none")
+    style._apply_names.assert_called_once_with("explicit_none")
 
 
 @pytest.mark.parametrize("StyleClass", [Style, DeprecatedStyle])
@@ -283,36 +283,36 @@ def test_property_with_implicit_default(StyleClass):
 
     # Default value is None
     assert style.implicit is None
-    style.apply.assert_not_called()
+    style._apply_names.assert_not_called()
 
     # Modify the value
     style.implicit = 10
 
     assert style.implicit == 10
-    style.apply.assert_called_once_with("implicit")
+    style._apply_names.assert_called_once_with("implicit")
 
     # Clear the applicator mock
-    style.apply.reset_mock()
+    style._reset_mocks()
 
     # Set the value to the same value.
     # No dirty notification is sent
     style.implicit = 10
     assert style.implicit == 10
-    style.apply.assert_not_called()
+    style._apply_names.assert_not_called()
 
     # Set the value to something new
     # A dirty notification is set.
     style.implicit = 20
     assert style.implicit == 20
-    style.apply.assert_called_once_with("implicit")
+    style._apply_names.assert_called_once_with("implicit")
 
     # Clear the applicator mock
-    style.apply.reset_mock()
+    style._reset_mocks()
 
     # Clear the property
     del style.implicit
     assert style.implicit is None
-    style.apply.assert_called_once_with("implicit")
+    style._apply_names.assert_called_once_with("implicit")
 
 
 @pytest.mark.parametrize("StyleClass", [Style, DeprecatedStyle])
@@ -323,7 +323,7 @@ def test_set_initial_no_apply(StyleClass):
     # 0 is the initial value
     style.explicit_value = 0
 
-    style.apply.assert_not_called()
+    style._apply_names.assert_not_called()
 
 
 @pytest.mark.parametrize("StyleClass", [Style, DeprecatedStyle])
@@ -336,7 +336,7 @@ def test_directional_property(StyleClass):
     assert style.thing_right == 0
     assert style.thing_bottom == 0
     assert style.thing_left == 0
-    style.apply.assert_not_called()
+    style._apply_names.assert_not_called()
 
     # Set a value in one axis
     style.thing_top = 10
@@ -346,10 +346,10 @@ def test_directional_property(StyleClass):
     assert style.thing_right == 0
     assert style.thing_bottom == 0
     assert style.thing_left == 0
-    style.apply.assert_called_once_with("thing_top")
+    style._apply_names.assert_called_once_with("thing_top")
 
     # Clear the applicator mock
-    style.apply.reset_mock()
+    style._reset_mocks()
 
     # Set a value directly with a single item
     style.thing = (10,)
@@ -359,7 +359,7 @@ def test_directional_property(StyleClass):
     assert style.thing_right == 10
     assert style.thing_bottom == 10
     assert style.thing_left == 10
-    style.apply.assert_has_calls(
+    style._apply_names.assert_has_calls(
         [
             call("thing_right"),
             call("thing_bottom"),
@@ -368,7 +368,7 @@ def test_directional_property(StyleClass):
     )
 
     # Clear the applicator mock
-    style.apply.reset_mock()
+    style._reset_mocks()
 
     # Set a value directly with a single item
     style.thing = 30
@@ -378,7 +378,7 @@ def test_directional_property(StyleClass):
     assert style.thing_right == 30
     assert style.thing_bottom == 30
     assert style.thing_left == 30
-    style.apply.assert_has_calls(
+    style._apply_names.assert_has_calls(
         [
             call("thing_top"),
             call("thing_right"),
@@ -388,7 +388,7 @@ def test_directional_property(StyleClass):
     )
 
     # Clear the applicator mock
-    style.apply.reset_mock()
+    style._reset_mocks()
 
     # Set a value directly with a 2 values
     style.thing = (10, 20)
@@ -398,7 +398,7 @@ def test_directional_property(StyleClass):
     assert style.thing_right == 20
     assert style.thing_bottom == 10
     assert style.thing_left == 20
-    style.apply.assert_has_calls(
+    style._apply_names.assert_has_calls(
         [
             call("thing_top"),
             call("thing_right"),
@@ -408,7 +408,7 @@ def test_directional_property(StyleClass):
     )
 
     # Clear the applicator mock
-    style.apply.reset_mock()
+    style._reset_mocks()
 
     # Set a value directly with a 3 values
     style.thing = (10, 20, 30)
@@ -418,10 +418,10 @@ def test_directional_property(StyleClass):
     assert style.thing_right == 20
     assert style.thing_bottom == 30
     assert style.thing_left == 20
-    style.apply.assert_called_once_with("thing_bottom")
+    style._apply_names.assert_called_once_with("thing_bottom")
 
     # Clear the applicator mock
-    style.apply.reset_mock()
+    style._reset_mocks()
 
     # Set a value directly with a 4 values
     style.thing = (10, 20, 30, 40)
@@ -431,7 +431,7 @@ def test_directional_property(StyleClass):
     assert style.thing_right == 20
     assert style.thing_bottom == 30
     assert style.thing_left == 40
-    style.apply.assert_called_once_with("thing_left")
+    style._apply_names.assert_called_once_with("thing_left")
 
     # Set a value directly with an invalid number of values
     with pytest.raises(ValueError):
@@ -441,7 +441,7 @@ def test_directional_property(StyleClass):
         style.thing = (10, 20, 30, 40, 50)
 
     # Clear the applicator mock
-    style.apply.reset_mock()
+    style._reset_mocks()
 
     # Clear a value on one axis
     del style.thing_top
@@ -451,13 +451,13 @@ def test_directional_property(StyleClass):
     assert style.thing_right == 20
     assert style.thing_bottom == 30
     assert style.thing_left == 40
-    style.apply.assert_called_once_with("thing_top")
+    style._apply_names.assert_called_once_with("thing_top")
 
     # Restore the top thing
     style.thing_top = 10
 
     # Clear the applicator mock
-    style.apply.reset_mock()
+    style._reset_mocks()
 
     # Clear a value directly
     del style.thing
@@ -467,7 +467,7 @@ def test_directional_property(StyleClass):
     assert style.thing_right == 0
     assert style.thing_bottom == 0
     assert style.thing_left == 0
-    style.apply.assert_has_calls(
+    style._apply_names.assert_has_calls(
         [
             call("thing_right"),
             call("thing_bottom"),
@@ -617,7 +617,7 @@ def test_set_multiple_properties(StyleClass):
     assert style.explicit_const is VALUE1
     assert style.explicit_none == 10
     assert style.explicit_value == 20
-    style.apply.assert_has_calls(
+    style._apply_names.assert_has_calls(
         [
             call("explicit_value"),
             call("explicit_none"),
@@ -631,7 +631,7 @@ def test_set_multiple_properties(StyleClass):
     assert style.explicit_const is VALUE2
     assert style.explicit_value == 30
     assert style.explicit_none == 10
-    style.apply.assert_has_calls(
+    style._apply_names.assert_has_calls(
         [
             call("explicit_const"),
             call("explicit_value"),
@@ -640,13 +640,13 @@ def test_set_multiple_properties(StyleClass):
     )
 
     # Clear the applicator mock
-    style.apply.reset_mock()
+    style._reset_mocks()
 
     # Setting a non-property
     with pytest.raises(NameError):
         style.update(not_a_property=10)
 
-    style.apply.assert_not_called()
+    style._apply_names.assert_not_called()
 
 
 @pytest.mark.parametrize("StyleClass", [Style, DeprecatedStyle])
@@ -883,4 +883,4 @@ def test_deprecated_reapply():
     with pytest.warns(DeprecationWarning):
         style.reapply()
 
-    style.apply.assert_called_once_with()
+    style._apply_all.assert_called_once()

--- a/travertino/tests/test_declaration.py
+++ b/travertino/tests/test_declaration.py
@@ -146,7 +146,7 @@ def test_deprecated_copy():
 @pytest.mark.parametrize("StyleClass", [Style, DeprecatedStyle])
 def test_apply(StyleClass):
     style = StyleClass(explicit_const=VALUE2, implicit=VALUE3)
-    style.apply.assert_has_calls([call("explicit_const"), call("implicit")])
+    style.apply.mock_calls = [call("explicit_const"), call("implicit")]
     style.apply.reset_mock()
 
     style.apply()

--- a/travertino/tests/test_declaration.py
+++ b/travertino/tests/test_declaration.py
@@ -15,7 +15,7 @@ from travertino.declaration import (
     validated_property,
 )
 
-from .utils import mock_attr, prep_style_class
+from .utils import apply_dataclass, mock_apply
 
 VALUE1 = "value1"
 VALUE2 = "value2"
@@ -23,8 +23,8 @@ VALUE3 = "value3"
 VALUES = [VALUE1, VALUE2, VALUE3, None]
 
 
-@prep_style_class
-@mock_attr("apply")
+@mock_apply
+@apply_dataclass
 class Style(BaseStyle):
     # Some properties with explicit initial values
     explicit_const: str | int = validated_property(
@@ -57,7 +57,7 @@ VALUE_CHOICES = Choices(*VALUES, integer=True)
 with catch_warnings():
     filterwarnings("ignore", category=DeprecationWarning)
 
-    @mock_attr("apply")
+    @mock_apply
     class DeprecatedStyle(BaseStyle):
         pass
 
@@ -98,8 +98,8 @@ class Sibling(BaseStyle):
     pass
 
 
-@prep_style_class
-@mock_attr("apply")
+@mock_apply
+@apply_dataclass
 class MockedApplyStyle(BaseStyle):
     pass
 

--- a/travertino/tests/test_declaration.py
+++ b/travertino/tests/test_declaration.py
@@ -98,8 +98,8 @@ class Sibling(BaseStyle):
 
 
 @prep_style_class
-@mock_attr("reapply")
-class MockedReapplyStyle(BaseStyle):
+@mock_attr("apply_all")
+class MockedApplyAllStyle(BaseStyle):
     pass
 
 
@@ -134,19 +134,19 @@ def test_create_and_copy(StyleClass):
 
 
 def test_deprecated_copy():
-    style = MockedReapplyStyle()
+    style = MockedApplyAllStyle()
 
     with pytest.warns(DeprecationWarning):
         style_copy = style.copy(applicator=object())
 
-    style_copy.reapply.assert_called_once()
+    style_copy.apply_all.assert_called_once()
 
 
 @pytest.mark.parametrize("StyleClass", [Style, DeprecatedStyle])
-def test_reapply(StyleClass):
+def test_apply_all(StyleClass):
     style = StyleClass(explicit_const=VALUE2, implicit=VALUE3)
 
-    style.reapply()
+    style.apply_all()
     style.apply.assert_has_calls(
         [
             call("explicit_const"),

--- a/travertino/tests/test_layout.py
+++ b/travertino/tests/test_layout.py
@@ -5,7 +5,10 @@ from travertino.layout import BaseBox, Viewport
 from travertino.node import Node
 from travertino.size import BaseIntrinsicSize
 
+from .utils import apply_dataclass
 
+
+@apply_dataclass
 class Style(BaseStyle):
     class IntrinsicSize(BaseIntrinsicSize):
         pass

--- a/travertino/tests/test_node.py
+++ b/travertino/tests/test_node.py
@@ -337,6 +337,7 @@ def test_create_with_no_applicator():
     # Style copies on assignment.
     assert isinstance(node.style, Style)
     assert node.style == style
+    assert node.style.int_prop == 5
     assert node.style is not style
 
     # Since no applicator has been assigned, the overall style wasn't applied. However,
@@ -353,6 +354,7 @@ def test_create_with_applicator():
     # Style copies on assignment.
     assert isinstance(node.style, Style)
     assert node.style == style
+    assert node.style.int_prop == 5
     assert node.style is not style
 
     # Applicator assignment does *not* copy.
@@ -361,8 +363,9 @@ def test_create_with_applicator():
     assert applicator.node is node
     assert node.style._applicator is applicator
 
-    # Assigning a non-None applicator should always apply the style.
-    node.style.apply.assert_has_calls([call("int_prop"), call()])
+    # First, call("int_prop") is called when style object is created.
+    # Assigning a non-None applicator should always apply style.
+    node.style.apply.mock_calls = [call("int_prop"), call()]
 
 
 @pytest.mark.parametrize(
@@ -386,7 +389,7 @@ def test_assign_applicator(node):
     assert node.style._applicator is applicator
 
     # Assigning a non-None applicator should always apply style.
-    node.style.apply.assert_called_once()
+    node.style.apply.assert_called_once_with()
 
 
 @pytest.mark.parametrize(
@@ -440,19 +443,20 @@ def test_assign_style_with_applicator():
     style_1 = Style(int_prop=5)
     node = Node(style=style_1, applicator=Mock())
 
-    node.style.apply.reset_mock()
     style_2 = Style(int_prop=10)
     node.style = style_2
 
     # Style copies on assignment.
     assert isinstance(node.style, Style)
     assert node.style == style_2
+    assert node.style.int_prop == 10
     assert node.style is not style_2
 
     assert node.style != style_1
 
+    # call("int_prop") is called when the style object is created.
     # Since an applicator has already been assigned, assigning style applies the style.
-    node.style.apply.assert_has_calls([call("int_prop"), call()])
+    node.style.apply.mock_calls = [call("int_prop"), call()]
 
 
 def test_assign_style_with_no_applicator():
@@ -460,19 +464,19 @@ def test_assign_style_with_no_applicator():
     style_1 = Style(int_prop=5)
     node = Node(style=style_1)
 
-    node.style.apply.reset_mock()
     style_2 = Style(int_prop=10)
     node.style = style_2
 
     # Style copies on assignment.
     assert isinstance(node.style, Style)
     assert node.style == style_2
+    assert node.style.int_prop == 10
     assert node.style is not style_2
 
     assert node.style != style_1
 
     # Since no applicator has been assigned, the overall style wasn't applied. However,
-    # apply("int_prop") was still called.
+    # apply("int_prop") was still called when creating the style.
     node.style.apply.assert_called_once_with("int_prop")
 
 

--- a/travertino/tests/test_node.py
+++ b/travertino/tests/test_node.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, call
+from unittest.mock import Mock
 from warnings import catch_warnings, filterwarnings
 
 import pytest
@@ -216,7 +216,7 @@ def test_refresh_no_op():
     """Refresh is a no-op if no applicator is set."""
     node = Node(style=Style())
     node.refresh(Viewport(width=100, height=100))
-    node.style.apply.assert_not_called()
+    node.style._apply_all.assert_not_called()
 
 
 @pytest.mark.parametrize("StyleClass", [TypeErrorStyle, OldTypeErrorStyle])
@@ -341,7 +341,7 @@ def test_create_with_no_applicator():
 
     # Since no applicator has been assigned, the overall style wasn't applied. However,
     # apply("int_prop") was still called.
-    node.style.apply.assert_called_once_with("int_prop")
+    node.style._apply_names.assert_called_once_with("int_prop")
 
 
 def test_create_with_applicator():
@@ -362,7 +362,7 @@ def test_create_with_applicator():
     assert node.style._applicator is applicator
 
     # Assigning a non-None applicator should always apply the style.
-    node.style.apply.assert_has_calls([call("int_prop"), call()])
+    node.style._apply_all.assert_called_once_with()
 
 
 @pytest.mark.parametrize(
@@ -374,7 +374,7 @@ def test_create_with_applicator():
 )
 def test_assign_applicator(node):
     """A node can be assigned an applicator after creation."""
-    node.style.apply.reset_mock()
+    node.style._reset_mocks()
 
     applicator = Mock()
     node.applicator = applicator
@@ -386,7 +386,7 @@ def test_assign_applicator(node):
     assert node.style._applicator is applicator
 
     # Assigning a non-None applicator should always apply style.
-    node.style.apply.assert_called_once()
+    node.style._apply_all.assert_called_once()
 
 
 @pytest.mark.parametrize(
@@ -398,7 +398,7 @@ def test_assign_applicator(node):
 )
 def test_assign_applicator_none(node):
     """A node can have its applicator set to None."""
-    node.style.apply.reset_mock()
+    node.style._reset_mocks()
 
     node.applicator = None
     assert node.applicator is None
@@ -406,7 +406,7 @@ def test_assign_applicator_none(node):
     # Should be updated on style as well
     assert node.style._applicator is None
     # Assigning None to applicator does not trigger apply.
-    node.style.apply.assert_not_called()
+    node.style._apply_all.assert_not_called()
 
 
 def assign_new_applicator():
@@ -440,7 +440,7 @@ def test_assign_style_with_applicator():
     style_1 = Style(int_prop=5)
     node = Node(style=style_1, applicator=Mock())
 
-    node.style.apply.reset_mock()
+    node.style._reset_mocks()
     style_2 = Style(int_prop=10)
     node.style = style_2
 
@@ -452,7 +452,7 @@ def test_assign_style_with_applicator():
     assert node.style != style_1
 
     # Since an applicator has already been assigned, assigning style applies the style.
-    node.style.apply.assert_has_calls([call("int_prop"), call()])
+    node.style._apply_all.assert_called_once()
 
 
 def test_assign_style_with_no_applicator():
@@ -460,7 +460,7 @@ def test_assign_style_with_no_applicator():
     style_1 = Style(int_prop=5)
     node = Node(style=style_1)
 
-    node.style.apply.reset_mock()
+    node.style._reset_mocks()
     style_2 = Style(int_prop=10)
     node.style = style_2
 
@@ -473,7 +473,7 @@ def test_assign_style_with_no_applicator():
 
     # Since no applicator has been assigned, the overall style wasn't applied. However,
     # apply("int_prop") was still called.
-    node.style.apply.assert_called_once_with("int_prop")
+    node.style._apply_names.assert_called_once_with("int_prop")
 
 
 def test_apply_before_node_is_ready():

--- a/travertino/tests/test_node.py
+++ b/travertino/tests/test_node.py
@@ -365,7 +365,7 @@ def test_create_with_applicator():
 
     # First, call("int_prop") is called when style object is created.
     # Assigning a non-None applicator should always apply style.
-    node.style.apply.mock_calls = [call("int_prop"), call()]
+    assert node.style.apply.mock_calls == [call("int_prop"), call()]
 
 
 @pytest.mark.parametrize(

--- a/travertino/tests/test_node.py
+++ b/travertino/tests/test_node.py
@@ -456,7 +456,7 @@ def test_assign_style_with_applicator():
 
     # call("int_prop") is called when the style object is created.
     # Since an applicator has already been assigned, assigning style applies the style.
-    node.style.apply.mock_calls = [call("int_prop"), call()]
+    assert node.style.apply.mock_calls == [call("int_prop"), call()]
 
 
 def test_assign_style_with_no_applicator():

--- a/travertino/tests/test_node.py
+++ b/travertino/tests/test_node.py
@@ -8,11 +8,11 @@ from travertino.layout import BaseBox, Viewport
 from travertino.node import Node
 from travertino.size import BaseIntrinsicSize
 
-from .utils import mock_attr, prep_style_class
+from .utils import apply_dataclass, mock_apply
 
 
-@prep_style_class
-@mock_attr("apply")
+@mock_apply
+@apply_dataclass
 class Style(BaseStyle):
     int_prop: int = validated_property(integer=True)
 
@@ -28,8 +28,8 @@ class Style(BaseStyle):
         self._applicator.node.layout.content_height = viewport.height * 2
 
 
-@prep_style_class
-@mock_attr("apply")
+@mock_apply
+@apply_dataclass
 class OldStyle(Style):
     # Uses two-argument layout(), as in Toga <= 0.4.8
     def layout(self, node, viewport):
@@ -37,23 +37,23 @@ class OldStyle(Style):
         super().layout(viewport)
 
 
-@prep_style_class
-@mock_attr("apply")
+@mock_apply
+@apply_dataclass
 class TypeErrorStyle(Style):
     # Uses the correct signature, but raises an unrelated TypeError in layout
     def layout(self, viewport):
         raise TypeError("An unrelated TypeError has occurred somewhere in layout()")
 
 
-@prep_style_class
-@mock_attr("apply")
+@mock_apply
+@apply_dataclass
 class OldTypeErrorStyle(Style):
     # Just to be extra safe...
     def layout(self, node, viewport):
         raise TypeError("An unrelated TypeError has occurred somewhere in layout()")
 
 
-@prep_style_class
+@apply_dataclass
 class BrokenStyle(BaseStyle):
     def apply(self):
         raise AttributeError("Missing attribute, node not ready for style application")
@@ -70,6 +70,7 @@ class BrokenStyle(BaseStyle):
         self._applicator.node.layout.content_height = viewport.height * 2
 
 
+@apply_dataclass
 class AttributeTestStyle(BaseStyle):
     class IntrinsicSize(BaseIntrinsicSize):
         pass

--- a/travertino/tests/test_node.py
+++ b/travertino/tests/test_node.py
@@ -12,7 +12,7 @@ from .utils import mock_attr, prep_style_class
 
 
 @prep_style_class
-@mock_attr("apply_all")
+@mock_attr("reapply")
 class Style(BaseStyle):
     int_prop: int = validated_property(integer=True)
 
@@ -52,7 +52,7 @@ class OldTypeErrorStyle(Style):
 
 @prep_style_class
 class BrokenStyle(BaseStyle):
-    def apply_all(self):
+    def reapply(self):
         raise AttributeError("Missing attribute, node not ready for style application")
 
     class IntrinsicSize(BaseIntrinsicSize):
@@ -74,7 +74,7 @@ class AttributeTestStyle(BaseStyle):
     class Box(BaseBox):
         pass
 
-    def apply_all(self):
+    def reapply(self):
         assert self._applicator.node.style is self
 
 
@@ -212,7 +212,7 @@ def test_refresh_no_op():
     """Refresh is a no-op if no applicator is set."""
     node = Node(style=Style())
     node.refresh(Viewport(width=100, height=100))
-    node.style.apply_all.assert_not_called()
+    node.style.reapply.assert_not_called()
 
 
 @pytest.mark.parametrize("StyleClass", [TypeErrorStyle, OldTypeErrorStyle])
@@ -336,7 +336,7 @@ def test_create_with_no_applicator():
     assert node.style is not style
 
     # Since no applicator has been assigned, style wasn't applied.
-    node.style.apply_all.assert_not_called()
+    node.style.reapply.assert_not_called()
 
 
 def test_create_with_applicator():
@@ -357,7 +357,7 @@ def test_create_with_applicator():
     assert node.style._applicator is applicator
 
     # Assigning a non-None applicator should always apply style.
-    node.style.apply_all.assert_called_once()
+    node.style.reapply.assert_called_once()
 
 
 @pytest.mark.parametrize(
@@ -369,7 +369,7 @@ def test_create_with_applicator():
 )
 def test_assign_applicator(node):
     """A node can be assigned an applicator after creation."""
-    node.style.apply_all.reset_mock()
+    node.style.reapply.reset_mock()
 
     applicator = Mock()
     node.applicator = applicator
@@ -381,7 +381,7 @@ def test_assign_applicator(node):
     assert node.style._applicator is applicator
 
     # Assigning a non-None applicator should always apply style.
-    node.style.apply_all.assert_called_once()
+    node.style.reapply.assert_called_once()
 
 
 @pytest.mark.parametrize(
@@ -393,15 +393,15 @@ def test_assign_applicator(node):
 )
 def test_assign_applicator_none(node):
     """A node can have its applicator set to None."""
-    node.style.apply_all.reset_mock()
+    node.style.reapply.reset_mock()
 
     node.applicator = None
     assert node.applicator is None
 
     # Should be updated on style as well
     assert node.style._applicator is None
-    # Assigning None to applicator does not trigger application.
-    node.style.apply_all.assert_not_called()
+    # Assigning None to applicator does not trigger reapply.
+    node.style.reapply.assert_not_called()
 
 
 def assign_new_applicator():
@@ -431,11 +431,11 @@ def assign_new_applicator_none():
 
 
 def test_assign_style_with_applicator():
-    """Assigning a new style triggers apply_all if an applicator is already present."""
+    """Assigning a new style triggers a reapply if an applicator is already present."""
     style_1 = Style(int_prop=5)
     node = Node(style=style_1, applicator=Mock())
 
-    node.style.apply_all.reset_mock()
+    node.style.reapply.reset_mock()
     style_2 = Style(int_prop=10)
     node.style = style_2
 
@@ -447,15 +447,15 @@ def test_assign_style_with_applicator():
     assert node.style != style_1
 
     # Since an applicator has already been assigned, assigning style applies the style.
-    node.style.apply_all.assert_called_once()
+    node.style.reapply.assert_called_once()
 
 
 def test_assign_style_with_no_applicator():
-    """Assigning new style doesn't trigger apply_all if an applicator isn't present."""
+    """Assigning new style doesn't trigger a reapply if an applicator isn' present."""
     style_1 = Style(int_prop=5)
     node = Node(style=style_1)
 
-    node.style.apply_all.reset_mock()
+    node.style.reapply.reset_mock()
     style_2 = Style(int_prop=10)
     node.style = style_2
 
@@ -467,11 +467,11 @@ def test_assign_style_with_no_applicator():
     assert node.style != style_1
 
     # Since no applicator was present, style should not be applied.
-    node.style.apply_all.assert_not_called()
+    node.style.reapply.assert_not_called()
 
 
 def test_apply_before_node_is_ready():
-    """Triggering apply_all raises a warning if the node is not ready to apply style."""
+    """Triggering a reapply raises a warning if the node is not ready to apply style."""
     style = BrokenStyle()
     applicator = Mock()
 
@@ -489,10 +489,10 @@ def test_apply_before_node_is_ready():
 def test_applicator_has_node_reference():
     """Applicator should have a reference to its node before style is first applied."""
 
-    # We can't just check it after creating the widget, because at that point the style
-    # will have already been applied. AttributeTestStyle has an apply_all() method that
-    # asserts the reference trail of style -> applicator -> node -> style is already
-    # intact at the point that apply_all is called.
+    # We can't just check it after creating the widget, because at that point the
+    # reapply will have already happened. AttributeTestStyle has a reapply() method
+    # that asserts the reference trail of style -> applicator -> node -> style is
+    # already intact at the point that reapply is called.
 
     with catch_warnings():
         filterwarnings("error", category=RuntimeWarning)

--- a/travertino/tests/test_node.py
+++ b/travertino/tests/test_node.py
@@ -56,7 +56,6 @@ class OldTypeErrorStyle(Style):
 @prep_style_class
 class BrokenStyle(BaseStyle):
     def apply(self):
-        print("Broken apply called")
         raise AttributeError("Missing attribute, node not ready for style application")
 
     class IntrinsicSize(BaseIntrinsicSize):

--- a/travertino/tests/test_node.py
+++ b/travertino/tests/test_node.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock
+from unittest.mock import Mock, call
 from warnings import catch_warnings, filterwarnings
 
 import pytest
@@ -216,7 +216,7 @@ def test_refresh_no_op():
     """Refresh is a no-op if no applicator is set."""
     node = Node(style=Style())
     node.refresh(Viewport(width=100, height=100))
-    node.style._apply_all.assert_not_called()
+    node.style.apply.assert_not_called()
 
 
 @pytest.mark.parametrize("StyleClass", [TypeErrorStyle, OldTypeErrorStyle])
@@ -341,7 +341,7 @@ def test_create_with_no_applicator():
 
     # Since no applicator has been assigned, the overall style wasn't applied. However,
     # apply("int_prop") was still called.
-    node.style._apply_names.assert_called_once_with("int_prop")
+    node.style.apply.assert_called_once_with("int_prop")
 
 
 def test_create_with_applicator():
@@ -362,7 +362,7 @@ def test_create_with_applicator():
     assert node.style._applicator is applicator
 
     # Assigning a non-None applicator should always apply the style.
-    node.style._apply_all.assert_called_once_with()
+    node.style.apply.assert_has_calls([call("int_prop"), call()])
 
 
 @pytest.mark.parametrize(
@@ -374,7 +374,7 @@ def test_create_with_applicator():
 )
 def test_assign_applicator(node):
     """A node can be assigned an applicator after creation."""
-    node.style._reset_mocks()
+    node.style.apply.reset_mock()
 
     applicator = Mock()
     node.applicator = applicator
@@ -386,7 +386,7 @@ def test_assign_applicator(node):
     assert node.style._applicator is applicator
 
     # Assigning a non-None applicator should always apply style.
-    node.style._apply_all.assert_called_once()
+    node.style.apply.assert_called_once()
 
 
 @pytest.mark.parametrize(
@@ -398,7 +398,7 @@ def test_assign_applicator(node):
 )
 def test_assign_applicator_none(node):
     """A node can have its applicator set to None."""
-    node.style._reset_mocks()
+    node.style.apply.reset_mock()
 
     node.applicator = None
     assert node.applicator is None
@@ -406,7 +406,7 @@ def test_assign_applicator_none(node):
     # Should be updated on style as well
     assert node.style._applicator is None
     # Assigning None to applicator does not trigger apply.
-    node.style._apply_all.assert_not_called()
+    node.style.apply.assert_not_called()
 
 
 def assign_new_applicator():
@@ -440,7 +440,7 @@ def test_assign_style_with_applicator():
     style_1 = Style(int_prop=5)
     node = Node(style=style_1, applicator=Mock())
 
-    node.style._reset_mocks()
+    node.style.apply.reset_mock()
     style_2 = Style(int_prop=10)
     node.style = style_2
 
@@ -452,7 +452,7 @@ def test_assign_style_with_applicator():
     assert node.style != style_1
 
     # Since an applicator has already been assigned, assigning style applies the style.
-    node.style._apply_all.assert_called_once()
+    node.style.apply.assert_has_calls([call("int_prop"), call()])
 
 
 def test_assign_style_with_no_applicator():
@@ -460,7 +460,7 @@ def test_assign_style_with_no_applicator():
     style_1 = Style(int_prop=5)
     node = Node(style=style_1)
 
-    node.style._reset_mocks()
+    node.style.apply.reset_mock()
     style_2 = Style(int_prop=10)
     node.style = style_2
 
@@ -473,7 +473,7 @@ def test_assign_style_with_no_applicator():
 
     # Since no applicator has been assigned, the overall style wasn't applied. However,
     # apply("int_prop") was still called.
-    node.style._apply_names.assert_called_once_with("int_prop")
+    node.style.apply.assert_called_once_with("int_prop")
 
 
 def test_apply_before_node_is_ready():

--- a/travertino/tests/test_node.py
+++ b/travertino/tests/test_node.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock
+from unittest.mock import Mock, call
 from warnings import catch_warnings, filterwarnings
 
 import pytest
@@ -12,7 +12,7 @@ from .utils import mock_attr, prep_style_class
 
 
 @prep_style_class
-@mock_attr("reapply")
+@mock_attr("apply")
 class Style(BaseStyle):
     int_prop: int = validated_property(integer=True)
 
@@ -29,6 +29,7 @@ class Style(BaseStyle):
 
 
 @prep_style_class
+@mock_attr("apply")
 class OldStyle(Style):
     # Uses two-argument layout(), as in Toga <= 0.4.8
     def layout(self, node, viewport):
@@ -37,6 +38,7 @@ class OldStyle(Style):
 
 
 @prep_style_class
+@mock_attr("apply")
 class TypeErrorStyle(Style):
     # Uses the correct signature, but raises an unrelated TypeError in layout
     def layout(self, viewport):
@@ -44,6 +46,7 @@ class TypeErrorStyle(Style):
 
 
 @prep_style_class
+@mock_attr("apply")
 class OldTypeErrorStyle(Style):
     # Just to be extra safe...
     def layout(self, node, viewport):
@@ -52,7 +55,8 @@ class OldTypeErrorStyle(Style):
 
 @prep_style_class
 class BrokenStyle(BaseStyle):
-    def reapply(self):
+    def apply(self):
+        print("Broken apply called")
         raise AttributeError("Missing attribute, node not ready for style application")
 
     class IntrinsicSize(BaseIntrinsicSize):
@@ -74,7 +78,7 @@ class AttributeTestStyle(BaseStyle):
     class Box(BaseBox):
         pass
 
-    def reapply(self):
+    def apply(self):
         assert self._applicator.node.style is self
 
 
@@ -212,7 +216,7 @@ def test_refresh_no_op():
     """Refresh is a no-op if no applicator is set."""
     node = Node(style=Style())
     node.refresh(Viewport(width=100, height=100))
-    node.style.reapply.assert_not_called()
+    node.style.apply.assert_not_called()
 
 
 @pytest.mark.parametrize("StyleClass", [TypeErrorStyle, OldTypeErrorStyle])
@@ -335,8 +339,9 @@ def test_create_with_no_applicator():
     assert node.style == style
     assert node.style is not style
 
-    # Since no applicator has been assigned, style wasn't applied.
-    node.style.reapply.assert_not_called()
+    # Since no applicator has been assigned, the overall style wasn't applied. However,
+    # apply("int_prop") was still called.
+    node.style.apply.assert_called_once_with("int_prop")
 
 
 def test_create_with_applicator():
@@ -356,8 +361,8 @@ def test_create_with_applicator():
     assert applicator.node is node
     assert node.style._applicator is applicator
 
-    # Assigning a non-None applicator should always apply style.
-    node.style.reapply.assert_called_once()
+    # Assigning a non-None applicator should always apply the style.
+    node.style.apply.assert_has_calls([call("int_prop"), call()])
 
 
 @pytest.mark.parametrize(
@@ -369,7 +374,7 @@ def test_create_with_applicator():
 )
 def test_assign_applicator(node):
     """A node can be assigned an applicator after creation."""
-    node.style.reapply.reset_mock()
+    node.style.apply.reset_mock()
 
     applicator = Mock()
     node.applicator = applicator
@@ -381,7 +386,7 @@ def test_assign_applicator(node):
     assert node.style._applicator is applicator
 
     # Assigning a non-None applicator should always apply style.
-    node.style.reapply.assert_called_once()
+    node.style.apply.assert_called_once()
 
 
 @pytest.mark.parametrize(
@@ -393,15 +398,15 @@ def test_assign_applicator(node):
 )
 def test_assign_applicator_none(node):
     """A node can have its applicator set to None."""
-    node.style.reapply.reset_mock()
+    node.style.apply.reset_mock()
 
     node.applicator = None
     assert node.applicator is None
 
     # Should be updated on style as well
     assert node.style._applicator is None
-    # Assigning None to applicator does not trigger reapply.
-    node.style.reapply.assert_not_called()
+    # Assigning None to applicator does not trigger apply.
+    node.style.apply.assert_not_called()
 
 
 def assign_new_applicator():
@@ -431,11 +436,11 @@ def assign_new_applicator_none():
 
 
 def test_assign_style_with_applicator():
-    """Assigning a new style triggers a reapply if an applicator is already present."""
+    """Assigning a new style triggers an apply if an applicator is already present."""
     style_1 = Style(int_prop=5)
     node = Node(style=style_1, applicator=Mock())
 
-    node.style.reapply.reset_mock()
+    node.style.apply.reset_mock()
     style_2 = Style(int_prop=10)
     node.style = style_2
 
@@ -447,15 +452,15 @@ def test_assign_style_with_applicator():
     assert node.style != style_1
 
     # Since an applicator has already been assigned, assigning style applies the style.
-    node.style.reapply.assert_called_once()
+    node.style.apply.assert_has_calls([call("int_prop"), call()])
 
 
 def test_assign_style_with_no_applicator():
-    """Assigning new style doesn't trigger a reapply if an applicator isn' present."""
+    """Assigning new style doesn't trigger an apply if an applicator isn' present."""
     style_1 = Style(int_prop=5)
     node = Node(style=style_1)
 
-    node.style.reapply.reset_mock()
+    node.style.apply.reset_mock()
     style_2 = Style(int_prop=10)
     node.style = style_2
 
@@ -466,12 +471,13 @@ def test_assign_style_with_no_applicator():
 
     assert node.style != style_1
 
-    # Since no applicator was present, style should not be applied.
-    node.style.reapply.assert_not_called()
+    # Since no applicator has been assigned, the overall style wasn't applied. However,
+    # apply("int_prop") was still called.
+    node.style.apply.assert_called_once_with("int_prop")
 
 
 def test_apply_before_node_is_ready():
-    """Triggering a reapply raises a warning if the node is not ready to apply style."""
+    """Triggering an apply raises a warning if the node is not ready to apply style."""
     style = BrokenStyle()
     applicator = Mock()
 
@@ -490,9 +496,9 @@ def test_applicator_has_node_reference():
     """Applicator should have a reference to its node before style is first applied."""
 
     # We can't just check it after creating the widget, because at that point the
-    # reapply will have already happened. AttributeTestStyle has a reapply() method
+    # apply will have already happened. AttributeTestStyle has an apply() method
     # that asserts the reference trail of style -> applicator -> node -> style is
-    # already intact at the point that reapply is called.
+    # already intact at the point that apply is called.
 
     with catch_warnings():
         filterwarnings("error", category=RuntimeWarning)

--- a/travertino/tests/utils.py
+++ b/travertino/tests/utils.py
@@ -18,31 +18,11 @@ def apply_dataclass(cls):
 
 
 def mock_apply(cls):
-    """Mock a style class's apply() method.
-
-    Because apply() is called with or without arguments in different circumstances, and
-    due to limited granularity in Mock's assertions (e.g. you can't check that multiple
-    calls are there, but no other calls), the two usages are dispatched to separate
-    mocks.
-    """
+    """Mock a style class's apply() method."""
     orig_init = cls.__init__
 
-    def apply(self, *args, **kwargs):
-        if args or kwargs:
-            self._apply_names(*args, **kwargs)
-        else:
-            self._apply_all()
-
-    def reset_mocks(self):
-        self._apply_names.reset_mock()
-        self._apply_all.reset_mock()
-
-    cls.apply = apply
-    cls._reset_mocks = reset_mocks
-
     def __init__(self, *args, **kwargs):
-        self._apply_names = Mock()
-        self._apply_all = Mock()
+        self.apply = Mock()
         orig_init(self, *args, **kwargs)
 
     cls.__init__ = __init__

--- a/travertino/tests/utils.py
+++ b/travertino/tests/utils.py
@@ -13,8 +13,8 @@ from travertino.colors import hsl, hsla, rgb, rgba
 
 
 def prep_style_class(cls):
-    """Decorator to apply dataclass and mock apply."""
-    return mock_attr("apply")(dataclass(**_DATACLASS_KWARGS)(cls))
+    """Decorator to apply dataclass"""
+    return dataclass(**_DATACLASS_KWARGS)(cls)
 
 
 def mock_attr(attr):

--- a/travertino/tests/utils.py
+++ b/travertino/tests/utils.py
@@ -4,33 +4,29 @@ from unittest.mock import Mock
 
 import pytest
 
+from travertino.colors import hsl, hsla, rgb, rgba
+
 if sys.version_info < (3, 10):
     _DATACLASS_KWARGS = {"init": False}
 else:
     _DATACLASS_KWARGS = {"kw_only": True}
 
-from travertino.colors import hsl, hsla, rgb, rgba
 
-
-def prep_style_class(cls):
-    """Decorator to apply dataclass"""
+def apply_dataclass(cls):
+    """Decorator to apply dataclass with arguments depending on Python version"""
     return dataclass(**_DATACLASS_KWARGS)(cls)
 
 
-def mock_attr(attr):
-    """Mock an arbitrary attribute of a class."""
+def mock_apply(cls):
+    """Mock a style class's apply() method."""
+    orig_init = cls.__init__
 
-    def returned_decorator(cls):
-        orig_init = cls.__init__
+    def __init__(self, *args, **kwargs):
+        self.apply = Mock()
+        orig_init(self, *args, **kwargs)
 
-        def __init__(self, *args, **kwargs):
-            setattr(self, attr, Mock())
-            orig_init(self, *args, **kwargs)
-
-        cls.__init__ = __init__
-        return cls
-
-    return returned_decorator
+    cls.__init__ = __init__
+    return cls
 
 
 def assert_equal_color(actual, expected, abs=1e-6):


### PR DESCRIPTION
The name of `BaseStyle.reapply()` doesn't really reflect what it does. The presence of `apply()` and `reapply()` implies they do at least roughly the same thing, except one is for the first time and the other is for subsequent uses — whereas the actual difference is that `apply()` applies a single property, while `reapply()` applies all of them. Ironically, it's the *first* of the two methods to be (successfully) called, once the applicator is assigned.

~~I'd like to rename `reapply` to `apply_all`. I'm also all ears to alternate spellings, if you think something else would be preferable.~~

EDIT: Based on discussion, this now modifies `apply()` such that calling it with no arguments replaces the use of `reapply()`.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
