### PR TITLE
Disable smart quotes on macOS for MultilineTextInput

### DIFF
--- a/changes/3546.bugfix.rst
+++ b/changes/3546.bugfix.rst
@@ -1,0 +1,1 @@
+Disables the default enabled smart quote behavior on macOS.

--- a/changes/3546.bugfix.rst
+++ b/changes/3546.bugfix.rst
@@ -1,1 +1,1 @@
-Disables the default enabled smart quote behavior on macOS.
+Due to a default behavior on macOS, ``MultilineTextInput`` automatically converted straight quotes to smart quotes. This behavior has now been disabled.

--- a/cocoa/src/toga_cocoa/widgets/multilinetextinput.py
+++ b/cocoa/src/toga_cocoa/widgets/multilinetextinput.py
@@ -45,6 +45,7 @@ class MultilineTextInput(Widget):
         self.native_text.verticallyResizable = True
         self.native_text.horizontallyResizable = False
         self.native_text.usesAdaptiveColorMappingForDarkAppearance = True
+        self.native_text.toggleAutomaticQuoteSubstitution(None)
 
         self.native_text.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable
 

--- a/cocoa/src/toga_cocoa/widgets/multilinetextinput.py
+++ b/cocoa/src/toga_cocoa/widgets/multilinetextinput.py
@@ -45,7 +45,8 @@ class MultilineTextInput(Widget):
         self.native_text.verticallyResizable = True
         self.native_text.horizontallyResizable = False
         self.native_text.usesAdaptiveColorMappingForDarkAppearance = True
-        self.native_text.toggleAutomaticQuoteSubstitution(None)
+        self.native_text.setAutomaticQuoteSubstitutionEnabled(False)
+        self.native_text.setAutomaticDashSubstitutionEnabled(False)
 
         self.native_text.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable
 

--- a/gtk/tests_backend/widgets/base.py
+++ b/gtk/tests_backend/widgets/base.py
@@ -125,6 +125,8 @@ class SimpleProbe(BaseProbe, FontMixin):
                 ".": Gdk.KEY_period,
                 "\n": Gdk.KEY_Return,
                 "<esc>": Gdk.KEY_Escape,
+                "'": Gdk.KEY_apostrophe,
+                '"': Gdk.KEY_quotedbl,
             }.get(char, Gdk.KEY_question),
         )
 

--- a/testbed/tests/widgets/test_multilinetextinput.py
+++ b/testbed/tests/widgets/test_multilinetextinput.py
@@ -27,6 +27,7 @@ from .test_textinput import (  # noqa: F401
     test_on_change_focus,
     test_on_change_programmatic,
     test_on_change_user,
+    test_quote_dash_substitution_disabled,
     test_undo_redo,
     test_value_not_hidden,
 )

--- a/testbed/tests/widgets/test_textinput.py
+++ b/testbed/tests/widgets/test_textinput.py
@@ -107,6 +107,36 @@ async def test_on_change_user(widget, probe, on_change):
         assert widget.value == expected
 
 
+@pytest.mark.parametrize(
+    "test_input",
+    [
+        '""',
+        "''",
+        "--",
+        "---",
+        'Humorless "test" input',
+        "Can't 'bee' bothered",
+        "Bee dashing--or fail miserably. --- No One Ever",
+    ],
+)
+async def test_quote_dash_substitution_disabled(widget, probe, on_change, test_input):
+    """Verify automatic smart quote and dash substitution are disabled"""
+    # This test simulates typing, so the widget must be focused.
+    widget.focus()
+    widget.value = ""
+    on_change.reset_mock()
+
+    for count, char in enumerate(test_input, start=1):
+        await probe.type_character(char)
+        await probe.redraw(f"Typed {char!r}")
+
+        # The number of events equals the number of characters typed.
+        assert on_change.mock_calls == [call(widget)] * count
+        expected = test_input[:count]
+        assert probe.value == expected
+        assert widget.value == expected
+
+
 async def test_on_change_focus(widget, probe, on_change, focused, placeholder, other):
     """The on_change handler is not triggered by focus changes, even if they cause a
     placeholder to appear or disappear."""


### PR DESCRIPTION
<!--- Describe your changes in detail -->
This disables the macOS default smart quotes behavior in the MultilineTextField widget. Smart quotes are enabled by default in macOS, and without this fix, double quotes are converted to smart quotes in the widget, which breaks using it to write to code or config files. 

As debugging this was difficult, this change was suggested as an immediate fix.

It was initially suggested to use `isAutomaticQuoteSubstitutionEnabled`, however this did not work in testing. The instance method implemented here was linked in the docs for the suggested fix, and in testing, it resolves the issue.
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
This is an immediate solution for #3546. Leaving the issue open as there was mention of a potential feature to allow the user to enable or disable this feature.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
