### PR TITLE
Correct event firing on Winforms tables

### DIFF
--- a/changes/3472.bugfix.rst
+++ b/changes/3472.bugfix.rst
@@ -1,0 +1,1 @@
+Table Widget on Windows now only fires one event on item selection.

--- a/cocoa/tests_backend/widgets/base.py
+++ b/cocoa/tests_backend/widgets/base.py
@@ -1,7 +1,11 @@
 from rubicon.objc import NSPoint
 
 from toga.colors import TRANSPARENT
-from toga_cocoa.keys import NSEventModifierFlagCommand, NSEventModifierFlagShift
+from toga_cocoa.keys import (
+    NSEventModifierFlagCommand,
+    NSEventModifierFlagControl,
+    NSEventModifierFlagShift,
+)
 from toga_cocoa.libs import NSEvent, NSEventType
 
 from ..fonts import FontMixin
@@ -108,7 +112,7 @@ class SimpleProbe(BaseProbe, FontMixin):
     def has_focus(self):
         return self.native.window.firstResponder == self.native
 
-    async def type_character(self, char, modifierFlags=0):
+    async def type_character(self, char, *, shift=False, ctrl=False, alt=False):
         # Convert the requested character into a Cocoa keycode.
         # This table is incomplete, but covers all the basics.
         key_code = {
@@ -146,7 +150,16 @@ class SimpleProbe(BaseProbe, FontMixin):
             "z": 6,
         }.get(char.lower(), 0)
 
-        if modifierFlags:
+        modifiers = 0
+        if shift:
+            modifiers |= NSEventModifierFlagShift
+        if ctrl:
+            modifiers |= NSEventModifierFlagControl
+        if alt:
+            modifiers |= NSEventModifierFlagCommand
+
+        # if any modifier are in effect, there's no character
+        if modifiers:
             char = None
 
         # This posts a single keyDown followed by a keyUp, matching "normal"
@@ -155,7 +168,7 @@ class SimpleProbe(BaseProbe, FontMixin):
             NSEvent.keyEventWithType(
                 NSEventType.KeyDown,
                 location=NSPoint(0, 0),  # key presses don't have a location.
-                modifierFlags=modifierFlags,
+                modifierFlags=modifiers,
                 timestamp=0,
                 windowNumber=self.native.window.windowNumber,
                 context=None,
@@ -169,7 +182,7 @@ class SimpleProbe(BaseProbe, FontMixin):
             NSEvent.keyEventWithType(
                 NSEventType.KeyUp,
                 location=NSPoint(0, 0),  # key presses don't have a location.
-                modifierFlags=modifierFlags,
+                modifierFlags=modifiers,
                 timestamp=0,
                 windowNumber=self.native.window.windowNumber,
                 context=None,

--- a/cocoa/tests_backend/widgets/base.py
+++ b/cocoa/tests_backend/widgets/base.py
@@ -217,9 +217,7 @@ class SimpleProbe(BaseProbe, FontMixin):
         )
 
     async def undo(self):
-        await self.type_character("z", modifierFlags=NSEventModifierFlagCommand)
+        await self.type_character("z", alt=True)
 
     async def redo(self):
-        await self.type_character(
-            "z", modifierFlags=NSEventModifierFlagCommand | NSEventModifierFlagShift
-        )
+        await self.type_character("z", alt=True, shift=True)

--- a/cocoa/tests_backend/widgets/table.py
+++ b/cocoa/tests_backend/widgets/table.py
@@ -1,12 +1,11 @@
 from pytest import skip
 from rubicon.objc import NSPoint
 
+from toga_cocoa.keys import NSEventModifierFlagCommand
 from toga_cocoa.libs import NSEventType, NSScrollView, NSTableView
 
 from .base import SimpleProbe
 from .properties import toga_color
-
-NSEventModifierFlagCommand = 1 << 20
 
 
 class TableProbe(SimpleProbe):
@@ -96,7 +95,7 @@ class TableProbe(SimpleProbe):
         )
 
     async def select_all(self):
-        await self.type_character("A", modifierFlags=NSEventModifierFlagCommand),
+        await self.type_character("A", alt=True),
 
     async def select_row(self, row, add=False):
         point = self.row_position(row)

--- a/cocoa/tests_backend/widgets/tree.py
+++ b/cocoa/tests_backend/widgets/tree.py
@@ -3,12 +3,11 @@ import asyncio
 from pytest import skip
 from rubicon.objc import NSPoint
 
+from toga_cocoa.keys import NSEventModifierFlagCommand
 from toga_cocoa.libs import NSEventType, NSOutlineView, NSScrollView
 
 from .base import SimpleProbe
 from .properties import toga_color
-
-NSEventModifierFlagCommand = 1 << 20
 
 
 class TreeProbe(SimpleProbe):
@@ -132,7 +131,7 @@ class TreeProbe(SimpleProbe):
         )
 
     async def select_all(self):
-        await self.type_character("A", modifierFlags=NSEventModifierFlagCommand),
+        await self.type_character("A", alt=True),
 
     async def select_row(self, row_path, add=False):
         point = self.row_position(row_path)

--- a/testbed/tests/widgets/test_table.py
+++ b/testbed/tests/widgets/test_table.py
@@ -99,18 +99,6 @@ async def multiselect_widget(source, on_select_handler):
 
 
 @pytest.fixture
-async def multiselect_keyboard_widget(source, on_select_handler):
-    skip_on_platforms("iOS", "macOS")
-    return toga.Table(
-        ["A", "B", "C"],
-        data=source,
-        multiple_select=True,
-        on_select=on_select_handler,
-        style=Pack(flex=1),
-    )
-
-
-@pytest.fixture
 async def multiselect_probe(main_window, multiselect_widget):
     old_content = main_window.content
 
@@ -118,20 +106,6 @@ async def multiselect_probe(main_window, multiselect_widget):
     main_window.content = box
     probe = get_probe(multiselect_widget)
     await probe.redraw("Constructing multiselect Table probe")
-    probe.assert_container(box)
-    yield probe
-
-    main_window.content = old_content
-
-
-@pytest.fixture
-async def multiselect_keyboard_probe(main_window, multiselect_keyboard_widget):
-    old_content = main_window.content
-
-    box = toga.Box(children=[multiselect_keyboard_widget])
-    main_window.content = box
-    probe = get_probe(multiselect_keyboard_widget)
-    await probe.redraw("Constructing multiselect Keyboard Table probe")
     probe.assert_container(box)
     yield probe
 
@@ -331,8 +305,8 @@ async def test_multiselect(
 
 
 async def test_multiselect_keyboard_control(
-    multiselect_keyboard_widget,
-    multiselect_keyboard_probe,
+    multiselect_widget,
+    multiselect_probe,
     source,
     on_select_handler,
 ):
@@ -346,40 +320,40 @@ async def test_multiselect_keyboard_control(
     case does not trigger the VirtualItemSelectionRangeChanged event, hence
     the need for this workaround.
     """
-    await multiselect_keyboard_probe.redraw("No row is selected in multiselect table")
+    await multiselect_probe.redraw("No row is selected in multiselect table")
 
     # Initial selection is empty
-    assert multiselect_keyboard_widget.selection == []
+    assert multiselect_widget.selection == []
     on_select_handler.assert_not_called()
 
-    await multiselect_keyboard_probe.acquire_keyboard_focus()
+    await multiselect_probe.acquire_keyboard_focus()
 
     # A single row can be added to the selection
-    await multiselect_keyboard_probe.redraw("First row selected")
-    assert multiselect_keyboard_widget.selection == [source[0]]
+    await multiselect_probe.redraw("First row selected")
+    assert multiselect_widget.selection == [source[0]]
 
-    await multiselect_keyboard_probe.type_character("<down>", shift=True)
-    await multiselect_keyboard_probe.redraw(
+    await multiselect_probe.type_character("<down>", shift=True)
+    await multiselect_probe.redraw(
         "Down arrow pressed - " "second row added to the selection"
     )
-    assert multiselect_keyboard_widget.selection == [source[0], source[1]]
-    on_select_handler.assert_called_with(multiselect_keyboard_widget)
+    assert multiselect_widget.selection == [source[0], source[1]]
+    on_select_handler.assert_called_with(multiselect_widget)
     on_select_handler.reset_mock()
 
-    await multiselect_keyboard_probe.type_character("<down>", shift=True)
-    await multiselect_keyboard_probe.redraw(
+    await multiselect_probe.type_character("<down>", shift=True)
+    await multiselect_probe.redraw(
         "Down arrow pressed - " "third row added to the selection"
     )
-    assert multiselect_keyboard_widget.selection == [source[0], source[1], source[2]]
-    on_select_handler.assert_called_with(multiselect_keyboard_widget)
+    assert multiselect_widget.selection == [source[0], source[1], source[2]]
+    on_select_handler.assert_called_with(multiselect_widget)
     on_select_handler.reset_mock()
 
-    await multiselect_keyboard_probe.type_character("<up>", shift=True)
-    await multiselect_keyboard_probe.redraw(
+    await multiselect_probe.type_character("<up>", shift=True)
+    await multiselect_probe.redraw(
         "Down arrow pressed - " "third row removed from the selection"
     )
-    assert multiselect_keyboard_widget.selection == [source[0], source[1]]
-    on_select_handler.assert_called_with(multiselect_keyboard_widget)
+    assert multiselect_widget.selection == [source[0], source[1]]
+    on_select_handler.assert_called_with(multiselect_widget)
     on_select_handler.reset_mock()
 
 

--- a/testbed/tests/widgets/test_table.py
+++ b/testbed/tests/widgets/test_table.py
@@ -99,6 +99,18 @@ async def multiselect_widget(source, on_select_handler):
 
 
 @pytest.fixture
+async def multiselect_keyboard_widget(source, on_select_handler):
+    skip_on_platforms("iOS", "macOS")
+    return toga.Table(
+        ["A", "B", "C"],
+        data=source,
+        multiple_select=True,
+        on_select=on_select_handler,
+        style=Pack(flex=1),
+    )
+
+
+@pytest.fixture
 async def multiselect_probe(main_window, multiselect_widget):
     old_content = main_window.content
 
@@ -106,6 +118,20 @@ async def multiselect_probe(main_window, multiselect_widget):
     main_window.content = box
     probe = get_probe(multiselect_widget)
     await probe.redraw("Constructing multiselect Table probe")
+    probe.assert_container(box)
+    yield probe
+
+    main_window.content = old_content
+
+
+@pytest.fixture
+async def multiselect_keyboard_probe(main_window, multiselect_keyboard_widget):
+    old_content = main_window.content
+
+    box = toga.Box(children=[multiselect_keyboard_widget])
+    main_window.content = box
+    probe = get_probe(multiselect_keyboard_widget)
+    await probe.redraw("Constructing multiselect Keyboard Table probe")
     probe.assert_container(box)
     yield probe
 
@@ -305,8 +331,8 @@ async def test_multiselect(
 
 
 async def test_multiselect_keyboard_control(
-    multiselect_widget,
-    multiselect_probe,
+    multiselect_keyboard_widget,
+    multiselect_keyboard_probe,
     source,
     on_select_handler,
 ):
@@ -320,40 +346,40 @@ async def test_multiselect_keyboard_control(
     case does not trigger the VirtualItemSelectionRangeChanged event, hence
     the need for this workaround.
     """
-    await multiselect_probe.redraw("No row is selected in multiselect table")
+    await multiselect_keyboard_probe.redraw("No row is selected in multiselect table")
 
     # Initial selection is empty
-    assert multiselect_widget.selection == []
+    assert multiselect_keyboard_widget.selection == []
     on_select_handler.assert_not_called()
 
-    await multiselect_probe.acquire_keyboard_focus()
+    await multiselect_keyboard_probe.acquire_keyboard_focus()
 
     # A single row can be added to the selection
-    await multiselect_probe.redraw("First row selected")
-    assert multiselect_widget.selection == [source[0]]
+    await multiselect_keyboard_probe.redraw("First row selected")
+    assert multiselect_keyboard_widget.selection == [source[0]]
 
-    await multiselect_probe.type_character("<down>", shift=True)
-    await multiselect_probe.redraw(
+    await multiselect_keyboard_probe.type_character("<down>", shift=True)
+    await multiselect_keyboard_probe.redraw(
         "Down arrow pressed - " "second row added to the selection"
     )
-    assert multiselect_widget.selection == [source[0], source[1]]
-    on_select_handler.assert_called_with(multiselect_widget)
+    assert multiselect_keyboard_widget.selection == [source[0], source[1]]
+    on_select_handler.assert_called_with(multiselect_keyboard_widget)
     on_select_handler.reset_mock()
 
-    await multiselect_probe.type_character("<down>", shift=True)
-    await multiselect_probe.redraw(
+    await multiselect_keyboard_probe.type_character("<down>", shift=True)
+    await multiselect_keyboard_probe.redraw(
         "Down arrow pressed - " "third row added to the selection"
     )
-    assert multiselect_widget.selection == [source[0], source[1], source[2]]
-    on_select_handler.assert_called_with(multiselect_widget)
+    assert multiselect_keyboard_widget.selection == [source[0], source[1], source[2]]
+    on_select_handler.assert_called_with(multiselect_keyboard_widget)
     on_select_handler.reset_mock()
 
-    await multiselect_probe.type_character("<up>", shift=True)
-    await multiselect_probe.redraw(
+    await multiselect_keyboard_probe.type_character("<up>", shift=True)
+    await multiselect_keyboard_probe.redraw(
         "Down arrow pressed - " "third row removed from the selection"
     )
-    assert multiselect_widget.selection == [source[0], source[1]]
-    on_select_handler.assert_called_with(multiselect_widget)
+    assert multiselect_keyboard_widget.selection == [source[0], source[1]]
+    on_select_handler.assert_called_with(multiselect_keyboard_widget)
     on_select_handler.reset_mock()
 
 

--- a/testbed/tests/widgets/test_table.py
+++ b/testbed/tests/widgets/test_table.py
@@ -310,15 +310,10 @@ async def test_multiselect_keyboard_control(
     source,
     on_select_handler,
 ):
-    """A multiselect table can be controlled by keyboard.
-    This is a workaround to create a scenario where multiple items are
-    selected while invoking VirtualItemSelectionRangeChanged event.
-    It simulates the behavior of a user pressing the down arrow key
-    while holding the shift key.
+    """Selection on a multiselect table can be controlled by keyboard.
 
-    Directly changing the selection state of items in the multiselect test
-    case does not trigger the VirtualItemSelectionRangeChanged event, hence
-    the need for this workaround.
+    Keyboard navigation can produce different events to mouse navigation,
+    so we need to test keyboard selection independent of mouse selection.
     """
     await multiselect_probe.redraw("No row is selected in multiselect table")
 
@@ -334,7 +329,7 @@ async def test_multiselect_keyboard_control(
 
     await multiselect_probe.type_character("<down>", shift=True)
     await multiselect_probe.redraw(
-        "Down arrow pressed - " "second row added to the selection"
+        "Down arrow pressed - second row added to the selection"
     )
     assert multiselect_widget.selection == [source[0], source[1]]
     on_select_handler.assert_called_with(multiselect_widget)
@@ -342,7 +337,7 @@ async def test_multiselect_keyboard_control(
 
     await multiselect_probe.type_character("<down>", shift=True)
     await multiselect_probe.redraw(
-        "Down arrow pressed - " "third row added to the selection"
+        "Down arrow pressed - third row added to the selection"
     )
     assert multiselect_widget.selection == [source[0], source[1], source[2]]
     on_select_handler.assert_called_with(multiselect_widget)
@@ -350,7 +345,7 @@ async def test_multiselect_keyboard_control(
 
     await multiselect_probe.type_character("<up>", shift=True)
     await multiselect_probe.redraw(
-        "Down arrow pressed - " "third row removed from the selection"
+        "Up arrow pressed - third row removed from the selection"
     )
     assert multiselect_widget.selection == [source[0], source[1]]
     on_select_handler.assert_called_with(multiselect_widget)

--- a/winforms/src/toga_winforms/widgets/table.py
+++ b/winforms/src/toga_winforms/widgets/table.py
@@ -156,15 +156,19 @@ class Table(Widget):
             e.Index = i
 
     def winforms_item_selection_changed(self, sender, e):
-        if hasattr(e, "Item"):
-            self.interface.on_select()
+        self.interface.on_select()
 
     def winforms_virtual_items_selection_range_changed(self, sender, e):
-        # Event handler for ListViewVirtualItemsSelectionRangeChanged
-        # with condition that only multiple items (>1) are selected
-        if (
-            len(list(self.native.SelectedIndices)) > 1
-        ):  # Only when multiple items' selection states are changed
+        # Event handler for the ListView.VirtualItemsSelectionRangeChanged
+        # with condition that only multiple items (>1) are selected.
+        # A ListView.VirtualItemsSelectionRangeChanged event will also be raised
+        # alongside a ListView.ItemSelectionChanged event when selecting a new
+        # item to replace an already selected item. This is due to the new selection
+        # action causing multiple items' selection state being changed.
+        # The number of selected items is checked before the on_select() is called.
+        # This is a workaround to avoid calling the on_select() method twice
+        # when selecting a new item to replace an already selected item.
+        if len(list(self.native.SelectedIndices)) > 1:
             self.interface.on_select()
 
     def winforms_double_click(self, sender, e):

--- a/winforms/src/toga_winforms/widgets/table.py
+++ b/winforms/src/toga_winforms/widgets/table.py
@@ -67,7 +67,7 @@ class Table(Widget):
             self.winforms_search_for_virtual_item
         )
         self.native.VirtualItemsSelectionRangeChanged += WeakrefCallable(
-            self.winforms_item_selection_changed
+            self.winforms_virtual_items_selection_range_changed
         )
         self.add_action_events()
 
@@ -156,7 +156,16 @@ class Table(Widget):
             e.Index = i
 
     def winforms_item_selection_changed(self, sender, e):
-        self.interface.on_select()
+        if hasattr(e, "Item"):
+            self.interface.on_select()
+
+    def winforms_virtual_items_selection_range_changed(self, sender, e):
+        # Event handler for ListViewVirtualItemsSelectionRangeChanged
+        # with condition that only multiple items (>1) are selected
+        if (
+            len(list(self.native.SelectedIndices)) > 1
+        ):  # Only when multiple items' selection states are changed
+            self.interface.on_select()
 
     def winforms_double_click(self, sender, e):
         hit_test = self.native.HitTest(e.X, e.Y)


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Add additional event handler dedicated for `ListViewVirtualItemsSelectionRangeChanged` events, so `winforms_item_selection_changed` method no longer handles both the `ListViewItemSelectionChanged` and `ListViewVirtualItemsSelectionRangeChanged` event. 

For single selection tables, only `ListViewItemSelectionChanged` event is being handled when new items are being selected. 

For multiple selection tables, only `ListViewVirtualItemsSelectionRangeChanged` event is being handled when multiple items' selection states are changed.

<!--- What problem does this change solve? -->
Fix #3265 
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
