### PR TITLE
List `travertino` before `core` when installing from local directories

### DIFF
--- a/changes/3169.misc.rst
+++ b/changes/3169.misc.rst
@@ -1,0 +1,1 @@
+List travertino before core when installing from local directories

--- a/examples/activityindicator/pyproject.toml
+++ b/examples/activityindicator/pyproject.toml
@@ -15,8 +15,8 @@ formal_name = "Activity Indicator"
 description = "A testing app"
 sources = ["activityindicator"]
 requires = [
-    "../../core",
     "../../travertino",
+    "../../core",
 ]
 
 

--- a/examples/beeliza/pyproject.toml
+++ b/examples/beeliza/pyproject.toml
@@ -15,8 +15,8 @@ formal_name = "Beeliza"
 description = "A testing app"
 sources = ["beeliza"]
 requires = [
-    "../../core",
     "../../travertino",
+    "../../core",
 ]
 
 

--- a/examples/box/pyproject.toml
+++ b/examples/box/pyproject.toml
@@ -15,8 +15,8 @@ formal_name = "Box Demo"
 description = "A testing app"
 sources = ["box"]
 requires = [
-    "../../core",
     "../../travertino",
+    "../../core",
 ]
 
 

--- a/examples/button/pyproject.toml
+++ b/examples/button/pyproject.toml
@@ -15,8 +15,8 @@ formal_name = "Button Demo"
 description = "A testing app"
 sources = ["button"]
 requires = [
-    "../../core",
     "../../travertino",
+    "../../core",
 ]
 
 

--- a/examples/canvas/pyproject.toml
+++ b/examples/canvas/pyproject.toml
@@ -15,8 +15,8 @@ formal_name = "Canvas Demo"
 description = "A testing app"
 sources = ["canvas"]
 requires = [
-    "../../core",
     "../../travertino",
+    "../../core",
 ]
 
 

--- a/examples/colors/pyproject.toml
+++ b/examples/colors/pyproject.toml
@@ -15,8 +15,8 @@ formal_name = "colors"
 description = "A testing app"
 sources = ["colors"]
 requires = [
-    "../../core",
     "../../travertino",
+    "../../core",
 ]
 
 

--- a/examples/command/pyproject.toml
+++ b/examples/command/pyproject.toml
@@ -15,8 +15,8 @@ formal_name = "Command Example"
 description = "A testing app"
 sources = ["command"]
 requires = [
-    "../../core",
     "../../travertino",
+    "../../core",
 ]
 
 

--- a/examples/date_and_time/pyproject.toml
+++ b/examples/date_and_time/pyproject.toml
@@ -15,8 +15,8 @@ formal_name = "Date And Time"
 description = "A testing app"
 sources = ["date_and_time"]
 requires = [
-    "../../core",
     "../../travertino",
+    "../../core",
 ]
 
 

--- a/examples/detailedlist/pyproject.toml
+++ b/examples/detailedlist/pyproject.toml
@@ -15,8 +15,8 @@ formal_name = "DetailedList Demo"
 description = "A testing app"
 sources = ["detailedlist"]
 requires = [
-    "../../core",
     "../../travertino",
+    "../../core",
 ]
 
 

--- a/examples/dialogs/pyproject.toml
+++ b/examples/dialogs/pyproject.toml
@@ -15,8 +15,8 @@ formal_name = "Dialog Demo"
 description = "A testing app"
 sources = ["dialogs"]
 requires = [
-    "../../core",
     "../../travertino",
+    "../../core",
 ]
 
 

--- a/examples/divider/pyproject.toml
+++ b/examples/divider/pyproject.toml
@@ -15,8 +15,8 @@ formal_name = "Divider Demo"
 description = "A testing app"
 sources = ["divider"]
 requires = [
-    "../../core",
     "../../travertino",
+    "../../core",
 ]
 
 

--- a/examples/documentapp/pyproject.toml
+++ b/examples/documentapp/pyproject.toml
@@ -15,8 +15,8 @@ formal_name = "Document App"
 description = "A testing app"
 sources = ["documentapp"]
 requires = [
-    "../../core",
     "../../travertino",
+    "../../core",
 ]
 
 

--- a/examples/examples_overview/pyproject.toml
+++ b/examples/examples_overview/pyproject.toml
@@ -15,8 +15,8 @@ formal_name = "Examples Overview"
 description = "A testing app"
 sources = ["examples_overview"]
 requires = [
-    "../../core",
     "../../travertino",
+    "../../core",
 ]
 
 

--- a/examples/focus/pyproject.toml
+++ b/examples/focus/pyproject.toml
@@ -15,8 +15,8 @@ formal_name = "Focus Demo"
 description = "A testing app"
 sources = ["focus"]
 requires = [
-    "../../core",
     "../../travertino",
+    "../../core",
 ]
 
 

--- a/examples/font/pyproject.toml
+++ b/examples/font/pyproject.toml
@@ -15,8 +15,8 @@ formal_name = "Font Example"
 description = "A testing app"
 sources = ["font"]
 requires = [
-    "../../core",
     "../../travertino",
+    "../../core",
 ]
 
 

--- a/examples/font_size/pyproject.toml
+++ b/examples/font_size/pyproject.toml
@@ -15,8 +15,8 @@ formal_name = "Font size Test"
 description = "A testing app"
 sources = ["font_size"]
 requires = [
-    "../../core",
     "../../travertino",
+    "../../core",
 ]
 
 [tool.briefcase.app.font_size.macOS]

--- a/examples/handlers/pyproject.toml
+++ b/examples/handlers/pyproject.toml
@@ -15,8 +15,8 @@ formal_name = "Handler Demo"
 description = "A testing app"
 sources = ["handlers"]
 requires = [
-    "../../core",
     "../../travertino",
+    "../../core",
     "httpx",
 ]
 

--- a/examples/imageview/pyproject.toml
+++ b/examples/imageview/pyproject.toml
@@ -15,8 +15,8 @@ formal_name = "ImageView Demo"
 description = "A testing app"
 sources = ["imageview"]
 requires = [
-    "../../core",
     "../../travertino",
+    "../../core",
 ]
 
 

--- a/examples/layout/pyproject.toml
+++ b/examples/layout/pyproject.toml
@@ -15,8 +15,8 @@ formal_name = "Layout Test"
 description = "A testing app"
 sources = ["layout"]
 requires = [
-    "../../core",
     "../../travertino",
+    "../../core",
 ]
 
 

--- a/examples/multilinetextinput/pyproject.toml
+++ b/examples/multilinetextinput/pyproject.toml
@@ -15,8 +15,8 @@ formal_name = "MultilineTextInput Demo"
 description = "A testing app"
 sources = ["multilinetextinput"]
 requires = [
-    "../../core",
     "../../travertino",
+    "../../core",
 ]
 
 

--- a/examples/numberinput/pyproject.toml
+++ b/examples/numberinput/pyproject.toml
@@ -15,8 +15,8 @@ formal_name = "Demo NumberInput"
 description = "A testing app"
 sources = ["numberinput"]
 requires = [
-    "../../core",
     "../../travertino",
+    "../../core",
 ]
 
 

--- a/examples/optioncontainer/pyproject.toml
+++ b/examples/optioncontainer/pyproject.toml
@@ -15,8 +15,8 @@ formal_name = "Option Container Example"
 description = "A testing app"
 sources = ["optioncontainer"]
 requires = [
-    "../../core",
     "../../travertino",
+    "../../core",
 ]
 
 

--- a/examples/positron-django/pyproject.toml
+++ b/examples/positron-django/pyproject.toml
@@ -16,8 +16,8 @@ description = "Electron, but in Python"
 icon = "src/positron/resources/positron"
 sources = ["src/positron", "src/webapp"]
 requires = [
-    "../../core",
     "../../travertino",
+    "../../core",
     "django~=4.1",
 ]
 

--- a/examples/positron-static/pyproject.toml
+++ b/examples/positron-static/pyproject.toml
@@ -16,8 +16,8 @@ description = "Electron, but in Python"
 icon = "src/positron/resources/positron"
 sources = ["src/positron"]
 requires = [
-    "../../core",
     "../../travertino",
+    "../../core",
 ]
 
 

--- a/examples/progressbar/pyproject.toml
+++ b/examples/progressbar/pyproject.toml
@@ -15,8 +15,8 @@ formal_name = "ProgressBar demo"
 description = "A testing app"
 sources = ["progressbar"]
 requires = [
-    "../../core",
     "../../travertino",
+    "../../core",
 ]
 
 

--- a/examples/resize/pyproject.toml
+++ b/examples/resize/pyproject.toml
@@ -15,8 +15,8 @@ formal_name = "Resize Test"
 description = "A testing app"
 sources = ["resize"]
 requires = [
-    "../../core",
     "../../travertino",
+    "../../core",
 ]
 
 

--- a/examples/screenshot/pyproject.toml
+++ b/examples/screenshot/pyproject.toml
@@ -15,8 +15,8 @@ formal_name = "Screenshot Generator"
 description = "A testing app"
 sources = ["screenshot"]
 requires = [
-    "../../core",
     "../../travertino",
+    "../../core",
     "pillow",
 ]
 

--- a/examples/scrollcontainer/pyproject.toml
+++ b/examples/scrollcontainer/pyproject.toml
@@ -15,8 +15,8 @@ formal_name = "ScrollContainer Demo"
 description = "A testing app"
 sources = ["scrollcontainer"]
 requires = [
-    "../../core",
     "../../travertino",
+    "../../core",
 ]
 
 

--- a/examples/selection/pyproject.toml
+++ b/examples/selection/pyproject.toml
@@ -15,8 +15,8 @@ formal_name = "Selection Demo"
 description = "A testing app"
 sources = ["selection"]
 requires = [
-    "../../core",
     "../../travertino",
+    "../../core",
 ]
 
 

--- a/examples/slider/pyproject.toml
+++ b/examples/slider/pyproject.toml
@@ -15,8 +15,8 @@ formal_name = "Slider Demo"
 description = "A testing app"
 sources = ["slider"]
 requires = [
-    "../../core",
     "../../travertino",
+    "../../core",
 ]
 
 

--- a/examples/splitcontainer/pyproject.toml
+++ b/examples/splitcontainer/pyproject.toml
@@ -15,8 +15,8 @@ formal_name = "SplitContainer Demo"
 description = "A testing app"
 sources = ["splitcontainer"]
 requires = [
-    "../../core",
     "../../travertino",
+    "../../core",
 ]
 
 

--- a/examples/switch_demo/pyproject.toml
+++ b/examples/switch_demo/pyproject.toml
@@ -15,8 +15,8 @@ formal_name = "Switch Demo"
 description = "A testing app"
 sources = ["switch_demo"]
 requires = [
-    "../../core",
     "../../travertino",
+    "../../core",
 ]
 
 

--- a/examples/table/pyproject.toml
+++ b/examples/table/pyproject.toml
@@ -15,8 +15,8 @@ formal_name = "Table Demo"
 description = "A testing app"
 sources = ["table"]
 requires = [
-    "../../core",
     "../../travertino",
+    "../../core",
 ]
 
 [tool.briefcase.app.table.macOS]

--- a/examples/table_source/pyproject.toml
+++ b/examples/table_source/pyproject.toml
@@ -15,8 +15,8 @@ formal_name = "TableSource Demo"
 description = "A testing app"
 sources = ["table_source"]
 requires = [
-    "../../core",
     "../../travertino",
+    "../../core",
 ]
 
 

--- a/examples/textinput/pyproject.toml
+++ b/examples/textinput/pyproject.toml
@@ -15,8 +15,8 @@ formal_name = "Text Input Demo"
 description = "A testing app"
 sources = ["textinput"]
 requires = [
-    "../../core",
     "../../travertino",
+    "../../core",
 ]
 
 

--- a/examples/tree/pyproject.toml
+++ b/examples/tree/pyproject.toml
@@ -15,8 +15,8 @@ formal_name = "Tree Demo"
 description = "A testing app"
 sources = ["tree"]
 requires = [
-    "../../core",
     "../../travertino",
+    "../../core",
 ]
 
 

--- a/examples/tree_source/pyproject.toml
+++ b/examples/tree_source/pyproject.toml
@@ -15,8 +15,8 @@ formal_name = "TreeSource Demo"
 description = "A testing app"
 sources = ["tree_source"]
 requires = [
-    "../../core",
     "../../travertino",
+    "../../core",
 ]
 
 

--- a/examples/tutorial0/pyproject.toml
+++ b/examples/tutorial0/pyproject.toml
@@ -15,8 +15,8 @@ formal_name = "Tutorial 0"
 description = "A testing app"
 sources = ["tutorial"]
 requires = [
-    "../../core",
     "../../travertino",
+    "../../core",
 ]
 
 

--- a/examples/tutorial1/pyproject.toml
+++ b/examples/tutorial1/pyproject.toml
@@ -15,8 +15,8 @@ formal_name = "Tutorial 1"
 description = "A testing app"
 sources = ["tutorial"]
 requires = [
-    "../../core",
     "../../travertino",
+    "../../core",
 ]
 
 

--- a/examples/tutorial2/pyproject.toml
+++ b/examples/tutorial2/pyproject.toml
@@ -15,8 +15,8 @@ formal_name = "Tutorial 2"
 description = "A testing app"
 sources = ["tutorial"]
 requires = [
-    "../../core",
     "../../travertino",
+    "../../core",
 ]
 
 

--- a/examples/tutorial3/pyproject.toml
+++ b/examples/tutorial3/pyproject.toml
@@ -15,8 +15,8 @@ formal_name = "Tutorial 3"
 description = "A testing app"
 sources = ["tutorial"]
 requires = [
-    "../../core",
     "../../travertino",
+    "../../core",
 ]
 
 

--- a/examples/tutorial4/pyproject.toml
+++ b/examples/tutorial4/pyproject.toml
@@ -15,8 +15,8 @@ formal_name = "Tutorial 4"
 description = "A testing app"
 sources = ["tutorial"]
 requires = [
-    "../../core",
     "../../travertino",
+    "../../core",
 ]
 
 

--- a/examples/webview/pyproject.toml
+++ b/examples/webview/pyproject.toml
@@ -15,8 +15,8 @@ formal_name = "WebView Demo"
 description = "A demo app using all WebView features"
 sources = ["webview"]
 requires = [
-    "../../core",
     "../../travertino",
+    "../../core",
 ]
 
 [tool.briefcase.app.webview.macOS]

--- a/examples/window/pyproject.toml
+++ b/examples/window/pyproject.toml
@@ -15,8 +15,8 @@ formal_name = "Window Demo"
 description = "A testing app"
 sources = ["window"]
 requires = [
-    "../../core",
     "../../travertino",
+    "../../core",
 ]
 
 

--- a/testbed/pyproject.toml
+++ b/testbed/pyproject.toml
@@ -34,8 +34,8 @@ test_sources = [
     "tests",
 ]
 requires = [
-    "../core",
     "../travertino",
+    "../core",
 ]
 
 # Some CI configurations (e.g., Textual) manually override `requires` to specify


### PR DESCRIPTION
#3155 added Travertino to the requirements list of all the example apps. But when installing from local directories, it looks like Chaquopy's old version of pip requires them to be listed in dependency order.

This also affects the testbed, but it didn't break CI because it was able to find a matching Travertino wheel in the `dist` directory.

Before:

```
> Task :app:generateDebugPythonRequirements
Chaquopy: Installing for arm64-v8a
Looking in indexes: https://pypi.org/simple, https://chaquo.com/pypi-13.1
Processing /Users/msmith/git/beeware/toga/core
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
    Preparing wheel metadata: started
    Preparing wheel metadata: finished with status 'done'
Processing /Users/msmith/git/beeware/toga/travertino
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
    Preparing wheel metadata: started
    Preparing wheel metadata: finished with status 'done'
Processing /Users/msmith/git/beeware/toga/android
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
    Preparing wheel metadata: started
    Preparing wheel metadata: finished with status 'done'
ERROR: Could not find a version that satisfies the requirement travertino==0.4.9.dev572+gea6adab4d.d20250207 (from toga-core==0.4.9.dev572+gea6adab4d.d20250207->-r requirements.txt (line 2)) (from versions: 0.0.1, 0.1.0, 0.1.1, 0.1.2, 0.1.3, 0.2.0, 0.3.0)
ERROR: No matching distribution found for travertino==0.4.9.dev572+gea6adab4d.d20250207 (from toga-core==0.4.9.dev572+gea6adab4d.d20250207->-r requirements.txt (line 2))
Chaquopy: Exit status 1
```

After:
```
> Task :app:generateDebugPythonRequirements
Chaquopy: Installing for arm64-v8a
Looking in indexes: https://pypi.org/simple, https://chaquo.com/pypi-13.1
Processing /Users/msmith/git/beeware/toga/travertino
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
    Preparing wheel metadata: started
    Preparing wheel metadata: finished with status 'done'
Processing /Users/msmith/git/beeware/toga/core
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
    Preparing wheel metadata: started
    Preparing wheel metadata: finished with status 'done'
Processing /Users/msmith/git/beeware/toga/android
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
    Preparing wheel metadata: started
    Preparing wheel metadata: finished with status 'done'
Building wheels for collected packages: travertino, toga-core, toga-android
  Building wheel for travertino (PEP 517): started
  Building wheel for travertino (PEP 517): finished with status 'done'
  Created wheel for travertino: filename=travertino-0.4.9.dev572+gea6adab4d.d20250207-py3-none-any.whl size=20577 sha256=5e3f997d7e99ec8bd349bdc4d256b966cc92c18749b98a6b781a2d6d6cebf68e
  Stored in directory: /private/var/folders/2t/th8vxc813_gcch7lkh1sbbmc0000gp/T/pip-ephem-wheel-cache-cef73mwd/wheels/50/68/06/96b21e14163f0edd24587f0067b9cb8c3bc865184fbbb3fe6f
  Building wheel for toga-core (PEP 517): started
  Building wheel for toga-core (PEP 517): finished with status 'done'
  Created wheel for toga-core: filename=toga_core-0.4.9.dev572+gea6adab4d.d20250207-py3-none-any.whl size=581485 sha256=244d13f319bd4ac6a2b133907bfb7990bc213236347a1dec97f148e9f66fd6fd
  Stored in directory: /private/var/folders/2t/th8vxc813_gcch7lkh1sbbmc0000gp/T/pip-ephem-wheel-cache-cef73mwd/wheels/66/ce/a3/586dd1554be23d847701b25f12e1fb23768f67797368f20536
  Building wheel for toga-android (PEP 517): started
  Building wheel for toga-android (PEP 517): finished with status 'done'
  Created wheel for toga-android: filename=toga_android-0.4.9.dev572+gea6adab4d.d20250207-py3-none-any.whl size=70773 sha256=8124afcdc3159ef0071d546c40466c44557c5573c9c7d12e34cf15ce8a7ff367
  Stored in directory: /private/var/folders/2t/th8vxc813_gcch7lkh1sbbmc0000gp/T/pip-ephem-wheel-cache-cef73mwd/wheels/95/bc/78/d17a7002f938ad322e179aaee572c8dce511468af9aeff854a
Successfully built travertino toga-core toga-android
Installing collected packages: travertino, toga-core, toga-android
Successfully installed toga-android-0.4.9.dev572+gea6adab4d.d20250207 toga-core-0.4.9.dev572+gea6adab4d.d20250207 travertino-0.4.9.dev572+gea6adab4d.d20250207
```