### PR TITLE
Fix 3661 drag with modifiers

### DIFF
--- a/changes/3661.bugfix.rst
+++ b/changes/3661.bugfix.rst
@@ -1,0 +1,1 @@
+Mouse drag now works when modifier keys (e.g. Num Lock, Shift) are active.

--- a/gtk/src/toga_gtk/widgets/canvas.py
+++ b/gtk/src/toga_gtk/widgets/canvas.py
@@ -81,6 +81,8 @@ class Canvas(Widget):
             pass
 
     def mouse_move(self, obj, event):
+        """Handles mouse movement by calling the drag and/or alternative drag
+        methods. Modifier keys have no effect."""
         if event.state & ~Gdk.ModifierType.BUTTON3_MASK & Gdk.ModifierType.BUTTON1_MASK:
             self.interface.on_drag(event.x, event.y)
         if event.state & Gdk.ModifierType.BUTTON3_MASK:

--- a/gtk/src/toga_gtk/widgets/canvas.py
+++ b/gtk/src/toga_gtk/widgets/canvas.py
@@ -81,9 +81,9 @@ class Canvas(Widget):
             pass
 
     def mouse_move(self, obj, event):
-        if event.state == Gdk.ModifierType.BUTTON1_MASK:
+        if event.state & ~Gdk.ModifierType.BUTTON3_MASK & Gdk.ModifierType.BUTTON1_MASK:
             self.interface.on_drag(event.x, event.y)
-        if event.state == Gdk.ModifierType.BUTTON3_MASK:
+        if event.state & Gdk.ModifierType.BUTTON3_MASK:
             self.interface.on_alt_drag(event.x, event.y)
 
     def mouse_up(self, obj, event):

--- a/gtk/tests_backend/widgets/canvas.py
+++ b/gtk/tests_backend/widgets/canvas.py
@@ -75,7 +75,7 @@ class CanvasProbe(SimpleProbe):
 
         event = Gdk.Event.new(Gdk.EventType.MOTION_NOTIFY)
         event.button = 1
-        event.state = Gdk.ModifierType.BUTTON1_MASK
+        event.state = Gdk.ModifierType.BUTTON1_MASK | Gdk.ModifierType.MOD2_MASK
         event.x = (x1 + x2) // 2
         event.y = (y1 + y2) // 2
         self.native.emit("motion-notify-event", event)
@@ -107,7 +107,7 @@ class CanvasProbe(SimpleProbe):
         self.native.emit("button-press-event", event)
 
         event = Gdk.Event.new(Gdk.EventType.MOTION_NOTIFY)
-        event.state = Gdk.ModifierType.BUTTON3_MASK
+        event.state = Gdk.ModifierType.BUTTON3_MASK | Gdk.ModifierType.MOD2_MASK
         event.x = (x1 + x2) // 2
         event.y = (y1 + y2) // 2
         self.native.emit("motion-notify-event", event)


### PR DESCRIPTION
Fix the issue #3661 by handling modifier keys in `mouse_move` and update the tests by including a modifier key in it.

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
