### PR TITLE
Fixed bug 3399 - Textual backend now uses documented run API.

### DIFF
--- a/changes/3399.bugfix.rst
+++ b/changes/3399.bugfix.rst
@@ -1,0 +1,1 @@
+Removed work around to suppress textual backend logging messages when app is closed.

--- a/textual/pyproject.toml
+++ b/textual/pyproject.toml
@@ -66,7 +66,7 @@ root = ".."
 
 [tool.setuptools_dynamic_dependencies]
 dependencies = [
-    "textual >= 3.0.0, < 4.0.0",
+    "textual >= 3.2.0, < 4.0.0",
     "toga-core == {version}",
 ]
 

--- a/textual/src/toga_textual/app.py
+++ b/textual/src/toga_textual/app.py
@@ -1,5 +1,4 @@
 import asyncio
-import threading
 
 import toga
 from textual.app import App as TextualApp
@@ -58,21 +57,7 @@ class App:
         self.native.exit()
 
     def main_loop(self):
-        # This is duplicating the bulk of TextualApp.run(); however, that entry point
-        # doesn't give any control over the event loop that is used. The key detail
-        # is that the _context() is required to capture logging messages generated
-        # as the app is shutting down. See textualize/textual#5091.
-        with self.native._context():
-            try:
-                self.native._loop = self.loop
-                self.native._thread_id = threading.get_ident()
-
-                self.loop.run_until_complete(
-                    self.native.run_async(headless=self.headless)
-                )
-            finally:
-                self.native._loop = None
-                self.native._thread_id = 0
+        self.native.run(headless=self.headless, loop=self.loop)
 
     def set_icon(self, icon):
         pass


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Replaced the implementation of the Toga Textual App class' main_loop() method with an implementation that uses the (now documented) self.native.run(headless=self.headless, loop=self.loop) API

<!--- What problem does this change solve? -->
No user visible change but bug work around has been replaced by appropriate documented
function call.

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Fixes #3399 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x] All new features have been tested (bug fix has been tested)
- [ ] All new features have been documented (no documentation changes required).
- [x ] I have read the **CONTRIBUTING.md** file
- [x ] I will abide by the code of conduct
