### PR TITLE
Remove Travertino dev dependencies

### DIFF
--- a/travertino/pyproject.toml
+++ b/travertino/pyproject.toml
@@ -42,17 +42,6 @@ classifiers = [
     "Topic :: Software Development :: User Interfaces",
 ]
 
-[project.optional-dependencies]
-# These are needed in order to run Travertino's test suite.
-dev = [
-    "coverage[toml] == 7.9.2",
-    "coverage-conditional-plugin == 0.9.0",
-    "pytest == 8.4.1",
-    "tox == 4.27.0",
-    # typing-extensions needed for TypeAlias added in Py 3.10
-    "typing-extensions == 4.12.2 ; python_version < '3.10'",
-]
-
 [project.urls]
 Homepage = "https://beeware.org/travertino"
 Funding = "https://beeware.org/contributing/membership/"


### PR DESCRIPTION
With Travertino lumped into the Toga repository, its testing is handled by the root tox configuation. I was looking at it just now, and unless I'm missing something we never actually install *Travertino's* optional dev dependencies; we just use core for all the non-testbed testing. Removing them doesn't interfere with testing locally; pushing to double check that CI isn't doing something I'm not noticing.

We could, of course, alter the tox config to use `travertino[dev]`, but if keeping it all in one place works, that does seem simpler.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
