### PR TITLE
Check DEFAULT_FLAGS based on Glib version, not GTK version.

### DIFF
--- a/changes/3525.bugfix.rst
+++ b/changes/3525.bugfix.rst
@@ -1,0 +1,1 @@
+GTK4 applications now starts correctly on slightly older GNU/Linux versions.

--- a/changes/3525.bugfix.rst
+++ b/changes/3525.bugfix.rst
@@ -1,1 +1,1 @@
-GTK4 applications now starts correctly on slightly older GNU/Linux versions.
+Older Linux distributions (such as Ubuntu 22.04) that ship with GLib < 2.74 can now use GTK4 with Toga.

--- a/gtk/src/toga_gtk/app.py
+++ b/gtk/src/toga_gtk/app.py
@@ -6,6 +6,7 @@ from toga.command import Separator
 
 from .keys import gtk_accel
 from .libs import (
+    GLIB_VERSION,
     GTK_VERSION,
     IS_WAYLAND,
     TOGA_DEFAULT_STYLES,
@@ -33,12 +34,12 @@ class App:
         self.loop = self.policy.get_event_loop()
 
         # Stimulate the build of the app
-        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+        if GLIB_VERSION < (2, 74, 0):  # pragma: no-cover
             self.native = Gtk.Application(
                 application_id=self.interface.app_id,
                 flags=Gio.ApplicationFlags.FLAGS_NONE,
             )
-        else:  # pragma: no-cover-if-gtk3
+        else:  # pragma: no-cover
             self.native = Gtk.Application(
                 application_id=self.interface.app_id,
                 flags=Gio.ApplicationFlags.DEFAULT_FLAGS,

--- a/gtk/src/toga_gtk/app.py
+++ b/gtk/src/toga_gtk/app.py
@@ -34,12 +34,14 @@ class App:
         self.loop = self.policy.get_event_loop()
 
         # Stimulate the build of the app
-        if GLIB_VERSION < (2, 74, 0):  # pragma: no-cover
+        # No coverage for either because both GTK3 and
+        # GTK4 could potentially go on the either cases
+        if GLIB_VERSION < (2, 74, 0):  # pragma: no cover
             self.native = Gtk.Application(
                 application_id=self.interface.app_id,
                 flags=Gio.ApplicationFlags.FLAGS_NONE,
             )
-        else:  # pragma: no-cover
+        else:  # pragma: no cover
             self.native = Gtk.Application(
                 application_id=self.interface.app_id,
                 flags=Gio.ApplicationFlags.DEFAULT_FLAGS,

--- a/gtk/src/toga_gtk/app.py
+++ b/gtk/src/toga_gtk/app.py
@@ -38,12 +38,12 @@ class App:
         # a newer version of glib or if GTK4 is used with an older version
         # of glib.  On local runs, coverage errors here can be safely
         # ignored if the version of software is as described above.
-        if GLIB_VERSION < (2, 74, 0):  # pragma: no-cover-if-gtk3
+        if GLIB_VERSION < (2, 74, 0):  # pragma: no-cover-if-gtk4
             self.native = Gtk.Application(
                 application_id=self.interface.app_id,
                 flags=Gio.ApplicationFlags.FLAGS_NONE,
             )
-        else:  # pragma: no-cover-if-gtk4
+        else:  # pragma: no-cover-if-gtk3
             self.native = Gtk.Application(
                 application_id=self.interface.app_id,
                 flags=Gio.ApplicationFlags.DEFAULT_FLAGS,

--- a/gtk/src/toga_gtk/app.py
+++ b/gtk/src/toga_gtk/app.py
@@ -34,14 +34,16 @@ class App:
         self.loop = self.policy.get_event_loop()
 
         # Stimulate the build of the app
-        # No coverage for either because both GTK3 and
-        # GTK4 could potentially go on the either cases
-        if GLIB_VERSION < (2, 74, 0):  # pragma: no cover
+        # *Note* -- the coverage may be inaccurate if GTK3 is used with
+        # a newer version of glib or if GTK4 is used with an older version
+        # of glib.  On local runs, coverage errors here can be safely
+        # ignored if the version of software is as described above.
+        if GLIB_VERSION < (2, 74, 0):  # pragma: no-cover-if-gtk3
             self.native = Gtk.Application(
                 application_id=self.interface.app_id,
                 flags=Gio.ApplicationFlags.FLAGS_NONE,
             )
-        else:  # pragma: no cover
+        else:  # pragma: no-cover-if-gtk4
             self.native = Gtk.Application(
                 application_id=self.interface.app_id,
                 flags=Gio.ApplicationFlags.DEFAULT_FLAGS,

--- a/gtk/src/toga_gtk/libs/gtk.py
+++ b/gtk/src/toga_gtk/libs/gtk.py
@@ -23,6 +23,12 @@ GTK_VERSION: tuple[int, int, int] = (
     Gtk.get_micro_version(),
 )
 
+GLIB_VERSION: tuple[int, int, int] = (
+    GLib.MAJOR_VERSION,
+    GLib.MAJOR_VERSION,
+    GLib.MAJOR_VERSION,
+)
+
 if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
     default_display = Gdk.Screen.get_default()
 else:  # pragma: no-cover-if-gtk3


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

Support slightly older GTK4 by checking Glib version instead.

Fixes #3524.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
