### PR TITLE
Correct global tox target, and add 3.14 support

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = towncrier-check,docs-lint,pre-commit,py3{9-14}-cov{,-trav},coverage{,-trav}platform
+envlist = towncrier-check,docs-lint,pre-commit,py3{9-14}-cov{,-trav},coverage{,-trav}-platform
 labels =
     test = py-cov{,-trav},coverage{,-trav}
     test-core = py-cov,coverage

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = towncrier-check,docs-lint,pre-commit,py3{9-13}-cov{,-trav},coverage{,-trav}platform
+envlist = towncrier-check,docs-lint,pre-commit,py3{9-14}-cov{,-trav},coverage{,-trav}platform
 labels =
     test = py-cov{,-trav},coverage{,-trav}
     test-core = py-cov,coverage
@@ -9,8 +9,9 @@ labels =
     test311 = py311-cov{,-trav},coverage311{,-trav}
     test312 = py312-cov{,-trav},coverage312{,-trav}
     test313 = py313-cov{,-trav},coverage313{,-trav}
-    test-fast = py3{9-13}-fast
-    test-platform = py3{9-13}-cov{,-trav},coverage{,-trav}-platform
+    test314 = py314-cov{,-trav},coverage314{,-trav}
+    test-fast = py3{9-14}-fast
+    test-platform = py3{9-14}-cov{,-trav},coverage{,-trav}-platform
 skip_missing_interpreters = True
 
 [testenv:pre-commit]
@@ -21,7 +22,7 @@ deps =
 commands = pre-commit run --all-files --show-diff-on-failure --color=always
 
 # The leading comma generates the "py" environment
-[testenv:py{,39,310,311,312,313}{,-fast,-cov}{,-trav}]
+[testenv:py{,39,310,311,312,313,314}{,-fast,-cov}{,-trav}]
 depends = pre-commit
 changedir =
     !trav: core
@@ -38,10 +39,10 @@ commands =
     cov  : python -m coverage run -m pytest {posargs:-vv --color yes}
     fast : python -m pytest {posargs:-vv --color yes -n auto}
 
-[testenv:coverage{,39,310,311,312,313}{,-trav}{,-html}{,-keep}{,-platform}]
+[testenv:coverage{,39,310,311,312,313,314}{,-trav}{,-html}{,-keep}{,-platform}]
 depends =
-    !trav: pre-commit,py3{9-13}{,-cov}
-    trav: pre-commit,py3{9-13}{,-trav}{,-cov}
+    !trav: pre-commit,py3{9-14}{,-cov}
+    trav: pre-commit,py3{9-14}{,-trav}{,-cov}
 changedir =
     !trav: core
     trav: travertino
@@ -54,6 +55,7 @@ base_python =
     coverage311: py311
     coverage312: py312
     coverage313: py313
+    coverage314: py314
 setenv =
     keep: COMBINE_KEEP = --keep
     !trav: PACKAGE_RCFILE = --rcfile {tox_root}{/}core{/}pyproject.toml


### PR DESCRIPTION
We have [received a report that our global tox target](https://github.com/beeware/toga/issues/3661#issuecomment-3130539312) doesn't currently work - it looks like there's a 1 character typo in the final `coverage{,-trav}-platform` target.

Since this touches the tox file and 3.14.0rc1 is out, I've taken this opportunity to add 3.14 to the Tox matrix.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
