### PR TITLE
Update BaseStyle.apply() signature

### DIFF
--- a/changes/3257.misc.rst
+++ b/changes/3257.misc.rst
@@ -1,0 +1,1 @@
+The new signature for ``Pack.apply()`` from #3160 is now reflected in ``BaseStyle.apply()``.

--- a/travertino/src/travertino/style.py
+++ b/travertino/src/travertino/style.py
@@ -92,7 +92,7 @@ class BaseStyle:
     # Interface that style declarations must define
     ######################################################################
 
-    def apply(self, name):
+    def apply(self, *names):
         raise NotImplementedError(
             "Style must define an apply method"
         )  # pragma: no cover


### PR DESCRIPTION
An oversight in #3160: the signature in `BaseStyle.apply()` was never updated to match the new signature of `Pack.apply()`.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
