### PR TITLE
Ensure the startup method returns valid content by raising a ValueError when None is returned

### DIFF
--- a/changes/3444.bugfix.rst
+++ b/changes/3444.bugfix.rst
@@ -1,1 +1,1 @@
-`Add error handling for Window content setter AttributeErrors`
+Add error handling for Window content setter AttributeErrors

--- a/changes/3444.bugfix.rst
+++ b/changes/3444.bugfix.rst
@@ -1,1 +1,1 @@
-Ensure the startup method returns valid content by raising a ValueError when None is returned
+Apps that use a function-based app startup method now validate that the startup method returns content that can be added to the main window.

--- a/changes/3444.bugfix.rst
+++ b/changes/3444.bugfix.rst
@@ -1,0 +1,1 @@
+`Add error handling for Window content setter AttributeErrors`

--- a/changes/3444.bugfix.rst
+++ b/changes/3444.bugfix.rst
@@ -1,1 +1,1 @@
-Add error handling for Window content setter AttributeErrors
+Ensure the startup method returns valid content by raising a ValueError when None is returned

--- a/core/src/toga/app.py
+++ b/core/src/toga/app.py
@@ -663,9 +663,13 @@ class App:
         self.main_window = MainWindow(title=self.formal_name, id="main")
 
         if self._startup_method:
-            self.main_window.content = self._startup_method(self)
-
-        self.main_window.show()
+            content = self._startup_method(self)
+            if content is None:
+                raise ValueError(
+                    "You need to return a value from your startup method "
+                    "that is your main window's content"
+                )
+            self.main_window.content = content
 
     ######################################################################
     # App resources

--- a/core/src/toga/app.py
+++ b/core/src/toga/app.py
@@ -666,8 +666,9 @@ class App:
             content = self._startup_method(self)
             if content is None:
                 raise ValueError(
-                    "You need to return a value from your startup method "
-                    "that is your main window's content"
+                    "Your app's startup method has not provided any content for your "
+                    "app's main window. Did you remember to return the main content "
+                    "container in your startup method?"
                 )
             self.main_window.content = content
 

--- a/core/src/toga/window.py
+++ b/core/src/toga/window.py
@@ -404,23 +404,20 @@ class Window:
         if self._content:
             self._content.window = None
 
-        try:
-            # Assign the content widget to the same app as the window.
-            widget.app = self.app
+        # Assign the content widget to the same app as the window.
+        widget.app = self.app
 
-            # Assign the content widget to the window.
-            widget.window = self
+        # Assign the content widget to the window.
+        widget.window = self
 
-            # Track our new content
-            self._content = widget
+        # Track our new content
+        self._content = widget
 
-            # Manifest the widget
-            self._impl.set_content(widget._impl)
+        # Manifest the widget
+        self._impl.set_content(widget._impl)
 
-            # Update the geometry of the widget
-            widget.refresh()
-        except AttributeError as e:
-            print(f"Error: {e}")
+        # Update the geometry of the widget
+        widget.refresh()
 
     @property
     def widgets(self) -> FilteredWidgetRegistry:

--- a/core/src/toga/window.py
+++ b/core/src/toga/window.py
@@ -404,20 +404,23 @@ class Window:
         if self._content:
             self._content.window = None
 
-        # Assign the content widget to the same app as the window.
-        widget.app = self.app
+        try:
+            # Assign the content widget to the same app as the window.
+            widget.app = self.app
 
-        # Assign the content widget to the window.
-        widget.window = self
+            # Assign the content widget to the window.
+            widget.window = self
 
-        # Track our new content
-        self._content = widget
+            # Track our new content
+            self._content = widget
 
-        # Manifest the widget
-        self._impl.set_content(widget._impl)
+            # Manifest the widget
+            self._impl.set_content(widget._impl)
 
-        # Update the geometry of the widget
-        widget.refresh()
+            # Update the geometry of the widget
+            widget.refresh()
+        except AttributeError as e:
+            print(f"Error: {e}")
 
     @property
     def widgets(self) -> FilteredWidgetRegistry:

--- a/core/tests/app/test_app.py
+++ b/core/tests/app/test_app.py
@@ -703,6 +703,19 @@ def test_startup_method(event_loop):
     assert isinstance(app.main_window, toga.MainWindow)
 
 
+def test_startup_method_returns_none():
+    """Test that startup method returning None raises appropriate error"""
+
+    def startup_none(app):
+        pass
+
+    with pytest.raises(ValueError):
+
+        toga.App(
+            formal_name="Test App", app_id="org.example.test", startup=startup_none
+        )
+
+
 def test_startup_subclass(event_loop):
     """App can be subclassed."""
 

--- a/core/tests/app/test_app.py
+++ b/core/tests/app/test_app.py
@@ -709,8 +709,10 @@ def test_startup_method_returns_none():
     def startup_none(app):
         pass
 
-    with pytest.raises(ValueError):
-
+    with pytest.raises(
+        ValueError,
+        match=r"Your app's startup method has not provided any content",
+    ):
         toga.App(
             formal_name="Test App", app_id="org.example.test", startup=startup_none
         )


### PR DESCRIPTION
<!--- Describe your changes in detail -->

Add a raise ValueError to the startup method

<!--- What problem does this change solve? -->
Ensure the startup method returns valid content by raising a ValueError when None is returned

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

Fixes #3444 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
