### PR TITLE
Standardize and clean up colors

### DIFF
--- a/travertino/src/travertino/colors.py
+++ b/travertino/src/travertino/colors.py
@@ -1,49 +1,57 @@
 from __future__ import annotations
 
+import string
+from contextlib import contextmanager
+from itertools import batched
+
 from .constants import *  # noqa: F403
 
 
-def _clamp(value, upper=1):
-    return min(upper, max(0, value))
-
-
-def _clamp_hex(value):
-    return round(_clamp(value, upper=255))
+def _clamp(value, lower, upper):
+    return min(upper, max(lower, value))
 
 
 class Color:
-    "A base class for all colorspace representations."
+    """A base class for all colorspace representations."""
 
     def __eq__(self, other):
         try:
-            c1 = self.rgba
-            c2 = other.rgba
+            c1 = self.rgb
+            c2 = other.rgb
 
             return c1.r == c2.r and c1.g == c2.g and c1.b == c2.b and c1.a == c2.a
         except AttributeError:
             return False
 
-    @classmethod
-    def _validate_between(cls, content_name, value, min_value, max_value):
-        if value < min_value or value > max_value:
-            raise ValueError(
-                f"{content_name} value should be between {min_value}-{max_value}. "
-                f"Got {value}"
-            )
+    @staticmethod
+    @contextmanager
+    def _try_validate(name, value):
+        try:
+            yield
+        except (ValueError, TypeError) as exc:
+            raise TypeError(
+                f"Value for {name} must be a number; got {value!r}"
+            ) from exc
 
     @classmethod
-    def _validate_partial(cls, content_name, value):
-        cls._validate_between(content_name, value, 0, 1)
+    def _validate_zero_to_one(cls, name, value):
+        with cls._try_validate(name, value):
+            return _clamp(float(value), 0.0, 1.0)
 
-    @classmethod
-    def _validate_alpha(cls, value):
-        cls._validate_partial("alpha", value)
+    @property
+    def a(self) -> float:
+        return self._a
 
-    def blend_over(
-        self,
-        back_color: Color,
-    ) -> rgba:
-        """Performs the "over" straight alpha blending operation, compositing
+    @property
+    def rgba(self) -> rgb:
+        return self.rgb
+
+    @property
+    def hsla(self) -> hsl:
+        return self.hsl
+
+    def blend_over(self, back_color: Color) -> rgb:
+        """Perform the "over" straight alpha blending operation, compositing
         the front color over the back color.
 
         **Straight alpha blending** is not the same as
@@ -59,43 +67,44 @@ class Color:
         # https://en.wikipedia.org/wiki/Alpha_compositing#Description
 
         # Convert the input colors to rgba in order to do the calculation.
-        front_color = self.rgba
-        back_color = back_color.rgba
+        front_color = self.rgb
+        back_color = back_color.rgb
 
         if front_color.a == 1:
             # If the front color is fully opaque then the result will be the same as
             # front color.
             return front_color
 
-        blended_alpha = _clamp(front_color.a + ((1 - front_color.a) * back_color.a))
+        blended_alpha = _clamp(
+            front_color.a + ((1 - front_color.a) * back_color.a),
+            0.0,
+            1.0,
+        )
 
         if blended_alpha == 0:
             # Don't further blend the color, to prevent divide by 0.
-            return rgba(0, 0, 0, 0)
+            return rgb(0, 0, 0, 0)
         else:
             bands = {}
             for band in "rgb":
                 front = getattr(front_color, band)
                 back = getattr(back_color, band)
-                bands[band] = _clamp_hex(
-                    (
-                        (front * front_color.a)
-                        + (back * back_color.a * (1 - front_color.a))
-                    )
-                    / blended_alpha
-                )
+                bands[band] = (
+                    (front * front_color.a)
+                    + (back * back_color.a * (1 - front_color.a))
+                ) / blended_alpha
 
-            return rgba(**bands, a=blended_alpha)
+            return rgb(**bands, a=blended_alpha)
 
-    def unblend_over(self, back_color: Color, front_color_alpha: float) -> rgba:
-        """Performs the reverse of the "over" straight alpha blending operation,
+    def unblend_over(self, back_color: Color, front_color_alpha: float) -> rgb:
+        """Perform the reverse of the "over" straight alpha blending operation,
         returning the front color.
 
         Note: Unblending of blended colors might produce front color with slightly
         imprecise component values compared to the original front color. This is
         due to the loss of some amount of precision during the calculation and
         conversion process between the different color formats. For example,
-        unblending of a hsla blended color might might produce a slightly imprecise
+        unblending of an hsla blended color might might produce a slightly imprecise
         original front color, since the alpha blending and unblending is calculated
         after conversion to rgba values.
 
@@ -115,8 +124,8 @@ class Color:
         # are derived from the "over" straight alpha blending operation formula,
         # see: https://en.wikipedia.org/wiki/Alpha_compositing#Description
 
-        blended_color = self.rgba
-        back_color = back_color.rgba
+        blended_color = self.rgb
+        back_color = back_color.rgb
         if not 0 < front_color_alpha <= 1:
             raise ValueError(
                 "The value of front_color_alpha must be within the range of (0, 1]."
@@ -126,54 +135,58 @@ class Color:
             for band in "rgb":
                 blended = getattr(blended_color, band)
                 back = getattr(back_color, band)
-                bands[band] = _clamp_hex(
-                    (
-                        (blended * blended_color.a)
-                        - (back * back_color.a * (1 - front_color_alpha))
-                    )
-                    / front_color_alpha
-                )
+                bands[band] = (
+                    (blended * blended_color.a)
+                    - (back * back_color.a * (1 - front_color_alpha))
+                ) / front_color_alpha
 
-            return rgba(**bands, a=front_color_alpha)
+            return rgb(**bands, a=front_color_alpha)
 
 
-class rgba(Color):
-    "A representation of an RGBA color."
+class rgb(Color):
+    """A representation of an RGB(A) color."""
 
-    def __init__(self, r, g, b, a):
-        self._validate_rgb("red", r)
-        self._validate_rgb("green", g)
-        self._validate_rgb("blue", b)
-        self._validate_alpha(a)
-        self.r = r
-        self.g = g
-        self.b = b
-        self.a = a
+    def __init__(self, r, g, b, a=1.0):
+        self._r = self._validate_band("red", r)
+        self._g = self._validate_band("green", g)
+        self._b = self._validate_band("blue", b)
+        self._a = self._validate_zero_to_one("alpha", a)
 
     def __hash__(self):
-        return hash(("RGBA-color", self.r, self.g, self.b, self.a))
+        return hash(("RGB-color", self.r, self.g, self.b, self.a))
 
     def __repr__(self):
-        return f"rgba({self.r}, {self.g}, {self.b}, {self.a})"
+        return f"rgb({self.r}, {self.g}, {self.b}, {self.a})"
+
+    def __str__(self):
+        return f"rgb({self.r} {self.g} {self.b} / {self.a})"
 
     @classmethod
-    def _validate_rgb(cls, content_name, value):
-        cls._validate_between(content_name, value, 0, 255)
+    def _validate_band(cls, name, value):
+        with cls._try_validate(name, value):
+            return _clamp(round(value), 0, 255)
 
     @property
-    def rgba(self):
-        # Explicitly return a rgba value, to ensure that classes which inherit the
-        # parent rgba class, actually return the rgba() value, instead of the child
-        # class. For example, without this fix, doing rgb(20, 20, 20).rgba will
-        # return rgb(20, 20, 20), instead of rgba(20, 20, 20, 1).
-        return rgba(self.r, self.g, self.b, self.a)
+    def r(self) -> int:
+        return self._r
 
     @property
-    def rgb(self):
-        return rgb(self.r, self.g, self.b)
+    def g(self) -> int:
+        return self._g
 
     @property
-    def hsla(self) -> hsla:
+    def b(self) -> int:
+        return self._b
+
+    @property
+    def rgb(self) -> rgb:
+        return self
+
+    @property
+    def hsl(self) -> hsl:
+        if cached := getattr(self, "_hsl", None):
+            return cached
+
         # Formula used here is from: https://en.wikipedia.org/wiki/HSL_and_HSV#From_RGB
         r_prime = self.r / 255
         g_prime = self.g / 255
@@ -200,61 +213,53 @@ class rgba(Color):
         else:
             saturation = chroma / (1 - abs((2 * value) - chroma - 1))
 
-        return hsla(
-            hue % 360,  # [0,360)
-            _clamp(saturation),  # [0,1]
-            _clamp(lightness),  # [0,1]
-            self.a,  # [0,1]
-        )
-
-    @property
-    def hsl(self):
-        return self.hsla.hsl
+        self._hsl = hsl(hue, saturation, lightness, self.a)
+        return self._hsl
 
 
-class rgb(rgba):
-    "A representation of an RGB color"
-
-    def __init__(self, r, g, b):
-        super().__init__(r, g, b, 1.0)
-
-    def __repr__(self):
-        return f"rgb({self.r}, {self.g}, {self.b})"
+rgba = rgb
 
 
-class hsla(Color):
-    "A representation of an HSLA color."
+class hsl(Color):
+    """A representation of an HSL(A) color."""
 
     def __init__(self, h, s, l, a=1.0):  # noqa: E741
-        self._validate_between("hue", h, 0, 360)
-        self._validate_partial("saturation", s)
-        self._validate_partial("lightness", l)
-        self._validate_alpha(a)
-        self.h = h
-        self.s = s
-        self.l = l
-        self.a = a
+        with self._try_validate("hue", h):
+            self._h = round(h) % 360
+        self._s = self._validate_zero_to_one("saturation", s)
+        self._l = self._validate_zero_to_one("lightness", l)
+        self._a = self._validate_zero_to_one("alpha", a)
 
     def __hash__(self):
-        return hash(("HSLA-color", self.h, self.s, self.l, self.a))
+        return hash(("HSL-color", self.h, self.s, self.l, self.a))
 
     def __repr__(self):
-        return f"hsla({self.h}, {self.s}, {self.l}, {self.a})"
+        return f"hsl({self.h}, {self.s}, {self.l}, {self.a})"
+
+    def __str__(self):
+        return f"hsl({self.h} {round(self.s * 100)}% {round(self.l * 100)}% / {self.a})"
 
     @property
-    def hsla(self):
-        # Explicitly return a hsla value, to ensure that classes which inherit the
-        # parent hsla class, actually return the hsla() value, instead of the child
-        # class. For example, without this fix, doing hsl(210, 1, 0.5).hsla will
-        # return hsl(210, 1, 0.5), instead of hsla(210, 1, 0.5, 1).
-        return hsla(self.h, self.s, self.l, self.a)
+    def h(self) -> int:
+        return self._h
 
     @property
-    def hsl(self):
-        return hsl(self.h, self.s, self.l)
+    def s(self) -> float:
+        return self._s
 
     @property
-    def rgba(self):
+    def l(self) -> float:  # noqa: E743
+        return self._l
+
+    @property
+    def hsl(self) -> hsl:
+        return self
+
+    @property
+    def rgb(self) -> rgb:
+        if cached := getattr(self, "_rgb", None):
+            return cached
+
         c = (1.0 - abs(2.0 * self.l - 1.0)) * self.s
         h = self.h / 60.0
         x = c * (1.0 - abs(h % 2 - 1.0))
@@ -273,137 +278,52 @@ class hsla(Color):
         else:
             r, g, b = c + m, m, x + m
 
-        return rgba(
-            round(r * 0xFF),
-            round(g * 0xFF),
-            round(b * 0xFF),
-            self.a,
-        )
-
-    @property
-    def rgb(self):
-        return self.rgba.rgb
+        self._rgb = rgb(r * 0xFF, g * 0xFF, b * 0xFF, self.a)
+        return self._rgb
 
 
-class hsl(hsla):
-    "A representation of an HSL color"
-
-    def __init__(self, h, s, l):  # noqa: E741
-        super().__init__(h, s, l, 1.0)
-
-    def __repr__(self):
-        return f"hsl({self.h}, {self.s}, {self.l})"
+hsla = hsl
 
 
-def color(value):
+def color(value: str) -> Color:
     """Parse a color from a value.
 
     Accepts:
-    * rgb() instances
-    * hsl() instances
+    * An rgb() or hsl() instance
+    * A named color
     * '#rgb'
     * '#rgba'
     * '#rrggbb'
     * '#rrggbbaa'
-    * '#RGB'
-    * '#RGBA'
-    * '#RRGGBB'
-    * '#RRGGBBAA'
-    * 'rgb(0, 0, 0)'
-    * 'rgba(0, 0, 0, 0.0)'
-    * 'hsl(0, 0%, 0%)'
-    * 'hsla(0, 0%, 0%, 0.0)'
-    * A named color
     """
 
     if isinstance(value, Color):
         return value
 
     elif isinstance(value, str):
-        if value[0] == "#":
-            if len(value) == 4:
+        if result := NAMED_COLOR.get(value.lower()):
+            return result
+
+        pound, *digits = value
+        if pound == "#" and all(d in string.hexdigits for d in digits):
+            values = None
+
+            if len(digits) in {3, 4}:
+                values = [f"{d}{d}" for d in digits]
+
+            elif len(digits) in {6, 8}:
+                values = [f"{d1}{d2}" for d1, d2 in batched(digits, 2)]
+
+            if values:
+                r, g, b, *a = values
                 return rgb(
-                    r=int(value[1] + value[1], 16),
-                    g=int(value[2] + value[2], 16),
-                    b=int(value[3] + value[3], 16),
+                    r=int(r, 16),
+                    g=int(g, 16),
+                    b=int(b, 16),
+                    a=(int(a[0], 16) / 0xFF) if a else 1.0,
                 )
-            elif len(value) == 5:
-                return rgba(
-                    r=int(value[1] + value[1], 16),
-                    g=int(value[2] + value[2], 16),
-                    b=int(value[3] + value[3], 16),
-                    a=int(value[4] + value[4], 16) / 0xFF,
-                )
-            elif len(value) == 7:
-                return rgb(
-                    r=int(value[1:3], 16),
-                    g=int(value[3:5], 16),
-                    b=int(value[5:7], 16),
-                )
-            elif len(value) == 9:
-                return rgba(
-                    r=int(value[1:3], 16),
-                    g=int(value[3:5], 16),
-                    b=int(value[5:7], 16),
-                    a=int(value[7:9], 16) / 0xFF,
-                )
-        elif value.startswith("rgba"):
-            try:
-                values = value[5:-1].split(",")
-                if len(values) == 4:
-                    return rgba(
-                        int(values[0]),
-                        int(values[1]),
-                        int(values[2]),
-                        float(
-                            values[3],
-                        ),
-                    )
-            except ValueError:
-                pass
-        elif value.startswith("rgb"):
-            try:
-                values = value[4:-1].split(",")
-                if len(values) == 3:
-                    return rgb(
-                        int(values[0]),
-                        int(values[1]),
-                        int(values[2]),
-                    )
-            except ValueError:
-                pass
 
-        elif value.startswith("hsla"):
-            try:
-                values = value[5:-1].split(",")
-                if len(values) == 4:
-                    return hsla(
-                        int(values[0]),
-                        int(values[1].strip().rstrip("%")) / 100.0,
-                        int(values[2].strip().rstrip("%")) / 100.0,
-                        float(values[3]),
-                    )
-            except ValueError:
-                pass
-
-        elif value.startswith("hsl"):
-            try:
-                values = value[4:-1].split(",")
-                if len(values) == 3:
-                    return hsl(
-                        int(values[0]),
-                        int(values[1].strip().rstrip("%")) / 100.0,
-                        int(values[2].strip().rstrip("%")) / 100.0,
-                    )
-            except ValueError:
-                pass
-        else:
-            try:
-                return NAMED_COLOR[value.lower()]
-            except KeyError:
-                pass
-
-    raise ValueError(f"Unknown color {value}")
+    raise ValueError(f"Unknown color: {value!r}")
 
 
 NAMED_COLOR = {

--- a/travertino/tests/colors/test_alpha_blending.py
+++ b/travertino/tests/colors/test_alpha_blending.py
@@ -2,276 +2,143 @@ import re
 
 import pytest
 
-from travertino.colors import hsl, hsla, rgb, rgba
+from travertino.colors import hsl, rgb
 
 from ..utils import assert_equal_color
 
-
-@pytest.mark.parametrize(
+front_back_blended = pytest.mark.parametrize(
     "front_color, back_color, expected_blended_color",
     [
-        # Test with rgba color inputs:
-        #
-        # Black, gray, white front colors
-        (rgba(0, 0, 0, 0), rgba(0, 0, 0, 0), rgba(0, 0, 0, 0)),
-        (rgba(0, 0, 0, 0), rgba(50, 128, 200, 1.0), rgba(50, 128, 200, 1)),
-        (rgba(0, 0, 0, 1.0), rgba(50, 128, 200, 0.9), rgba(0, 0, 0, 1.0)),
-        (rgba(128, 128, 128, 1.0), rgba(50, 128, 200, 0.5), rgba(128, 128, 128, 1.0)),
-        (rgba(255, 255, 255, 1.0), rgba(50, 128, 200, 0.0), rgba(255, 255, 255, 1.0)),
-        # Primaries
-        (rgba(255, 0, 0, 1.0), rgba(0, 255, 0, 1.0), rgba(255, 0, 0, 1.0)),
-        (rgba(0, 255, 0, 1.0), rgba(255, 0, 0, 1.0), rgba(0, 255, 0, 1.0)),
-        (rgba(0, 0, 255, 1.0), rgba(255, 0, 0, 1.0), rgba(0, 0, 255, 1.0)),
-        # Color with different channel values, including transparency
-        (rgba(50, 128, 200, 0.0), rgba(255, 255, 255, 1.0), rgba(255, 255, 255, 1)),
-        (rgba(50, 128, 200, 0.5), rgba(128, 128, 128, 1.0), rgba(89, 128, 164, 1)),
-        (rgba(50, 128, 200, 0.9), rgba(0, 0, 0, 1.0), rgba(45, 115, 180, 1)),
-        (rgba(50, 128, 200, 1.0), rgba(0, 0, 0, 0), rgba(50, 128, 200, 1.0)),
-        # Both front_color and back_color having intermediate alpha
-        (
-            rgba(100, 200, 255, 0.15),
-            rgba(255, 100, 200, 0.85),
-            rgba(228, 117, 209, 0.87),
-        ),
-        (rgba(120, 180, 240, 0.2), rgba(240, 120, 180, 0.8), rgba(211, 134, 194, 0.84)),
-        (rgba(150, 50, 100, 0.4), rgba(100, 150, 50, 0.6), rgba(126, 97, 76, 0.76)),
-        (rgba(50, 60, 70, 0.55), rgba(70, 80, 90, 0.45), rgba(55, 65, 75, 0.75)),
-        (rgba(255, 255, 0, 0.3), rgba(0, 255, 255, 0.7), rgba(97, 255, 158, 0.79)),
-        #
         # Test with rgb color inputs:
         #
-        # Black, gray, white front colors
-        (rgb(0, 0, 0), rgb(0, 0, 0), rgba(0, 0, 0, 1.0)),
-        (rgb(0, 0, 0), rgb(50, 128, 200), rgba(0, 0, 0, 1.0)),
-        (rgb(128, 128, 128), rgb(50, 128, 200), rgba(128, 128, 128, 1.0)),
-        (rgb(255, 255, 255), rgb(50, 128, 200), rgba(255, 255, 255, 1.0)),
-        # Primaries
-        (rgb(255, 0, 0), rgb(0, 255, 0), rgba(255, 0, 0, 1.0)),
-        (rgb(0, 255, 0), rgb(255, 0, 0), rgba(0, 255, 0, 1.0)),
-        (rgb(0, 0, 255), rgb(255, 0, 0), rgba(0, 0, 255, 1.0)),
-        # Color with different channel values
-        (rgb(50, 128, 200), rgb(255, 255, 255), rgba(50, 128, 200, 1.0)),
-        (rgb(50, 128, 200), rgb(128, 128, 128), rgba(50, 128, 200, 1.0)),
-        (rgb(50, 128, 200), rgb(0, 0, 0), rgba(50, 128, 200, 1.0)),
-        # Both front_color and back_color having intermediate values
-        (rgb(100, 200, 255), rgb(255, 100, 200), rgba(100, 200, 255, 1.0)),
-        (rgb(120, 180, 240), rgb(240, 120, 180), rgba(120, 180, 240, 1.0)),
-        (rgb(150, 50, 100), rgb(100, 150, 50), rgba(150, 50, 100, 1.0)),
-        (rgb(50, 60, 70), rgb(70, 80, 90), rgba(50, 60, 70, 1.0)),
-        (rgb(255, 255, 0), rgb(0, 255, 255), rgba(255, 255, 0, 1.0)),
-        #
-        # Test with hsla color inputs:
-        #
-        # Black, gray, white front colors
-        (hsla(0, 0, 0, 0), hsla(0, 0, 0, 0), rgba(0, 0, 0, 0)),
-        (hsla(0, 0, 0, 0), hsla(208.8, 0.6, 0.49, 1.0), rgba(50, 128, 200, 1)),
-        (hsla(0, 0, 0, 1.0), hsla(208.8, 0.6, 0.49, 0.9), rgba(0, 0, 0, 1.0)),
-        (hsla(0, 0, 0.5, 1.0), hsla(208.8, 0.6, 0.49, 0.5), rgba(128, 128, 128, 1.0)),
-        (hsla(0, 0, 1, 1.0), hsla(208.8, 0.6, 0.49, 0.0), rgba(255, 255, 255, 1.0)),
-        # Primaries
-        (hsla(0, 1, 0.5, 1.0), hsla(120.0, 1, 0.5, 1.0), rgba(255, 0, 0, 1.0)),
-        (hsla(120.0, 1, 0.5, 1.0), hsla(0, 1, 0.5, 1.0), rgba(0, 255, 0, 1.0)),
-        (hsla(240.0, 1, 0.5, 1.0), hsla(0, 1, 0.5, 1.0), rgba(0, 0, 255, 1.0)),
-        # Color with different channel values, including transparency
-        (hsla(208.8, 0.6, 0.49, 0.0), hsla(0, 0, 1, 1.0), rgba(255, 255, 255, 1)),
-        (hsla(208.8, 0.6, 0.49, 0.5), hsla(0, 0, 0.5, 1.0), rgba(89, 128, 164, 1)),
-        (hsla(208.8, 0.6, 0.49, 0.9), hsla(0, 0, 0, 1.0), rgba(45, 115, 180, 1)),
-        (hsla(208.8, 0.6, 0.49, 1.0), hsla(0, 0, 0, 0), rgba(50, 128, 200, 1.0)),
-        # Both front_color and back_color having intermediate alpha
+        # Black, gray, white front colors...
+        (rgb(0, 0, 0), rgb(0, 0, 0), rgb(0, 0, 0)),
+        (rgb(0, 0, 0), rgb(50, 128, 200, 0.9), rgb(0, 0, 0)),
+        (rgb(128, 128, 128), rgb(50, 128, 200, 0.5), rgb(128, 128, 128)),
+        (rgb(255, 255, 255), rgb(50, 128, 200, 0.0), rgb(255, 255, 255)),
+        # ...plus transparency
+        (rgb(0, 0, 0, 0), rgb(0, 0, 0, 0), rgb(0, 0, 0, 0)),
+        (rgb(0, 0, 0, 0), rgb(50, 128, 200), rgb(50, 128, 200)),
+        # Opaque primaries
+        (rgb(255, 0, 0), rgb(0, 255, 0), rgb(255, 0, 0)),
+        (rgb(0, 255, 0), rgb(255, 0, 0), rgb(0, 255, 0)),
+        (rgb(0, 0, 255), rgb(255, 0, 0), rgb(0, 0, 255)),
+        # Color with different channel values...
+        (rgb(50, 128, 200), rgb(255, 255, 255), rgb(50, 128, 200)),
+        (rgb(50, 128, 200), rgb(128, 128, 128), rgb(50, 128, 200)),
+        (rgb(50, 128, 200), rgb(0, 0, 0), rgb(50, 128, 200)),
+        # ...plus transparency
+        (rgb(50, 128, 200, 0.0), rgb(255, 255, 255, 1.0), rgb(255, 255, 255)),
+        (rgb(50, 128, 200, 0.5), rgb(128, 128, 128, 1.0), rgb(89, 128, 164)),
+        (rgb(50, 128, 200, 0.9), rgb(0, 0, 0, 1.0), rgb(45, 115, 180)),
+        (rgb(50, 128, 200, 1.0), rgb(0, 0, 0, 0), rgb(50, 128, 200)),
+        # Both front_color and back_color having intermediate values...
+        (rgb(100, 200, 255), rgb(255, 100, 200), rgb(100, 200, 255)),
+        (rgb(120, 180, 240), rgb(240, 120, 180), rgb(120, 180, 240)),
+        (rgb(150, 50, 100), rgb(100, 150, 50), rgb(150, 50, 100)),
+        (rgb(50, 60, 70), rgb(70, 80, 90), rgb(50, 60, 70)),
+        (rgb(255, 255, 0), rgb(0, 255, 255), rgb(255, 255, 0)),
+        # ...and intermediate alpha too
         (
-            hsla(201.29, 1, 0.7, 0.15),
-            hsla(321.29, 1, 0.7, 0.85),
-            rgba(229, 119, 210, 0.87),
+            rgb(100, 200, 255, 0.15),
+            rgb(255, 100, 200, 0.85),
+            rgb(228, 117, 209, 0.87),
         ),
-        (
-            hsla(210.0, 0.8, 0.71, 0.2),
-            hsla(330.0, 0.8, 0.71, 0.8),
-            rgba(212, 136, 195, 0.84),
-        ),
-        (
-            hsla(330.0, 0.5, 0.39, 0.4),
-            hsla(90.0, 0.5, 0.39, 0.6),
-            rgba(125, 97, 76, 0.76),
-        ),
-        (
-            hsla(210.0, 0.17, 0.24, 0.55),
-            hsla(210.0, 0.12, 0.31, 0.45),
-            rgba(56, 66, 77, 0.75),
-        ),
-        (hsla(60.0, 1, 0.5, 0.3), hsla(180.0, 1, 0.5, 0.7), rgba(97, 255, 158, 0.79)),
+        (rgb(120, 180, 240, 0.2), rgb(240, 120, 180, 0.8), rgb(211, 134, 194, 0.84)),
+        (rgb(150, 50, 100, 0.4), rgb(100, 150, 50, 0.6), rgb(126, 97, 76, 0.76)),
+        (rgb(50, 60, 70, 0.55), rgb(70, 80, 90, 0.45), rgb(55, 65, 75, 0.75)),
+        (rgb(255, 255, 0, 0.3), rgb(0, 255, 255, 0.7), rgb(97, 255, 158, 0.79)),
         #
         # Test with hsl color inputs:
         #
-        # Black, gray, white front colors
-        (hsl(0, 0, 0), hsl(0, 0, 0), rgba(0, 0, 0, 1.0)),
-        (hsl(0, 0, 0), hsl(208.8, 0.6, 0.49), rgba(0, 0, 0, 1.0)),
-        (hsl(0, 0, 0.5), hsl(208.8, 0.6, 0.49), rgba(128, 128, 128, 1.0)),
-        (hsl(0, 0, 1), hsl(208.8, 0.6, 0.49), rgba(255, 255, 255, 1.0)),
-        # Primaries
-        (hsl(0, 1, 0.5), hsl(120.0, 1, 0.5), rgba(255, 0, 0, 1.0)),
-        (hsl(120.0, 1, 0.5), hsl(0, 1, 0.5), rgba(0, 255, 0, 1.0)),
-        (hsl(240.0, 1, 0.5), hsl(0, 1, 0.5), rgba(0, 0, 255, 1.0)),
-        # Color with different channel values
-        (hsl(208.8, 0.6, 0.49), hsl(0, 0, 1), rgba(50, 128, 200, 1.0)),
-        (hsl(208.8, 0.6, 0.49), hsl(0, 0, 0.5), rgba(50, 128, 200, 1.0)),
-        (hsl(208.8, 0.6, 0.49), hsl(0, 0, 0), rgba(50, 128, 200, 1.0)),
-        # Both front_color and back_color having intermediate values
-        (hsl(201.29, 1, 0.7), hsl(321.29, 1, 0.7), rgba(102, 201, 255, 1.0)),
-        (hsl(210.0, 0.8, 0.71), hsl(330.0, 0.8, 0.71), rgba(122, 181, 240, 1.0)),
-        (hsl(330.0, 0.5, 0.39), hsl(90.0, 0.5, 0.39), rgba(149, 50, 99, 1.0)),
-        (hsl(210.0, 0.17, 0.24), hsl(210.0, 0.12, 0.31), rgba(51, 61, 72, 1.0)),
-        (hsl(60.0, 1, 0.5), hsl(180.0, 1, 0.5), rgba(255, 255, 0, 1.0)),
-        #
+        # Black, gray, white front colors...
+        (hsl(0, 0, 0), hsl(0, 0, 0), rgb(0, 0, 0, 1.0)),
+        (hsl(0, 0, 0), hsl(208.8, 0.6, 0.49), rgb(0, 0, 0, 1.0)),
+        (hsl(0, 0, 0.5), hsl(208.8, 0.6, 0.49), rgb(128, 128, 128, 1.0)),
+        (hsl(0, 0, 1), hsl(208.8, 0.6, 0.49), rgb(255, 255, 255, 1.0)),
+        # ...plus transparency
+        (hsl(0, 0, 0, 0), hsl(0, 0, 0, 0), rgb(0, 0, 0, 0)),
+        (hsl(0, 0, 0, 0), hsl(208.8, 0.6, 0.49, 1.0), rgb(50, 128, 200, 1)),
+        (hsl(0, 0, 0, 1.0), hsl(208.8, 0.6, 0.49, 0.9), rgb(0, 0, 0, 1.0)),
+        (hsl(0, 0, 0.5, 1.0), hsl(208.8, 0.6, 0.49, 0.5), rgb(128, 128, 128, 1.0)),
+        (hsl(0, 0, 1, 1.0), hsl(208.8, 0.6, 0.49, 0.0), rgb(255, 255, 255, 1.0)),
+        # Opaque primaries
+        (hsl(0, 1, 0.5), hsl(120.0, 1, 0.5), rgb(255, 0, 0)),
+        (hsl(120.0, 1, 0.5), hsl(0, 1, 0.5), rgb(0, 255, 0)),
+        (hsl(240.0, 1, 0.5), hsl(0, 1, 0.5), rgb(0, 0, 255)),
+        # Transparent primaries
+        (hsl(0, 1, 0.5), hsl(120.0, 1, 0.5), rgb(255, 0, 0)),
+        (hsl(120.0, 1, 0.5), hsl(0, 1, 0.5), rgb(0, 255, 0)),
+        (hsl(240.0, 1, 0.5), hsl(0, 1, 0.5), rgb(0, 0, 255)),
+        # Color with different channel values...
+        (hsl(208.8, 0.6, 0.49), hsl(0, 0, 1), rgb(50, 128, 200, 1.0)),
+        (hsl(208.8, 0.6, 0.49), hsl(0, 0, 0.5), rgb(50, 128, 200, 1.0)),
+        (hsl(208.8, 0.6, 0.49), hsl(0, 0, 0), rgb(50, 128, 200, 1.0)),
+        # ...plus transparency
+        (hsl(208.8, 0.6, 0.49, 0.0), hsl(0, 0, 1, 1.0), rgb(255, 255, 255, 1)),
+        (rgb(50, 128, 200, 0.5), hsl(0, 0, 0.5), rgb(89, 128, 164, 1)),
+        (hsl(208.8, 0.6, 0.49), rgb(0, 0, 0, 1.0), rgb(50, 128, 200, 1.0)),
+        (hsl(208.8, 0.6, 0.49, 1.0), rgb(0, 0, 0, 0), rgb(50, 128, 200, 1.0)),
+        # Both front_color and back_color having intermediate values...
+        (hsl(201.29, 1, 0.7), hsl(321.29, 1, 0.7), rgb(102, 201, 255, 1.0)),
+        (hsl(210.0, 0.8, 0.71), hsl(330.0, 0.8, 0.71), rgb(122, 181, 240, 1.0)),
+        (hsl(330.0, 0.5, 0.39), hsl(90.0, 0.5, 0.39), rgb(149, 50, 99, 1.0)),
+        (hsl(210.0, 0.17, 0.24), hsl(210.0, 0.12, 0.31), rgb(51, 61, 72, 1.0)),
+        (hsl(60.0, 1, 0.5), hsl(180.0, 1, 0.5), rgb(255, 255, 0, 1.0)),
+        # ...and intermediate alpha too
+        (
+            hsl(201.29, 1, 0.7, 0.15),
+            hsl(321.29, 1, 0.7, 0.85),
+            rgb(229, 119, 210, 0.87),
+        ),
+        (
+            hsl(210.0, 0.8, 0.71, 0.2),
+            hsl(330.0, 0.8, 0.71, 0.8),
+            rgb(212, 136, 195, 0.84),
+        ),
+        (
+            hsl(330.0, 0.5, 0.39, 0.4),
+            hsl(90.0, 0.5, 0.39, 0.6),
+            rgb(125, 97, 76, 0.76),
+        ),
+        (
+            hsl(210.0, 0.17, 0.24, 0.55),
+            hsl(210.0, 0.12, 0.31, 0.45),
+            rgb(56, 66, 77, 0.75),
+        ),
+        (hsl(60.0, 1, 0.5, 0.3), hsl(180.0, 1, 0.5, 0.7), rgb(97, 255, 158, 0.79)),
         # Test with mixed color class inputs:
         #
         # Black, gray, white front colors
-        (rgb(0, 0, 0), rgb(0, 0, 0), rgba(0, 0, 0, 1.0)),
-        (hsla(0, 0, 0, 0), rgb(50, 128, 200), rgba(50, 128, 200, 1)),
-        (rgb(0, 0, 0), rgb(50, 128, 200), rgba(0, 0, 0, 1.0)),
-        (rgba(128, 128, 128, 1.0), rgba(50, 128, 200, 0.5), rgba(128, 128, 128, 1.0)),
-        (rgb(255, 255, 255), rgb(50, 128, 200), rgba(255, 255, 255, 1.0)),
+        (hsl(0, 0, 0, 0), rgb(50, 128, 200), rgb(50, 128, 200, 1)),
         # Primaries
-        (hsl(0, 1, 0.5), hsl(120.0, 1, 0.5), rgba(255, 0, 0, 1.0)),
-        (rgb(0, 255, 0), hsla(0, 1, 0.5, 1.0), rgba(0, 255, 0, 1.0)),
-        (rgb(0, 0, 255), hsla(0, 1, 0.5, 1.0), rgba(0, 0, 255, 1.0)),
+        (rgb(0, 255, 0), hsl(0, 1, 0.5, 1.0), rgb(0, 255, 0, 1.0)),
+        (rgb(0, 0, 255), hsl(0, 1, 0.5, 1.0), rgb(0, 0, 255, 1.0)),
         # Color with different channel values, including transparency
-        (hsla(208.8, 0.6, 0.49, 0.0), hsla(0, 0, 1, 1.0), rgba(255, 255, 255, 1)),
-        (rgba(50, 128, 200, 0.5), hsl(0, 0, 0.5), rgba(89, 128, 164, 1)),
-        (hsl(208.8, 0.6, 0.49), rgba(0, 0, 0, 1.0), rgba(50, 128, 200, 1.0)),
-        (hsla(208.8, 0.6, 0.49, 1.0), rgba(0, 0, 0, 0), rgba(50, 128, 200, 1.0)),
+        (rgb(50, 128, 200, 0.5), hsl(0, 0, 0.5), rgb(89, 128, 164, 1)),
+        (hsl(208.8, 0.6, 0.49), rgb(0, 0, 0, 1.0), rgb(50, 128, 200, 1.0)),
+        (hsl(208.8, 0.6, 0.49, 1.0), rgb(0, 0, 0, 0), rgb(50, 128, 200, 1.0)),
         # Both front_color and back_color having intermediate values
-        (hsla(201.29, 1, 0.7, 0.15), hsl(321.29, 1, 0.7), rgba(232, 117, 209, 1)),
-        (hsl(210.0, 0.8, 0.71), hsla(330.0, 0.8, 0.71, 0.8), rgba(122, 181, 240, 1.0)),
-        (rgba(150, 50, 100, 0.4), hsla(90.0, 0.5, 0.39, 0.6), rgba(126, 97, 76, 0.76)),
-        (rgba(50, 60, 70, 0.55), hsla(210.0, 0.12, 0.31, 0.45), rgba(55, 65, 75, 0.75)),
-        (hsla(60.0, 1, 0.5, 0.3), hsla(180.0, 1, 0.5, 0.7), rgba(97, 255, 158, 0.79)),
+        (rgb(150, 50, 100, 0.4), hsl(90.0, 0.5, 0.39, 0.6), rgb(126, 97, 76, 0.76)),
+        (rgb(50, 60, 70, 0.55), hsl(210.0, 0.12, 0.31, 0.45), rgb(55, 65, 75, 0.75)),
     ],
 )
+
+
+@front_back_blended
 def test_alpha_blending_over(front_color, back_color, expected_blended_color):
     """The front color can be composited over the back color."""
     # Calculate the blended color using the blend_over() method on the Color class.
     calculated_blended_color = front_color.blend_over(back_color)
     # The calculated blended color will be equal to the expected blended color.
-    assert_equal_color(calculated_blended_color, expected_blended_color.rgba, abs=1)
+    assert_equal_color(calculated_blended_color, expected_blended_color.rgb, abs=1)
 
 
-@pytest.mark.parametrize(
-    "front_color, back_color",
-    [
-        # Test with rgba color inputs:
-        #
-        # Black, gray, white front colors
-        (rgba(0, 0, 0, 0), rgba(50, 128, 200, 1.0)),
-        (rgba(0, 0, 0, 1.0), rgba(50, 128, 200, 0.9)),
-        (rgba(128, 128, 128, 1.0), rgba(50, 128, 200, 0.5)),
-        (rgba(255, 255, 255, 1.0), rgba(50, 128, 200, 0.0)),
-        # Primaries
-        (rgba(255, 0, 0, 1.0), rgba(0, 255, 0, 1.0)),
-        (rgba(0, 255, 0, 1.0), rgba(255, 0, 0, 1.0)),
-        (rgba(0, 0, 255, 1.0), rgba(255, 0, 0, 1.0)),
-        # Color with different channel values, including transparency
-        (rgba(50, 128, 200, 0.0), rgba(255, 255, 255, 1.0)),
-        (rgba(50, 128, 200, 0.5), rgba(128, 128, 128, 1.0)),
-        (rgba(50, 128, 200, 0.9), rgba(0, 0, 0, 1.0)),
-        (rgba(50, 128, 200, 1.0), rgba(0, 0, 0, 0)),
-        # Both front_color and back_color having intermediate alpha
-        (rgba(100, 200, 255, 0.15), rgba(255, 100, 200, 0.85)),
-        (rgba(120, 180, 240, 0.2), rgba(240, 120, 180, 0.8)),
-        (rgba(150, 50, 100, 0.4), rgba(100, 150, 50, 0.6)),
-        (rgba(50, 60, 70, 0.55), rgba(70, 80, 90, 0.45)),
-        (rgba(255, 255, 0, 0.3), rgba(0, 255, 255, 0.7)),
-        #
-        # Test with rgb color inputs:
-        #
-        # Black, gray, white front colors
-        (rgb(0, 0, 0), rgb(50, 128, 200)),
-        (rgb(128, 128, 128), rgb(50, 128, 200)),
-        (rgb(255, 255, 255), rgb(50, 128, 200)),
-        # Primaries
-        (rgb(255, 0, 0), rgb(0, 255, 0)),
-        (rgb(0, 255, 0), rgb(255, 0, 0)),
-        (rgb(0, 0, 255), rgb(255, 0, 0)),
-        # Color with different channel values
-        (rgb(50, 128, 200), rgb(255, 255, 255)),
-        (rgb(50, 128, 200), rgb(128, 128, 128)),
-        (rgb(50, 128, 200), rgb(0, 0, 0)),
-        # Both front_color and back_color having intermediate values
-        (rgb(100, 200, 255), rgb(255, 100, 200)),
-        (rgb(120, 180, 240), rgb(240, 120, 180)),
-        (rgb(150, 50, 100), rgb(100, 150, 50)),
-        (rgb(50, 60, 70), rgb(70, 80, 90)),
-        (rgb(255, 255, 0), rgb(0, 255, 255)),
-        #
-        # Test with hsla color inputs:
-        #
-        # Black, gray, white front colors
-        (hsla(0, 0, 0, 0), hsla(208.8, 0.6, 0.49, 1.0)),
-        (hsla(0, 0, 0, 1.0), hsla(208.8, 0.6, 0.49, 0.9)),
-        (hsla(0, 0, 0.5, 1.0), hsla(208.8, 0.6, 0.49, 0.5)),
-        (hsla(0, 0, 1, 1.0), hsla(208.8, 0.6, 0.49, 0.0)),
-        # Primaries
-        (hsla(0, 1, 0.5, 1.0), hsla(120.0, 1, 0.5, 1.0)),
-        (hsla(120.0, 1, 0.5, 1.0), hsla(0, 1, 0.5, 1.0)),
-        (hsla(240.0, 1, 0.5, 1.0), hsla(0, 1, 0.5, 1.0)),
-        # Color with different channel values, including transparency
-        (hsla(208.8, 0.6, 0.49, 0.0), hsla(0, 0, 1, 1.0)),
-        (hsla(208.8, 0.6, 0.49, 0.5), hsla(0, 0, 0.5, 1.0)),
-        (hsla(208.8, 0.6, 0.49, 0.9), hsla(0, 0, 0, 1.0)),
-        (hsla(208.8, 0.6, 0.49, 1.0), hsla(0, 0, 0, 0)),
-        # Both front_color and back_color having intermediate alpha
-        (hsla(201.29, 1, 0.7, 0.15), hsla(321.29, 1, 0.7, 0.85)),
-        (hsla(210.0, 0.8, 0.71, 0.2), hsla(330.0, 0.8, 0.71, 0.8)),
-        (hsla(330.0, 0.5, 0.39, 0.4), hsla(90.0, 0.5, 0.39, 0.6)),
-        (hsla(210.0, 0.17, 0.24, 0.55), hsla(210.0, 0.12, 0.31, 0.45)),
-        (hsla(60.0, 1, 0.5, 0.3), hsla(180.0, 1, 0.5, 0.7)),
-        #
-        # Test with hsl color inputs:
-        #
-        # Black, gray, white front colors
-        (hsl(0, 0, 0), hsl(208.8, 0.6, 0.4902)),
-        (hsl(0, 0, 0.502), hsl(208.8, 0.6, 0.4902)),
-        (hsl(0, 0, 1), hsl(208.8, 0.6, 0.4902)),
-        # Primaries
-        (hsl(0, 1, 0.5), hsl(120.0, 1, 0.5)),
-        (hsl(120.0, 1, 0.5), hsl(0, 1, 0.5)),
-        (hsl(240.0, 1, 0.5), hsl(0, 1, 0.5)),
-        # Color with different channel values
-        (hsl(208.8, 0.6, 0.4902), hsl(0, 0, 1)),
-        (hsl(208.8, 0.6, 0.4902), hsl(0, 0, 0.502)),
-        (hsl(208.8, 0.6, 0.4902), hsl(0, 0, 0)),
-        # Both front_color and back_color having intermediate values
-        (hsl(201.2903, 1, 0.6961), hsl(321.2903, 1, 0.6961)),
-        (hsl(210.0, 0.8, 0.7059), hsl(330.0, 0.8, 0.7059)),
-        (hsl(330.0, 0.5, 0.3922), hsl(90.0, 0.5, 0.3922)),
-        (hsl(210.0, 0.1667, 0.2353), hsl(210.0, 0.125, 0.3137)),
-        (hsl(60.0, 1, 0.5), hsl(180.0, 1, 0.5)),
-        #
-        # Test with mixed color class inputs:
-        #
-        # Black, gray, white front colors
-        (hsl(0, 0, 0), hsl(208.8, 0.6, 0.4902)),
-        (hsl(0, 0, 0), rgba(50, 128, 200, 0.9)),
-        (rgba(128, 128, 128, 1.0), hsla(208.8, 0.6, 0.4902, 0.5)),
-        (hsla(0, 0, 1, 1.0), hsl(208.8, 0.6, 0.4902)),
-        # Primaries
-        (hsl(0, 1, 0.5), rgba(0, 255, 0, 1.0)),
-        (hsla(120.0, 1, 0.5, 1.0), hsl(0, 1, 0.5)),
-        (rgba(0, 0, 255, 1.0), rgba(255, 0, 0, 1.0)),
-        # Color with different channel values, including transparency
-        (hsla(208.8, 0.6, 0.4902, 0.0), rgba(255, 255, 255, 1.0)),
-        (rgb(50, 128, 200), rgba(128, 128, 128, 1.0)),
-        (rgba(50, 128, 200, 0.9), hsl(0, 0, 0)),
-        (rgb(50, 128, 200), hsla(0, 0, 0, 0)),
-        # Both front_color and back_color having intermediate values
-        (hsla(201.2903, 1, 0.6961, 0.15), rgb(255, 100, 200)),
-        (hsl(210.0, 0.8, 0.7059), rgb(240, 120, 180)),
-        (rgb(150, 50, 100), hsl(90.0, 0.5, 0.3922)),
-        (hsla(210.0, 0.1667, 0.2353, 0.55), rgba(70, 80, 90, 0.45)),
-        (rgba(255, 255, 0, 0.3), hsla(180.0, 1, 0.5, 0.7)),
-    ],
-)
-def test_alpha_unblend_over(front_color, back_color):
+@front_back_blended
+def test_alpha_unblend_over(front_color, back_color, expected_blended_color):
     """The alpha blended color can be unblended to get the original front color."""
+    _ = expected_blended_color  # Not used for this test
+
     calculated_blended_color = front_color.blend_over(back_color)
     if front_color.a == 0:
         # When the front color has an alpha value of 0, then all information
@@ -293,4 +160,4 @@ def test_alpha_unblend_over(front_color, back_color):
         )
         # The derived front color from the blended color, will be equal to the
         # original front color, within the given tolerance range.
-        assert_equal_color(calculated_front_color, front_color.rgba, abs=3)
+        assert_equal_color(calculated_front_color, front_color.rgb, abs=3)

--- a/travertino/tests/colors/test_color_conversion.py
+++ b/travertino/tests/colors/test_color_conversion.py
@@ -1,335 +1,165 @@
 import pytest
 
-from travertino.colors import hsl, hsla, rgb, rgba
+from travertino.colors import hsl, rgb
 
 from ..utils import assert_equal_color
 
 
 @pytest.mark.parametrize(
-    "input_color, expected_color",
+    "color, method",
+    [
+        (rgb(10, 20, 30), "rgb"),
+        (hsl(120, 0.5, 0.5), "hsl"),
+    ],
+)
+def test_conversion_noop(color, method):
+    """rgb.rgb and hsl.hsl return the original color."""
+    assert getattr(color, method) is color
+    assert getattr(color, f"{method}a") is color
+
+
+@pytest.mark.parametrize(
+    "color, method",
+    [
+        (rgb(10, 20, 30), "hsl"),
+        (hsl(120, 0.5, 0.5), "rgb"),
+    ],
+)
+def test_conversion_caching(color, method):
+    """Conversions (hsl.rgb and rgb.hsl) are cached after first call."""
+    assert getattr(color, method) is getattr(color, method)
+    assert getattr(color, f"{method}a") is getattr(color, f"{method}a")
+
+
+equivalent_colors = pytest.mark.parametrize(
+    "rgb_color, hsl_color",
     [
         # Black, gray, white,
-        (rgba(0, 0, 0, 0), rgb(0, 0, 0)),
-        (rgba(0, 0, 0, 1.0), rgb(0, 0, 0)),
-        (rgba(128, 128, 128, 1.0), rgb(128, 128, 128)),
-        (rgba(255, 255, 255, 1.0), rgb(255, 255, 255)),
+        (rgb(0, 0, 0, 0), hsl(0, 0, 0, 0)),
+        (rgb(0, 0, 0, 1.0), hsl(0, 0, 0, 1)),
+        (rgb(128, 128, 128, 1.0), hsl(0, 0, 0.502, 1)),
+        (rgb(255, 255, 255, 1.0), hsl(0, 0, 1, 1)),
         # Primaries
-        (rgba(255, 0, 0, 1.0), rgb(255, 0, 0)),
-        (rgba(0, 255, 0, 1.0), rgb(0, 255, 0)),
-        (rgba(0, 0, 255, 1.0), rgb(0, 0, 255)),
+        (rgb(255, 0, 0, 1.0), hsl(0, 1, 0.5, 1)),
+        (rgb(0, 255, 0, 1.0), hsl(120, 1, 0.5, 1)),
+        (rgb(0, 0, 255, 1.0), hsl(240, 1, 0.5, 1)),
         # Color with different channel values, including transparency
-        (rgba(50, 128, 200, 0.0), rgb(50, 128, 200)),
-        (rgba(50, 128, 200, 0.5), rgb(50, 128, 200)),
-        (rgba(50, 128, 200, 0.9), rgb(50, 128, 200)),
-        (rgba(50, 128, 200, 1.0), rgb(50, 128, 200)),
+        (rgb(50, 128, 200, 0.0), hsl(209, 0.6, 0.4902, 0)),
+        (rgb(50, 128, 200, 0.5), hsl(209, 0.6, 0.4902, 0.5)),
+        (rgb(50, 128, 200, 0.9), hsl(209, 0.6, 0.4902, 0.9)),
+        (rgb(50, 128, 200, 1.0), hsl(209, 0.6, 0.4902, 1)),
         # Color having intermediate alpha values
-        (rgba(100, 200, 255, 0.15), rgb(100, 200, 255)),
-        (rgba(120, 180, 240, 0.2), rgb(120, 180, 240)),
-        (rgba(150, 50, 100, 0.4), rgb(150, 50, 100)),
-        (rgba(50, 60, 70, 0.55), rgb(50, 60, 70)),
-        (rgba(255, 255, 0, 0.3), rgb(255, 255, 0)),
-    ],
-)
-def test_rgba_to_rgb(input_color, expected_color):
-    """A rgba color can be converted to rgb."""
-    assert_equal_color(input_color.rgb, expected_color)
-
-
-@pytest.mark.parametrize(
-    "input_color, expected_color",
-    [
-        # Black, gray, white,
-        (rgba(0, 0, 0, 0), hsla(0, 0, 0, 0)),
-        (rgba(0, 0, 0, 1.0), hsla(0, 0, 0, 1)),
-        (rgba(128, 128, 128, 1.0), hsla(0, 0, 0.502, 1)),
-        (rgba(255, 255, 255, 1.0), hsla(0, 0, 1, 1)),
+        (rgb(100, 201, 255, 0.15), hsl(201, 1, 0.6961, 0.15)),
+        (rgb(120, 180, 240, 0.2), hsl(210, 0.8, 0.7059, 0.2)),
+        (rgb(150, 50, 100, 0.4), hsl(330, 0.5, 0.3922, 0.4)),
+        (rgb(50, 60, 70, 0.55), hsl(210, 0.1667, 0.2353, 0.55)),
+        (rgb(255, 255, 0, 0.3), hsl(60, 1, 0.5, 0.3)),
+        # The following were transferred over from what used to be test_hsl in
+        # test_constructor.py:
+        # Blacks
+        (rgb(0x00, 0x00, 0x00), hsl(0, 0.0, 0.0)),
+        (rgb(0x00, 0x00, 0x00), hsl(60, 0.0, 0.0)),
+        (rgb(0x00, 0x00, 0x00), hsl(180, 0.0, 0.0)),
+        (rgb(0x00, 0x00, 0x00), hsl(240, 0.0, 0.0)),
+        (rgb(0x00, 0x00, 0x00), hsl(360, 0.0, 0.0)),
+        # Whites
+        (rgb(0xFF, 0xFF, 0xFF), hsl(0, 0.0, 1.0)),
+        (rgb(0xFF, 0xFF, 0xFF), hsl(60, 0.0, 1.0)),
+        (rgb(0xFF, 0xFF, 0xFF), hsl(180, 0.0, 1.0)),
+        (rgb(0xFF, 0xFF, 0xFF), hsl(240, 0.0, 1.0)),
+        (rgb(0xFF, 0xFF, 0xFF), hsl(360, 0.0, 1.0)),
+        # Grays
+        (rgb(0x33, 0x33, 0x33), hsl(0, 0.0, 0.2)),
+        (rgb(0x66, 0x66, 0x66), hsl(0, 0.0, 0.4)),
+        (rgb(0x80, 0x80, 0x80), hsl(0, 0.0, 0.502)),
+        (rgb(0x99, 0x99, 0x99), hsl(0, 0.0, 0.6)),
+        (rgb(0xCC, 0xCC, 0xCC), hsl(0, 0.0, 0.8)),
         # Primaries
-        (rgba(255, 0, 0, 1.0), hsla(0, 1, 0.5, 1)),
-        (rgba(0, 255, 0, 1.0), hsla(120.0, 1, 0.5, 1)),
-        (rgba(0, 0, 255, 1.0), hsla(240.0, 1, 0.5, 1)),
-        # Color with different channel values, including transparency
-        (rgba(50, 128, 200, 0.0), hsla(208.8, 0.6, 0.4902, 0)),
-        (rgba(50, 128, 200, 0.5), hsla(208.8, 0.6, 0.4902, 0.5)),
-        (rgba(50, 128, 200, 0.9), hsla(208.8, 0.6, 0.4902, 0.9)),
-        (rgba(50, 128, 200, 1.0), hsla(208.8, 0.6, 0.4902, 1)),
-        # Color having intermediate alpha values
-        (rgba(100, 200, 255, 0.15), hsla(201.2903, 1, 0.6961, 0.15)),
-        (rgba(120, 180, 240, 0.2), hsla(210.0, 0.8, 0.7059, 0.2)),
-        (rgba(150, 50, 100, 0.4), hsla(330.0, 0.5, 0.3922, 0.4)),
-        (rgba(50, 60, 70, 0.55), hsla(210.0, 0.1667, 0.2353, 0.55)),
-        (rgba(255, 255, 0, 0.3), hsla(60.0, 1, 0.5, 0.3)),
+        (rgb(0xFF, 0x00, 0x00), hsl(0, 1.0, 0.5)),
+        (rgb(0xFF, 0x80, 0x00), hsl(30, 1.0, 0.5)),
+        (rgb(0xFF, 0xFF, 0x00), hsl(60, 1.0, 0.5)),
+        (rgb(0x80, 0xFF, 0x00), hsl(90, 1.0, 0.5)),
+        (rgb(0x00, 0xFF, 0x00), hsl(120, 1.0, 0.5)),
+        (rgb(0x00, 0xFF, 0x80), hsl(150, 1.0, 0.5)),
+        (rgb(0x00, 0xFF, 0xFF), hsl(180, 1.0, 0.5)),
+        (rgb(0x00, 0x80, 0xFF), hsl(210, 1.0, 0.5)),
+        (rgb(0x00, 0x00, 0xFF), hsl(240, 1.0, 0.5)),
+        (rgb(0x80, 0x00, 0xFF), hsl(270, 1.0, 0.5)),
+        (rgb(0xFF, 0x00, 0xFF), hsl(300, 1.0, 0.5)),
+        (rgb(0xFF, 0x00, 0x80), hsl(330, 1.0, 0.5)),
+        (rgb(0xFF, 0x00, 0x00), hsl(360, 1.0, 0.5)),
+        # Muted
+        (rgb(0x50, 0x30, 0x30), hsl(0, 0.25, 0.25)),
+        (rgb(0x50, 0x40, 0x30), hsl(30, 0.25, 0.25)),
+        (rgb(0x50, 0x50, 0x30), hsl(60, 0.25, 0.25)),
+        (rgb(0x40, 0x50, 0x30), hsl(90, 0.25, 0.25)),
+        (rgb(0x30, 0x50, 0x30), hsl(120, 0.25, 0.25)),
+        (rgb(0x30, 0x50, 0x40), hsl(150, 0.25, 0.25)),
+        (rgb(0x30, 0x50, 0x50), hsl(180, 0.25, 0.25)),
+        (rgb(0x30, 0x40, 0x50), hsl(210, 0.25, 0.25)),
+        (rgb(0x30, 0x30, 0x50), hsl(240, 0.25, 0.25)),
+        (rgb(0x40, 0x30, 0x50), hsl(270, 0.25, 0.25)),
+        (rgb(0x50, 0x30, 0x50), hsl(300, 0.25, 0.25)),
+        (rgb(0x50, 0x30, 0x40), hsl(330, 0.25, 0.25)),
+        (rgb(0x50, 0x30, 0x30), hsl(360, 0.25, 0.25)),
+        (rgb(0xCF, 0xAF, 0xAF), hsl(0, 0.25, 0.75)),
+        (rgb(0xCF, 0xBF, 0xAF), hsl(30, 0.25, 0.75)),
+        (rgb(0xCF, 0xCF, 0xAF), hsl(60, 0.25, 0.75)),
+        (rgb(0xBF, 0xCF, 0xAF), hsl(90, 0.25, 0.75)),
+        (rgb(0xAF, 0xCF, 0xAF), hsl(120, 0.25, 0.75)),
+        (rgb(0xAF, 0xCF, 0xBF), hsl(150, 0.25, 0.75)),
+        (rgb(0xAF, 0xCF, 0xCF), hsl(180, 0.25, 0.75)),
+        (rgb(0xAF, 0xBF, 0xCF), hsl(210, 0.25, 0.75)),
+        (rgb(0xAF, 0xAF, 0xCF), hsl(240, 0.25, 0.75)),
+        (rgb(0xBF, 0xAF, 0xCF), hsl(270, 0.25, 0.75)),
+        (rgb(0xCF, 0xAF, 0xCF), hsl(300, 0.25, 0.75)),
+        (rgb(0xCF, 0xAF, 0xBF), hsl(330, 0.25, 0.75)),
+        (rgb(0xCF, 0xAF, 0xAF), hsl(360, 0.25, 0.75)),
+        (rgb(0xEF, 0x8F, 0x8F), hsl(0, 0.75, 0.75)),
+        (rgb(0xEF, 0xBF, 0x8F), hsl(30, 0.75, 0.75)),
+        (rgb(0xEF, 0xEF, 0x8F), hsl(60, 0.75, 0.75)),
+        (rgb(0xBF, 0xEF, 0x8F), hsl(90, 0.75, 0.75)),
+        (rgb(0x8F, 0xEF, 0x8F), hsl(120, 0.75, 0.75)),
+        (rgb(0x8F, 0xEF, 0xBF), hsl(150, 0.75, 0.75)),
+        (rgb(0x8F, 0xEF, 0xEF), hsl(180, 0.75, 0.75)),
+        (rgb(0x8F, 0xBF, 0xEF), hsl(210, 0.75, 0.75)),
+        (rgb(0x8F, 0x8F, 0xEF), hsl(240, 0.75, 0.75)),
+        (rgb(0xBF, 0x8F, 0xEF), hsl(270, 0.75, 0.75)),
+        (rgb(0xEF, 0x8F, 0xEF), hsl(300, 0.75, 0.75)),
+        (rgb(0xEF, 0x8F, 0xBF), hsl(330, 0.75, 0.75)),
+        (rgb(0xEF, 0x8F, 0x8F), hsl(360, 0.75, 0.75)),
+        (rgb(0x70, 0x10, 0x10), hsl(0, 0.75, 0.25)),
+        (rgb(0x70, 0x40, 0x10), hsl(30, 0.75, 0.25)),
+        (rgb(0x70, 0x70, 0x10), hsl(60, 0.75, 0.25)),
+        (rgb(0x40, 0x70, 0x10), hsl(90, 0.75, 0.25)),
+        (rgb(0x10, 0x70, 0x10), hsl(120, 0.75, 0.25)),
+        (rgb(0x10, 0x70, 0x40), hsl(150, 0.75, 0.25)),
+        (rgb(0x10, 0x70, 0x70), hsl(180, 0.75, 0.25)),
+        (rgb(0x10, 0x40, 0x70), hsl(210, 0.75, 0.25)),
+        (rgb(0x10, 0x10, 0x70), hsl(240, 0.75, 0.25)),
+        (rgb(0x40, 0x10, 0x70), hsl(270, 0.75, 0.25)),
+        (rgb(0x70, 0x10, 0x70), hsl(300, 0.75, 0.25)),
+        (rgb(0x70, 0x10, 0x40), hsl(330, 0.75, 0.25)),
+        (rgb(0x70, 0x10, 0x10), hsl(360, 0.75, 0.25)),
+        # With alpha
+        (rgb(0x00, 0x00, 0x00, 0.3), hsl(60, 0.0, 0.0, 0.3)),
+        (rgb(0xFF, 0xFF, 0xFF, 0.3), hsl(60, 0.0, 1.0, 0.3)),
+        (rgb(0xFF, 0xFF, 0x00, 0.3), hsl(60, 1.0, 0.5, 0.3)),
+        (rgb(0x50, 0x50, 0x30, 0.3), hsl(60, 0.25, 0.25, 0.3)),
+        (rgb(0xCF, 0xCF, 0xAF, 0.3), hsl(60, 0.25, 0.75, 0.3)),
+        (rgb(0xEF, 0xEF, 0x8F, 0.3), hsl(60, 0.75, 0.75, 0.3)),
+        (rgb(0x70, 0x70, 0x10, 0.3), hsl(60, 0.75, 0.25, 0.3)),
     ],
 )
-def test_rgba_to_hsla(input_color, expected_color):
-    """A rgba color can be converted to hsla."""
-    assert_equal_color(input_color.hsla, expected_color, abs=1e-4)
 
 
-@pytest.mark.parametrize(
-    "input_color, expected_color",
-    [
-        # Black, gray, white,
-        (rgba(0, 0, 0, 0), hsl(0, 0, 0)),
-        (rgba(0, 0, 0, 1.0), hsl(0, 0, 0)),
-        (rgba(128, 128, 128, 1.0), hsl(0, 0, 0.502)),
-        (rgba(255, 255, 255, 1.0), hsl(0, 0, 1)),
-        # Primaries
-        (rgba(255, 0, 0, 1.0), hsl(0, 1, 0.5)),
-        (rgba(0, 255, 0, 1.0), hsl(120.0, 1, 0.5)),
-        (rgba(0, 0, 255, 1.0), hsl(240.0, 1, 0.5)),
-        # Color with different channel values, including transparency
-        (rgba(50, 128, 200, 0.0), hsl(208.8, 0.6, 0.4902)),
-        (rgba(50, 128, 200, 0.5), hsl(208.8, 0.6, 0.4902)),
-        (rgba(50, 128, 200, 0.9), hsl(208.8, 0.6, 0.4902)),
-        (rgba(50, 128, 200, 1.0), hsl(208.8, 0.6, 0.4902)),
-        # Color having intermediate alpha values
-        (rgba(100, 200, 255, 0.15), hsl(201.2903, 1, 0.6961)),
-        (rgba(120, 180, 240, 0.2), hsl(210.0, 0.8, 0.7059)),
-        (rgba(150, 50, 100, 0.4), hsl(330.0, 0.5, 0.3922)),
-        (rgba(50, 60, 70, 0.55), hsl(210.0, 0.1667, 0.2353)),
-        (rgba(255, 255, 0, 0.3), hsl(60.0, 1, 0.5)),
-    ],
-)
-def test_rgba_to_hsl(input_color, expected_color):
-    """A rgba color can be converted to hsl."""
-    assert_equal_color(input_color.hsl, expected_color, abs=1e-4)
+@equivalent_colors
+def test_rgb_to_hsl(rgb_color, hsl_color):
+    """An rgb color can be converted to hsl."""
+    assert_equal_color(rgb_color.hsl, hsl_color, abs=1e-3)
 
 
-@pytest.mark.parametrize(
-    "input_color, expected_color",
-    [
-        # Black, gray, white,
-        (rgb(0, 0, 0), rgba(0, 0, 0, 1.0)),
-        (rgb(128, 128, 128), rgba(128, 128, 128, 1.0)),
-        (rgb(255, 255, 255), rgba(255, 255, 255, 1.0)),
-        # Primaries
-        (rgb(255, 0, 0), rgba(255, 0, 0, 1.0)),
-        (rgb(0, 255, 0), rgba(0, 255, 0, 1.0)),
-        (rgb(0, 0, 255), rgba(0, 0, 255, 1.0)),
-        # Color with different channel values
-        (rgb(50, 128, 200), rgba(50, 128, 200, 1.0)),
-        (rgb(100, 200, 255), rgba(100, 200, 255, 1.0)),
-        (rgb(120, 180, 240), rgba(120, 180, 240, 1.0)),
-        (rgb(150, 50, 100), rgba(150, 50, 100, 1.0)),
-        (rgb(50, 60, 70), rgba(50, 60, 70, 1.0)),
-        (rgb(255, 255, 0), rgba(255, 255, 0, 1.0)),
-    ],
-)
-def test_rgb_to_rgba(input_color, expected_color):
-    """A rgb color can be converted to rgba."""
-    assert_equal_color(input_color.rgba, expected_color)
-
-
-@pytest.mark.parametrize(
-    "input_color, expected_color",
-    [
-        # Black, gray, white,
-        (rgb(0, 0, 0), hsla(0, 0, 0, 1)),
-        (rgb(128, 128, 128), hsla(0, 0, 0.502, 1)),
-        (rgb(255, 255, 255), hsla(0, 0, 1, 1)),
-        # Primaries
-        (rgb(255, 0, 0), hsla(0, 1, 0.5, 1)),
-        (rgb(0, 255, 0), hsla(120.0, 1, 0.5, 1)),
-        (rgb(0, 0, 255), hsla(240.0, 1, 0.5, 1)),
-        # Color with different channel values
-        (rgb(50, 128, 200), hsla(208.8, 0.6, 0.4902, 1)),
-        (rgb(100, 200, 255), hsla(201.2903, 1, 0.6961, 1)),
-        (rgb(120, 180, 240), hsla(210.0, 0.8, 0.7059, 1)),
-        (rgb(150, 50, 100), hsla(330.0, 0.5, 0.3922, 1)),
-        (rgb(50, 60, 70), hsla(210.0, 0.1667, 0.2353, 1)),
-        (rgb(255, 255, 0), hsla(60.0, 1, 0.5, 1)),
-    ],
-)
-def test_rgb_to_hsla(input_color, expected_color):
-    """A rgb color can be converted to hsla."""
-    assert_equal_color(input_color.hsla, expected_color, abs=1e-4)
-
-
-@pytest.mark.parametrize(
-    "input_color, expected_color",
-    [
-        # Black, gray, white,
-        (rgb(0, 0, 0), hsl(0, 0, 0)),
-        (rgb(128, 128, 128), hsl(0, 0, 0.502)),
-        (rgb(255, 255, 255), hsl(0, 0, 1)),
-        # Primaries
-        (rgb(255, 0, 0), hsl(0, 1, 0.5)),
-        (rgb(0, 255, 0), hsl(120.0, 1, 0.5)),
-        (rgb(0, 0, 255), hsl(240.0, 1, 0.5)),
-        # Color with different channel values
-        (rgb(50, 128, 200), hsl(208.8, 0.6, 0.4902)),
-        (rgb(100, 200, 255), hsl(201.2903, 1, 0.6961)),
-        (rgb(120, 180, 240), hsl(210.0, 0.8, 0.7059)),
-        (rgb(150, 50, 100), hsl(330.0, 0.5, 0.3922)),
-        (rgb(50, 60, 70), hsl(210.0, 0.1667, 0.2353)),
-        (rgb(255, 255, 0), hsl(60.0, 1, 0.5)),
-    ],
-)
-def test_rgb_to_hsl(input_color, expected_color):
-    """A rgb color can be converted to hsl."""
-    assert_equal_color(input_color.hsl, expected_color, abs=1e-4)
-
-
-@pytest.mark.parametrize(
-    "input_color, expected_color",
-    [
-        # Black, gray, white,
-        (hsla(0, 0, 0, 0), hsl(0, 0, 0)),
-        (hsla(0, 0, 0, 1), hsl(0, 0, 0)),
-        (hsla(0, 0, 0.502, 1), hsl(0, 0, 0.502)),
-        (hsla(0, 0, 1, 1), hsl(0, 0, 1)),
-        # Primaries
-        (hsla(0, 1, 0.5, 1), hsl(0, 1, 0.5)),
-        (hsla(120.0, 1, 0.5, 1), hsl(120.0, 1, 0.5)),
-        (hsla(240.0, 1, 0.5, 1), hsl(240.0, 1, 0.5)),
-        # Color with different channel values, including transparency
-        (hsla(208.8, 0.6, 0.4902, 0), hsl(208.8, 0.6, 0.4902)),
-        (hsla(208.8, 0.6, 0.4902, 0.5), hsl(208.8, 0.6, 0.4902)),
-        (hsla(208.8, 0.6, 0.4902, 0.9), hsl(208.8, 0.6, 0.4902)),
-        (hsla(208.8, 0.6, 0.4902, 1), hsl(208.8, 0.6, 0.4902)),
-        # Color having intermediate alpha values
-        (hsla(201.2903, 1, 0.6961, 0.15), hsl(201.2903, 1, 0.6961)),
-        (hsla(210.0, 0.8, 0.7059, 0.2), hsl(210.0, 0.8, 0.7059)),
-        (hsla(330.0, 0.5, 0.3922, 0.4), hsl(330.0, 0.5, 0.3922)),
-        (hsla(210.0, 0.1667, 0.2353, 0.55), hsl(210.0, 0.1667, 0.2353)),
-        (hsla(60.0, 1, 0.5, 0.3), hsl(60.0, 1, 0.5)),
-    ],
-)
-def test_hsla_to_hsl(input_color, expected_color):
-    """A hsla color can be converted to hsl."""
-    assert_equal_color(input_color.hsl, expected_color)
-
-
-@pytest.mark.parametrize(
-    "input_color, expected_color",
-    [
-        # Black, gray, white,
-        (hsla(0, 0, 0, 0), rgba(0, 0, 0, 0)),
-        (hsla(0, 0, 0, 1), rgba(0, 0, 0, 1.0)),
-        (hsla(0, 0, 0.502, 1), rgba(128, 128, 128, 1.0)),
-        (hsla(0, 0, 1, 1), rgba(255, 255, 255, 1.0)),
-        # Primaries
-        (hsla(0, 1, 0.5, 1), rgba(255, 0, 0, 1.0)),
-        (hsla(120.0, 1, 0.5, 1), rgba(0, 255, 0, 1.0)),
-        (hsla(240.0, 1, 0.5, 1), rgba(0, 0, 255, 1.0)),
-        # Color with different channel values, including transparency
-        (hsla(208.8, 0.6, 0.4902, 0), rgba(50, 128, 200, 0.0)),
-        (hsla(208.8, 0.6, 0.4902, 0.5), rgba(50, 128, 200, 0.5)),
-        (hsla(208.8, 0.6, 0.4902, 0.9), rgba(50, 128, 200, 0.9)),
-        (hsla(208.8, 0.6, 0.4902, 1), rgba(50, 128, 200, 1.0)),
-        # Color having intermediate alpha values
-        (hsla(201.2903, 1, 0.6961, 0.15), rgba(100, 200, 255, 0.15)),
-        (hsla(210.0, 0.8, 0.7059, 0.2), rgba(120, 180, 240, 0.2)),
-        (hsla(330.0, 0.5, 0.3922, 0.4), rgba(150, 50, 100, 0.4)),
-        (hsla(210.0, 0.1667, 0.2353, 0.55), rgba(50, 60, 70, 0.55)),
-        (hsla(60.0, 1, 0.5, 0.3), rgba(255, 255, 0, 0.3)),
-    ],
-)
-def test_hsla_to_rgba(input_color, expected_color):
-    """A hsla color can be converted to rgba."""
-    assert_equal_color(input_color.rgba, expected_color)
-
-
-@pytest.mark.parametrize(
-    "input_color, expected_color",
-    [
-        # Black, gray, white,
-        (hsla(0, 0, 0, 0), rgb(0, 0, 0)),
-        (hsla(0, 0, 0, 1), rgb(0, 0, 0)),
-        (hsla(0, 0, 0.502, 1), rgb(128, 128, 128)),
-        (hsla(0, 0, 1, 1), rgb(255, 255, 255)),
-        # Primaries
-        (hsla(0, 1, 0.5, 1), rgb(255, 0, 0)),
-        (hsla(120.0, 1, 0.5, 1), rgb(0, 255, 0)),
-        (hsla(240.0, 1, 0.5, 1), rgb(0, 0, 255)),
-        # Color with different channel values, including transparency
-        (hsla(208.8, 0.6, 0.4902, 0), rgb(50, 128, 200)),
-        (hsla(208.8, 0.6, 0.4902, 0.5), rgb(50, 128, 200)),
-        (hsla(208.8, 0.6, 0.4902, 0.9), rgb(50, 128, 200)),
-        (hsla(208.8, 0.6, 0.4902, 1), rgb(50, 128, 200)),
-        # Color having intermediate alpha values
-        (hsla(201.2903, 1, 0.6961, 0.15), rgb(100, 200, 255)),
-        (hsla(210.0, 0.8, 0.7059, 0.2), rgb(120, 180, 240)),
-        (hsla(330.0, 0.5, 0.3922, 0.4), rgb(150, 50, 100)),
-        (hsla(210.0, 0.1667, 0.2353, 0.55), rgb(50, 60, 70)),
-        (hsla(60.0, 1, 0.5, 0.3), rgb(255, 255, 0)),
-    ],
-)
-def test_hsla_to_rgb(input_color, expected_color):
-    """A hsla color can be converted to rgb."""
-    assert_equal_color(input_color.rgb, expected_color)
-
-
-@pytest.mark.parametrize(
-    "input_color, expected_color",
-    [
-        # Black, gray, white,
-        (hsl(0, 0, 0), hsla(0, 0, 0, 1.0)),
-        (hsl(0, 0, 0.502), hsla(0, 0, 0.502, 1.0)),
-        (hsl(0, 0, 1), hsla(0, 0, 1, 1.0)),
-        # Primaries
-        (hsl(0, 1, 0.5), hsla(0, 1, 0.5, 1.0)),
-        (hsl(120.0, 1, 0.5), hsla(120.0, 1, 0.5, 1.0)),
-        (hsl(240.0, 1, 0.5), hsla(240.0, 1, 0.5, 1.0)),
-        # Color with different channel values
-        (hsl(208.8, 0.6, 0.4902), hsla(208.8, 0.6, 0.4902, 1.0)),
-        (hsl(201.2903, 1, 0.6961), hsla(201.2903, 1, 0.6961, 1.0)),
-        (hsl(210.0, 0.8, 0.7059), hsla(210.0, 0.8, 0.7059, 1.0)),
-        (hsl(330.0, 0.5, 0.3922), hsla(330.0, 0.5, 0.3922, 1.0)),
-        (hsl(210.0, 0.1667, 0.2353), hsla(210.0, 0.1667, 0.2353, 1.0)),
-        (hsl(60.0, 1, 0.5), hsla(60.0, 1, 0.5, 1.0)),
-    ],
-)
-def test_hsl_to_hsla(input_color, expected_color):
-    """A hsl color can be converted to hsla."""
-    assert_equal_color(input_color.hsla, expected_color)
-
-
-@pytest.mark.parametrize(
-    "input_color, expected_color",
-    [
-        # Black, gray, white,
-        (hsl(0, 0, 0), rgba(0, 0, 0, 1.0)),
-        (hsl(0, 0, 0.502), rgba(128, 128, 128, 1.0)),
-        (hsl(0, 0, 1), rgba(255, 255, 255, 1.0)),
-        # Primaries
-        (hsl(0, 1, 0.5), rgba(255, 0, 0, 1.0)),
-        (hsl(120.0, 1, 0.5), rgba(0, 255, 0, 1.0)),
-        (hsl(240.0, 1, 0.5), rgba(0, 0, 255, 1.0)),
-        # Color with different channel values
-        (hsl(208.8, 0.6, 0.4902), rgba(50, 128, 200, 1.0)),
-        (hsl(201.2903, 1, 0.6961), rgba(100, 200, 255, 1.0)),
-        (hsl(210.0, 0.8, 0.7059), rgba(120, 180, 240, 1.0)),
-        (hsl(330.0, 0.5, 0.3922), rgba(150, 50, 100, 1.0)),
-        (hsl(210.0, 0.1667, 0.2353), rgba(50, 60, 70, 1.0)),
-        (hsl(60.0, 1, 0.5), rgba(255, 255, 0, 1.0)),
-    ],
-)
-def test_hsl_to_rgba(input_color, expected_color):
-    """A hsl color can be converted to rgba."""
-    assert_equal_color(input_color.rgba, expected_color)
-
-
-@pytest.mark.parametrize(
-    "input_color, expected_color",
-    [
-        # Black, gray, white,
-        (hsl(0, 0, 0), rgb(0, 0, 0)),
-        (hsl(0, 0, 0.502), rgb(128, 128, 128)),
-        (hsl(0, 0, 1), rgb(255, 255, 255)),
-        # Primaries
-        (hsl(0, 1, 0.5), rgb(255, 0, 0)),
-        (hsl(120.0, 1, 0.5), rgb(0, 255, 0)),
-        (hsl(240.0, 1, 0.5), rgb(0, 0, 255)),
-        # Color with different channel values
-        (hsl(208.8, 0.6, 0.4902), rgb(50, 128, 200)),
-        (hsl(201.2903, 1, 0.6961), rgb(100, 200, 255)),
-        (hsl(210.0, 0.8, 0.7059), rgb(120, 180, 240)),
-        (hsl(330.0, 0.5, 0.3922), rgb(150, 50, 100)),
-        (hsl(210.0, 0.1667, 0.2353), rgb(50, 60, 70)),
-        (hsl(60.0, 1, 0.5), rgb(255, 255, 0)),
-    ],
-)
-def test_hsl_to_rgb(input_color, expected_color):
-    """A hsl color can be converted to rgb."""
-    assert_equal_color(input_color.rgb, expected_color)
+@equivalent_colors
+def test_hsl_to_rgb(rgb_color, hsl_color):
+    """An hsl color can be converted to rgb."""
+    assert_equal_color(hsl_color.rgb, rgb_color)

--- a/travertino/tests/colors/test_constructor.py
+++ b/travertino/tests/colors/test_constructor.py
@@ -1,200 +1,191 @@
+from decimal import Decimal
+from fractions import Fraction
+
 import pytest
 
 from travertino.colors import hsl, hsla, rgb, rgba
 
 
-def assert_equal_color(actual, expected):
-    assert actual.rgba.r == expected.rgba.r
-    assert actual.rgba.g == expected.rgba.g
-    assert actual.rgba.b == expected.rgba.b
-    assert actual.rgba.a == expected.rgba.a
-
-
 @pytest.mark.parametrize(
-    "constructor, value, string",
+    "constructors, value, expected_repr, expected_str",
     [
-        (rgb, (10, 20, 30), "rgb(10, 20, 30)"),
-        (rgba, (10, 20, 30, 0.5), "rgba(10, 20, 30, 0.5)"),
-        (hsl, (10, 0.2, 0.3), "hsl(10, 0.2, 0.3)"),
-        (hsla, (10, 0.2, 0.3, 0.5), "hsla(10, 0.2, 0.3, 0.5)"),
+        ((rgb, rgba), (10, 20, 30), "rgb(10, 20, 30, 1.0)", "rgb(10 20 30 / 1.0)"),
+        ((rgb, rgba), (10, 20, 30, 0.5), "rgb(10, 20, 30, 0.5)", "rgb(10 20 30 / 0.5)"),
+        (
+            (hsl, hsla),
+            (10, 0.2, 0.3),
+            "hsl(10, 0.2, 0.3, 1.0)",
+            "hsl(10 20% 30% / 1.0)",
+        ),
+        (
+            (hsl, hsla),
+            (10, 0.2, 0.3, 0.5),
+            "hsl(10, 0.2, 0.3, 0.5)",
+            "hsl(10 20% 30% / 0.5)",
+        ),
     ],
 )
-def test_repr(constructor, value, string):
-    assert repr(constructor(*value)) == string
+@pytest.mark.parametrize("use_alias", [True, False])
+def test_repr_and_str(constructors, value, expected_repr, expected_str, use_alias):
+    """Colors' __str__ and __repr__ methods work properly."""
+    constructor = constructors[use_alias]
+    color = constructor(*value)
+    assert repr(color) == expected_repr
+    assert str(color) == expected_str
+
+
+def test_aliases():
+    """rgba and hsl should be direct aliases."""
+    assert rgba is rgb
+    assert hsla is hsl
 
 
 def test_rgb_hash():
+    """Hashes are consistent for the same color and uneqaul otherwise."""
     assert hash(rgb(10, 20, 30)) == hash(rgb(10, 20, 30))
     assert hash(rgb(10, 20, 30)) != hash(rgb(30, 20, 10))
-
-
-def test_rgba_hash():
-    assert hash(rgba(10, 20, 30, 0.5)) == hash(rgba(10, 20, 30, 0.5))
-    assert hash(rgba(10, 20, 30, 1.0)) == hash(rgb(10, 20, 30))
+    assert hash(rgb(10, 20, 30, 0.5)) == hash(rgb(10, 20, 30, 0.5))
+    assert hash(rgb(10, 20, 30, 1.0)) == hash(rgb(10, 20, 30))
     assert hash(rgb(10, 20, 30)) != hash(rgb(30, 20, 10))
 
 
 def test_hsl_hash():
+    """Hashes are consistent for the same color and uneqaul otherwise."""
     assert hash(hsl(10, 0.2, 0.3)) == hash(hsl(10, 0.2, 0.3))
     assert hash(hsl(10, 0.3, 0.2)) != hash(hsl(10, 0.2, 0.3))
-
-
-def test_hsla_hash():
-    assert hash(hsla(10, 0.2, 0.3, 0.5)) == hash(hsla(10, 0.2, 0.3, 0.5))
-    assert hash(hsla(10, 0.2, 0.3, 1.0)) == hash(hsl(10, 0.2, 0.3))
-    assert hash(hsla(10, 0.3, 0.2, 0.5)) != hash(hsla(10, 0.2, 0.3, 0.5))
-    assert hash(hsla(10, 0, 0, 0.5)) != hash(rgba(10, 0, 0, 0.5))
+    assert hash(hsl(10, 0.2, 0.3, 0.5)) == hash(hsl(10, 0.2, 0.3, 0.5))
+    assert hash(hsl(10, 0.2, 0.3, 1.0)) == hash(hsl(10, 0.2, 0.3))
+    assert hash(hsl(10, 0.3, 0.2, 0.5)) != hash(hsl(10, 0.2, 0.3, 0.5))
+    assert hash(hsl(10, 0, 0, 0.5)) != hash(rgb(10, 0, 0, 0.5))
 
 
 @pytest.mark.parametrize(
-    "value, expected",
+    "constructor, value, name, actual",
     [
-        # Blacks
-        ((0, 0.0, 0.0), (0x00, 0x00, 0x00)),
-        ((60, 0.0, 0.0), (0x00, 0x00, 0x00)),
-        ((180, 0.0, 0.0), (0x00, 0x00, 0x00)),
-        ((240, 0.0, 0.0), (0x00, 0x00, 0x00)),
-        ((360, 0.0, 0.0), (0x00, 0x00, 0x00)),
-        # Whites
-        ((0, 0.0, 1.0), (0xFF, 0xFF, 0xFF)),
-        ((60, 0.0, 1.0), (0xFF, 0xFF, 0xFF)),
-        ((180, 0.0, 1.0), (0xFF, 0xFF, 0xFF)),
-        ((240, 0.0, 1.0), (0xFF, 0xFF, 0xFF)),
-        ((360, 0.0, 1.0), (0xFF, 0xFF, 0xFF)),
-        # Grays
-        ((0, 0.0, 0.2), (0x33, 0x33, 0x33)),
-        ((0, 0.0, 0.4), (0x66, 0x66, 0x66)),
-        ((0, 0.0, 0.5), (0x80, 0x80, 0x80)),
-        ((0, 0.0, 0.6), (0x99, 0x99, 0x99)),
-        ((0, 0.0, 0.8), (0xCC, 0xCC, 0xCC)),
-        # Primaries
-        ((0, 1.0, 0.5), (0xFF, 0x00, 0x00)),
-        ((30, 1.0, 0.5), (0xFF, 0x80, 0x00)),
-        ((60, 1.0, 0.5), (0xFF, 0xFF, 0x00)),
-        ((90, 1.0, 0.5), (0x80, 0xFF, 0x00)),
-        ((120, 1.0, 0.5), (0x00, 0xFF, 0x00)),
-        ((150, 1.0, 0.5), (0x00, 0xFF, 0x80)),
-        ((180, 1.0, 0.5), (0x00, 0xFF, 0xFF)),
-        ((210, 1.0, 0.5), (0x00, 0x80, 0xFF)),
-        ((240, 1.0, 0.5), (0x00, 0x00, 0xFF)),
-        ((270, 1.0, 0.5), (0x80, 0x00, 0xFF)),
-        ((300, 1.0, 0.5), (0xFF, 0x00, 0xFF)),
-        ((330, 1.0, 0.5), (0xFF, 0x00, 0x80)),
-        ((360, 1.0, 0.5), (0xFF, 0x00, 0x00)),
-        # Muted
-        ((0, 0.25, 0.25), (0x50, 0x30, 0x30)),
-        ((30, 0.25, 0.25), (0x50, 0x40, 0x30)),
-        ((60, 0.25, 0.25), (0x50, 0x50, 0x30)),
-        ((90, 0.25, 0.25), (0x40, 0x50, 0x30)),
-        ((120, 0.25, 0.25), (0x30, 0x50, 0x30)),
-        ((150, 0.25, 0.25), (0x30, 0x50, 0x40)),
-        ((180, 0.25, 0.25), (0x30, 0x50, 0x50)),
-        ((210, 0.25, 0.25), (0x30, 0x40, 0x50)),
-        ((240, 0.25, 0.25), (0x30, 0x30, 0x50)),
-        ((270, 0.25, 0.25), (0x40, 0x30, 0x50)),
-        ((300, 0.25, 0.25), (0x50, 0x30, 0x50)),
-        ((330, 0.25, 0.25), (0x50, 0x30, 0x40)),
-        ((360, 0.25, 0.25), (0x50, 0x30, 0x30)),
-        ((0, 0.25, 0.75), (0xCF, 0xAF, 0xAF)),
-        ((30, 0.25, 0.75), (0xCF, 0xBF, 0xAF)),
-        ((60, 0.25, 0.75), (0xCF, 0xCF, 0xAF)),
-        ((90, 0.25, 0.75), (0xBF, 0xCF, 0xAF)),
-        ((120, 0.25, 0.75), (0xAF, 0xCF, 0xAF)),
-        ((150, 0.25, 0.75), (0xAF, 0xCF, 0xBF)),
-        ((180, 0.25, 0.75), (0xAF, 0xCF, 0xCF)),
-        ((210, 0.25, 0.75), (0xAF, 0xBF, 0xCF)),
-        ((240, 0.25, 0.75), (0xAF, 0xAF, 0xCF)),
-        ((270, 0.25, 0.75), (0xBF, 0xAF, 0xCF)),
-        ((300, 0.25, 0.75), (0xCF, 0xAF, 0xCF)),
-        ((330, 0.25, 0.75), (0xCF, 0xAF, 0xBF)),
-        ((360, 0.25, 0.75), (0xCF, 0xAF, 0xAF)),
-        ((0, 0.75, 0.75), (0xEF, 0x8F, 0x8F)),
-        ((30, 0.75, 0.75), (0xEF, 0xBF, 0x8F)),
-        ((60, 0.75, 0.75), (0xEF, 0xEF, 0x8F)),
-        ((90, 0.75, 0.75), (0xBF, 0xEF, 0x8F)),
-        ((120, 0.75, 0.75), (0x8F, 0xEF, 0x8F)),
-        ((150, 0.75, 0.75), (0x8F, 0xEF, 0xBF)),
-        ((180, 0.75, 0.75), (0x8F, 0xEF, 0xEF)),
-        ((210, 0.75, 0.75), (0x8F, 0xBF, 0xEF)),
-        ((240, 0.75, 0.75), (0x8F, 0x8F, 0xEF)),
-        ((270, 0.75, 0.75), (0xBF, 0x8F, 0xEF)),
-        ((300, 0.75, 0.75), (0xEF, 0x8F, 0xEF)),
-        ((330, 0.75, 0.75), (0xEF, 0x8F, 0xBF)),
-        ((360, 0.75, 0.75), (0xEF, 0x8F, 0x8F)),
-        ((0, 0.75, 0.25), (0x70, 0x10, 0x10)),
-        ((30, 0.75, 0.25), (0x70, 0x40, 0x10)),
-        ((60, 0.75, 0.25), (0x70, 0x70, 0x10)),
-        ((90, 0.75, 0.25), (0x40, 0x70, 0x10)),
-        ((120, 0.75, 0.25), (0x10, 0x70, 0x10)),
-        ((150, 0.75, 0.25), (0x10, 0x70, 0x40)),
-        ((180, 0.75, 0.25), (0x10, 0x70, 0x70)),
-        ((210, 0.75, 0.25), (0x10, 0x40, 0x70)),
-        ((240, 0.75, 0.25), (0x10, 0x10, 0x70)),
-        ((270, 0.75, 0.25), (0x40, 0x10, 0x70)),
-        ((300, 0.75, 0.25), (0x70, 0x10, 0x70)),
-        ((330, 0.75, 0.25), (0x70, 0x10, 0x40)),
-        ((360, 0.75, 0.25), (0x70, 0x10, 0x10)),
+        (rgb, ("a", 120, 10, 0.5), "red", "a"),
+        (rgb, (None, 120, 10, 0.5), "red", None),
+        (rgb, (120, "a", 10, 0.5), "green", "a"),
+        (rgb, (120, None, 10, 0.5), "green", None),
+        (rgb, (120, 10, "a", 0.5), "blue", "a"),
+        (rgb, (120, 10, None, 0.5), "blue", None),
+        (rgb, (120, 10, 60, "a"), "alpha", "a"),
+        (rgb, (120, 10, 60, None), "alpha", None),
+        #
+        (hsl, ("a", 0.5, 0.8, 0.5), "hue", "a"),
+        (hsl, (None, 0.5, 0.8, 0.5), "hue", None),
+        (hsl, (120, "a", 0.8, 0.5), "saturation", "a"),
+        (hsl, (120, None, 0.8, 0.5), "saturation", None),
+        (hsl, (120, 0.8, "a", 0.5), "lightness", "a"),
+        (hsl, (120, 0.8, None, 0.5), "lightness", None),
+        (hsl, (120, 0.8, 0.5, "a"), "alpha", "a"),
+        (hsl, (120, 0.8, 0.5, None), "alpha", None),
     ],
 )
-def test_hsl(value, expected):
-    assert_equal_color(hsl(*value), rgb(*expected))
-
-
-@pytest.mark.parametrize(
-    "value, expected",
-    [
-        ((60, 0.0, 0.0, 0.3), (0x00, 0x00, 0x00, 0.3)),
-        ((60, 0.0, 1.0, 0.3), (0xFF, 0xFF, 0xFF, 0.3)),
-        ((60, 1.0, 0.5, 0.3), (0xFF, 0xFF, 0x00, 0.3)),
-        ((60, 0.25, 0.25, 0.3), (0x50, 0x50, 0x30, 0.3)),
-        ((60, 0.25, 0.75, 0.3), (0xCF, 0xCF, 0xAF, 0.3)),
-        ((60, 0.75, 0.75, 0.3), (0xEF, 0xEF, 0x8F, 0.3)),
-        ((60, 0.75, 0.25, 0.3), (0x70, 0x70, 0x10, 0.3)),
-    ],
-)
-def test_hsl_alpha(value, expected):
-    assert_equal_color(hsla(*value), rgba(*expected))
-
-
-@pytest.mark.parametrize(
-    "constructor, value, name, min, max, actual",
-    [
-        (rgb, (-1, 120, 10), "red", 0, 255, -1),
-        (rgb, (256, 120, 10), "red", 0, 255, 256),
-        (rgb, (120, -1, 10), "green", 0, 255, -1),
-        (rgb, (120, 256, 10), "green", 0, 255, 256),
-        (rgb, (120, 10, -1), "blue", 0, 255, -1),
-        (rgb, (120, 10, 256), "blue", 0, 255, 256),
-        #
-        (rgba, (-1, 120, 10, 0.5), "red", 0, 255, -1),
-        (rgba, (256, 120, 10, 0.5), "red", 0, 255, 256),
-        (rgba, (120, -1, 10, 0.5), "green", 0, 255, -1),
-        (rgba, (120, 256, 10, 0.5), "green", 0, 255, 256),
-        (rgba, (120, 10, -1, 0.5), "blue", 0, 255, -1),
-        (rgba, (120, 10, 256, 0.5), "blue", 0, 255, 256),
-        (rgba, (120, 10, 60, -0.5), "alpha", 0, 1, -0.5),
-        (rgba, (120, 10, 60, 1.1), "alpha", 0, 1, 1.1),
-        #
-        (hsl, (-1, 0.5, 0.8), "hue", 0, 360, -1),
-        (hsl, (361, 0.5, 0.8), "hue", 0, 360, 361),
-        (hsl, (120, -0.1, 0.8), "saturation", 0, 1, -0.1),
-        (hsl, (120, 1.1, 0.8), "saturation", 0, 1, 1.1),
-        (hsl, (120, 0.8, -0.1), "lightness", 0, 1, -0.1),
-        (hsl, (120, 0.8, 1.1), "lightness", 0, 1, 1.1),
-        #
-        (hsla, (-1, 0.5, 0.8, 0.5), "hue", 0, 360, -1),
-        (hsla, (361, 0.5, 0.8, 0.5), "hue", 0, 360, 361),
-        (hsla, (120, -0.1, 0.8, 0.5), "saturation", 0, 1, -0.1),
-        (hsla, (120, 1.1, 0.8, 0.5), "saturation", 0, 1, 1.1),
-        (hsla, (120, 0.8, -0.1, 0.5), "lightness", 0, 1, -0.1),
-        (hsla, (120, 0.8, 1.1, 0.5), "lightness", 0, 1, 1.1),
-        (hsla, (120, 0.8, 0.5, -0.1), "alpha", 0, 1, -0.1),
-        (hsla, (120, 0.8, 0.5, 1.1), "alpha", 0, 1, 1.1),
-    ],
-)
-def test_invalid_color_constructor(constructor, value, name, min, max, actual):
+def test_invalid_color_constructor(constructor, value, name, actual):
+    """Invalid types are rejected."""
     with pytest.raises(
-        ValueError,
-        match=rf"^{name} value should be between {min}-{max}\. Got {actual}$",
+        TypeError,
+        match=rf"^Value for {name} must be a number; got {actual!r}$",
     ):
         constructor(*value)
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (25, 25),
+        (100.0, 100),
+        (50.3, 50),
+        (50.8, 51),
+        (Decimal("1"), 1),
+        (Decimal("10.7"), 11),
+        (Fraction(2, 3), 1),
+        (Fraction(1, 16), 0),
+        (-1, 0),
+        (-100, 0),
+        (300, 255),
+    ],
+)
+@pytest.mark.parametrize("band", ["r", "g", "b"])
+def test_rgb_normalization(value, expected, band):
+    """Values are clipped and/or converted appropriately."""
+    args = {"r": 10, "g": 10, "b": 10} | {band: value}
+    color = rgb(**args)
+    actual = getattr(color, band)
+    assert isinstance(actual, int)
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (25, 25),
+        (100.0, 100),
+        (50.3, 50),
+        (50.8, 51),
+        (Decimal("1"), 1),
+        (Decimal("10.7"), 11),
+        (Fraction(2, 3), 1),
+        (Fraction(1, 16), 0),
+        (-1, 359),
+        (-100, 260),
+        (380, 20),
+        (800, 80),
+    ],
+)
+def test_hue_normalization(value, expected):
+    """Values are wrapped and/or converted appropriately."""
+    color = hsl(h=value, s=0.5, l=0.5)
+    actual = color.h
+    assert isinstance(actual, int)
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (0.5, 0.5),
+        (1.0, 1.0),
+        (1, 1.0),
+        (-1, 0.0),
+        (-100, 0.0),
+        (10, 1.0),
+        (Decimal(".2"), 0.2),
+        (Fraction(3, 16), 0.1875),
+    ],
+)
+@pytest.mark.parametrize(
+    "constructor, attribute",
+    [
+        (rgb, "a"),
+        (hsl, "s"),
+        (hsl, "l"),
+        (hsl, "a"),
+    ],
+)
+def test_zero_to_one_normalization(value, expected, constructor, attribute):
+    """Values are clipped and/or converted appropriately."""
+    if constructor is rgb:
+        args = {"r": 10, "g": 10, "b": 10}
+    else:
+        args = {"h": 10, "s": 0.5, "l": 0.5}
+
+    args |= {attribute: value}
+    color = constructor(**args)
+    actual = getattr(color, attribute)
+    assert isinstance(actual, float)
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "color, attributes",
+    [
+        (rgb(10, 10, 10), ("r", "g", "b", "a")),
+        (hsl(10, 1, 1), ("h", "s", "l", "a")),
+    ],
+)
+def test_read_only(color, attributes):
+    """A color's attributes cannot be changed."""
+    for attribute in attributes:
+        with pytest.raises(AttributeError):
+            setattr(color, attribute, 0)

--- a/travertino/tests/colors/test_parsing.py
+++ b/travertino/tests/colors/test_parsing.py
@@ -1,14 +1,14 @@
 import pytest
 
-from travertino.colors import color, hsl, hsla, rgb, rgba
+from travertino.colors import color, hsl, rgb, rgba
 
 
 def assert_equal_hsl(value, expected):
     # Nothing fancy - a color is equal if the attributes are all the same
     actual = color(value)
     assert actual.h == expected.h
-    assert actual.s == expected.s
-    assert actual.l == expected.l
+    assert actual.s == pytest.approx(expected.s, abs=0.001)
+    assert actual.l == pytest.approx(expected.l, abs=0.001)
     assert actual.a == pytest.approx(expected.a, abs=0.001)
 
 
@@ -29,42 +29,13 @@ def test_noop():
 @pytest.mark.parametrize(
     "value, expected",
     [
-        ("rgb(1,2,3)", (1, 2, 3)),
-        ("rgb(1, 2, 3)", (1, 2, 3)),
-        ("rgb( 1 , 2 , 3)", (1, 2, 3)),
         ("#123", (0x11, 0x22, 0x33)),
         ("#112233", (0x11, 0x22, 0x33)),
         ("#abc", (0xAA, 0xBB, 0xCC)),
         ("#ABC", (0xAA, 0xBB, 0xCC)),
         ("#abcdef", (0xAB, 0xCD, 0xEF)),
         ("#ABCDEF", (0xAB, 0xCD, 0xEF)),
-    ],
-)
-def test_rgb(value, expected):
-    assert_equal_rgb(value, rgb(*expected))
-
-
-@pytest.mark.parametrize(
-    "value",
-    [
-        "10, 20",
-        "a, 10, 20",
-        "10, b, 20",
-        "10, 20, c",
-        "10, 20, 30, 0.5",
-    ],
-)
-def test_rgb_invalid(value):
-    with pytest.raises(ValueError):
-        color(f"rgb({value})")
-
-
-@pytest.mark.parametrize(
-    "value, expected",
-    [
-        ("rgba(1,2,3,0.5)", (1, 2, 3, 0.5)),
-        ("rgba(1, 2, 3, 0.5)", (1, 2, 3, 0.5)),
-        ("rgba( 1 , 2 , 3 , 0.5)", (1, 2, 3, 0.5)),
+        #
         ("#1234", (0x11, 0x22, 0x33, 0.2666)),
         ("#11223344", (0x11, 0x22, 0x33, 0.2666)),
         ("#abcd", (0xAA, 0xBB, 0xCC, 0.8666)),
@@ -73,79 +44,8 @@ def test_rgb_invalid(value):
         ("#ABCDEFBA", (0xAB, 0xCD, 0xEF, 0.7294)),
     ],
 )
-def test_rgba(value, expected):
-    assert_equal_rgb(value, rgba(*expected))
-
-
-@pytest.mark.parametrize(
-    "value",
-    [
-        "10, 20, 30",
-        "a, 10, 20, 0.5",
-        "10, b, 20, 0.5",
-        "10, 20, c, 0.5",
-        "10, 20, 30, c",
-        "10, 20, 30, 0.5, 5",
-    ],
-)
-def test_rgba_invalid(value):
-    with pytest.raises(ValueError):
-        color(f"rgba({value})")
-
-
-@pytest.mark.parametrize(
-    "value",
-    [
-        "1,20%,30%",
-        "1, 20%, 30%",
-        "1, 20% , 30%",
-    ],
-)
-def test_hsl(value):
-    assert_equal_hsl(f"hsl({value})", hsl(1, 0.2, 0.3))
-
-
-@pytest.mark.parametrize(
-    "value",
-    [
-        "1, 20%",
-        "a, 20%, 30%",
-        "1, a, 30%",
-        "1, 20%, a)",
-        "1, 20%, 30%, 0.5)",
-    ],
-)
-def test_hsl_invalid(value):
-    with pytest.raises(ValueError):
-        color(f"hsl({value}")
-
-
-@pytest.mark.parametrize(
-    "value",
-    [
-        "1,20%,30%,0.5",
-        "1, 20%, 30%, 0.5",
-        " 1, 20% , 30% , 0.5",
-    ],
-)
-def test_hsla(value):
-    assert_equal_hsl(f"hsla({value})", hsla(1, 0.2, 0.3, 0.5))
-
-
-@pytest.mark.parametrize(
-    "value",
-    [
-        "1, 20%, 30%",
-        "a, 20%, 30%, 0.5",
-        "1, a, 30%, 0.5",
-        "1, 20%, a, 0.5",
-        "1, 20%, 30%, a",
-        "1, 20%, 30%, 0.5, 5",
-    ],
-)
-def test_hsla_invalid(value):
-    with pytest.raises(ValueError):
-        color(f"hsla({value})")
+def test_hex_rgb(value, expected):
+    assert_equal_rgb(value, rgb(*expected))
 
 
 @pytest.mark.parametrize(
@@ -175,7 +75,23 @@ def test_named_color_invalid():
     "num_digits",
     [1, 2, 5, 7, 9, 10],
 )
-def test_hash_mark_invalid(num_digits):
+def test_hash_mark_invalid_length(num_digits):
     """An invalid number of digts after # raises a ValueError."""
     with pytest.raises(ValueError):
         color(f"#{'1' * num_digits}")
+
+
+def test_invalid_hex_rgb():
+    """Digits out of the hex range raise an error."""
+    with pytest.raises(ValueError):
+        color("#aabbccddhh")
+
+
+@pytest.mark.parametrize(
+    "value",
+    [None, 25, rgb],
+)
+def test_other_invalid_inputs(value):
+    """Other random junk doesn't work either."""
+    with pytest.raises(ValueError):
+        color(value)

--- a/travertino/tests/utils.py
+++ b/travertino/tests/utils.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from travertino.colors import hsl, hsla, rgb, rgba
+from travertino.colors import hsl, rgb
 
 if sys.version_info < (3, 10):
     _DATACLASS_KWARGS = {"init": False, "repr": False}
@@ -46,26 +46,20 @@ class CopyingMock(Mock):
 
 
 def assert_equal_color(actual, expected, abs=1e-6):
-    if {type(actual), type(expected)} == {rgba}:
-        assert actual.rgba.r == pytest.approx(expected.rgba.r, abs=abs)
-        assert actual.rgba.g == pytest.approx(expected.rgba.g, abs=abs)
-        assert actual.rgba.b == pytest.approx(expected.rgba.b, abs=abs)
-        assert actual.rgba.a == pytest.approx(expected.rgba.a, abs=abs)
-    elif {type(actual), type(expected)} == {rgb}:
-        assert actual.rgb.r == pytest.approx(expected.rgb.r, abs=abs)
-        assert actual.rgb.g == pytest.approx(expected.rgb.g, abs=abs)
-        assert actual.rgb.b == pytest.approx(expected.rgb.b, abs=abs)
-    elif {type(actual), type(expected)} == {hsla}:
-        assert actual.hsla.h == pytest.approx(expected.hsla.h, abs=abs)
-        assert actual.hsla.s == pytest.approx(expected.hsla.s, abs=abs)
-        assert actual.hsla.l == pytest.approx(expected.hsla.l, abs=abs)
-        assert actual.hsla.a == pytest.approx(expected.hsla.a, abs=abs)
-    elif {type(actual), type(expected)} == {hsl}:
-        assert actual.hsl.h == pytest.approx(expected.hsl.h, abs=abs)
-        assert actual.hsl.s == pytest.approx(expected.hsl.s, abs=abs)
-        assert actual.hsl.l == pytest.approx(expected.hsl.l, abs=abs)
+    if type(actual) is type(expected) is rgb:
+        assert actual.r == pytest.approx(expected.r, abs=abs)
+        assert actual.g == pytest.approx(expected.g, abs=abs)
+        assert actual.b == pytest.approx(expected.b, abs=abs)
+        assert actual.a == pytest.approx(expected.a, abs=abs)
+    elif type(actual) is type(expected) is hsl:
+        if not (actual.s == 0 or actual.l in {0, 1}):
+            # Don't test hue if color is white/black/grey.
+            assert actual.h == pytest.approx(expected.h, abs=abs)
+        assert actual.s == pytest.approx(expected.s, abs=abs)
+        assert actual.l == pytest.approx(expected.l, abs=abs)
+        assert actual.a == pytest.approx(expected.a, abs=abs)
     else:
         raise ValueError(
             "Actual color and expected color should be of the same type. "
-            f"But got actual:{type(actual)} and expected:{type(expected)}."
+            f"But got actual: {type(actual)} and expected: {type(expected)}."
         )


### PR DESCRIPTION
Fixes #3611

- Previously, there was an `rgba` and an `hsla` class, and then `rgb` and `hsl` inherited from those, each locking their alpha in at opaque. In order to better align with CSS, now those parent classes are renamed to `rgb` and `hsl`, and the child classes are removed; `rgba` and `hsla` are simply direct aliases.
- Also in order to better match CSS, the constructors now silently clip (or in the case of hue, wrap) out-of-range values rather than throwing errors. They also convert them to consistent types: integers for red, blue, green, and hue; and floats for saturation, lightness, and alpha.
- `rgb` and `hsl`, in addition to their copy-pasteable-into-Python `__repr__`, gain a `__str__` that uses modern CSS syntax. For `rgb` this is simply a nice update, but for `hsl` it corrects [color rendering issues in web](https://github.com/beeware/toga/issues/3611#issuecomment-3108051814).
- Color objects are now read-only (in the sense that their `r`/`g`/`b`/`a` or `h`/`s`/`l`/`a` attributes are now properties with no setters). This also means that `rgb.rgb`/`hsl.hsl` can simply return itself, and `rgb.hsl`/`hsl.rgb` can cache its result after performing the calculation once.
- The string-parsing `color()` function now no longer attempts to handle `"rgb(...)"` / `"hsl(...)"` syntax; it still handles `#RGB` hex strings and named colors.

I could use some guidance on change notes for this. Should I include a removal note for the removed string-parsing, even though it was never documented? Should the rest of it be multiple changes notes, or one big one with a bulleted list?

The test diffs are a mess to try and read. Basically, aside from adding tests for the functional changes, I:
- Grouped `rgb`/`rgba` and `hsl`/`hsla` tests together, removing anything clearly a duplicate;
- Removed duplication by saving and reusing parametrizations for multiple tests;
- Removed the `test_hsl`/`test_hsla` test in test_constructor.py, since it was a camouflaged color conversion test. Its test cases have now been rehomed to the test_color_conversions.py.
 


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
