### PR TITLE
Fix `Document.extensions` docstring

### DIFF
--- a/changes/2975.misc.rst
+++ b/changes/2975.misc.rst
@@ -1,0 +1,1 @@
+Fix document.extensions docstring

--- a/core/src/toga/documents.py
+++ b/core/src/toga/documents.py
@@ -20,11 +20,10 @@ class Document(ABC):
     #: class variable that subclasses should define.
     description: str
 
-    #: A list of extensions that documents of this type might use,
-    #: without leading dots (e.g.,
-    #: ``["doc", "txt"]``). The list must have at least one extension; the first is the
-    #: default extension for documents of this type. This is a class variable that
-    #: subclasses should define.
+    #: A list of extensions that documents of this type might use, without leading dots
+    #: (e.g., ``["doc", "txt"]``). The list must have at least one extension; the first
+    #: is the default extension for documents of this type. This is a class variable
+    #: that subclasses should define.
     extensions: list[str]
 
     def __init__(self, app: App):

--- a/core/src/toga/documents.py
+++ b/core/src/toga/documents.py
@@ -21,7 +21,7 @@ class Document(ABC):
     description: str
 
     #: A list of extensions that documents of this type might use,
-    # without leading dots (e.g.,
+    #: without leading dots (e.g.,
     #: ``["doc", "txt"]``). The list must have at least one extension; the first is the
     #: default extension for documents of this type. This is a class variable that
     #: subclasses should define.


### PR DESCRIPTION
This was broken in #2993. It doesn't appear that any similar breakages happened at the same time.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
