### PR TITLE
Add some missing travertino dependencies.

### DIFF
--- a/changes/3346.misc.rst
+++ b/changes/3346.misc.rst
@@ -1,0 +1,1 @@
+The dependencies for some of the example apps were corrected.

--- a/examples/hardware/pyproject.toml
+++ b/examples/hardware/pyproject.toml
@@ -15,6 +15,7 @@ formal_name = "Hardware"
 description = "A testing app"
 sources = ['hardware']
 requires = [
+    '../../travertino',
     '../../core',
 ]
 

--- a/examples/mapview/pyproject.toml
+++ b/examples/mapview/pyproject.toml
@@ -15,6 +15,7 @@ formal_name = "Map View"
 description = "A testing app"
 sources = ['mapview']
 requires = [
+    '../../travertino',
     '../../core',
 ]
 

--- a/examples/passwordinput/pyproject.toml
+++ b/examples/passwordinput/pyproject.toml
@@ -15,6 +15,7 @@ formal_name = "Password Input Demo"
 description = "A testing app"
 sources = ['passwordinput']
 requires = [
+    '../../travertino',
     '../../core',
 ]
 

--- a/examples/simpleapp/pyproject.toml
+++ b/examples/simpleapp/pyproject.toml
@@ -15,6 +15,7 @@ formal_name = "Simple App"
 description = "A testing app"
 sources = ['simpleapp']
 requires = [
+    '../../travertino',
     '../../core',
 ]
 

--- a/examples/statusiconapp/pyproject.toml
+++ b/examples/statusiconapp/pyproject.toml
@@ -15,6 +15,7 @@ formal_name = "Status Icon App"
 description = "A testing app"
 sources = ['statusiconapp']
 requires = [
+    '../../travertino',
     '../../core',
 ]
 


### PR DESCRIPTION
Adds in a dependency on travertino for 5 example apps that were missing it.

I'm not sure how these 5 were missed in previous updates, but they clearly were.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
