### PR TITLE
Replace symbolic reference to Q with numeric value.

### DIFF
--- a/android/src/toga_android/app.py
+++ b/android/src/toga_android/app.py
@@ -40,17 +40,17 @@ class TogaApp(dynamic_proxy(IPythonApp)):
 
     def onResume(self):  # pragma: no cover
         print("Toga app: onResume")
-        # onTopResumedActivityChanged is not available on android versions less
-        # than Q. onResume is the best indicator for the gain input focus event.
+        # onTopResumedActivityChanged is not available on android versions less than Q
+        # (API level 29). onResume is the best indicator for the gain input focus event.
         # https://developer.android.com/reference/android/app/Activity#onWindowFocusChanged(boolean):~:text=If%20the%20intent,the%20best%20indicator.
-        if Build.VERSION.SDK_INT < Build.VERSION_CODES.Q:
+        if Build.VERSION.SDK_INT < 29:
             self._impl.interface.current_window.on_gain_focus()
 
     def onPause(self):  # pragma: no cover
         print("Toga app: onPause")
-        # onTopResumedActivityChanged is not available on android versions less
-        # than Q. onPause is the best indicator for the lost input focus event.
-        if Build.VERSION.SDK_INT < Build.VERSION_CODES.Q:
+        # onTopResumedActivityChanged is not available on android versions less than Q
+        # (API level 29). onPause is the best indicator for the lost input focus event.
+        if Build.VERSION.SDK_INT < 29:
             self._impl.interface.current_window.on_lose_focus()
 
     def onStop(self):  # pragma: no cover

--- a/changes/3554.bugfix.rst
+++ b/changes/3554.bugfix.rst
@@ -1,0 +1,1 @@
+A crash on Android 9 (and earlier) caused by a symbol that wasn't available on those versions has been resolved.


### PR DESCRIPTION
Referencing the `Build.VERSION_CODES.Q` symbol directly causes crashes when you run on pre-Q versions, as the symbol doesn't exist. Replace the use of the symbol with the numeric equivalent, matching what is done elsewhere in Toga's Android backend.

Fixes #3554.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
