### PR TITLE
Switch to Micropython-incompatible syntax

### DIFF
--- a/changes/3186.misc.rst
+++ b/changes/3186.misc.rst
@@ -1,0 +1,1 @@
+Syntax avoided for compatibility with MicroPython was reintroduced.

--- a/core/src/toga/style/mixin.py
+++ b/core/src/toga/style/mixin.py
@@ -17,14 +17,13 @@ class StyleProperty:
 
 def style_mixin(style_cls):
     mixin_dict = {
-        name: StyleProperty() for name in style_cls._BASE_ALL_PROPERTIES[style_cls]
+        "__doc__": (
+            f"""Allows accessing the {style_cls.__name__} {style_cls._doc_link} directly
+            on the widget. For example, instead of ``widget.style.color``, you can
+            simply write ``widget.color``.
+            """
+        ),
+        **{name: StyleProperty() for name in style_cls._BASE_ALL_PROPERTIES[style_cls]},
     }
-
-    mixin_dict["__doc__"] = (
-        f"""Allows accessing the {style_cls.__name__} {style_cls._doc_link} directly on
-        the widget. For example, instead of ``widget.style.color``, you can simply write
-        ``widget.color``.
-        """
-    )
 
     return type(style_cls.__name__ + "Mixin", (), mixin_dict)

--- a/travertino/src/travertino/declaration.py
+++ b/travertino/src/travertino/declaration.py
@@ -137,8 +137,7 @@ class validated_property:
         if obj is None:
             return self
 
-        value = getattr(obj, f"_{self.name}", None)
-        return self.initial if value is None else value
+        return getattr(obj, f"_{self.name}", self.initial)
 
     def __set__(self, obj, value):
         if value is self:

--- a/travertino/src/travertino/declaration.py
+++ b/travertino/src/travertino/declaration.py
@@ -406,7 +406,7 @@ class BaseStyle:
             raise KeyError(name)
 
     def keys(self):
-        return {name for name in self}
+        return {*self}
 
     def items(self):
         return [(name, self[name]) for name in self]


### PR DESCRIPTION
In #3086 and #3151, I found once I submitted to CI that I was running up against limitations of MicroPython's syntax in `style_mixin()` and `BaseStyle.keys()`, respectively. There's nothing *wrong* with what I ended up using instead... but I think my first drafts read better, and we're no longer bound by MicroPython.

While I was making stylistic cleanups, I also simplified a couple of lines in `validated_property.__get__()`.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
