### PR TITLE
Correct end-of-life handling for Winforms Proactor.

### DIFF
--- a/changes/3266.bugfix.rst
+++ b/changes/3266.bugfix.rst
@@ -1,0 +1,1 @@
+The asyncio event loop used on Winforms now shuts down correctly, ensuring there are no dangling resources on application exit.

--- a/winforms/src/toga_winforms/app.py
+++ b/winforms/src/toga_winforms/app.py
@@ -168,6 +168,8 @@ class App:
             # preserve the Python stacktrace
             self._exception = e
         else:
+            # Ensure the event loop is fully closed.
+            self.loop.close()
             self._exception = None
 
     def main_loop(self):

--- a/winforms/src/toga_winforms/libs/proactor.py
+++ b/winforms/src/toga_winforms/libs/proactor.py
@@ -87,7 +87,10 @@ class WinformsProactorEventLoop(asyncio.ProactorEventLoop):
         self.task = Action[Task](self.tick)
         Task.Delay(5).ContinueWith(self.task)
 
-    def tick(self, *args, **kwargs):
+    # This function doesn't report as covered because it runs on a
+    # non-Python-created thread (see App.run_app). But it must actually be
+    # covered, otherwise nothing would work.
+    def tick(self, *args, **kwargs):  # pragma: no cover
         """Cause a single iteration of the event loop to run on the main GUI thread."""
         action = Action(self.run_once_recurring)
         self.app.app_dispatcher.Invoke(action)
@@ -99,7 +102,8 @@ class WinformsProactorEventLoop(asyncio.ProactorEventLoop):
         assert self._inner_loop is None
         self._inner_loop = (callback, args)
 
-    def winforms_application_exit(self, app, event):
+    # We can't get coverage for app shutdown, so this handler must be no-cover.
+    def winforms_application_exit(self, app, event):  # pragma: no cover
         """Perform cleanup that needs to occur when the app exits.
 
         This largely duplicates the "finally" behavior of the default Proactor
@@ -128,8 +132,10 @@ class WinformsProactorEventLoop(asyncio.ProactorEventLoop):
         try:
             # If the app is exiting, stop the asyncio event loop.
             # Otherwise, perform one more tick of the event loop.
+            # We can't get coverage of app shutdown, so that branch
+            # is marked no cover
             if self.app._is_exiting:
-                self.stop()
+                self.stop()  # pragma: no cover
             else:
                 self._run_once()
 

--- a/winforms/src/toga_winforms/libs/proactor.py
+++ b/winforms/src/toga_winforms/libs/proactor.py
@@ -8,6 +8,8 @@ import System.Windows.Forms as WinForms
 from System import Action
 from System.Threading.Tasks import Task
 
+from .wrapper import WeakrefCallable
+
 
 class WinformsProactorEventLoop(asyncio.ProactorEventLoop):
     def run_forever(self, app):
@@ -66,7 +68,12 @@ class WinformsProactorEventLoop(asyncio.ProactorEventLoop):
         # single iteration of the asyncio event loop to be executed. Each time
         # we do this, we queue *another* tick() message in 5ms time. In this
         # way, we'll get a continuous stream of tick() calls, without blocking
-        # the Winforms event loop.
+        # the Winforms event loop. We also add a handler for ApplicationExit
+        # to ensure that loop cleanup occurs when the app exits.
+
+        WinForms.Application.ApplicationExit += WeakrefCallable(
+            self.winforms_application_exit
+        )
 
         # Queue the first asyncio tick.
         self.enqueue_tick()
@@ -77,19 +84,13 @@ class WinformsProactorEventLoop(asyncio.ProactorEventLoop):
 
     def enqueue_tick(self):
         # Queue a call to tick in 5ms.
-        if not self.app._is_exiting:  # pragma: no branch
-            self.task = Action[Task](self.tick)
-            Task.Delay(5).ContinueWith(self.task)
+        self.task = Action[Task](self.tick)
+        Task.Delay(5).ContinueWith(self.task)
 
     def tick(self, *args, **kwargs):
         """Cause a single iteration of the event loop to run on the main GUI thread."""
-
-        # This function doesn't report as covered, probably because it runs on a
-        # non-Python-created thread (see App.run_app). But it must actually be covered,
-        # otherwise nothing would work.
-        if not self.app._is_exiting:  # pragma: no cover
-            action = Action(self.run_once_recurring)
-            self.app.app_dispatcher.Invoke(action)
+        action = Action(self.run_once_recurring)
+        self.app.app_dispatcher.Invoke(action)
 
     # The native dialog `Show` methods are all blocking, as they run an inner native
     # event loop. Call them via this method to ensure the inner loop is correctly linked
@@ -98,45 +99,51 @@ class WinformsProactorEventLoop(asyncio.ProactorEventLoop):
         assert self._inner_loop is None
         self._inner_loop = (callback, args)
 
-    def run_once_recurring(self):
-        """Run one iteration of the event loop, and enqueue the next iteration (if we're
-        not stopping).
+    def winforms_application_exit(self, app, event):
+        """Perform cleanup that needs to occur when the app exits.
 
         This largely duplicates the "finally" behavior of the default Proactor
         run_forever implementation.
         """
+        if sys.version_info < (3, 13):
+            # If we're stopping, we can do the "finally" handling from
+            # the BaseEventLoop run_forever(). In Python 3.13.0a2, this
+            # was refactored into the `_run_forever_cleanup()` helper.
+            # We run testbed on Py3.12, so the else branch is marked
+            # nocover.
+            # === START BaseEventLoop.run_forever() finally handling ===
+            self._stopping = False
+            self._thread_id = None
+            events._set_running_loop(None)
+            self._set_coroutine_origin_tracking(False)
+            sys.set_asyncgen_hooks(*self._old_agen_hooks)
+            # === END BaseEventLoop.run_forever() finally handling ===
+        else:  # pragma: no cover
+            self._run_forever_cleanup()
+
+    def run_once_recurring(self):
+        """Run one iteration of the event loop, and enqueue the next iteration (if we're
+        not stopping).
+        """
         try:
-            # Perform one tick of the event loop.
-            self._run_once()
-
-            if self._stopping:  # pragma: no cover
-                if sys.version_info < (3, 13):
-                    # If we're stopping, we can do the "finally" handling from
-                    # the BaseEventLoop run_forever(). In Python 3.13.0a2, this
-                    # was refactored into the `_run_forever_cleanup()` helper.
-                    # We run testbed on Py3.10, so the else branch is marked
-                    # nocover.
-                    # === START BaseEventLoop.run_forever() finally handling ===
-                    self._stopping = False
-                    self._thread_id = None
-                    events._set_running_loop(None)
-                    self._set_coroutine_origin_tracking(False)
-                    sys.set_asyncgen_hooks(*self._old_agen_hooks)
-                    # === END BaseEventLoop.run_forever() finally handling ===
-                else:  # pragma: no cover
-                    self._run_forever_cleanup()
+            # If the app is exiting, stop the asyncio event loop.
+            # Otherwise, perform one more tick of the event loop.
+            if self.app._is_exiting:
+                self.stop()
             else:
-                # Otherwise, live to tick another day. Enqueue the next tick,
-                # and make sure there will be *something* to be processed.
-                # If you don't ensure there is at least one message on the
-                # queue, the select() call will block, locking the app.
-                self.enqueue_tick()
-                self.call_soon(self._loop_self_reading)
+                self._run_once()
 
-                if self._inner_loop:
-                    callback, args = self._inner_loop
-                    self._inner_loop = None
-                    callback(*args)
+            # Enqueue the next tick, and make sure there will be *something*
+            # to be processed. If you don't ensure there is at least one
+            # message on the queue, the select() call will block, locking
+            # the app.
+            self.enqueue_tick()
+            self.call_soon(self._loop_self_reading)
+
+            if self._inner_loop:
+                callback, args = self._inner_loop
+                self._inner_loop = None
+                callback(*args)
 
         # Exceptions thrown by this method will be silently ignored.
         except BaseException:  # pragma: no cover


### PR DESCRIPTION
When a Winforms app shuts down, it doesn't appear to be triggering the end-of-life loop handling. As a result, if PYTHONDEVMODE=1 is enabled (or, if warnings are enabled and/or asyncio debug mode is enabled), an app will raise errors about unclosed event loops, unclosed sockets, and pending operations at deallocation.

The Winforms Proactor is essentially a deconstructed version of `asyncio.loop.run_forever()` - it pulls out the "run once" logic to invoke each iteration on a timer callback. In the old implementation, the "loop cleanup" logic (the code contained in the `finally` block of the original `run_forever()` method) was being invoked as part of the "run once" logic, presumably on the basis that on the last tick, the loop will have been stopped, and cleanup logic could be invoked.

The problem is that the processing of ticks is dependent on the existence of the underlying Winforms app. If the app has stopped, there is no dispatcher that can be used to invoke a tick - and so, depending on how quickly the app shuts down, the final tick may not run. 

This PR restructures the code so that the final tick handling is performed in a direct response to the App exiting (using the Winforms event). This guarantees that the loop shutdown logic will be invoked. It also simplifies the `run_once` and `tick` mechanisms, because they can assume that if they're invoked, the app is running. The only "odd" case, is if the app has requested an exit, in which case the event loop can explicitly start stopping. There is also an explicit call to close the event loop in the "normal" app lifecycle; this is required because we're using `run_forever`, rather than `run_until_complete`, so at the end of the app's life, the loop has *stopped*, but is still *open*.

This bug wasn't present in 0.4.9, but it's not immediately obvious why. I'm assuming something in the 0.5 dev process introduced a minor speedup, resulting in the "no last tick" issue becoming reliably reproducible. Regardless, using the ApplicationExit event makes more sense as a cleanup mechanism, and it no longer generates the warnings.

Fixes #3266.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
