### PR TITLE
Update Slider docs to use min and max instead of range.

### DIFF
--- a/changes/3447.misc.rst
+++ b/changes/3447.misc.rst
@@ -1,0 +1,1 @@
+Documentation update, replacing the `range` keyword with `min` and `max` keywords in the Slider widget example.

--- a/docs/reference/api/widgets/slider.rst
+++ b/docs/reference/api/widgets/slider.rst
@@ -59,10 +59,10 @@ A slider can either be continuous (allowing any value within the range), or disc
         print(slider.value)
 
     # Continuous slider, with an event handler.
-    toga.Slider(range=(-5, 10), value=7, on_change=my_callback)
+    toga.Slider(min=-5, max=10, value=7, on_change=my_callback)
 
     # Discrete slider, accepting the values [0, 1.5, 3, 4.5, 6, 7.5].
-    toga.Slider(range=(0, 7.5), tick_count=6)
+    toga.Slider(min=0, max=7.5, tick_count=6)
 
 
 Reference


### PR DESCRIPTION
Update Slider widget documentation as requested in #3447 , replacing the `range` keyword with `min` and `max`.

Fixes #3447.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
