### PR TITLE
Correct type annotation for directional properties.

### DIFF
--- a/changes/3396.bugfix.rst
+++ b/changes/3396.bugfix.rst
@@ -1,0 +1,1 @@
+The type annotation for directional style properties (``margin``, the deprecated alias ``padding``) has been corrected.

--- a/core/src/toga/style/pack.py
+++ b/core/src/toga/style/pack.py
@@ -206,7 +206,7 @@ class Pack(BaseStyle):
     height: str | int = validated_property(NONE, integer=True, initial=NONE)
     flex: float = validated_property(number=True, initial=0)
 
-    margin: int | tuple[int] = directional_property("margin{}")
+    margin: int | tuple[int, ...] = directional_property("margin{}")
     margin_top: int = validated_property(integer=True, initial=0)
     margin_right: int = validated_property(integer=True, initial=0)
     margin_bottom: int = validated_property(integer=True, initial=0)
@@ -249,7 +249,7 @@ class Pack(BaseStyle):
     # 2024-12: Backwards compatibility for Toga < 0.5.0
     ######################################################################
 
-    padding: int | tuple[int] = aliased_property(source="margin", deprecated=True)
+    padding: int | tuple[int, ...] = aliased_property(source="margin", deprecated=True)
     padding_top: int = aliased_property(source="margin_top", deprecated=True)
     padding_right: int = aliased_property(source="margin_right", deprecated=True)
     padding_bottom: int = aliased_property(source="margin_bottom", deprecated=True)


### PR DESCRIPTION
Directional style properties can take a tuple of integers of length 1-4. 

`tuple[int]` is the type annotation for a tuple of a single int; the type annotation for a tuple of arbitrary length, all of which are ints, is [documented to be `tuple[int, ...]`](https://docs.python.org/3/library/typing.html#annotating-tuples).

Strictly, this type annotation will allow a 5+ element integer tuple, but I'm not sure the type strictness will be an improvement from the perspective of documentation.

Fixes #3396.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
