### PR TITLE
Dummy backend: implement Documents/Desktop/Pictures stubs; print docu…

### DIFF
--- a/changes/3551.misc
+++ b/changes/3551.misc
@@ -1,0 +1,1 @@
+Implement Documents, Desktop & Pictures paths in the Dummy backend and update the simple test app to print them.

--- a/core/tests/testbed/interactive.py
+++ b/core/tests/testbed/interactive.py
@@ -22,6 +22,10 @@ def main():
     print(f"app.paths.logs={app.paths.logs.resolve()}")
     print(f"app.paths.toga={app.paths.toga.resolve()}")
 
+    print(f"app.paths.documents={app.paths.documents}")
+    print(f"app.paths.desktop={app.paths.desktop}")
+    print(f"app.paths.pictures={app.paths.pictures}")
+
 
 if __name__ == "__main__":
     main()

--- a/core/tests/testbed/simple/app.py
+++ b/core/tests/testbed/simple/app.py
@@ -10,6 +10,9 @@ def main():
     print(f"app.paths.cache={app.paths.cache.resolve()}")
     print(f"app.paths.logs={app.paths.logs.resolve()}")
     print(f"app.paths.toga={app.paths.toga.resolve()}")
+    print(f"app.paths.documents={app.paths.documents.resolve()}")
+    print(f"app.paths.desktop={app.paths.desktop.resolve()}")
+    print(f"app.paths.pictures={app.paths.pictures.resolve()}")
 
 
 if __name__ == "__main__":

--- a/dummy/src/toga_dummy/paths.py
+++ b/dummy/src/toga_dummy/paths.py
@@ -18,3 +18,12 @@ class Paths:
 
     def get_logs_path(self):
         return Path.home() / "logs" / App.app.app_id
+
+    def get_documents_path(self):
+        return Path.home() / "Documents"
+
+    def get_pictures_path(self):
+        return Path.home() / "Pictures"
+
+    def get_desktop_path(self):
+        return Path.home() / "Desktop"


### PR DESCRIPTION
…ments in simple test app

<!--- Describe your changes in detail -->
This patch adds implementations for get_documents_path, get_desktop_path, and get_pictures_path in the Dummy backend so that app.paths.documents, app.paths.desktop, and app.paths.pictures resolve to the user’s ~/Documents, ~/Desktop, and ~/Pictures directories, respectively. It also updates the simple testbed app to print out the documents path (and optionally desktop/pictures) so that the existing user‐space path integration tests pass in non‐interactive mode.
<!--- What problem does this change solve? -->
Fixes #3551
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
