### PR TITLE
Add FastAPI backend support for Toga projects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -446,9 +446,13 @@ jobs:
         - "Positron (Django)"
         - "Positron (Static)"
         - "Positron (Site-specific)"
+        - "Positron (FastAPI)"
         include:
         - bootstrap: "Positron (Django)"
           new-options: '-Q "bootstrap=Toga Positron (Django server)"'
+
+        - bootstrap: "Positron (FastAPI)"
+          new-options: '-Q "bootstrap=Toga Positron (FastAPI server)"'
 
         - bootstrap: "Positron (Static)"
           new-options: '-Q "bootstrap=Toga Positron (Static server)"'

--- a/changes/3327.feature.rst
+++ b/changes/3327.feature.rst
@@ -1,0 +1,1 @@
+Projects created with Toga can now use FastAPI as a backend option.

--- a/positron/README.md
+++ b/positron/README.md
@@ -32,9 +32,10 @@ framework you want to use:
     3) Pygame                                (does not support iOS/Android/Web deployment)
     4) Console                               (does not support iOS/Android/Web deployment)
     5) Toga Positron (Django server)         (does not support Web deployment)
-    6) Toga Positron (Site-specific browser) (does not support Web deployment)
-    7) Toga Positron (Static server)         (does not support Web deployment)
-    8) None
+    6) Toga Positron (FastAPI server)         (does not support Web deployment)
+    7) Toga Positron (Site-specific browser) (does not support Web deployment)
+    8) Toga Positron (Static server)         (does not support Web deployment)
+    9) None
 
     GUI framework [1]:
 
@@ -77,6 +78,20 @@ To create an initial database, use `manage.py` - e.g.,:
 
 This will create an initial `db.sqlite3` file with a superuser account. All users
 of the app will have this superuser account in their database.
+
+### FastAPI Backend Support
+
+The `Positron (FastAPI)` backend enables you to create a Toga application that serves a FastAPI-powered web backend.
+
+This creates a template with:
+	•	A FastAPI app in server.py
+	•	A Toga app that serves the ASGI app
+	•	Uses asyncio.start_server to serve HTTP requests directly without needing Uvicorn
+
+FastAPI backend is ideal for developers who want a modern async web backend embedded in a native app.
+
+Note: This bootstrap is currently intended for local desktop use, not production deployments.
+
 
 ### Site-specific browser
 

--- a/positron/pyproject.toml
+++ b/positron/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = ["briefcase >= 0.3.21"]
 
 [project.entry-points."briefcase.bootstraps"]
 "Toga Positron (Django server)" = "positron.django:DjangoPositronBootstrap"
+"Toga Positron (FastAPI server)" = "positron.fastapi:FastAPIPositronBootstrap"
 "Toga Positron (Static server)" = "positron.static:StaticPositronBootstrap"
 "Toga Positron (Site-specific browser)" = "positron.sitespecific:SiteSpecificPositronBootstrap"
 

--- a/positron/src/positron/fastapi.py
+++ b/positron/src/positron/fastapi.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from briefcase.bootstraps import TogaGuiBootstrap
+
+
+def validate_path(value: str) -> bool:
+    if not value.startswith("/"):
+        raise ValueError("Path must start with a /")
+    return True
+
+
+def templated_content(template_name: str, **context) -> str:
+    template = (
+        Path(__file__).parent / f"fastapi_template/{template_name}.tmpl"
+    ).read_text(encoding="utf-8")
+    return template.format(**context)
+
+
+def templated_file(template_name: str, output_path: Path, **context) -> None:
+    (output_path / template_name).write_text(
+        templated_content(template_name, **context), encoding="utf-8"
+    )
+
+
+class FastAPIPositronBootstrap(TogaGuiBootstrap):
+    display_name_annotation = "runs a FastAPI backend (local web server)"
+
+    def app_source(self) -> str:
+        return templated_content("app.py")
+
+    def pyproject_table_briefcase_app_extra_content(self) -> str:
+        return """
+requires = [
+    "fastapi~=0.110.0",
+    "asgiref~=3.7.2",
+]
+"""
+
+    def extra_context(self, project_overrides: dict[str, str]) -> dict[str, Any] | None:
+        return {}
+
+    def post_generate(self, base_path: Path):
+        app_path = base_path / "src" / self.context["module_name"]
+
+        self.console.debug("Writing server.py")
+        templated_file(
+            "server.py",
+            app_path,
+            module_name=self.context["module_name"],
+        )

--- a/positron/src/positron/fastapi_template/app.py.tmpl
+++ b/positron/src/positron/fastapi_template/app.py.tmpl
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import asyncio
+import socket
+from threading import Thread
+
+import toga
+from asgiref.compatibility import guarantee_single_callable
+
+from .server import app as fastapi_app
+
+
+class SimpleReceive:
+    def __init__(self):
+        self._has_sent = False
+
+    async def __call__(self):
+        if not self._has_sent:
+            self._has_sent = True
+            return {{"type": "http.request", "body": b"", "more_body": False}}
+
+
+class {{{{ cookiecutter.class_name }}}}(toga.App):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    async def handle_client(self, reader, writer):
+        request_line = await reader.readline()
+        if not request_line:
+            writer.close()
+            await writer.wait_closed()
+            return
+
+        method, path, _ = request_line.decode().split()
+        headers = []
+        while True:
+            line = await reader.readline()
+            if line == b"\r\n":
+                break
+            headers.append(line)
+
+        scope = {{
+            "type": "http",
+            "http_version": "1.1",
+            "method": method,
+            "path": path,
+            "scheme": "http",
+            "headers": [],
+            "query_string": b"",
+            "client": writer.get_extra_info("peername"),
+            "server": writer.get_extra_info("sockname"),
+        }}
+
+        async def send(message):
+            if message["type"] == "http.response.start":
+                status_code = message["status"]
+                writer.write(f"HTTP/1.1 {{status_code}} OK\r\n".encode())
+                for name, value in message.get("headers", []):
+                    writer.write(name + b": " + value + b"\r\n")
+                writer.write(b"\r\n")
+
+            elif message["type"] == "http.response.body":
+                writer.write(message.get("body", b""))
+                await writer.drain()
+                writer.close()
+
+        asgi_app = guarantee_single_callable(fastapi_app)
+        receive = SimpleReceive()
+        await asgi_app(scope, receive, send)
+
+    async def start_server(self):
+        self.port = self.get_free_port()
+        self.server = await asyncio.start_server(self.handle_client, "127.0.0.1", self.port)
+        print(f"🚀 Serving on http://127.0.0.1:{{self.port}}/")
+        self.server_ready.set_result(True)
+
+    @staticmethod
+    def get_free_port():
+        s = socket.socket()
+        s.bind(("127.0.0.1", 0))
+        _, port = s.getsockname()
+        s.close()
+        return port
+
+    def startup(self):
+        loop = asyncio.get_running_loop()
+        self.server_ready = loop.create_future()
+        self.web_view = toga.WebView()
+        asyncio.create_task(self.start_server())
+        self.main_window = toga.MainWindow(title=self.formal_name)
+        self.main_window.content = self.web_view
+
+    async def on_running(self):
+        await self.server_ready
+        self.web_view.url = f"http://127.0.0.1:{{self.port}}/"
+        self.main_window.show()
+
+
+def main():
+    return {{{{ cookiecutter.class_name }}}}()

--- a/positron/src/positron/fastapi_template/server.py.tmpl
+++ b/positron/src/positron/fastapi_template/server.py.tmpl
@@ -1,0 +1,8 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/")
+async def read_root():
+    return "Hello from FastAPI!"


### PR DESCRIPTION
## Add FastAPI backend support to Toga Positron

### Description

This pull request introduces a new backend option for Toga's Positron bootstrap system: FastAPI.

With this backend, developers can initialize a new Toga app using `briefcase new` and select FastAPI as the backend framework. The generated app includes:

- A working FastAPI server
- Integration with Toga's WebView to render the app UI from the FastAPI server
- A minimal ASGI-compatible server implementation using only standard Python libraries (`asyncio` and `streams`) — no external HTTP server dependencies such as `uvicorn` are required

### What problem does this change solve?

Currently, Positron supports Django, static HTML, and single-page apps. However, there is no support for FastAPI, which has become a popular async web framework for Python.

This change provides a modern, async-capable backend option that enables developers to build desktop apps powered by FastAPI and ASGI, while maintaining full compatibility with Toga's architecture.

### Related issues

Fixes #3327 

---

## PR Checklist:

- [x] All new features have been tested  
- [x] All new features have been documented  
- [x] I have read the **CONTRIBUTING.md** file  
- [x] I will abide by the code of conduct