### PR TITLE
Correct textual app execution to prevent stray log messages

### DIFF
--- a/changes/3342.bugfix.rst
+++ b/changes/3342.bugfix.rst
@@ -1,1 +1,1 @@
-An incompatibility with Textual 3.0 that caused log messages to be generated on the console on app exist has been resolved.
+An incompatibility with Textual 3.0 that caused log messages to be generated on the console on app exit has been resolved.

--- a/changes/3342.bugfix.rst
+++ b/changes/3342.bugfix.rst
@@ -1,0 +1,1 @@
+An incompatibility with Textual 3.0 that caused log messages to be generated on the console on app exist has been resolved.

--- a/textual/pyproject.toml
+++ b/textual/pyproject.toml
@@ -66,7 +66,7 @@ root = ".."
 
 [tool.setuptools_dynamic_dependencies]
 dependencies = [
-    "textual >= 0.44.0",
+    "textual >= 3.0.0, < 4.0.0",
     "toga-core == {version}",
 ]
 


### PR DESCRIPTION
If an app is run with Textual 3.0, it generates log messages on output due to textualize/textual#5091. 

This was discovered in the context of #3299. The existing version pin was open ended, and allowed for major version changes to be required in by Toga codebase without testing.

This PR bumps the minimum Textual version to 3.0, and imposes a 4.0 upper bound to avoid similar problems emerging.

It also changes the way that the Textual app is started (effectively reproducing `textual.App.run()`) so that the log messages on exit are captured.

Fixes #3343.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
