### PR TITLE
Change non-value returning widget event handlers to None

### DIFF
--- a/core/src/toga/widgets/button.py
+++ b/core/src/toga/widgets/button.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
 
 class OnPressHandler(Protocol):
-    def __call__(self, widget: Button, **kwargs: Any) -> object:
+    def __call__(self, widget: Button, **kwargs: Any) -> None:
         """A handler that will be invoked when a button is pressed.
 
         :param widget: The button that was pressed.

--- a/core/src/toga/widgets/canvas/canvas.py
+++ b/core/src/toga/widgets/canvas/canvas.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 
 
 class OnTouchHandler(Protocol):
-    def __call__(self, widget: Canvas, x: int, y: int, **kwargs: Any) -> object:
+    def __call__(self, widget: Canvas, x: int, y: int, **kwargs: Any) -> None:
         """A handler that will be invoked when a :any:`Canvas` is touched with a finger
         or mouse.
 
@@ -42,7 +42,7 @@ class OnTouchHandler(Protocol):
 class OnResizeHandler(Protocol):
     def __call__(
         self, widget: Canvas, width: int, height: int, **kwargs: Any
-    ) -> object:
+    ) -> None:
         """A handler that will be invoked when a :any:`Canvas` is resized.
 
         :param widget: The canvas that was resized.

--- a/core/src/toga/widgets/dateinput.py
+++ b/core/src/toga/widgets/dateinput.py
@@ -17,7 +17,7 @@ MAX_DATE = datetime.date(8999, 12, 31)
 
 
 class OnChangeHandler(Protocol):
-    def __call__(self, widget: DateInput, **kwargs: Any) -> object:
+    def __call__(self, widget: DateInput, **kwargs: Any) -> None:
         """A handler that will be invoked when a change occurs.
 
         :param widget: The DateInput that was changed.

--- a/core/src/toga/widgets/detailedlist.py
+++ b/core/src/toga/widgets/detailedlist.py
@@ -13,7 +13,7 @@ SourceT = TypeVar("SourceT", bound=Source)
 
 
 class OnPrimaryActionHandler(Protocol):
-    def __call__(self, widget: DetailedList, row: Any, **kwargs: Any) -> object:
+    def __call__(self, widget: DetailedList, row: Any, **kwargs: Any) -> None:
         """A handler to invoke for the primary action.
 
         :param widget: The DetailedList that was invoked.
@@ -23,7 +23,7 @@ class OnPrimaryActionHandler(Protocol):
 
 
 class OnSecondaryActionHandler(Protocol):
-    def __call__(self, widget: DetailedList, row: Any, **kwargs: Any) -> object:
+    def __call__(self, widget: DetailedList, row: Any, **kwargs: Any) -> None:
         """A handler to invoke for the secondary action.
 
         :param widget: The DetailedList that was invoked.
@@ -33,7 +33,7 @@ class OnSecondaryActionHandler(Protocol):
 
 
 class OnRefreshHandler(Protocol):
-    def __call__(self, widget: DetailedList, **kwargs: Any) -> object:
+    def __call__(self, widget: DetailedList, **kwargs: Any) -> None:
         """A handler to invoke when the detailed list is refreshed.
 
         :param widget: The DetailedList that was refreshed.
@@ -42,7 +42,7 @@ class OnRefreshHandler(Protocol):
 
 
 class OnSelectHandler(Protocol):
-    def __call__(self, widget: DetailedList, **kwargs: Any) -> object:
+    def __call__(self, widget: DetailedList, **kwargs: Any) -> None:
         """A handler to invoke when the detailed list is selected.
 
         :param widget: The DetailedList that was selected.

--- a/core/src/toga/widgets/mapview.py
+++ b/core/src/toga/widgets/mapview.py
@@ -121,7 +121,7 @@ class MapPinSet:
 
 
 class OnSelectHandler(Protocol):
-    def __call__(self, widget: MapView, *, pin: MapPin, **kwargs: Any) -> object:
+    def __call__(self, widget: MapView, *, pin: MapPin, **kwargs: Any) -> None:
         """A handler that will be invoked when the user selects a map pin.
 
         :param widget: The MapView that was selected.

--- a/core/src/toga/widgets/multilinetextinput.py
+++ b/core/src/toga/widgets/multilinetextinput.py
@@ -9,7 +9,7 @@ from .base import StyleT, Widget
 
 
 class OnChangeHandler(Protocol):
-    def __call__(self, widget: MultilineTextInput, **kwargs: Any) -> object:
+    def __call__(self, widget: MultilineTextInput, **kwargs: Any) -> None:
         """A handler to invoke when the value is changed.
 
         :param widget: The MultilineTextInput that was changed.

--- a/core/src/toga/widgets/numberinput.py
+++ b/core/src/toga/widgets/numberinput.py
@@ -72,7 +72,7 @@ def _clean_decimal_str(value: str) -> str:
 
 
 class OnChangeHandler(Protocol):
-    def __call__(self, widget: NumberInput, **kwargs: Any) -> object:
+    def __call__(self, widget: NumberInput, **kwargs: Any) -> None:
         """A handler to invoke when the value is changed.
 
         :param widget: The NumberInput that was changed.

--- a/core/src/toga/widgets/scrollcontainer.py
+++ b/core/src/toga/widgets/scrollcontainer.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
 
 class OnScrollHandler(Protocol):
-    def __call__(self, widget: ScrollContainer, **kwargs: Any) -> object:
+    def __call__(self, widget: ScrollContainer, **kwargs: Any) -> None:
         """A handler to invoke when the container is scrolled.
 
         :param widget: The ScrollContainer that was scrolled.

--- a/core/src/toga/widgets/selection.py
+++ b/core/src/toga/widgets/selection.py
@@ -13,7 +13,7 @@ SourceT = TypeVar("SourceT", bound=Source)
 
 
 class OnChangeHandler(Protocol):
-    def __call__(self, widget: Selection, **kwargs: Any) -> object:
+    def __call__(self, widget: Selection, **kwargs: Any) -> None:
         """A handler to invoke when the value is changed.
 
         :param widget: The Selection that was changed.

--- a/core/src/toga/widgets/slider.py
+++ b/core/src/toga/widgets/slider.py
@@ -11,7 +11,7 @@ from .base import StyleT, Widget
 
 
 class OnChangeHandler(Protocol):
-    def __call__(self, widget: Slider, **kwargs: Any) -> object:
+    def __call__(self, widget: Slider, **kwargs: Any) -> None:
         """A handler to invoke when the value is changed.
 
         :param widget: The Slider that was changed.
@@ -20,7 +20,7 @@ class OnChangeHandler(Protocol):
 
 
 class OnPressHandler(Protocol):
-    def __call__(self, widget: Slider, **kwargs: Any) -> object:
+    def __call__(self, widget: Slider, **kwargs: Any) -> None:
         """A handler to invoke when the slider is pressed.
 
         :param widget: The Slider that was pressed.
@@ -29,7 +29,7 @@ class OnPressHandler(Protocol):
 
 
 class OnReleaseHandler(Protocol):
-    def __call__(self, widget: Slider, **kwargs: Any) -> object:
+    def __call__(self, widget: Slider, **kwargs: Any) -> None:
         """A handler to invoke when the slider is pressed.
 
         :param widget: The Slider that was released.

--- a/core/src/toga/widgets/switch.py
+++ b/core/src/toga/widgets/switch.py
@@ -9,7 +9,7 @@ from .base import StyleT, Widget
 
 
 class OnChangeHandler(Protocol):
-    def __call__(self, widget: Switch, **kwargs: Any) -> object:
+    def __call__(self, widget: Switch, **kwargs: Any) -> None:
         """A handler to invoke when the value is changed.
 
         :param widget: The Switch that was changed.

--- a/core/src/toga/widgets/table.py
+++ b/core/src/toga/widgets/table.py
@@ -14,7 +14,7 @@ SourceT = TypeVar("SourceT", bound=Source)
 
 
 class OnSelectHandler(Protocol):
-    def __call__(self, widget: Table, **kwargs: Any) -> object:
+    def __call__(self, widget: Table, **kwargs: Any) -> None:
         """A handler to invoke when the table is selected.
 
         :param widget: The Table that was selected.
@@ -23,7 +23,7 @@ class OnSelectHandler(Protocol):
 
 
 class OnActivateHandler(Protocol):
-    def __call__(self, widget: Table, row: Any, **kwargs: Any) -> object:
+    def __call__(self, widget: Table, row: Any, **kwargs: Any) -> None:
         """A handler to invoke when the table is activated.
 
         :param widget: The Table that was activated.

--- a/core/src/toga/widgets/textinput.py
+++ b/core/src/toga/widgets/textinput.py
@@ -10,7 +10,7 @@ from .base import StyleT, Widget
 
 
 class OnChangeHandler(Protocol):
-    def __call__(self, widget: TextInput, **kwargs: Any) -> object:
+    def __call__(self, widget: TextInput, **kwargs: Any) -> None:
         """A handler to invoke when the text input is changed.
 
         :param widget: The TextInput that was changed.
@@ -19,7 +19,7 @@ class OnChangeHandler(Protocol):
 
 
 class OnConfirmHandler(Protocol):
-    def __call__(self, widget: TextInput, **kwargs: Any) -> object:
+    def __call__(self, widget: TextInput, **kwargs: Any) -> None:
         """A handler to invoke when the text input is confirmed.
 
         :param widget: The TextInput that was confirmed.
@@ -28,7 +28,7 @@ class OnConfirmHandler(Protocol):
 
 
 class OnGainFocusHandler(Protocol):
-    def __call__(self, widget: TextInput, **kwargs: Any) -> object:
+    def __call__(self, widget: TextInput, **kwargs: Any) -> None:
         """A handler to invoke when the text input gains focus.
 
         :param widget: The TextInput that gained focus.
@@ -37,7 +37,7 @@ class OnGainFocusHandler(Protocol):
 
 
 class OnLoseFocusHandler(Protocol):
-    def __call__(self, widget: TextInput, **kwargs: Any) -> object:
+    def __call__(self, widget: TextInput, **kwargs: Any) -> None:
         """A handler to invoke when the text input loses focus.
 
         :param widget: The TextInput that lost focus.

--- a/core/src/toga/widgets/timeinput.py
+++ b/core/src/toga/widgets/timeinput.py
@@ -10,7 +10,7 @@ from .base import StyleT, Widget
 
 
 class OnChangeHandler(Protocol):
-    def __call__(self, widget: TimeInput, **kwargs: Any) -> object:
+    def __call__(self, widget: TimeInput, **kwargs: Any) -> None:
         """A handler to invoke when the time input is changed.
 
         :param widget: The TimeInput that was changed.

--- a/core/src/toga/widgets/tree.py
+++ b/core/src/toga/widgets/tree.py
@@ -15,7 +15,7 @@ SourceT = TypeVar("SourceT", bound=Source)
 
 
 class OnSelectHandler(Protocol):
-    def __call__(self, widget: Tree, **kwargs: Any) -> object:
+    def __call__(self, widget: Tree, **kwargs: Any) -> None:
         """A handler to invoke when the tree is selected.
 
         :param widget: The Tree that was selected.
@@ -24,7 +24,7 @@ class OnSelectHandler(Protocol):
 
 
 class OnActivateHandler(Protocol):
-    def __call__(self, widget: Tree, **kwargs: Any) -> object:
+    def __call__(self, widget: Tree, **kwargs: Any) -> None:
         """A handler to invoke when the tree is activated.
 
         :param widget: The Tree that was activated.

--- a/core/src/toga/widgets/webview.py
+++ b/core/src/toga/widgets/webview.py
@@ -17,7 +17,7 @@ class CookiesResult(AsyncResult):
 
 
 class OnWebViewLoadHandler(Protocol):
-    def __call__(self, widget: WebView, **kwargs: Any) -> object:
+    def __call__(self, widget: WebView, **kwargs: Any) -> None:
         """A handler to invoke when the WebView is loaded.
 
         :param widget: The WebView that was loaded.


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Related to https://github.com/beeware/toga/issues/3582

This PR changes widget event handlers in `toga/core/src/toga/widgets` from `object` to `None` if a given event handler does not return anything. 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
