### PR TITLE
Re-add anticlockwise parameter to docstrings (and mark as deprecated)

### DIFF
--- a/changes/3302.misc.rst
+++ b/changes/3302.misc.rst
@@ -1,0 +1,1 @@
+The deprecated ``anticlockwise`` parameter in Canvas was re-added to the relevant docstrings (and marked as deprecated).

--- a/core/src/toga/widgets/canvas/context.py
+++ b/core/src/toga/widgets/canvas/context.py
@@ -237,6 +237,7 @@ class Context(DrawingObject):
             X axis.
         :param counterclockwise: If true, the arc is swept counterclockwise. The default
             is clockwise.
+        :param anticlockwise: **DEPRECATED** - Use ``counterclockwise``.
         :returns: The ``Arc`` :any:`DrawingObject` for the operation.
         """
         arc = Arc(x, y, radius, startangle, endangle, counterclockwise, anticlockwise)
@@ -272,6 +273,7 @@ class Context(DrawingObject):
             X axis.
         :param counterclockwise: If true, the arc is swept counterclockwise. The default
             is clockwise.
+        :param anticlockwise: **DEPRECATED** - Use ``counterclockwise``.
         :returns: The ``Ellipse`` :any:`DrawingObject` for the operation.
         """
         ellipse = Ellipse(


### PR DESCRIPTION
I just missed it before you merged it, but I didn't re-add `anticlockwise` and mark it as deprecated after I changed it to `counterclockwise` in the docstrings.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
