### PR TITLE
Fixes an issue that causes linux applications to crash on Gtk 3.

### DIFF
--- a/changes/3296.bugfix.rst
+++ b/changes/3296.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed a bug that caused apps on linux to crash with Gtk3
+Support for GTK3 installs that use a GIO release older than 2.72 has been restored. Ubuntu 22.04, and other Debian 12-derived systems are affected by this issue.

--- a/changes/3296.bugfix.rst
+++ b/changes/3296.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug that caused apps on linux to crash with Gtk3

--- a/gtk/src/toga_gtk/app.py
+++ b/gtk/src/toga_gtk/app.py
@@ -33,10 +33,16 @@ class App:
         self.loop = self.policy.get_event_loop()
 
         # Stimulate the build of the app
-        self.native = Gtk.Application(
-            application_id=self.interface.app_id,
-            flags=Gio.ApplicationFlags.DEFAULT_FLAGS,
-        )
+        if GTK_VERSION < (4, 0, 0):
+            self.native = Gtk.Application(
+                application_id=self.interface.app_id,
+                flags=Gio.ApplicationFlags.FLAGS_NONE,
+            )
+        else:
+            self.native = Gtk.Application(
+                application_id=self.interface.app_id,
+                flags=Gio.ApplicationFlags.DEFAULT_FLAGS,
+            )
         self.native_about_dialog = None
 
         # Connect the GTK signal that will cause app startup to occur

--- a/gtk/src/toga_gtk/app.py
+++ b/gtk/src/toga_gtk/app.py
@@ -33,12 +33,12 @@ class App:
         self.loop = self.policy.get_event_loop()
 
         # Stimulate the build of the app
-        if GTK_VERSION < (4, 0, 0):
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             self.native = Gtk.Application(
                 application_id=self.interface.app_id,
                 flags=Gio.ApplicationFlags.FLAGS_NONE,
             )
-        else:
+        else:  # pragma: no-cover-if-gtk3
             self.native = Gtk.Application(
                 application_id=self.interface.app_id,
                 flags=Gio.ApplicationFlags.DEFAULT_FLAGS,


### PR DESCRIPTION
Gio.ApplicationFlags.DEFAULT_FLAGS does not exist for Gtk 3 and errors out into an AttributeError failing to create the application. Reverting back to FLAGS_NONE fixes this issue.

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
