### PR TITLE
NumberInput documentation fix

### DIFF
--- a/changes/3404.misc.rst
+++ b/changes/3404.misc.rst
@@ -1,0 +1,1 @@
+Documentation fix for `min` and `max` parameters in `NumberInput` widget usage.

--- a/docs/reference/api/widgets/numberinput.rst
+++ b/docs/reference/api/widgets/numberinput.rst
@@ -50,7 +50,7 @@ Usage
 
     import toga
 
-    widget = toga.NumberInput(min_value=1, max_value=10, step=0.001)
+    widget = toga.NumberInput(min=1, max=10, step=0.001)
     widget.value = 2.718
 
 NumberInput's properties can accept :class:`~decimal.Decimal`, :any:`int`, :any:`float`,


### PR DESCRIPTION
`min` and `max` are the current keywords. They _were_ previously documented incorrectly as `min_value` and `max_value`.

Note that the syntax highlighting is a little funny, I guess since these are Python function names:

![Toga_DocFix_PR3403](https://github.com/user-attachments/assets/5e5a88ad-d759-4d5b-adc5-4e26aba2e325)


<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
