### PR TITLE
Restore __init_subclass__

### DIFF
--- a/changes/3216.misc.rst
+++ b/changes/3216.misc.rst
@@ -1,0 +1,1 @@
+``BaseStyle.__init_subclass__`` has been restored, now that MicroPython compatibility is no longer a concern.

--- a/core/src/toga/style/mixin.py
+++ b/core/src/toga/style/mixin.py
@@ -23,7 +23,7 @@ def style_mixin(style_cls):
             simply write ``widget.color``.
             """
         ),
-        **{name: StyleProperty() for name in style_cls._BASE_ALL_PROPERTIES[style_cls]},
+        **{name: StyleProperty() for name in style_cls._ALL_PROPERTIES},
     }
 
     return type(style_cls.__name__ + "Mixin", (), mixin_dict)

--- a/travertino/src/travertino/style.py
+++ b/travertino/src/travertino/style.py
@@ -21,17 +21,12 @@ class BaseStyle:
     _BASE_PROPERTIES = defaultdict(set)
     _BASE_ALL_PROPERTIES = defaultdict(set)
 
-    # Give instances a direct reference to their properties.
+    def __init_subclass__(cls):
+        # Give the subclass a direct reference to its properties.
+        cls._PROPERTIES = cls._BASE_PROPERTIES[cls]
+        cls._ALL_PROPERTIES = cls._BASE_ALL_PROPERTIES[cls]
 
-    @property
-    def _PROPERTIES(self):
-        return self._BASE_PROPERTIES[type(self)]
-
-    @property
-    def _ALL_PROPERTIES(self):
-        return self._BASE_ALL_PROPERTIES[type(self)]
-
-    # Fallback in case subclass isn't decorated as subclass (probably from using
+    # Fallback in case subclass isn't decorated as dataclass (probably from using
     # previous API) or for pre-3.10, before kw_only argument existed.
     def __init__(self, **properties):
         self.update(**properties)


### PR DESCRIPTION
One more bit of MicroPython compatibility that's no longer needed, from #3086. Why not be five lines shorter? : )

Also fixes a typo in the comment below, which I could swear I'd already done. Maybe that was in an unmerged PR back in the old repository.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
