### PR TITLE
Upgrade usage of Rubicon event loop to use Python 3.14-compatible API.

### DIFF
--- a/cocoa/pyproject.toml
+++ b/cocoa/pyproject.toml
@@ -64,7 +64,7 @@ root = ".."
 [tool.setuptools_dynamic_dependencies]
 dependencies = [
     "fonttools >= 4.42.1, < 5.0.0",
-    "rubicon-objc >= 0.5.0, < 0.6.0",
+    "rubicon-objc >= 0.5.1, < 0.6.0",
     "toga-core == {version}",
 ]
 

--- a/cocoa/src/toga_cocoa/app.py
+++ b/cocoa/src/toga_cocoa/app.py
@@ -9,7 +9,7 @@ from rubicon.objc import (
     objc_method,
     objc_property,
 )
-from rubicon.objc.eventloop import CocoaLifecycle, EventLoopPolicy
+from rubicon.objc.eventloop import CocoaLifecycle, RubiconEventLoop
 
 import toga
 from toga.command import Command, Group, Separator
@@ -105,8 +105,7 @@ class App:
 
         self._cursor_visible = True
 
-        asyncio.set_event_loop_policy(EventLoopPolicy())
-        self.loop = asyncio.new_event_loop()
+        self.loop = RubiconEventLoop()
 
         self.native = NSApplication.sharedApplication
 

--- a/iOS/pyproject.toml
+++ b/iOS/pyproject.toml
@@ -63,7 +63,7 @@ root = ".."
 [tool.setuptools_dynamic_dependencies]
 dependencies = [
     "fonttools >= 4.42.1, < 5.0.0",
-    "rubicon-objc >= 0.5.0, < 0.6.0",
+    "rubicon-objc >= 0.5.1, < 0.6.0",
     "toga-core == {version}",
 ]
 

--- a/iOS/src/toga_iOS/app.py
+++ b/iOS/src/toga_iOS/app.py
@@ -1,7 +1,5 @@
-import asyncio
-
 from rubicon.objc import objc_method
-from rubicon.objc.eventloop import EventLoopPolicy, iOSLifecycle
+from rubicon.objc.eventloop import RubiconEventLoop, iOSLifecycle
 
 import toga
 from toga_iOS.libs import UIResponder, UIScreen, av_foundation
@@ -69,8 +67,7 @@ class App:
         # Add a reference for the PythonAppDelegate class to use.
         App.app = self
 
-        asyncio.set_event_loop_policy(EventLoopPolicy())
-        self.loop = asyncio.new_event_loop()
+        self.loop = RubiconEventLoop()
 
     def create(self):
         """Calls the startup method on the interface."""


### PR DESCRIPTION
Python 3.14 deprecates the concept of an asyncio EventLoopPolicy; asyncio events should now create their own event loop that implements the policy directly. 

Rubicon 0.5.1 includes the code to support the new API, and provides a backwards-compatibility shim - but raises a warning on older Pythons to advise an upgrade to use the new shim.

This PR implements that upgrade.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
