### PR TITLE
Fix __contains__ check for directional_property

### DIFF
--- a/changes/3212.misc.rst
+++ b/changes/3212.misc.rst
@@ -1,0 +1,1 @@
+``__contains__`` checks for directional properties now no longer always erroneously return `True`.

--- a/travertino/src/travertino/properties/shorthand.py
+++ b/travertino/src/travertino/properties/shorthand.py
@@ -54,4 +54,4 @@ class directional_property:
             del obj[name]
 
     def is_set_on(self, obj):
-        return any(hasattr(obj, name) for name in self.property_names)
+        return any(name in obj for name in self.property_names)

--- a/travertino/tests/test_style.py
+++ b/travertino/tests/test_style.py
@@ -333,6 +333,7 @@ def test_directional_property(StyleClass):
     assert style.thing_right == 0
     assert style.thing_bottom == 0
     assert style.thing_left == 0
+    assert "thing" not in style
     style.apply.assert_not_called()
 
     # Set a value in one axis
@@ -343,6 +344,7 @@ def test_directional_property(StyleClass):
     assert style.thing_right == 0
     assert style.thing_bottom == 0
     assert style.thing_left == 0
+    assert "thing" in style
     style.apply.assert_called_once_with("thing_top")
 
     # Clear the applicator mock
@@ -356,6 +358,7 @@ def test_directional_property(StyleClass):
     assert style.thing_right == 10
     assert style.thing_bottom == 10
     assert style.thing_left == 10
+    assert "thing" in style
     style.apply.assert_has_calls(
         [
             call("thing_right"),
@@ -375,6 +378,7 @@ def test_directional_property(StyleClass):
     assert style.thing_right == 30
     assert style.thing_bottom == 30
     assert style.thing_left == 30
+    assert "thing" in style
     style.apply.assert_has_calls(
         [
             call("thing_top"),
@@ -387,7 +391,7 @@ def test_directional_property(StyleClass):
     # Clear the applicator mock
     style.apply.reset_mock()
 
-    # Set a value directly with a 2 values
+    # Set a value directly with 2 values
     style.thing = (10, 20)
 
     assert style.thing == (10, 20, 10, 20)
@@ -395,6 +399,7 @@ def test_directional_property(StyleClass):
     assert style.thing_right == 20
     assert style.thing_bottom == 10
     assert style.thing_left == 20
+    assert "thing" in style
     style.apply.assert_has_calls(
         [
             call("thing_top"),
@@ -407,7 +412,7 @@ def test_directional_property(StyleClass):
     # Clear the applicator mock
     style.apply.reset_mock()
 
-    # Set a value directly with a 3 values
+    # Set a value directly with 3 values
     style.thing = (10, 20, 30)
 
     assert style.thing == (10, 20, 30, 20)
@@ -415,12 +420,13 @@ def test_directional_property(StyleClass):
     assert style.thing_right == 20
     assert style.thing_bottom == 30
     assert style.thing_left == 20
+    assert "thing" in style
     style.apply.assert_called_once_with("thing_bottom")
 
     # Clear the applicator mock
     style.apply.reset_mock()
 
-    # Set a value directly with a 4 values
+    # Set a value directly with 4 values
     style.thing = (10, 20, 30, 40)
 
     assert style.thing == (10, 20, 30, 40)
@@ -428,6 +434,7 @@ def test_directional_property(StyleClass):
     assert style.thing_right == 20
     assert style.thing_bottom == 30
     assert style.thing_left == 40
+    assert "thing" in style
     style.apply.assert_called_once_with("thing_left")
 
     # Set a value directly with an invalid number of values
@@ -448,6 +455,7 @@ def test_directional_property(StyleClass):
     assert style.thing_right == 20
     assert style.thing_bottom == 30
     assert style.thing_left == 40
+    assert "thing" in style
     style.apply.assert_called_once_with("thing_top")
 
     # Restore the top thing
@@ -464,6 +472,7 @@ def test_directional_property(StyleClass):
     assert style.thing_right == 0
     assert style.thing_bottom == 0
     assert style.thing_left == 0
+    assert "thing" not in style
     style.apply.assert_has_calls(
         [
             call("thing_right"),


### PR DESCRIPTION
Because I wrote `hasattr(obj, name)` rather than `hasattr(obj, f"_{name}")`, the `is_set_on` method for `directional_property` currently looks for the existence of the descriptors themselves rather than the private stored values, and thus always returns `True`.

But even better than `hasattr(obj, f"_{name}")` is `name in obj`, to leverage the `is_set_on` method of each individual property in question.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
