### PR TITLE
Move _package_version to travertino

### DIFF
--- a/android/src/toga_android/__init__.py
+++ b/android/src/toga_android/__init__.py
@@ -1,3 +1,3 @@
-import toga
+import travertino
 
-__version__ = toga._package_version(__file__, __name__)
+__version__ = travertino._package_version(__file__, __name__)

--- a/changes/3183.misc.rst
+++ b/changes/3183.misc.rst
@@ -1,0 +1,1 @@
+Move ``_package_version`` to travertino

--- a/cocoa/src/toga_cocoa/__init__.py
+++ b/cocoa/src/toga_cocoa/__init__.py
@@ -1,3 +1,3 @@
-import toga
+import travertino
 
-__version__ = toga._package_version(__file__, __name__)
+__version__ = travertino._package_version(__file__, __name__)

--- a/core/src/toga/__init__.py
+++ b/core/src/toga/__init__.py
@@ -121,4 +121,5 @@ class NotImplementedWarning(RuntimeWarning):
         warnings.warn(NotImplementedWarning(f"[{platform}] Not implemented: {feature}"))
 
 
-__version__ = _package_version(__file__, __name__)
+# __name__ is "toga" in this file; we need the version of the toga-core package.
+__version__ = _package_version(__file__, "toga-core")

--- a/core/src/toga/__init__.py
+++ b/core/src/toga/__init__.py
@@ -121,5 +121,5 @@ class NotImplementedWarning(RuntimeWarning):
         warnings.warn(NotImplementedWarning(f"[{platform}] Not implemented: {feature}"))
 
 
-# __name__ is "toga" in this file; we need the version of the toga-core package.
+# __name__ is "toga" in this file, but the distribution name is "toga-core".
 __version__ = _package_version(__file__, "toga-core")

--- a/core/src/toga/__init__.py
+++ b/core/src/toga/__init__.py
@@ -11,6 +11,8 @@ if sys.implementation.name != "cpython":  # pragma: no cover
 import warnings
 from importlib import import_module
 
+from travertino import _package_version
+
 toga_core_imports = {
     # toga.app imports
     "App": "toga.app",
@@ -117,30 +119,6 @@ class NotImplementedWarning(RuntimeWarning):
     def warn(cls, platform: str, feature: str) -> None:
         """Raise a warning that a feature isn't implemented on a platform."""
         warnings.warn(NotImplementedWarning(f"[{platform}] Not implemented: {feature}"))
-
-
-def _package_version(file, name):
-    try:
-        # Read version from SCM metadata
-        # This will only exist in a development environment
-        from setuptools_scm import get_version
-
-        # Excluded from coverage because a pure test environment (such as the one
-        # used by tox in CI) won't have setuptools_scm
-        return get_version(root="../../..", relative_to=file)  # pragma: no cover
-    except (
-        ModuleNotFoundError,
-        LookupError,
-    ):  # pragma: no-cover-if-missing-setuptools_scm
-        # If setuptools_scm isn't in the environment, the call to import will fail.
-        # If it *is* in the environment, but the code isn't a git checkout (e.g.,
-        # it's been pip installed non-editable) the call to get_version() will fail.
-        # If either of these occurs, read version from the installer metadata.
-        import importlib.metadata
-
-        # The Toga package names as defined in setup.cfg all use dashes.
-        package = "toga-core" if name == "toga" else name.replace("_", "-")
-        return importlib.metadata.version(package)
 
 
 __version__ = _package_version(__file__, __name__)

--- a/dummy/src/toga_dummy/__init__.py
+++ b/dummy/src/toga_dummy/__init__.py
@@ -1,5 +1,5 @@
-import toga
+import travertino
 
 from . import factory  # noqa: F401
 
-__version__ = toga._package_version(__file__, __name__)
+__version__ = travertino._package_version(__file__, __name__)

--- a/gtk/src/toga_gtk/__init__.py
+++ b/gtk/src/toga_gtk/__init__.py
@@ -1,3 +1,3 @@
-import toga
+import travertino
 
-__version__ = toga._package_version(__file__, __name__)
+__version__ = travertino._package_version(__file__, __name__)

--- a/iOS/src/toga_iOS/__init__.py
+++ b/iOS/src/toga_iOS/__init__.py
@@ -1,3 +1,3 @@
-import toga
+import travertino
 
-__version__ = toga._package_version(__file__, __name__)
+__version__ = travertino._package_version(__file__, __name__)

--- a/textual/src/toga_textual/__init__.py
+++ b/textual/src/toga_textual/__init__.py
@@ -1,3 +1,3 @@
-import toga
+import travertino
 
-__version__ = toga._package_version(__file__, __name__)
+__version__ = travertino._package_version(__file__, __name__)

--- a/travertino/src/travertino/__init__.py
+++ b/travertino/src/travertino/__init__.py
@@ -1,17 +1,25 @@
-try:
-    # Read version from SCM metadata
-    # This will only exist in a development environment
-    from setuptools_scm import get_version
+def _package_version(file, name):
+    try:
+        # Read version from SCM metadata
+        # This will only exist in a development environment
+        from setuptools_scm import get_version
 
-    # Excluded from coverage because a pure test environment (such as the one
-    # used by tox in CI) won't have setuptools_scm
-    __version__ = get_version("../../..", relative_to=__file__)  # pragma: no cover
-except (ModuleNotFoundError, LookupError):
-    # If setuptools_scm isn't in the environment, the call to import will fail.
-    # If it *is* in the environment, but the code isn't a git checkout (e.g.,
-    # it's been pip installed non-editable) the call to get_version() will fail.
-    # If either of these occurs, read version from the installer metadata.
+        # Excluded from coverage because a pure test environment (such as the one
+        # used by tox in CI) won't have setuptools_scm
+        return get_version(root="../../..", relative_to=file)  # pragma: no cover
+    except (
+        ModuleNotFoundError,
+        LookupError,
+    ):  # pragma: no-cover-if-missing-setuptools_scm
+        # If setuptools_scm isn't in the environment, the call to import will fail.
+        # If it *is* in the environment, but the code isn't a git checkout (e.g.,
+        # it's been pip installed non-editable) the call to get_version() will fail.
+        # If either of these occurs, read version from the installer metadata.
+        import importlib.metadata
 
-    from importlib.metadata import version
+        # The Toga package names as defined in pyproject.toml all use dashes.
+        package = "toga-core" if name == "toga" else name.replace("_", "-")
+        return importlib.metadata.version(package)
 
-    __version__ = version("travertino")
+
+__version__ = _package_version(__file__, __name__)

--- a/travertino/src/travertino/__init__.py
+++ b/travertino/src/travertino/__init__.py
@@ -18,7 +18,7 @@ def _package_version(file, name):
         import importlib.metadata
 
         # The Toga package names as defined in pyproject.toml all use dashes.
-        package = "toga-core" if name == "toga" else name.replace("_", "-")
+        package = name.replace("_", "-")
         return importlib.metadata.version(package)
 
 

--- a/web/src/toga_web/__init__.py
+++ b/web/src/toga_web/__init__.py
@@ -1,3 +1,3 @@
-import toga
+import travertino
 
-__version__ = toga._package_version(__file__, __name__)
+__version__ = travertino._package_version(__file__, __name__)

--- a/winforms/src/toga_winforms/__init__.py
+++ b/winforms/src/toga_winforms/__init__.py
@@ -1,6 +1,5 @@
 import clr
-
-import toga
+import travertino
 
 from .libs.user32 import (
     DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2,
@@ -35,4 +34,4 @@ if SetProcessDpiAwarenessContext is not None:
     ):  # pragma: no cover
         print("WARNING: Failed to set the DPI Awareness mode for the app.")
 
-__version__ = toga._package_version(__file__, __name__)
+__version__ = travertino._package_version(__file__, __name__)


### PR DESCRIPTION
Now that Toga is pinned to a specific version of Travertino, we can consolidate the two copies of this code.