### PR TITLE
Remove unused max_python_version env var in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ on:
         value: ${{ jobs.package.outputs.artifact-basename }}
 
 env:
+  min_python_version: "3.10"
   FORCE_COLOR: "1"
 
 defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,6 @@ on:
         value: ${{ jobs.package.outputs.artifact-basename }}
 
 env:
-  min_python_version: "3.9"
-  max_python_version: "3.12"
   FORCE_COLOR: "1"
 
 defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ on:
         value: ${{ jobs.package.outputs.artifact-basename }}
 
 env:
-  min_python_version: "3.10"
+  min_python_version: "3.9"
   FORCE_COLOR: "1"
 
 defaults:

--- a/changes/3588.misc.rst
+++ b/changes/3588.misc.rst
@@ -1,1 +1,1 @@
-Unused ``min_python_version`` and ``max_python_version`` environment variables have been removed from GitHub CI configuration.
+Unused ``max_python_version`` environment variable has been removed from GitHub CI configuration.

--- a/changes/3588.misc.rst
+++ b/changes/3588.misc.rst
@@ -1,0 +1,1 @@
+Unused ``min_python_version`` and ``max_python_version`` environment variables have been removed from GitHub CI configuration.


### PR DESCRIPTION
We used to use both `min_python_version` and `max_python_version` in the CI configuration, but we don't use the `max` anymore. (I believe it was removed once we started testing on the whole matrix, rather than just the lowest and highest.) `max_python_version` has also never been updated from 3.12 to 3.13. We might as well just remove it, and we can always add it back in if and when we need it for something.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
