### PR TITLE
add 100% scaling fallback for older (pre-8.1) Windows versions

### DIFF
--- a/winforms/src/toga_winforms/libs/shcore.py
+++ b/winforms/src/toga_winforms/libs/shcore.py
@@ -1,5 +1,14 @@
 from ctypes import HRESULT, POINTER, windll, wintypes
 
-GetScaleFactorForMonitor = windll.shcore.GetScaleFactorForMonitor
-GetScaleFactorForMonitor.restype = HRESULT
-GetScaleFactorForMonitor.argtypes = [wintypes.HMONITOR, POINTER(wintypes.UINT)]
+try:
+	shcore = windll.shcore
+except FileNotFoundError:
+	# Windows <8.1
+	shcore = None
+
+if shcore:
+	GetScaleFactorForMonitor = shcore.GetScaleFactorForMonitor
+	GetScaleFactorForMonitor.restype = HRESULT
+	GetScaleFactorForMonitor.argtypes = [wintypes.HMONITOR, POINTER(wintypes.UINT)]
+else:
+	GetScaleFactorForMonitor = None

--- a/winforms/src/toga_winforms/screens.py
+++ b/winforms/src/toga_winforms/screens.py
@@ -32,6 +32,10 @@ class Screen(Scalable):
 
     @property
     def dpi_scale(self):
+        if shcore.GetScaleFactorForMonitor is None:
+            # Fallback for Windows <8.1
+            return 1.0
+
         screen_rect = wintypes.RECT(
             self.native.Bounds.Left,
             self.native.Bounds.Top,


### PR DESCRIPTION
this PR adds a fallback for `shcore.GetScaleFactorForMonitor` defaulting to 100% scaling on unsupported (older than Windows 8.1) systems. 

`GetScaleFactorForMonitor` [exists on Windows 8.1+](https://learn.microsoft.com/en-us/windows/win32/api/shellscalingapi/nf-shellscalingapi-getscalefactorformonitor#requirements) and with this fallback Toga is functional on systems as old as Windows Vista (when an updated .NET is installed)

![image](https://github.com/user-attachments/assets/2f97e254-b0e4-44c0-b203-67ef0eb27601)

I understand the project is not interested in supporting Windows 7 and older (as much as i personally am interested in those platforms as targets) but this is a very small change with minimal additional maintenance burden so on that basis I would like to see it accepted. A [warning message is already shown](https://github.com/beeware/toga/blob/22000bb10e5f24ea8909e80e246cd40fb87fbad9/winforms/src/toga_winforms/libs/user32.py#L26) on platforms older than Windows 10 v1703 so I don't think any illusion of support is created here.

(also, i know i'm supposed to add a user-facing changelog message, but i'm guessing something like "Fix crash on startup affecting Windows 7 and older versions" could misleadingly advertise a level of support that doesn't exist, so i've omitted that for now?)

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
