### PR TITLE
Support CSS font size keywords

### DIFF
--- a/changes/1814.misc.rst
+++ b/changes/1814.misc.rst
@@ -1,0 +1,1 @@
+Added support for CSS font size keywords in Android, Cocoa, GTK, iOS, and Windows.

--- a/cocoa/src/toga_cocoa/fonts.py
+++ b/cocoa/src/toga_cocoa/fonts.py
@@ -1,6 +1,12 @@
 from pathlib import Path
 
 from fontTools.ttLib import TTFont
+from travertino.constants import (
+    ABSOLUTE_FONT_SIZES,
+    FONT_SIZE_SCALE,
+    RELATIVE_FONT_SIZE_SCALE,
+    RELATIVE_FONT_SIZES,
+)
 
 from toga.fonts import (
     _REGISTERED_FONT_CACHE,
@@ -93,6 +99,22 @@ class Font:
 
             if self.interface.size == SYSTEM_DEFAULT_FONT_SIZE:
                 font_size = NSFont.systemFontSize
+            elif (
+                isinstance(self.interface.size, str)
+                and self.interface.size in ABSOLUTE_FONT_SIZES
+            ):
+                base_size = NSFont.systemFontSize
+                font_size = base_size * FONT_SIZE_SCALE.get(self.interface.size, 1.0)
+            elif (
+                isinstance(self.interface.size, str)
+                and self.interface.size in RELATIVE_FONT_SIZES
+            ):
+                parent_size = getattr(
+                    self.interface, "_parent_size", NSFont.systemFontSize
+                )
+                font_size = parent_size * RELATIVE_FONT_SIZE_SCALE.get(
+                    self.interface.size, 1.0
+                )
             else:
                 # A "point" in Apple APIs is equivalent to a CSS pixel, but the Toga
                 # public API works in CSS points, which are slightly larger

--- a/cocoa/tests_backend/fonts.py
+++ b/cocoa/tests_backend/fonts.py
@@ -1,3 +1,9 @@
+from travertino.constants import (
+    FONT_SIZE_SCALE,
+    RELATIVE_FONT_SIZE_SCALE,
+    RELATIVE_FONT_SIZES,
+)
+
 from toga.fonts import (
     BOLD,
     CURSIVE,
@@ -48,6 +54,16 @@ class FontMixin:
     def assert_font_size(self, expected):
         if expected == SYSTEM_DEFAULT_FONT_SIZE:
             assert self.font.pointSize == 13
+        elif isinstance(expected, str):
+            base_size = 13
+            if expected in RELATIVE_FONT_SIZES:
+                parent_size = getattr(self, "_parent_size", base_size)
+                expected_size = parent_size * RELATIVE_FONT_SIZE_SCALE.get(
+                    expected, 1.0
+                )
+            else:
+                expected_size = base_size * FONT_SIZE_SCALE.get(expected, 1.0)
+            assert abs(self.font.pointSize - expected_size) < 0.01
         else:
             assert self.font.pointSize == expected * 96 / 72
 

--- a/core/src/toga/fonts.py
+++ b/core/src/toga/fonts.py
@@ -5,6 +5,7 @@ from pathlib import Path
 # Use the Travertino font definitions as-is
 from travertino import constants
 from travertino.constants import (
+    ABSOLUTE_FONT_SIZES,
     BOLD,
     CURSIVE,
     FANTASY,
@@ -13,6 +14,7 @@ from travertino.constants import (
     MONOSPACE,
     NORMAL,
     OBLIQUE,
+    RELATIVE_FONT_SIZES,
     SANS_SERIF,
     SERIF,
     SMALL_CAPS,
@@ -62,7 +64,11 @@ class Font(BaseFont):
         size = (
             "default size"
             if self.size == SYSTEM_DEFAULT_FONT_SIZE
-            else f"{self.size}pt"
+            else (
+                f"{self.size}"
+                if self.size in ABSOLUTE_FONT_SIZES or self.size in RELATIVE_FONT_SIZES
+                else f"{self.size}pt"
+            )
         )
         weight = f" {self.weight}" if self.weight != NORMAL else ""
         variant = f" {self.variant}" if self.variant != NORMAL else ""

--- a/core/src/toga/style/pack.py
+++ b/core/src/toga/style/pack.py
@@ -7,6 +7,7 @@ if TYPE_CHECKING:
     from travertino.colors import rgb, hsl
 
 from travertino.constants import (  # noqa: F401
+    ABSOLUTE_FONT_SIZES,
     BOLD,
     BOTTOM,
     CENTER,
@@ -23,6 +24,7 @@ from travertino.constants import (  # noqa: F401
     NONE,
     NORMAL,
     OBLIQUE,
+    RELATIVE_FONT_SIZES,
     RIGHT,
     ROW,
     RTL,
@@ -107,7 +109,12 @@ class Pack(BaseStyle):
     font_style: str = validated_property(*FONT_STYLES, initial=NORMAL)
     font_variant: str = validated_property(*FONT_VARIANTS, initial=NORMAL)
     font_weight: str = validated_property(*FONT_WEIGHTS, initial=NORMAL)
-    font_size: int = validated_property(integer=True, initial=SYSTEM_DEFAULT_FONT_SIZE)
+    font_size: int | str = validated_property(
+        *ABSOLUTE_FONT_SIZES,
+        *RELATIVE_FONT_SIZES,
+        integer=True,
+        initial=SYSTEM_DEFAULT_FONT_SIZE,
+    )
 
     @classmethod
     def _debug(cls, *args: str) -> None:  # pragma: no cover
@@ -930,7 +937,13 @@ class Pack(BaseStyle):
             else:
                 css.append(f"font-family: {self.font_family};")
         if self.font_size != SYSTEM_DEFAULT_FONT_SIZE:
-            css.append(f"font-size: {self.font_size}pt;")
+            if isinstance(self.font_size, str) and (
+                self.font_size in ABSOLUTE_FONT_SIZES
+                or self.font_size in RELATIVE_FONT_SIZES
+            ):
+                css.append(f"font-size: {self.font_size};")
+            else:
+                css.append(f"font-size: {self.font_size}pt;")
         if self.font_weight != NORMAL:
             css.append(f"font-weight: {self.font_weight};")
         if self.font_style != NORMAL:

--- a/core/tests/style/pack/test_css.py
+++ b/core/tests/style/pack/test_css.py
@@ -450,6 +450,31 @@ from toga.style.pack import (
             id="font-size",
         ),
         pytest.param(
+            Pack(font_size="smaller"),
+            "flex-direction: row; flex: 0.0 0 auto; font-size: smaller;",
+            id="font-size-smaller",
+        ),
+        pytest.param(
+            Pack(font_size="small"),
+            "flex-direction: row; flex: 0.0 0 auto; font-size: small;",
+            id="font-size-small",
+        ),
+        pytest.param(
+            Pack(font_size="xx-small"),
+            "flex-direction: row; flex: 0.0 0 auto; font-size: xx-small;",
+            id="font-size-xx-small",
+        ),
+        pytest.param(
+            Pack(font_size="x-large"),
+            "flex-direction: row; flex: 0.0 0 auto; font-size: x-large;",
+            id="font-size-x-large",
+        ),
+        pytest.param(
+            Pack(font_size="large"),
+            "flex-direction: row; flex: 0.0 0 auto; font-size: large;",
+            id="font-size-large",
+        ),
+        pytest.param(
             Pack(font_size=SYSTEM_DEFAULT_FONT_SIZE),
             "flex-direction: row; flex: 0.0 0 auto;",
             id="font-size-explicit-default",

--- a/core/tests/test_fonts.py
+++ b/core/tests/test_fonts.py
@@ -95,6 +95,87 @@ def app():
             NORMAL,
             "system default size",
         ),
+        # Custom font, small size
+        (
+            "Custom Font",
+            "small",
+            NORMAL,
+            NORMAL,
+            NORMAL,
+            "Custom Font small",
+        ),
+        # System font, medium size
+        (
+            SYSTEM,
+            "medium",
+            NORMAL,
+            NORMAL,
+            NORMAL,
+            "system medium",
+        ),
+        # System font, large size
+        (
+            SYSTEM,
+            "large",
+            NORMAL,
+            NORMAL,
+            NORMAL,
+            "system large",
+        ),
+        # System font, x-small size
+        (
+            SYSTEM,
+            "x-small",
+            NORMAL,
+            NORMAL,
+            NORMAL,
+            "system x-small",
+        ),
+        # System font, xx-small size
+        (
+            SYSTEM,
+            "xx-small",
+            NORMAL,
+            NORMAL,
+            NORMAL,
+            "system xx-small",
+        ),
+        # System font, xx-large size
+        (
+            SYSTEM,
+            "xx-large",
+            NORMAL,
+            NORMAL,
+            NORMAL,
+            "system xx-large",
+        ),
+        # System font, x-large size
+        (
+            SYSTEM,
+            "x-large",
+            NORMAL,
+            NORMAL,
+            NORMAL,
+            "system x-large",
+        ),
+        # Custom font, smaller size
+        (
+            "Custom Font",
+            "smaller",
+            NORMAL,
+            NORMAL,
+            NORMAL,
+            "Custom Font smaller",
+        ),
+        # Custom font, larger size
+        (
+            "Custom Font",
+            "larger",
+            NORMAL,
+            NORMAL,
+            NORMAL,
+            "Custom Font larger",
+        ),
     ],
 )
 def test_builtin_font(family, size, weight, style, variant, as_str):

--- a/docs/reference/style/pack.rst
+++ b/docs/reference/style/pack.rst
@@ -287,11 +287,18 @@ The weight of the font to be used.
 ``font_size``
 -------------
 
-**Values:** ``<integer>``
+**Values:**
+    - ``<integer>`` (in :ref:`CSS points <css-units>`)
+    - Absolute keywords: ``xx-small`` | ``x-small`` | ``small`` | ``medium`` | ``large`` | ``x-large`` | ``xx-large``
+    - Relative keywords: ``larger`` | ``smaller``
 
 **Initial value:** System default
 
-The size of the font to be used, in :ref:`CSS points <css-units>`.
+The size of the font to be used. Can be specified in three ways:
+
+* An integer value in :ref:`CSS points <css-units>`
+* An absolute size keyword, which sets the size relative to the system's base font size
+* A relative size keyword, which adjusts the size relative to the parent element's font size
 
 The relationship between Pack and CSS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/gtk/src/toga_gtk/fonts.py
+++ b/gtk/src/toga_gtk/fonts.py
@@ -1,6 +1,11 @@
 from pathlib import Path
 from warnings import warn
 
+from travertino.constants import (
+    ABSOLUTE_FONT_SIZES,
+    RELATIVE_FONT_SIZES,
+)
+
 from toga.fonts import (
     _REGISTERED_FONT_CACHE,
     BOLD,
@@ -78,8 +83,13 @@ class Font:
 
             font.set_family(family)
 
-            # If this is a non-default font size, set the font size
-            if self.interface.size != SYSTEM_DEFAULT_FONT_SIZE:
+            # Default font as well as values in absolute and relative font
+            # size are handled by Pango. Otherwise set font size manually.
+            if (
+                self.interface.size != SYSTEM_DEFAULT_FONT_SIZE
+                and self.interface.size not in ABSOLUTE_FONT_SIZES
+                and self.interface.size not in RELATIVE_FONT_SIZES
+            ):
                 font.set_size(self.interface.size * Pango.SCALE)
 
             # Set font style

--- a/gtk/src/toga_gtk/libs/styles.py
+++ b/gtk/src/toga_gtk/libs/styles.py
@@ -1,3 +1,8 @@
+from travertino.constants import (
+    ABSOLUTE_FONT_SIZES,
+    RELATIVE_FONT_SIZES,
+)
+
 from toga.colors import TRANSPARENT
 from toga.fonts import SYSTEM_DEFAULT_FONT_SIZE
 
@@ -61,7 +66,10 @@ def get_font_css(value):
         "font-family": f"{value.family!r}",
     }
 
-    if value.size != SYSTEM_DEFAULT_FONT_SIZE:
+    # If value is an absolute or relative keyword, use those to set size instead
+    if value.size in ABSOLUTE_FONT_SIZES or value.size in RELATIVE_FONT_SIZES:
+        style["font-size"] = f"{value.size}"
+    elif value.size != SYSTEM_DEFAULT_FONT_SIZE:
         style["font-size"] = f"{value.size}pt"
 
     return style

--- a/gtk/tests_backend/fonts.py
+++ b/gtk/tests_backend/fonts.py
@@ -1,3 +1,10 @@
+from travertino.constants import (
+    ABSOLUTE_FONT_SIZES,
+    FONT_SIZE_SCALE,
+    RELATIVE_FONT_SIZE_SCALE,
+    RELATIVE_FONT_SIZES,
+)
+
 from toga.fonts import (
     BOLD,
     ITALIC,
@@ -29,6 +36,12 @@ class FontMixin:
             assert expected == SYSTEM_DEFAULT_FONT_SIZE
         elif expected == SYSTEM_DEFAULT_FONT_SIZE:
             assert 8 < int(self.font.get_size() / Pango.SCALE) < 18
+        elif expected in ABSOLUTE_FONT_SIZES:
+            scale = FONT_SIZE_SCALE.get(expected, 1.0)
+            assert 8 * scale < int(self.font.get_size() / Pango.SCALE) < 18 * scale
+        elif expected in RELATIVE_FONT_SIZES:
+            scale = RELATIVE_FONT_SIZE_SCALE.get(expected, 1.0)
+            assert 8 * scale < int(self.font.get_size() / Pango.SCALE) < 18 * scale
         else:
             assert int(self.font.get_size() / Pango.SCALE) == expected
 

--- a/gtk/tests_backend/fonts.py
+++ b/gtk/tests_backend/fonts.py
@@ -40,8 +40,14 @@ class FontMixin:
             scale = FONT_SIZE_SCALE.get(expected, 1.0)
             assert 8 * scale < int(self.font.get_size() / Pango.SCALE) < 18 * scale
         elif expected in RELATIVE_FONT_SIZES:
+            parent_size = getattr(
+                self, "_parent_size", self.font.get_size() / Pango.SCALE
+            )
             scale = RELATIVE_FONT_SIZE_SCALE.get(expected, 1.0)
-            assert 8 * scale < int(self.font.get_size() / Pango.SCALE) < 18 * scale
+            expected = parent_size * scale
+            assert (
+                abs(expected - int(self.font.get_size() / Pango.SCALE)) <= 5
+            )  # Same as checking 8 to 18
         else:
             assert int(self.font.get_size() / Pango.SCALE) == expected
 

--- a/iOS/src/toga_iOS/fonts.py
+++ b/iOS/src/toga_iOS/fonts.py
@@ -1,6 +1,12 @@
 from pathlib import Path
 
 from fontTools.ttLib import TTFont
+from travertino.constants import (
+    ABSOLUTE_FONT_SIZES,
+    FONT_SIZE_SCALE,
+    RELATIVE_FONT_SIZE_SCALE,
+    RELATIVE_FONT_SIZES,
+)
 
 from toga.fonts import (
     _REGISTERED_FONT_CACHE,
@@ -92,6 +98,23 @@ class Font:
 
             if self.interface.size == SYSTEM_DEFAULT_FONT_SIZE:
                 size = UIFont.labelFontSize
+            elif (
+                isinstance(self.interface.size, str)
+                and self.interface.size in ABSOLUTE_FONT_SIZES
+            ):
+                base_size = UIFont.labelFontSize
+                size = base_size * FONT_SIZE_SCALE.get(self.interface.size, 1.0)
+            elif (
+                isinstance(self.interface.size, str)
+                and self.interface.size in RELATIVE_FONT_SIZES
+            ):
+                # Get the parent's font size, or use MEDIUM as fallback
+                parent_size = getattr(
+                    self.interface, "_parent_size", UIFont.labelFontSize
+                )
+                size = parent_size * RELATIVE_FONT_SIZE_SCALE.get(
+                    self.interface.size, 1.0
+                )
             else:
                 # A "point" in Apple APIs is equivalent to a CSS pixel, but the Toga
                 # public API works in CSS points, which are slightly larger

--- a/iOS/tests_backend/fonts.py
+++ b/iOS/tests_backend/fonts.py
@@ -1,3 +1,9 @@
+from travertino.constants import (
+    FONT_SIZE_SCALE,
+    RELATIVE_FONT_SIZE_SCALE,
+    RELATIVE_FONT_SIZES,
+)
+
 from toga.fonts import (
     BOLD,
     CURSIVE,
@@ -51,6 +57,18 @@ class FontMixin:
     def assert_font_size(self, expected):
         if expected == SYSTEM_DEFAULT_FONT_SIZE:
             assert self.font.pointSize == 17
+        elif isinstance(expected, str):
+            base_size = 17
+            if expected in RELATIVE_FONT_SIZES:
+                # For relative sizes, we need to know the parent size
+                # In tests, assume MEDIUM as the parent size if not specified
+                parent_size = getattr(self, "_parent_size", base_size)
+                expected_size = parent_size * RELATIVE_FONT_SIZE_SCALE.get(
+                    expected, 1.0
+                )
+            else:
+                expected_size = base_size * FONT_SIZE_SCALE.get(expected, 1.0)
+            assert abs(self.font.pointSize - expected_size) < 0.01
         else:
             assert self.font.pointSize == expected * 96 / 72
 

--- a/testbed/tests/test_fonts.py
+++ b/testbed/tests/test_fonts.py
@@ -1,6 +1,10 @@
 from importlib import import_module
 
 import pytest
+from travertino.constants import (
+    ABSOLUTE_FONT_SIZES,
+    RELATIVE_FONT_SIZES,
+)
 
 import toga
 from toga.fonts import (
@@ -53,7 +57,12 @@ async def test_use_system_font_fallback(
 async def test_font_options(widget: toga.Label, font_probe):
     """Every combination of weight, style and variant can be used on a font."""
     for font_family in SYSTEM_DEFAULT_FONTS:
-        for font_size in [20, SYSTEM_DEFAULT_FONT_SIZE]:
+        for font_size in [
+            20,
+            SYSTEM_DEFAULT_FONT_SIZE,
+            *ABSOLUTE_FONT_SIZES,
+            *RELATIVE_FONT_SIZES,
+        ]:
             for font_weight in FONT_WEIGHTS:
                 for font_style in FONT_STYLES:
                     for font_variant in FONT_VARIANTS:

--- a/travertino/src/travertino/constants.py
+++ b/travertino/src/travertino/constants.py
@@ -90,7 +90,6 @@ MEDIUM = "medium"
 LARGE = "large"
 X_LARGE = "x-large"
 XX_LARGE = "xx-large"
-XXX_LARGE = "xxx-large"
 
 ABSOLUTE_FONT_SIZES = {
     XX_SMALL,
@@ -100,13 +99,29 @@ ABSOLUTE_FONT_SIZES = {
     LARGE,
     X_LARGE,
     XX_LARGE,
-    XXX_LARGE,
 }
 
 LARGER = "larger"
 SMALLER = "smaller"
 
 RELATIVE_FONT_SIZES = {LARGER, SMALLER}
+
+FONT_SIZE_SCALE_FACTOR = 1.2
+
+FONT_SIZE_SCALE = {
+    XX_SMALL: 0.512,  # ~(1/FONT_SIZE_SCALE_FACTOR)^3 - 60% smaller
+    X_SMALL: 0.64,  # ~(1/FONT_SIZE_SCALE_FACTOR)^2 - 40% smaller
+    SMALL: 0.8,  # ~(1/FONT_SIZE_SCALE_FACTOR) - 20% smaller
+    MEDIUM: 1.0,  # baseline
+    LARGE: 1.2,  # ~FONT_SIZE_SCALE_FACTOR - 20% larger
+    X_LARGE: 1.44,  # ~FONT_SIZE_SCALE_FACTOR^2 - 40% larger
+    XX_LARGE: 1.728,  # ~FONT_SIZE_SCALE_FACTOR^3 - 60% larger
+}
+
+RELATIVE_FONT_SIZE_SCALE = {
+    LARGER: FONT_SIZE_SCALE_FACTOR,  # 20% larger
+    SMALLER: 1 / FONT_SIZE_SCALE_FACTOR,  # 20% smaller
+}
 
 ######################################################################
 # Colors

--- a/travertino/src/travertino/fonts.py
+++ b/travertino/src/travertino/fonts.py
@@ -1,4 +1,5 @@
 from .constants import (
+    ABSOLUTE_FONT_SIZES,
     BOLD,
     FONT_STYLES,
     FONT_VARIANTS,
@@ -6,6 +7,7 @@ from .constants import (
     ITALIC,
     NORMAL,
     OBLIQUE,
+    RELATIVE_FONT_SIZES,
     SMALL_CAPS,
     SYSTEM_DEFAULT_FONT_SIZE,
 )
@@ -26,6 +28,11 @@ class Font:
             try:
                 if size.strip().endswith("pt"):
                     self.size = int(size[:-2])
+                elif (
+                    size.strip() in ABSOLUTE_FONT_SIZES
+                    or size.strip() in RELATIVE_FONT_SIZES
+                ):
+                    self.size = size.strip()
                 else:
                     raise ValueError(f"Invalid font size {size!r}")
             except Exception:
@@ -47,7 +54,9 @@ class Font:
             (
                 "system default size"
                 if self.size == SYSTEM_DEFAULT_FONT_SIZE
-                else f"{self.size}pt"
+                else (
+                    f"{self.size}" if isinstance(self.size, str) else f"{self.size}pt"
+                )
             ),
             self.family,
         )

--- a/travertino/tests/test_fonts.py
+++ b/travertino/tests/test_fonts.py
@@ -1,12 +1,23 @@
 import pytest
 
 from travertino.constants import (
+    ABSOLUTE_FONT_SIZES,
     BOLD,
     ITALIC,
+    LARGE,
+    LARGER,
+    MEDIUM,
     NORMAL,
     OBLIQUE,
+    RELATIVE_FONT_SIZES,
+    SMALL,
     SMALL_CAPS,
+    SMALLER,
     SYSTEM_DEFAULT_FONT_SIZE,
+    X_LARGE,
+    X_SMALL,
+    XX_LARGE,
+    XX_SMALL,
 )
 from travertino.fonts import Font
 
@@ -79,9 +90,61 @@ def test_simple_construction(size):
     assert_font(Font("Comic Sans", size), "Comic Sans", 12, NORMAL, NORMAL, NORMAL)
 
 
+@pytest.mark.parametrize(
+    "size",
+    [
+        XX_SMALL,
+        X_SMALL,
+        SMALL,
+        MEDIUM,
+        LARGE,
+        X_LARGE,
+        XX_LARGE,
+        LARGER,
+        SMALLER,
+    ],
+)
+def test_css_font_size_keywords(size):
+    font = Font("Comic Sans", size)
+    assert_font(font, "Comic Sans", size, NORMAL, NORMAL, NORMAL)
+    assert isinstance(font.size, str)
+    assert font.size in ABSOLUTE_FONT_SIZES or font.size in RELATIVE_FONT_SIZES
+
+
+@pytest.mark.parametrize(
+    "size, expected_repr",
+    [
+        (XX_SMALL, "<Font: xx-small Comic Sans>"),
+        (X_SMALL, "<Font: x-small Comic Sans>"),
+        (SMALL, "<Font: small Comic Sans>"),
+        (MEDIUM, "<Font: medium Comic Sans>"),
+        (LARGE, "<Font: large Comic Sans>"),
+        (X_LARGE, "<Font: x-large Comic Sans>"),
+        (XX_LARGE, "<Font: xx-large Comic Sans>"),
+        (LARGER, "<Font: larger Comic Sans>"),
+        (SMALLER, "<Font: smaller Comic Sans>"),
+    ],
+)
+def test_css_font_size_repr(size, expected_repr):
+    font = Font("Comic Sans", size)
+    assert repr(font) == expected_repr
+
+
 def test_invalid_construction():
     with pytest.raises(ValueError):
         Font("Comic Sans", "12 quatloos")
+
+    with pytest.raises(ValueError):
+        Font("Comic Sans", "invalid-size")
+
+    with pytest.raises(ValueError):
+        Font("Comic Sans", "")
+
+    try:
+        Font("Comic Sans", None)
+        assert False, "Should have raised TypeError"
+    except TypeError:
+        pass
 
 
 @pytest.mark.parametrize(

--- a/winforms/src/toga_winforms/fonts.py
+++ b/winforms/src/toga_winforms/fonts.py
@@ -8,6 +8,13 @@ from System.Drawing import (
 from System.Drawing.Text import PrivateFontCollection
 from System.IO import FileNotFoundException
 from System.Runtime.InteropServices import ExternalException
+from travertino.constants import (
+    ABSOLUTE_FONT_SIZES,
+    FONT_SIZE_SCALE,
+    RELATIVE_FONT_SIZE_SCALE,
+    RELATIVE_FONT_SIZES,
+    SYSTEM_DEFAULT_FONT_SIZE,
+)
 
 from toga.fonts import (
     _REGISTERED_FONT_CACHE,
@@ -18,7 +25,6 @@ from toga.fonts import (
     SANS_SERIF,
     SERIF,
     SYSTEM,
-    SYSTEM_DEFAULT_FONT_SIZE,
 )
 
 _FONT_CACHE = {}
@@ -93,6 +99,18 @@ class Font:
             # Convert font size to Winforms format
             if self.interface.size == SYSTEM_DEFAULT_FONT_SIZE:
                 font_size = DEFAULT_FONT.Size
+            elif (
+                isinstance(self.interface.size, str)
+                and self.interface.size in ABSOLUTE_FONT_SIZES
+            ):
+                font_size = DEFAULT_FONT.Size
+                font_size *= FONT_SIZE_SCALE.get(self.interface.size, 1.0)
+            elif (
+                isinstance(self.interface.size, str)
+                and self.interface.size in RELATIVE_FONT_SIZES
+            ):
+                font_size = getattr(self.interface, "_parent_size", DEFAULT_FONT.Size)
+                font_size *= RELATIVE_FONT_SIZE_SCALE.get(self.interface.size, 1.0)
             else:
                 font_size = self.interface.size
 

--- a/winforms/tests_backend/fonts.py
+++ b/winforms/tests_backend/fonts.py
@@ -1,4 +1,9 @@
 from System.Drawing import FontFamily, SystemFonts
+from travertino.constants import (
+    FONT_SIZE_SCALE,
+    RELATIVE_FONT_SIZE_SCALE,
+    RELATIVE_FONT_SIZES,
+)
 
 from toga.fonts import (
     BOLD,
@@ -45,8 +50,15 @@ class FontMixin:
 
     def assert_font_size(self, expected):
         if expected == SYSTEM_DEFAULT_FONT_SIZE:
-            expected = 9
-        assert self.font_size == expected
+            expected = 9.0
+        elif isinstance(expected, str):
+            base_size = 9.0
+            if expected in RELATIVE_FONT_SIZES:
+                parent_size = getattr(self, "_parent_size", base_size)
+                expected = parent_size * RELATIVE_FONT_SIZE_SCALE.get(expected, 1.0)
+            else:
+                expected = base_size * FONT_SIZE_SCALE.get(expected, 1.0)
+        assert abs(self.font.SizeInPoints - expected) < 0.1
 
     def assert_font_family(self, expected):
         assert str(self.font.Name) == {


### PR DESCRIPTION
Added backend support for CSS font-size keywords to Android, Cocoa, iOS, GTK, and Windows and updated the core and travertino testing suites. Includes updated documentation. 

Fixes issue #1814

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x ] All new features have been tested
- [ x] All new features have been documented
- [ x] I have read the **CONTRIBUTING.md** file
- [ x] I will abide by the code of conduct
