### PR TITLE
Refresh widget layout on text_direction change

### DIFF
--- a/changes/3268.bugfix.rest
+++ b/changes/3268.bugfix.rest
@@ -1,0 +1,1 @@
+Changing a widget's ``text_direction`` now triggers a layout refresh, since it can affect child positioning.

--- a/core/src/toga/style/pack.py
+++ b/core/src/toga/style/pack.py
@@ -285,6 +285,9 @@ class Pack(BaseStyle):
                         self._applicator.set_text_align(
                             RIGHT if self.text_direction == RTL else LEFT
                         )
+                    # Text direction affects how align_items (for a column) or
+                    # justify_content (for a row) is rendered.
+                    self._applicator.refresh()
                 elif name == "color":
                     self._applicator.set_color(self.color)
                 elif name == "background_color":

--- a/core/tests/style/test_applicator.py
+++ b/core/tests/style/test_applicator.py
@@ -3,15 +3,33 @@ import pytest
 from toga.colors import REBECCAPURPLE
 from toga.fonts import FANTASY
 from toga.style import TogaApplicator
-from toga.style.pack import HIDDEN, RIGHT, VISIBLE
-from toga_dummy.utils import assert_action_performed_with
+from toga.style.pack import (
+    BOLD,
+    CENTER,
+    COLUMN,
+    HIDDEN,
+    ITALIC,
+    NONE,
+    RIGHT,
+    RTL,
+    SMALL_CAPS,
+    VISIBLE,
+)
+from toga_dummy.utils import (
+    EventLog,
+    assert_action_not_performed,
+    assert_action_performed_with,
+)
 
 from ..utils import ExampleLeafWidget, ExampleWidget
 
 
 @pytest.fixture
 def grandchild():
-    return ExampleLeafWidget(id="grandchild_id")
+    widget = ExampleLeafWidget(id="grandchild_id")
+
+    EventLog.reset()
+    return widget
 
 
 @pytest.fixture
@@ -19,6 +37,7 @@ def child(grandchild):
     child = ExampleWidget(id="child_id")
     child.add(grandchild)
 
+    EventLog.reset()
     return child
 
 
@@ -27,6 +46,7 @@ def widget(child):
     widget = ExampleWidget(id="widget_id")
     widget.add(child)
 
+    EventLog.reset()
     return widget
 
 
@@ -153,3 +173,48 @@ def test_widget_alias_to_node(widget):
 
     assert applicator.widget is widget
     assert applicator.widget is applicator.node
+
+
+@pytest.mark.parametrize(
+    "name, value",
+    [
+        ("display", NONE),
+        ("direction", COLUMN),
+        ("align_items", CENTER),
+        ("justify_content", CENTER),
+        ("gap", 5),
+        ("width", 100),
+        ("height", 100),
+        ("flex", 5),
+        ("margin", 5),
+        ("margin_top", 5),
+        ("margin_right", 5),
+        ("margin_bottom", 5),
+        ("margin_left", 5),
+        ("text_direction", RTL),
+        ("font_family", "A Family"),
+        ("font_style", ITALIC),
+        ("font_variant", SMALL_CAPS),
+        ("font_weight", BOLD),
+        ("font_size", 12),
+    ],
+)
+def test_layout_properties(widget, name, value):
+    """Setting a property that could affect layout triggers a refresh."""
+    setattr(widget.style, name, value)
+    assert_action_performed_with(widget, "refresh")
+
+
+@pytest.mark.parametrize(
+    "name, value",
+    [
+        ("text_align", RIGHT),
+        ("color", REBECCAPURPLE),
+        ("background_color", REBECCAPURPLE),
+        ("visibility", HIDDEN),
+    ],
+)
+def test_non_layout_properties(widget, name, value):
+    """Setting a property that can't affect layout shouldn't trigger a refresh."""
+    setattr(widget.style, name, value)
+    assert_action_not_performed(widget, "refresh")


### PR DESCRIPTION
Some style properties trigger a widget refresh / layout recalculation when changed, and some don't. `text_direction` has, until now, been one of the latter. However, now that we have `align_items` and `justify_content`, changing `text_direction` can, in fact, alter how children are aligned.

I don't think there was an existing test of specifically which properties trigger a refresh and which didn't, so I've added those. At first I had an issue, in that `assert_action_not_performed(widget, "refresh")` always failed; this was because `refresh` was getting called in the fixture, before my test even received the widget. This also means that `test_refresh` could get a false positive:

```python
def test_refresh(widget):
    """Refresh requests are passed to the widget."""
    widget.applicator.refresh()

    assert_action_performed_with(widget, "refresh")
```

So I added an `EventLog.reset()` to each fixture before it returns its widget.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
