### PR TITLE
Fix type annotation on Pack.margin

### DIFF
--- a/changes/3396.bugfix.rst
+++ b/changes/3396.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed type annotation on `Pack.margin` to match documented types.
+The type annotation for directional style properties (``margin``, the deprecated alias ``padding``) has been corrected.

--- a/changes/3396.bugfix.rst
+++ b/changes/3396.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed type annotation on `Pack.margin` to match documented types.

--- a/core/src/toga/style/pack.py
+++ b/core/src/toga/style/pack.py
@@ -206,7 +206,13 @@ class Pack(BaseStyle):
     height: str | int = validated_property(NONE, integer=True, initial=NONE)
     flex: float = validated_property(number=True, initial=0)
 
-    margin: int | tuple[int] = directional_property("margin{}")
+    margin: (
+        int
+        | tuple[int]
+        | tuple[int, int]
+        | tuple[int, int, int]
+        | tuple[int, int, int, int]
+    ) = directional_property("margin{}")
     margin_top: int = validated_property(integer=True, initial=0)
     margin_right: int = validated_property(integer=True, initial=0)
     margin_bottom: int = validated_property(integer=True, initial=0)
@@ -249,7 +255,13 @@ class Pack(BaseStyle):
     # 2024-12: Backwards compatibility for Toga < 0.5.0
     ######################################################################
 
-    padding: int | tuple[int] = aliased_property(source="margin", deprecated=True)
+    padding: (
+        int
+        | tuple[int]
+        | tuple[int, int]
+        | tuple[int, int, int]
+        | tuple[int, int, int, int]
+    ) = aliased_property(source="margin", deprecated=True)
     padding_top: int = aliased_property(source="margin_top", deprecated=True)
     padding_right: int = aliased_property(source="margin_right", deprecated=True)
     padding_bottom: int = aliased_property(source="margin_bottom", deprecated=True)


### PR DESCRIPTION
Added correct type annotations to `Path.margin` (and deprecated `Path.padding`).

Fixes #3396.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
