### PR TITLE
Use the documented prototype for task factories.

### DIFF
--- a/changes/3394.bugfix.rst
+++ b/changes/3394.bugfix.rst
@@ -1,0 +1,1 @@
+A crash caused by the ``name`` argument added to asynchronous tasks in Python 3.13.3 has been corrected.

--- a/core/src/toga/app.py
+++ b/core/src/toga/app.py
@@ -467,17 +467,11 @@ class App:
         """
         platform_task_factory = self.loop.get_task_factory()
 
-        def factory(loop, coro, context=None):
+        def factory(loop, coro, **kwargs):
             if platform_task_factory is not None:
-                if sys.version_info < (3, 11):  # pragma: no-cover-if-gte-py311
-                    task = platform_task_factory(loop, coro)
-                else:  # pragma: no-cover-if-lt-py311
-                    task = platform_task_factory(loop, coro, context=context)
+                task = platform_task_factory(loop, coro, **kwargs)
             else:
-                if sys.version_info < (3, 11):  # pragma: no-cover-if-gte-py311
-                    task = asyncio.Task(coro, loop=loop)
-                else:  # pragma: no-cover-if-lt-py311
-                    task = asyncio.Task(coro, loop=loop, context=context)
+                task = asyncio.Task(coro, loop=loop, **kwargs)
 
             self._running_tasks.add(task)
             task.add_done_callback(self._running_tasks.discard)

--- a/core/tests/conftest.py
+++ b/core/tests/conftest.py
@@ -40,11 +40,8 @@ class TestApp(toga.App):
         # Ensure that Toga's task factory is tracking all tasks
         toga_task_factory = self.loop.get_task_factory()
 
-        def task_factory(loop, coro, context=None):
-            if sys.version_info < (3, 11):
-                task = toga_task_factory(loop, coro)
-            else:
-                task = toga_task_factory(loop, coro, context=context)
+        def task_factory(loop, coro, **kwargs):
+            task = toga_task_factory(loop, coro, **kwargs)
             assert task in self._running_tasks, f"missing task reference for {task}"
             return task
 


### PR DESCRIPTION
Fixes #3394 

Python 3.13.3 ensured that the `name` argument was passed down to task factories; this exposed a bug in Toga's task factory wrapper, as it didn't accomodate the `name` argument. A task factory is documented as having the prototype `factory(loop, coro, **kwargs)`; this modifies the Toga definitions to match that prototype. It can be assumed that the arguments passed to the factory will be internally compatible with Task, as they should be version locked with respect to features.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
