### PR TITLE
Exclude display=NONE nodes from layout

### DIFF
--- a/changes/3322.bugfix.rst
+++ b/changes/3322.bugfix.rst
@@ -1,0 +1,1 @@
+``Pack.display="none"`` now correctly hides a widget, and removes it from the layout.

--- a/core/src/toga/style/pack.py
+++ b/core/src/toga/style/pack.py
@@ -268,7 +268,7 @@ class Pack(BaseStyle):
     @property
     def _hidden(self) -> bool:
         """Does this style declaration define an object that should be hidden."""
-        return self.visibility == HIDDEN
+        return self.visibility == HIDDEN or self.display == NONE
 
     def _apply(self, names: set) -> None:
         if "text_align" in names:
@@ -287,19 +287,19 @@ class Pack(BaseStyle):
             self._applicator.set_color(self.color)
         if "background_color" in names:
             self._applicator.set_background_color(self.background_color)
-        if "visibility" in names:
-            value = self.visibility
-            if value == VISIBLE:
-                # If visibility is being set to VISIBLE, look up the chain to
-                # see if an ancestor is hidden.
+        if names & {"visibility", "display"}:
+            value = self._hidden
+
+            if not value:
+                # If this style is visible, look up the chain to see if an ancestor is
+                # hidden
                 widget = self._applicator.widget
                 while widget := widget.parent:
                     if widget.style._hidden:
-                        value = HIDDEN
+                        value = True
                         break
 
-            self._applicator.set_hidden(value == HIDDEN)
-
+            self._applicator.set_hidden(value)
         if names & {
             "font_family",
             "font_size",
@@ -420,7 +420,9 @@ class Pack(BaseStyle):
                 # self._debug(f"AUTO {available_height=}")
                 min_height = 0
 
-        if node.children:
+        if node.children and any(
+            child.style.display != NONE for child in node.children
+        ):
             min_width, width, min_height, height = self._layout_children(
                 available_width=available_width,
                 available_height=available_height,
@@ -514,7 +516,9 @@ class Pack(BaseStyle):
         # intrinsic non-flexible dimension. While iterating, collect the flex
         # total of remaining elements.
 
-        for i, child in enumerate(node.children):
+        children = [child for child in node.children if not child.style.display == NONE]
+
+        for i, child in enumerate(children):
             # self._debug(f"PASS 1 {child}")
             if child.style[main_name] != NONE:
                 # self._debug(f"- fixed {main_name} {child.style[main_name]}")
@@ -641,7 +645,7 @@ class Pack(BaseStyle):
             # the flex calculation.
 
             # self._debug(f"PASS 1a; {quantum=}")
-            for child in node.children:
+            for child in children:
                 child_intrinsic_main = getattr(child.intrinsic, main_name)
                 if child.style.flex and child_intrinsic_main is not None:
                     try:
@@ -669,7 +673,7 @@ class Pack(BaseStyle):
 
         # Pass 2: Lay out children with an intrinsic flexible main-axis size, or no
         # main-axis size specification at all.
-        for child in node.children:
+        for child in children:
             # self._debug(f"PASS 2 {child}")
             if child.style[main_name] != NONE:
                 # self._debug(f"- already laid out (explicit {main_name})")
@@ -787,7 +791,7 @@ class Pack(BaseStyle):
         cross = 0
         min_cross = 0
 
-        for child in node.children:
+        for child in children:
             # self._debug(f"PASS 3: {child} AT MAIN-AXIS OFFSET {offset}")
             if main_start == RIGHT:
                 # Needs special casing, since it's still ultimately content_left that
@@ -843,7 +847,7 @@ class Pack(BaseStyle):
             effective_cross_start = cross_start
             effective_cross_end = cross_end
 
-        for child in node.children:
+        for child in children:
             # self._debug(f"PASS 4: {child}")
             extra = cross - (
                 getattr(child.layout, f"content_{cross_name}")

--- a/core/tests/style/pack/layout/test_display.py
+++ b/core/tests/style/pack/layout/test_display.py
@@ -1,0 +1,88 @@
+from toga.style.pack import COLUMN, NONE, PACK, Pack
+
+from ..utils import ExampleNode, ExampleViewport, assert_layout
+
+
+def test_display_none():
+    """Setting a node to display=NONE removes it from the layout."""
+    root = ExampleNode(
+        "app",
+        style=Pack(direction=COLUMN),
+        children=[
+            ExampleNode(
+                "first",
+                style=Pack(width=100, height=110),
+            ),
+            rabbit := ExampleNode(
+                "second",
+                style=Pack(width=100, height=120),
+            ),
+            ExampleNode(
+                "third",
+                style=Pack(width=100, height=130),
+            ),
+        ],
+    )
+
+    root.style.layout(ExampleViewport(640, 480))
+    initial = (
+        root,
+        (100, 360),
+        (640, 480),
+        {
+            "origin": (0, 0),
+            "content": (640, 480),
+            "children": [
+                {
+                    "origin": (0, 0),
+                    "content": (100, 110),
+                },
+                {
+                    "origin": (0, 110),
+                    "content": (100, 120),
+                },
+                {
+                    "origin": (0, 230),
+                    "content": (100, 130),
+                },
+            ],
+        },
+    )
+    assert_layout(*initial)
+
+    # Turn off display for the middle child.
+    rabbit.style.display = NONE
+
+    root.style.layout(ExampleViewport(640, 480))
+    assert_layout(
+        root,
+        (100, 240),
+        (640, 480),
+        {
+            "origin": (0, 0),
+            "content": (640, 480),
+            "children": [
+                {
+                    "origin": (0, 0),
+                    "content": (100, 110),
+                },
+                # As far as the vanished node knows, its values haven't changed, because
+                # its layout hasn't been refreshed.
+                {
+                    "origin": (0, 110),
+                    "content": (100, 120),
+                },
+                # But the third child has slid upward to take its place.
+                {
+                    "origin": (0, 110),
+                    "content": (100, 130),
+                },
+            ],
+        },
+    )
+
+    rabbit.style.display = PACK
+
+    # Everything's back to normal.
+    root.style.layout(ExampleViewport(640, 480))
+    assert_layout(*initial)

--- a/docs/reference/style/pack.rst
+++ b/docs/reference/style/pack.rst
@@ -31,9 +31,8 @@ Pack style properties
 
 Used to define how to display the widget. A value of ``pack`` will apply
 the pack layout algorithm to this node and its descendants. A value of
-``none`` removes the widget from the layout entirely. Space will be allocated
-for the widget as if it were there, but the widget itself will not be
-visible.
+``none`` removes the widget from the layout entirely; it won't be shown,
+and it won't occupy space.
 
 ``visibility``
 --------------


### PR DESCRIPTION
- Fixes #3322
- Fixes #1502... I think. There are a number of things going on there, but if I'm reading it correctly, I think this is the last part remaining.

I've parametrized `display` into the existing tests for `visibility`, and added a new test to verify that a non-displayed widget is removed from the layout. I'm not entirely sure if it's sufficient, or if there are layout situations that could behave differently and should be tested as well.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
