### PR TITLE
Canvas example app UI improvements

### DIFF
--- a/changes/3321.feature.rst
+++ b/changes/3321.feature.rst
@@ -1,0 +1,1 @@
+The Canvas example app's UI controls have been reorganized and more clearly labeled.

--- a/examples/canvas/canvas/app.py
+++ b/examples/canvas/canvas/app.py
@@ -83,7 +83,10 @@ class ExampleCanvasApp(toga.App):
             on_change=self.refresh_canvas,
         )
         self.stroke_width_slider = toga.Slider(
-            min=1, max=10, value=1, on_change=self.refresh_canvas
+            min=1,
+            max=10,
+            value=1,
+            on_change=self.refresh_canvas,
         )
         self.dash_pattern_selection = toga.Selection(
             items=list(self.dash_patterns),
@@ -420,7 +423,8 @@ class ExampleCanvasApp(toga.App):
     def render_drawing(self):
         self.canvas.context.clear()
         self.canvas.context.translate(
-            self.width / 2 + self.x_translation, self.height / 2 + self.y_translation
+            self.width / 2 + self.x_translation,
+            self.height / 2 + self.y_translation,
         )
         self.canvas.context.rotate(self.rotation)
         self.canvas.context.scale(self.scale_x_slider.value, self.scale_y_slider.value)
@@ -500,7 +504,8 @@ class ExampleCanvasApp(toga.App):
 
     def draw_sea(self, context, factor):
         with context.ClosedPath(
-            self.x_middle - 1 * factor / 5, self.y_middle - 1 * factor / 5
+            self.x_middle - 1 * factor / 5,
+            self.y_middle - 1 * factor / 5,
         ) as closer:
             closer.bezier_curve_to(
                 self.x_middle - 1 * factor / 10,
@@ -511,10 +516,12 @@ class ExampleCanvasApp(toga.App):
                 self.y_middle - 1 * factor / 5,
             )
             closer.line_to(
-                self.x_middle + 1 * factor / 5, self.y_middle + 1 * factor / 5
+                self.x_middle + 1 * factor / 5,
+                self.y_middle + 1 * factor / 5,
             )
             closer.line_to(
-                self.x_middle - 1 * factor / 5, self.y_middle + 1 * factor / 5
+                self.x_middle - 1 * factor / 5,
+                self.y_middle + 1 * factor / 5,
             )
 
     def draw_star(self, context, factor):

--- a/examples/canvas/canvas/app.py
+++ b/examples/canvas/canvas/app.py
@@ -49,7 +49,8 @@ class ExampleCanvasApp(toga.App):
         )
 
         self.context_selection = toga.Selection(
-            items=[FILL, STROKE], on_change=self.on_context_change
+            items=[FILL, STROKE],
+            on_change=self.on_context_change,
         )
         self.drawing_shape_instructions = {
             INSTRUCTIONS: self.draw_instructions,
@@ -74,7 +75,8 @@ class ExampleCanvasApp(toga.App):
             on_change=self.on_shape_change,
         )
         self.color_selection = toga.Selection(
-            items=[BLACK, BLUE, GREEN, RED, YELLOW], on_change=self.refresh_canvas
+            items=[BLACK, BLUE, GREEN, RED, YELLOW],
+            on_change=self.refresh_canvas,
         )
         self.fill_rule_selection = toga.Selection(
             items=[value.name for value in FillRule],
@@ -84,26 +86,41 @@ class ExampleCanvasApp(toga.App):
             min=1, max=10, value=1, on_change=self.refresh_canvas
         )
         self.dash_pattern_selection = toga.Selection(
-            items=list(self.dash_patterns), on_change=self.refresh_canvas
+            items=list(self.dash_patterns),
+            on_change=self.refresh_canvas,
         )
         self.clicked_point = None
         self.translation = None
         self.rotation = 0
         self.scale_x_slider = toga.Slider(
-            min=0, max=2, value=1, tick_count=11, on_change=self.refresh_canvas
+            min=0,
+            max=2,
+            value=1,
+            tick_count=11,
+            on_change=self.refresh_canvas,
         )
         self.scale_y_slider = toga.Slider(
-            min=0, max=2, value=1, tick_count=11, on_change=self.refresh_canvas
+            min=0,
+            max=2,
+            value=1,
+            tick_count=11,
+            on_change=self.refresh_canvas,
         )
         self.font_selection = toga.Selection(
             items=[SYSTEM, MESSAGE, SERIF, SANS_SERIF, CURSIVE, FANTASY, MONOSPACE],
             on_change=self.refresh_canvas,
         )
         self.line_height_slider = toga.Slider(
-            min=1.0, max=10.0, value=1.2, on_change=self.refresh_canvas
+            min=1.0,
+            max=10.0,
+            value=1.2,
+            on_change=self.refresh_canvas,
         )
         self.font_size = toga.NumberInput(
-            min=6, max=72, value=14, on_change=self.refresh_canvas
+            min=6,
+            max=72,
+            value=14,
+            on_change=self.refresh_canvas,
         )
         self.italic_switch = toga.Switch(text="italic", on_change=self.refresh_canvas)
         self.bold_switch = toga.Switch(text="bold", on_change=self.refresh_canvas)

--- a/examples/canvas/canvas/app.py
+++ b/examples/canvas/canvas/app.py
@@ -70,13 +70,15 @@ class ExampleCanvasApp(toga.App):
             DASH_2_3_1: [2, 3, 1],
         }
         self.shape_selection = toga.Selection(
-            items=list(self.drawing_shape_instructions), on_change=self.on_shape_change
+            items=list(self.drawing_shape_instructions),
+            on_change=self.on_shape_change,
         )
         self.color_selection = toga.Selection(
             items=[BLACK, BLUE, GREEN, RED, YELLOW], on_change=self.refresh_canvas
         )
         self.fill_rule_selection = toga.Selection(
-            items=[value.name for value in FillRule], on_change=self.refresh_canvas
+            items=[value.name for value in FillRule],
+            on_change=self.refresh_canvas,
         )
         self.stroke_width_slider = toga.Slider(
             min=1, max=10, value=1, on_change=self.refresh_canvas
@@ -442,7 +444,7 @@ class ExampleCanvasApp(toga.App):
                 triangle.move_to(0, 0)
                 triangle.line_to(2 * triangle_size, 0)
                 triangle.line_to(triangle_size, triangle_size)
-                triangle.move_to(0, 0)
+                triangle.line_to(0, 0)
 
     def draw_rectangle(self, context, factor):
         context.rect(

--- a/examples/canvas/canvas/app.py
+++ b/examples/canvas/canvas/app.py
@@ -431,34 +431,18 @@ class ExampleCanvasApp(toga.App):
         # calculate offsets to centralize drawing in the bigger axis
         triangle_size = factor / 5
         gap = factor / 12
-        context.move_to(
-            self.x_middle - 2 * triangle_size - gap, self.y_middle - 2 * triangle_size
-        )
-        context.line_to(self.x_middle - gap, self.y_middle - 2 * triangle_size)
-        context.line_to(
-            self.x_middle - triangle_size - gap, self.y_middle - triangle_size
-        )
-        context.line_to(
-            self.x_middle - 2 * triangle_size - gap, self.y_middle - 2 * triangle_size
-        )
-        context.move_to(self.x_middle + gap, self.y_middle - 2 * triangle_size)
-        context.line_to(
-            self.x_middle + 2 * triangle_size + gap, self.y_middle - 2 * triangle_size
-        )
-        context.line_to(
-            self.x_middle + triangle_size + gap, self.y_middle - triangle_size
-        )
-        context.line_to(self.x_middle + gap, self.y_middle - 2 * triangle_size)
-        context.move_to(
-            self.x_middle - triangle_size, self.y_middle - triangle_size + gap
-        )
-        context.line_to(
-            self.x_middle + triangle_size, self.y_middle - triangle_size + gap
-        )
-        context.line_to(self.x_middle, self.y_middle + gap)
-        context.line_to(
-            self.x_middle - triangle_size, self.y_middle - triangle_size + gap
-        )
+
+        for x, y in [
+            (-2 * triangle_size - gap, -2 * triangle_size),
+            (gap, -2 * triangle_size),
+            (-triangle_size, -triangle_size + gap),
+        ]:
+            with context.Context() as triangle:
+                triangle.translate(self.x_middle + x, self.y_middle + y)
+                triangle.move_to(0, 0)
+                triangle.line_to(2 * triangle_size, 0)
+                triangle.line_to(triangle_size, triangle_size)
+                triangle.move_to(0, 0)
 
     def draw_rectangle(self, context, factor):
         context.rect(

--- a/examples/canvas/canvas/app.py
+++ b/examples/canvas/canvas/app.py
@@ -47,8 +47,9 @@ class ExampleCanvasApp(toga.App):
             on_alt_drag=self.on_alt_drag,
             on_alt_release=self.on_alt_release,
         )
+
         self.context_selection = toga.Selection(
-            items=[FILL, STROKE], on_change=self.refresh_canvas
+            items=[FILL, STROKE], on_change=self.on_context_change
         )
         self.drawing_shape_instructions = {
             INSTRUCTIONS: self.draw_instructions,
@@ -69,24 +70,19 @@ class ExampleCanvasApp(toga.App):
             DASH_2_3_1: [2, 3, 1],
         }
         self.shape_selection = toga.Selection(
-            items=list(self.drawing_shape_instructions.keys()),
-            on_change=self.on_shape_change,
+            items=list(self.drawing_shape_instructions), on_change=self.on_shape_change
         )
         self.color_selection = toga.Selection(
             items=[BLACK, BLUE, GREEN, RED, YELLOW], on_change=self.refresh_canvas
         )
         self.fill_rule_selection = toga.Selection(
-            items=[value.name for value in FillRule],
-            on_change=self.refresh_canvas,
+            items=[value.name for value in FillRule], on_change=self.refresh_canvas
         )
-        self.line_width_slider = toga.Slider(
+        self.stroke_width_slider = toga.Slider(
             min=1, max=10, value=1, on_change=self.refresh_canvas
         )
-        self.line_height_slider = toga.Slider(
-            min=1.0, max=10.0, value=1.2, on_change=self.refresh_canvas
-        )
         self.dash_pattern_selection = toga.Selection(
-            items=list(self.dash_patterns.keys()), on_change=self.refresh_canvas
+            items=list(self.dash_patterns), on_change=self.refresh_canvas
         )
         self.clicked_point = None
         self.translation = None
@@ -101,42 +97,49 @@ class ExampleCanvasApp(toga.App):
             items=[SYSTEM, MESSAGE, SERIF, SANS_SERIF, CURSIVE, FANTASY, MONOSPACE],
             on_change=self.refresh_canvas,
         )
+        self.line_height_slider = toga.Slider(
+            min=1.0, max=10.0, value=1.2, on_change=self.refresh_canvas
+        )
         self.font_size = toga.NumberInput(
             min=6, max=72, value=14, on_change=self.refresh_canvas
         )
         self.italic_switch = toga.Switch(text="italic", on_change=self.refresh_canvas)
         self.bold_switch = toga.Switch(text="bold", on_change=self.refresh_canvas)
-        label_style = Pack(margin=5)
+
+        row_style = Pack(direction=ROW, gap=10)
 
         # Add the content on the main window
         box = toga.Box(
-            style=Pack(direction=COLUMN),
+            style=Pack(direction=COLUMN, gap=15, margin=10),
             children=[
                 toga.Box(
-                    style=Pack(direction=ROW, margin=5),
+                    style=row_style,
                     children=[
+                        toga.Label("Fill / Stroke:"),
                         self.context_selection,
+                        toga.Label("Shape:"),
                         self.shape_selection,
+                        toga.Label("Color:"),
                         self.color_selection,
-                        self.fill_rule_selection,
                     ],
                 ),
                 toga.Box(
-                    style=Pack(direction=ROW, margin=5),
+                    style=row_style,
                     children=[
-                        toga.Label("Line Width:", style=label_style),
-                        self.line_width_slider,
-                        toga.Label("Line Height:", style=label_style),
-                        self.line_height_slider,
+                        toga.Label("Fill rule:"),
+                        self.fill_rule_selection,
+                        toga.Label("Stroke Width:"),
+                        self.stroke_width_slider,
+                        toga.Label("Stroke pattern:"),
                         self.dash_pattern_selection,
                     ],
                 ),
                 toga.Box(
-                    style=Pack(direction=ROW, margin=5),
+                    style=row_style,
                     children=[
-                        toga.Label("X Scale:", style=label_style),
+                        toga.Label("X Scale:"),
                         self.scale_x_slider,
-                        toga.Label("Y Scale:", style=label_style),
+                        toga.Label("Y Scale:"),
                         self.scale_y_slider,
                         toga.Button(
                             text="Reset transform", on_press=self.reset_transform
@@ -144,12 +147,14 @@ class ExampleCanvasApp(toga.App):
                     ],
                 ),
                 toga.Box(
-                    style=Pack(direction=ROW, margin=5),
+                    style=row_style,
                     children=[
-                        toga.Label("Font Family:", style=label_style),
+                        toga.Label("Font Family:"),
                         self.font_selection,
-                        toga.Label("Font Size:", style=label_style),
+                        toga.Label("Font Size:"),
                         self.font_size,
+                        toga.Label("Line Height:"),
+                        self.line_height_slider,
                         self.bold_switch,
                         self.italic_switch,
                     ],
@@ -161,6 +166,7 @@ class ExampleCanvasApp(toga.App):
         self.main_window.content = box
 
         self.change_shape()
+        self.change_context()
         self.render_drawing()
 
         self.commands.add(
@@ -294,6 +300,10 @@ class ExampleCanvasApp(toga.App):
         self.change_shape()
         self.refresh_canvas(widget)
 
+    def on_context_change(self, widget):
+        self.change_context()
+        self.refresh_canvas(widget)
+
     def on_press(self, widget, x, y):
         self.clicked_point = (x, y)
         self.render_drawing()
@@ -369,12 +379,21 @@ class ExampleCanvasApp(toga.App):
         angle2 = math.atan2(v2[1], v2[0])
         return angle1 - angle2
 
+    def change_context(self):
+        is_stroke = self.context_selection.value == STROKE
+        self.stroke_width_slider.enabled = is_stroke
+        self.dash_pattern_selection.enabled = is_stroke
+
+        # Note: if more contexts are added, this will have to be checked separately.
+        self.fill_rule_selection.enabled = not is_stroke
+
     def change_shape(self):
         is_text = self.shape_selection.value == INSTRUCTIONS
         self.font_selection.enabled = is_text
         self.font_size.enabled = is_text
         self.italic_switch.enabled = is_text
         self.bold_switch.enabled = is_text
+        self.line_height_slider.enabled = is_text
 
     def refresh_canvas(self, widget, **kwargs):
         self.render_drawing()
@@ -387,7 +406,7 @@ class ExampleCanvasApp(toga.App):
         self.canvas.context.rotate(self.rotation)
         self.canvas.context.scale(self.scale_x_slider.value, self.scale_y_slider.value)
         self.canvas.context.translate(-self.width / 2, -self.height / 2)
-        with self.get_context(self.canvas) as context:
+        with self.get_context() as context:
             self.draw_shape(context)
         self.canvas.context.reset_transform()
 
@@ -532,23 +551,19 @@ class ExampleCanvasApp(toga.App):
         )
 
     def get_weight(self):
-        if self.bold_switch.value:
-            return BOLD
-        return NORMAL
+        return BOLD if self.bold_switch.value else NORMAL
 
     def get_style(self):
-        if self.italic_switch.value:
-            return ITALIC
-        return NORMAL
+        return ITALIC if self.italic_switch.value else NORMAL
 
-    def get_context(self, canvas):
+    def get_context(self):
         if self.context_selection.value == STROKE:
-            return canvas.Stroke(
+            return self.canvas.Stroke(
                 color=str(self.color_selection.value),
-                line_width=self.line_width_slider.value,
+                line_width=self.stroke_width_slider.value,
                 line_dash=self.dash_patterns[self.dash_pattern_selection.value],
             )
-        return canvas.Fill(
+        return self.canvas.Fill(
             color=self.color_selection.value,
             fill_rule=FillRule[self.fill_rule_selection.value],
         )


### PR DESCRIPTION
I've made some changes to the Canvas example app, primarily in the controls.

- Additional labels and spacing
- The line height slider is now with the rest of the text controls, and it enables and disables along with them.
- Line width is re-labeled to stroke width, to be less ambiguous alongside text line height
- Fill rule moves down to the second line, alongside the stroke settings. These now enable and disable based on the current context.

### Before
![Screenshot 2025-03-31 at 9 40 44 PM](https://github.com/user-attachments/assets/fd42f5d7-7a2c-4bc9-a313-b8558615fae6)

### After
![Screenshot 2025-03-31 at 9 39 55 PM](https://github.com/user-attachments/assets/a05dfe9f-6a89-4ffb-a63e-1581bfff849c)

I also made some minor / stylistic code tweaks, while I was here:

- Condensed `get_weight` / `get_style` to one-liners
- Removed the unnecessary `canvas` parameter to `get_context`
- Changed two cases of `list(dictionary.keys())` to `list(dictionary)`, since it already takes the keys
- Condensed the hard-coded coordinates in `draw_triangles()` to a loop

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
