### PR TITLE
Add button icon size support

### DIFF
--- a/android/src/toga_android/icons.py
+++ b/android/src/toga_android/icons.py
@@ -6,7 +6,7 @@ class Icon:
     EXTENSIONS = [".png"]
     SIZES = None
 
-    def __init__(self, interface, path):
+    def __init__(self, interface, path, size=None):
         self.interface = interface
         self.interface._impl = self
 
@@ -14,12 +14,15 @@ class Icon:
             raise FileNotFoundError("No runtime app icon")
 
         self.path = path
+        self.size = size
 
         self.native = BitmapFactory.decodeFile(str(path))
         if self.native is None:
             raise ValueError(f"Unable to load icon from {path}")
 
     def as_drawable(self, widget, size):
+        if self.size is not None:
+            size = self.size
         bitmap = Bitmap.createScaledBitmap(
             self.native,
             widget.scale_in(size),

--- a/android/src/toga_android/widgets/button.py
+++ b/android/src/toga_android/widgets/button.py
@@ -9,6 +9,8 @@ from toga.colors import TRANSPARENT
 
 from .label import TextViewWidget
 
+DEFAULT_ICON_SIZE = 48
+
 
 class TogaOnClickListener(dynamic_proxy(View.OnClickListener)):
     def __init__(self, button_impl):
@@ -41,8 +43,9 @@ class Button(TextViewWidget):
     def set_icon(self, icon):
         self._icon = icon
         if icon:
-            # Scale icon to to a 48x48 CSS pixel bitmap drawable.
-            drawable = icon._impl.as_drawable(self, 48)
+            # Scale icon to a CSS pixel bitmap drawable (default to 48x48 if the size
+            # hasn't been provided).
+            drawable = icon._impl.as_drawable(self, DEFAULT_ICON_SIZE)
         else:
             drawable = None
 
@@ -57,10 +60,13 @@ class Button(TextViewWidget):
     def rehint(self):
         if self._icon:
             # Icons aren't considered "inside" the button, so they aren't part of the
-            # "measured" size. Hardcode a button size of 48x48 pixels with 10px of
-            # padding (in CSS pixels).
-            self.interface.intrinsic.width = at_least(68)
-            self.interface.intrinsic.height = 68
+            # "measured" size. Hardcode a button size of the icon size (or the 48x48
+            # pixels default) with 10px of padding on each side (in CSS pixels).
+            size = 20 + (
+                DEFAULT_ICON_SIZE if self._icon.size is None else self._icon.size
+            )
+            self.interface.intrinsic.width = at_least(size)
+            self.interface.intrinsic.height = size
         else:
             self.native.measure(
                 View.MeasureSpec.UNSPECIFIED,

--- a/android/tests_backend/widgets/button.py
+++ b/android/tests_backend/widgets/button.py
@@ -14,10 +14,10 @@ class ButtonProbe(LabelProbe):
     def assert_no_icon(self):
         return self.native.getCompoundDrawablesRelative()[0] is None
 
-    def assert_icon_size(self):
+    def assert_icon_size(self, size=48):
         icon = self.native.getCompoundDrawablesRelative()[0]
         if icon:
-            scaled_size = (self.impl.scale_in(48), self.impl.scale_in(48))
+            scaled_size = (self.impl.scale_in(size), self.impl.scale_in(size))
             assert (icon.getIntrinsicWidth(), icon.getIntrinsicHeight()) == scaled_size
         else:
             pytest.fail("Icon does not exist")

--- a/changes/3641.feature.rst
+++ b/changes/3641.feature.rst
@@ -1,0 +1,1 @@
+Add the ability to set the size of icons on buttons.

--- a/cocoa/src/toga_cocoa/icons.py
+++ b/cocoa/src/toga_cocoa/icons.py
@@ -9,9 +9,10 @@ class Icon:
     EXTENSIONS = [".icns", ".png", ".pdf"]
     SIZES = None
 
-    def __init__(self, interface, path):
+    def __init__(self, interface, path, size=None):
         self.interface = interface
         self.interface._impl = self
+        self.size = size
 
         if path is None:
             # Look to the app bundle, and get the icon. Set self.path as None
@@ -42,7 +43,8 @@ class Icon:
         if self.native is None:
             raise ValueError(f"Unable to load icon from {path}")
 
-    def _as_size(self, size):
+    def _as_size(self, default_size):
+        size = self.size if self.size is not None else default_size
         image = self.native.copy()
         image.setSize(NSSize(size, size))
         return image

--- a/cocoa/tests_backend/icons.py
+++ b/cocoa/tests_backend/icons.py
@@ -32,6 +32,19 @@ class IconProbe(BaseProbe):
         else:
             pytest.fail("Unknown icon resource")
 
+    def assert_icon_size(self, path):
+        if path == "resources/icons/green":
+            assert (
+                self.icon._impl.path
+                == self.app.paths.app / "resources/icons/green.icns"
+            )
+        elif path == "resources/icons/blue":
+            assert (
+                self.icon._impl.path == self.app.paths.app / "resources/icons/blue.png"
+            )
+        else:
+            pytest.fail("Unknown icon resource")
+
     def assert_default_icon_content(self):
         assert (
             self.icon._impl.path

--- a/cocoa/tests_backend/widgets/button.py
+++ b/cocoa/tests_backend/widgets/button.py
@@ -17,10 +17,10 @@ class ButtonProbe(SimpleProbe):
     def assert_no_icon(self):
         assert self.native.image is None
 
-    def assert_icon_size(self):
+    def assert_icon_size(self, size=32):
         icon = self.native.image
         if icon:
-            assert (icon.size.width, icon.size.height) == (32, 32)
+            assert (icon.size.width, icon.size.height) == (size, size)
         else:
             fail("Icon does not exist")
 

--- a/core/src/toga/icons.py
+++ b/core/src/toga/icons.py
@@ -69,6 +69,7 @@ class Icon:
     def __init__(
         self,
         path: str | Path,
+        size: int | None = None,
         *,
         system: bool = False,  # Deliberately undocumented; for internal use only
     ):
@@ -81,6 +82,8 @@ class Icon:
             icon will be :attr:`~toga.Icon.DEFAULT_ICON`. If an icon file is found, but
             it cannot be loaded (due to a file format or permission error), an exception
             will be raised.
+        :param size: The size of the icon. This attribute is currently only supported
+            within buttons.
         :param system: **For internal use only**
         """
         self.factory = get_platform_factory()
@@ -92,6 +95,7 @@ class Icon:
             else:
                 self.path = Path(path)
 
+            self.size = size
             self.system = system
             if self.system:
                 resource_path = Path(self.factory.__file__).parent / "resources"
@@ -118,7 +122,9 @@ class Icon:
                     resource_path=resource_path,
                 )
 
-            self._impl = self.factory.Icon(interface=self, path=full_path)
+            self._impl = self.factory.Icon(
+                interface=self, path=full_path, size=self.size
+            )
         except FileNotFoundError:
             # Icon path couldn't be found. If the path is the sentinel for the app
             # icon, and this isn't running as a script, fall back to the application
@@ -127,7 +133,9 @@ class Icon:
                 if toga.App.app.is_bundled:
                     try:
                         # Use the application binary's icon
-                        self._impl = self.factory.Icon(interface=self, path=None)
+                        self._impl = self.factory.Icon(
+                            interface=self, path=None, size=self.size
+                        )
                     except FileNotFoundError:
                         # Can't find the application binary's icon.
                         print(

--- a/dummy/src/toga_dummy/icons.py
+++ b/dummy/src/toga_dummy/icons.py
@@ -6,9 +6,10 @@ class Icon(LoggedObject):
     EXTENSIONS = [".png", ".ico"]
     SIZES = None
 
-    def __init__(self, interface, path):
+    def __init__(self, interface, path, size=None):
         super().__init__()
         self.interface = interface
+        self.size = size
         if self.ICON_FAILURE:
             raise self.ICON_FAILURE
         else:

--- a/examples/button/button/app.py
+++ b/examples/button/button/app.py
@@ -47,6 +47,7 @@ class ButtonApp(toga.App):
                 button4a,
                 button4b,
             ],
+            gap=10,
         )
 
         # Button with text and margin style
@@ -71,10 +72,16 @@ class ButtonApp(toga.App):
             icon=toga.Icon("resources/star"),
         )
 
+        # Button with a resized icon
+        button10 = toga.Button(
+            icon=toga.Icon("resources/star", size=16),
+        )
+
         # Add components for the second row of the outer box
         inner_box2 = toga.Box(
             direction=COLUMN,
-            children=[button5, button6, button7, button8, button9],
+            children=[button5, button6, button7, button8, button9, button10],
+            gap=10,
         )
 
         #  Create the outer box with 2 rows

--- a/gtk/src/toga_gtk/widgets/button.py
+++ b/gtk/src/toga_gtk/widgets/button.py
@@ -36,8 +36,7 @@ class Button(Widget):
                 self.native.set_always_show_image(False)
         else:  # pragma: no-cover-if-gtk3
             if icon:
-                icon._impl.native.set_icon_size(Gtk.IconSize.LARGE)
-                self.native.set_child(icon._impl.native)
+                self.native.set_child(icon._impl.native(Gtk.IconSize.LARGE))
             else:
                 text = self.native.get_label()
                 if text:

--- a/gtk/tests_backend/widgets/button.py
+++ b/gtk/tests_backend/widgets/button.py
@@ -16,10 +16,10 @@ class ButtonProbe(SimpleProbe):
     def assert_no_icon(self):
         assert self.native.get_image() is None
 
-    def assert_icon_size(self):
+    def assert_icon_size(self, size=32):
         icon = self.native.get_image().get_pixbuf()
         if icon:
-            assert (icon.get_width(), icon.get_height()) == (32, 32)
+            assert (icon.get_width(), icon.get_height()) == (size, size)
         else:
             pytest.fail("Icon does not exist")
 

--- a/iOS/src/toga_iOS/icons.py
+++ b/iOS/src/toga_iOS/icons.py
@@ -11,7 +11,7 @@ class Icon:
     EXTENSIONS = [".icns", ".png", ".bmp", ".ico"]
     SIZES = None
 
-    def __init__(self, interface, path):
+    def __init__(self, interface, path, size=None):
         self.interface = interface
 
         if path is None:
@@ -19,11 +19,13 @@ class Icon:
             raise FileNotFoundError("No runtime app icon")
 
         self.path = path
+        self.size = size
         self.native = UIImage.imageWithContentsOfFile(str(path))
         if self.native is None:
             raise ValueError(f"Unable to load icon from {path}")
 
-    def _as_size(self, size):
+    def _as_size(self, default_size):
+        size = self.size if self.size is not None else default_size
         renderer = UIGraphicsImageRenderer.alloc().initWithSize(NSSize(size, size))
 
         def _resize(context: UIGraphicsImageRendererContext) -> None:

--- a/iOS/tests_backend/widgets/button.py
+++ b/iOS/tests_backend/widgets/button.py
@@ -16,10 +16,10 @@ class ButtonProbe(SimpleProbe):
     def assert_no_icon(self):
         assert self.native.imageForState(UIControlStateNormal) is None
 
-    def assert_icon_size(self):
+    def assert_icon_size(self, size=48):
         icon = self.native.imageForState(UIControlStateNormal)
         if icon:
-            assert (icon.size.width, icon.size.height) == (48, 48)
+            assert (icon.size.width, icon.size.height) == (size, size)
         else:
             pytest.fail("Icon does not exist")
 

--- a/testbed/tests/widgets/test_button.py
+++ b/testbed/tests/widgets/test_button.py
@@ -87,6 +87,12 @@ async def test_icon(widget, probe):
     assert probe.height == initial_height
 
 
+async def test_icon_size(widget, probe):
+    """The button can have an icon of the specific size"""
+    widget.icon = toga.Icon("resources/icons/red", size=16)
+    probe.assert_icon_size(16)
+
+
 async def test_press(widget, probe):
     # Press the button before installing a handler
     await probe.press()

--- a/textual/src/toga_textual/icons.py
+++ b/textual/src/toga_textual/icons.py
@@ -2,7 +2,8 @@ class Icon:
     EXTENSIONS = [".png"]
     SIZES = None
 
-    def __init__(self, interface, path):
+    def __init__(self, interface, path, size=None):
         super().__init__()
         self.interface = interface
         self.path = path
+        self.size = size

--- a/web/src/toga_web/icons.py
+++ b/web/src/toga_web/icons.py
@@ -2,6 +2,7 @@ class Icon:
     EXTENSIONS = [".png", ".bmp", ".ico"]
     SIZES = None
 
-    def __init__(self, interface, path):
+    def __init__(self, interface, path, size=None):
         self.interface = interface
         self.path = path
+        self.size = size

--- a/winforms/src/toga_winforms/icons.py
+++ b/winforms/src/toga_winforms/icons.py
@@ -8,9 +8,10 @@ class Icon:
     EXTENSIONS = [".ico", ".png", ".bmp"]
     SIZES = None
 
-    def __init__(self, interface, path):
+    def __init__(self, interface, path, size=None):
         self.interface = interface
         self.path = path
+        self.size = size
 
         try:
             if path is None:

--- a/winforms/src/toga_winforms/widgets/button.py
+++ b/winforms/src/toga_winforms/widgets/button.py
@@ -1,6 +1,7 @@
 from decimal import ROUND_UP
 
 import System.Windows.Forms as WinForms
+from System.Drawing import Size
 from travertino.size import at_least
 
 from toga.colors import TRANSPARENT
@@ -14,6 +15,7 @@ class Button(Widget):
         self.native = WinForms.Button()
         self.native.AutoSizeMode = WinForms.AutoSizeMode.GrowAndShrink
         self.native.Click += WeakrefCallable(self.winforms_click)
+        self.native.ImageList = WinForms.ImageList()
 
         self._icon = None
 
@@ -40,9 +42,18 @@ class Button(Widget):
     def set_icon(self, icon):
         self._icon = icon
         if icon:
-            self.native.Image = icon._impl.native.ToBitmap()
+            size = icon.size if icon.size is not None else 48
+            # Use an image list to display the icon so the size can be set.
+            index = self.native.ImageList.Images.IndexOfKey(str(size))
+            if index == -1:
+                index = self.native.ImageList.Images.Count
+                self.native.ImageList.Images.Add(
+                    str(size), icon._impl.native.ToBitmap()
+                )
+            self.native.ImageList.ImageSize = Size(size, size)
+            self.native.ImageIndex = index
         else:
-            self.native.Image = None
+            self.native.ImageIndex = -1
 
     def set_background_color(self, color):
         super().set_background_color(

--- a/winforms/tests_backend/widgets/button.py
+++ b/winforms/tests_backend/widgets/button.py
@@ -17,7 +17,7 @@ class ButtonProbe(SimpleProbe):
     def assert_no_icon(self):
         assert self.native.Image is None
 
-    def assert_icon_size(self, size=32):
+    def assert_icon_size(self, size=48):
         icon = self.native.Image
         if icon:
             assert (icon.Size.Width, icon.Size.Height) == (size, size)

--- a/winforms/tests_backend/widgets/button.py
+++ b/winforms/tests_backend/widgets/button.py
@@ -17,9 +17,9 @@ class ButtonProbe(SimpleProbe):
     def assert_no_icon(self):
         assert self.native.Image is None
 
-    def assert_icon_size(self):
+    def assert_icon_size(self, size=32):
         icon = self.native.Image
         if icon:
-            assert (icon.Size.Width, icon.Size.Height) == (32, 32)
+            assert (icon.Size.Width, icon.Size.Height) == (size, size)
         else:
             pytest.fail("Icon does not exist")


### PR DESCRIPTION
This branch adds the ability to set the size of an icon and implements support for using that property in buttons (the size attribute does not make sense in many icon cases e.g. app icon, status icons and commands).

Supported platforms:
<img width="25%" height="25%" alt="android" src="https://github.com/user-attachments/assets/78cf1bce-4bb2-4c3f-ab0e-a8fd4ffe805f" />
<img width="25%" height="25%" alt="ios" src="https://github.com/user-attachments/assets/c677b7e5-8164-4a13-ab05-606dd09a2a84" />
<img width="50%" height="50%" alt="linux" src="https://github.com/user-attachments/assets/45d5ff6a-6cfa-42d4-885f-1db7244a66ca" />
<img width="50%" height="50%" alt="mac" src="https://github.com/user-attachments/assets/425ee4b1-d3b9-4601-bd0d-8c237e150edd" />
<img width="50%" height="50%" alt="windows" src="https://github.com/user-attachments/assets/14cbd60a-15d6-409d-af93-0064ebc61625" />


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
