### PR TITLE
Remove reapply from Android Widget.__init__

### DIFF
--- a/android/src/toga_android/widgets/base.py
+++ b/android/src/toga_android/widgets/base.py
@@ -63,10 +63,6 @@ class Widget(ABC, Scalable):
             )
         )
 
-        # Immediately re-apply styles. Some widgets may defer style application until
-        # they have been added to a container.
-        self.interface.style.reapply()
-
     @abstractmethod
     def create(self): ...
 

--- a/changes/3165.misc.rst
+++ b/changes/3165.misc.rst
@@ -1,0 +1,1 @@
+A redundant style reapplication was removed from the Android backend's Widget initializer.


### PR DESCRIPTION
The [comment](https://github.com/beeware/toga/pull/3160#pullrequestreview-2594637936) about Android needing to reapply styles after a widget's constructed piqued my curiosity... Does it?

I'm pretty sure this is just a holdover from before #2942, when all backends had to do this.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
