### PR TITLE
multilinetextinput: wait until the text change is fully completed on Gtk

### DIFF
--- a/changes/3658.bugfix.rst
+++ b/changes/3658.bugfix.rst
@@ -1,1 +1,1 @@
-On GTK, the scroll position will now be correctly reflected if a MultilineTextInput is programmatically scrolled immediately after changing text content. 
+On GTK, the scroll position will now be correctly reflected if a MultilineTextInput is programmatically scrolled immediately after changing text content.

--- a/changes/3658.bugfix.rst
+++ b/changes/3658.bugfix.rst
@@ -1,1 +1,1 @@
-multilinetextinput: wait until the text change is fully completed on Gtk, this is necessary to make scroll_to_bottom() after text change to work.
+On GTK, the scroll position will now be correctly reflected if a MultilineTextInput is programmatically scrolled immediately after changing text content. 

--- a/changes/3658.bugfix.rst
+++ b/changes/3658.bugfix.rst
@@ -1,0 +1,1 @@
+multilinetextinput: wait until the text change is fully completed on Gtk, this is necessary to make scroll_to_bottom() after text change to work.

--- a/gtk/src/toga_gtk/widgets/base.py
+++ b/gtk/src/toga_gtk/widgets/base.py
@@ -4,6 +4,7 @@ from travertino.size import at_least
 
 from ..libs import (
     GTK_VERSION,
+    GLib,
     Gtk,
     get_background_color_css,
     get_color_css,
@@ -221,3 +222,11 @@ class Widget:
             # print("REHINT", self, f"{width_info[0]}x{height_info[0]}")
             self.interface.intrinsic.width = at_least(min_size.width)
             self.interface.intrinsic.height = at_least(min_size.height)
+
+    def flush_gtk_events(self):
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            while Gtk.events_pending():
+                Gtk.main_iteration_do(blocking=False)
+        else:  # pragma: no-cover-if-gtk3
+            while GLib.main_context_default().pending():
+                GLib.main_context_default().iteration(may_block=False)

--- a/gtk/src/toga_gtk/widgets/multilinetextinput.py
+++ b/gtk/src/toga_gtk/widgets/multilinetextinput.py
@@ -91,12 +91,8 @@ class MultilineTextInput(Widget):
             else:
                 self.native_textview.set_buffer(self.buffer)
 
-        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
-            # Wait until the text change is fully completed
-            while Gtk.events_pending():
-                Gtk.main_iteration_do(blocking=False)
-        else:  # pragma: no-cover-if-gtk3
-            pass
+        # Wait until the text change is fully completed
+        self.flush_gtk_events()
 
     def get_readonly(self):
         return not self.native_textview.get_property("editable")

--- a/gtk/src/toga_gtk/widgets/multilinetextinput.py
+++ b/gtk/src/toga_gtk/widgets/multilinetextinput.py
@@ -91,6 +91,10 @@ class MultilineTextInput(Widget):
             else:
                 self.native_textview.set_buffer(self.buffer)
 
+        # Wait until the text change is fully completed
+        while Gtk.events_pending():
+            Gtk.main_iteration_do(blocking=False)
+
     def get_readonly(self):
         return not self.native_textview.get_property("editable")
 

--- a/gtk/src/toga_gtk/widgets/multilinetextinput.py
+++ b/gtk/src/toga_gtk/widgets/multilinetextinput.py
@@ -91,9 +91,12 @@ class MultilineTextInput(Widget):
             else:
                 self.native_textview.set_buffer(self.buffer)
 
-        # Wait until the text change is fully completed
-        while Gtk.events_pending():
-            Gtk.main_iteration_do(blocking=False)
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            # Wait until the text change is fully completed
+            while Gtk.events_pending():
+                Gtk.main_iteration_do(blocking=False)
+        else:  # pragma: no-cover-if-gtk3
+            pass
 
     def get_readonly(self):
         return not self.native_textview.get_property("editable")

--- a/testbed/tests/widgets/test_multilinetextinput.py
+++ b/testbed/tests/widgets/test_multilinetextinput.py
@@ -99,3 +99,22 @@ async def test_scroll_position(widget, probe):
     # The scroll position back at the origin.
     # Due to scroll bounce etc, this might be slightly off 0
     assert probe.vertical_scroll_position == pytest.approx(0.0, abs=10)
+
+
+async def test_scroll_after_text_change(widget, probe):
+    "Scrolling works after the text has been modified."
+    # The scroll position is at the origin.
+    assert probe.vertical_scroll_position == pytest.approx(0, abs=1)
+
+    # Run a lot of text modifications followed by a scroll
+    for i in range(50):
+        widget.value += f"Line {i}\n"
+        widget.scroll_to_bottom()
+
+    await probe.wait_for_scroll_completion()
+    await probe.redraw(
+        "The document has been modified a lot and scrolled to the bottom"
+    )
+
+    scroll_offset = probe.document_height - probe.height
+    assert probe.vertical_scroll_position == pytest.approx(scroll_offset, abs=30)


### PR DESCRIPTION
This is necessary to make scroll_to_bottom() after text change to work.

Fix #3658

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
