### PR TITLE
Modify ListSource.find to provide a default result if no matches foun…

### DIFF
--- a/core/src/toga/sources/list_source.py
+++ b/core/src/toga/sources/list_source.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping, Sequence
-from typing import Generic, TypeVar
+from typing import Any, Generic, TypeVar
 
 from .base import Source
 
 T = TypeVar("T")
+UNDEFINED = object()
 
 
 def _find_item(
@@ -218,7 +219,9 @@ class ListSource(Source):
         """
         return self._data.index(row)
 
-    def find(self, data: object, start: Row | None = None) -> Row:
+    def find(
+        self, data: object, start: Row | None = None, default: Any = UNDEFINED
+    ) -> Row:
         """Find the first item in the data that matches all the provided
         attributes.
 
@@ -233,13 +236,21 @@ class ListSource(Source):
             they won't be considered as part of the match.
         :param start: The instance from which to start the search. Defaults to ``None``,
             indicating that the first match should be returned.
-        :return: The matching Row object
-        :raises ValueError: If no match is found.
+        :param default: If provided, this value will be returned if no match is found.
+        :return: The matching Row object if found, or the value of ``default`` if
+            provided.
+        :raises ValueError: If no match is found and ``default`` is not provided.
         """
-        return _find_item(
-            candidates=self._data,
-            data=data,
-            accessors=self._accessors,
-            start=start,
-            error=f"No row matching {data!r} in data",
-        )
+        try:
+            return _find_item(
+                candidates=self._data,
+                data=data,
+                accessors=self._accessors,
+                start=start,
+                error=f"No row matching {data!r} in data",
+            )
+        except ValueError as e:
+            if default is UNDEFINED:
+                raise e
+            else:
+                return default

--- a/core/tests/sources/test_list_source.py
+++ b/core/tests/sources/test_list_source.py
@@ -405,7 +405,7 @@ def test_find(source):
     # A partial match is enough
     assert source.find({"val1": "third"}) == source[2]
 
-    # find will fail if the object doesn't exist
+    # find will raise ValueError if no match is found and no default is provided
     with pytest.raises(
         ValueError,
         match=r"No row matching {'val1': 'not there', 'val2': 999} in data",
@@ -421,3 +421,6 @@ def test_find(source):
         ),
     ):
         source.find({"val1": "first", "val2": 111, "value": "overspecified"})
+
+    # If a default is provided, it will be returned if no match is found
+    assert source.find({"val1": "not there", "val2": 999}, default=None) is None


### PR DESCRIPTION
Fixes #3609

Adds a :return: parameter to `ListSource.find`.

If a return parameter is passed to `ListSource.find` and no match is found, returns the return parameter.
If no return parameter is passed, raised ValueError as before.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
