### PR TITLE
Add check to ensure window content exists before calling the refresh …

### DIFF
--- a/changes/2818.bugfix.rst
+++ b/changes/2818.bugfix.rst
@@ -1,0 +1,1 @@
+Added a check to ensure window content exists before calling the refresh method for textual.

--- a/textual/src/toga_textual/window.py
+++ b/textual/src/toga_textual/window.py
@@ -109,7 +109,8 @@ class TogaWindow(TextualScreen):
         self.impl = impl
 
     def on_resize(self, event) -> None:
-        self.interface.content.refresh()
+        if self.interface.content is not None:
+            self.interface.content.refresh()
 
 
 class Window:


### PR DESCRIPTION
…method for textual

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

Resolves #2818, which details a bug in which the app crashes if there is no window content.  This PR updates the code so that it checks if window content exists before calling the refresh method.

Prior to this change, an error would be generated when running `TOGA_BACKEND=toga_textual python -c 'import toga; toga.App(formal_name="MyApp", app_id="MyApp").main_loop()'` (as mentioned in #2818).  This error now no longer occurs.  The output now looks like this:
<img width="1272" alt="image" src="https://github.com/user-attachments/assets/d2cf60f5-7859-4c25-840f-ac158a0ae4ab" />


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
