### PR TITLE
Add a write-only property in WebView to set the contents without an annoying empty string.

### DIFF
--- a/changes/2854.feature.rst
+++ b/changes/2854.feature.rst
@@ -1,0 +1,1 @@
+Add a write-only property in WebView to set the contents without an annoying empty string.

--- a/changes/2854.feature.rst
+++ b/changes/2854.feature.rst
@@ -1,1 +1,1 @@
-Add a write-only property in WebView to set the contents without an annoying empty string.
+The content of a WebView can now be assigned using the `content` property, without providing a root URL for the content.

--- a/core/src/toga/widgets/webview.py
+++ b/core/src/toga/widgets/webview.py
@@ -143,10 +143,15 @@ class WebView(Widget):
 
     @property
     def content(self):
-        """A placeholder getter for the content property, which raises an AttributeError
-        since there is no way to access the content displayed in a WebView on most APIs.
+        """A write-only attribute to set the HTML content currently displayed by the
+        WebView.
+
+        ``web_view.content = "<html>..."`` is equivalent to calling 
+        ``web_view.set_content("", "<html>...")``. 
+
+        :raises AttributeError: If an attempt is made to read the page content.
         """
-        raise AttributeError("'WebView' has a write-only 'content' attribute")
+        raise AttributeError("WebView.content is a write-only attribute.")
 
     @content.setter
     def content(self, value):

--- a/core/src/toga/widgets/webview.py
+++ b/core/src/toga/widgets/webview.py
@@ -142,6 +142,18 @@ class WebView(Widget):
         self._impl.set_content(root_url, content)
 
     @property
+    def content(self):
+        """A placeholder getter for the content property, which raises an AttributeError
+        since there is no way to access the content displayed in a WebView on most APIs.
+        """
+        raise AttributeError("'WebView' has a write-only 'content' attribute")
+
+    @content.setter
+    def content(self, value):
+        """Setter for content. Equivalent to the method set_content("", value)."""
+        self.set_content("", value)
+
+    @property
     def cookies(self) -> CookiesResult:
         """Retrieve cookies from the WebView.
 

--- a/core/src/toga/widgets/webview.py
+++ b/core/src/toga/widgets/webview.py
@@ -151,7 +151,7 @@ class WebView(Widget):
 
         :raises AttributeError: If an attempt is made to read the page content.
         """
-        raise AttributeError("WebView.content is a write-only attribute.")
+        raise AttributeError("WebView.content is a write-only attribute")
 
     @content.setter
     def content(self, value):

--- a/core/src/toga/widgets/webview.py
+++ b/core/src/toga/widgets/webview.py
@@ -146,8 +146,8 @@ class WebView(Widget):
         """A write-only attribute to set the HTML content currently displayed by the
         WebView.
 
-        ``web_view.content = "<html>..."`` is equivalent to calling 
-        ``web_view.set_content("", "<html>...")``. 
+        ``web_view.content = "<html>..."`` is equivalent to calling
+        ``web_view.set_content("", "<html>...")``.
 
         :raises AttributeError: If an attempt is made to read the page content.
         """

--- a/core/tests/widgets/test_webview.py
+++ b/core/tests/widgets/test_webview.py
@@ -183,6 +183,23 @@ def test_set_content(widget):
     )
 
 
+def test_set_content_with_property(widget):
+    """Static HTML content can be loaded into the page, using a setter."""
+    widget.content = "<h1>Fancy page</h1>"
+    assert_action_performed_with(
+        widget,
+        "set content",
+        root_url="",
+        content="<h1>Fancy page</h1>",
+    )
+
+
+def test_get_content_property_error(widget):
+    """Verify that using the getter on widget.content fails."""
+    with pytest.raises(AttributeError):
+        _ = widget.content
+
+
 def test_user_agent(widget):
     """The user agent can be customized."""
     widget.user_agent = "New user agent"


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Fixes #2854.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
