### PR TITLE
Enable highlighting of a selected table row in Winforms

### DIFF
--- a/changes/3269.bugfix.rst
+++ b/changes/3269.bugfix.rst
@@ -1,1 +1,1 @@
-Enable highlighting of a selected table row in Winforms.
+Enable persisted highlighting of a selected table row in Winforms.

--- a/changes/3269.bugfix.rst
+++ b/changes/3269.bugfix.rst
@@ -1,0 +1,1 @@
+Enable highlighting of a selected table row in Winforms.

--- a/winforms/src/toga_winforms/widgets/table.py
+++ b/winforms/src/toga_winforms/widgets/table.py
@@ -52,6 +52,7 @@ class Table(Widget):
         self.native.VirtualMode = True
         self.native.Columns.AddRange(dataColumn)
         self.native.SmallImageList = WinForms.ImageList()
+        self.native.HideSelection = False
 
         self.native.ItemSelectionChanged += WeakrefCallable(
             self.winforms_item_selection_changed


### PR DESCRIPTION
<!--- Describe the change -->
The current Windows behaviour differs from that of other platforms (eg MacOS), where selected rows are highlighted.  This change allows Toga on Windows to highlight a selected row in a table after the table has lost the focus.

For example, the upper table in this screenshot has the focus, but the row selection in the lower table now shows the grey highlight. Previously, the lower table would have given no indication of the row selection.
![image](https://github.com/user-attachments/assets/155fbce5-6e32-407d-bd11-d9e3ab4cc579)

<!--- What problem does this change solve? -->
This provides a similar visual indication of row selection to that provided on other (ie non-Windows) platforms.

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Fixes #3269.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct

I'm aware I need to add a change note file. I'll add that when I've figured out how (first PR).