### PR TITLE
Fix button click handling in Toga Web backend to correctly trigger event

### DIFF
--- a/changes/3451.bugfix
+++ b/changes/3451.bugfix
@@ -1,1 +1,0 @@
-Buttons in Toga Web now correctly respond to clicks and trigger their associated actions.

--- a/changes/3451.bugfix
+++ b/changes/3451.bugfix
@@ -1,0 +1,1 @@
+Buttons in Toga Web now correctly respond to clicks and trigger their associated actions.

--- a/changes/3451.bugfix.rst
+++ b/changes/3451.bugfix.rst
@@ -1,0 +1,1 @@
+Buttons in Toga Web now correctly respond to clicks and trigger their associated actions.

--- a/web/src/toga_web/widgets/button.py
+++ b/web/src/toga_web/widgets/button.py
@@ -6,9 +6,9 @@ from .base import Widget
 class Button(Widget):
     def create(self):
         self.native = self._create_native_widget("sl-button")
-        self.native.addEventListener("onclick", create_proxy(self.dom_onclick))
+        self.native.addEventListener("click", create_proxy(self.dom_click))
 
-    def dom_onclick(self, event):
+    def dom_click(self, event):
         self.interface.on_press()
 
     def get_text(self):


### PR DESCRIPTION
Use addEventListener("click", ...) to correctly attach button press handlers in Toga Web.
Fixes buttons in the Web backend not triggering on_press callbacks when clicked.
Fixes #3451 

## PR Checklist:
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
