### PR TITLE
Fix return type of OptionContainer tab label text in Cocoa

### DIFF
--- a/changes/3672.bugfix.rst
+++ b/changes/3672.bugfix.rst
@@ -1,0 +1,1 @@
+An issue with the text of OptionContainer tab labels being returned as a ``rubicon.objc.collections.ObjCStrInstance`` on macOS instead of a Python ``str`` has been fixed.

--- a/cocoa/src/toga_cocoa/widgets/optioncontainer.py
+++ b/cocoa/src/toga_cocoa/widgets/optioncontainer.py
@@ -132,7 +132,7 @@ class OptionContainer(Widget):
 
     def get_option_text(self, index):
         tabview = self.native.tabViewItemAtIndex(index)
-        return tabview.label
+        return str(tabview.label)
 
     def get_current_tab_index(self):
         return self.native.indexOfTabViewItem(self.native.selectedTabViewItem)

--- a/testbed/tests/widgets/test_optioncontainer.py
+++ b/testbed/tests/widgets/test_optioncontainer.py
@@ -85,6 +85,11 @@ test_cleanup = build_cleanup_test(
 )
 
 
+def assert_tab_text(tab, expected):
+    assert tab.text == expected
+    assert type(tab.text) is str
+
+
 async def test_select_tab(
     widget,
     probe,
@@ -301,11 +306,11 @@ async def test_select_tab_overflow(widget, probe, on_select_handler):
         widget.content[probe.max_tabs].icon = "resources/new-tab"
         widget.content[probe.max_tabs].enabled = False
 
-        assert widget.content[probe.max_tabs].text == "Extra Tab"
+        assert_tab_text(widget.content[probe.max_tabs], "Extra Tab")
         probe.assert_tab_icon(probe.max_tabs, "new-tab")
         assert not widget.content[probe.max_tabs].enabled
 
-        assert widget.content[probe.max_tabs + 1].text == "Tab B"
+        assert_tab_text(widget.content[probe.max_tabs + 1], "Tab B")
         probe.assert_tab_icon(probe.max_tabs + 1, None)
         assert widget.content[probe.max_tabs + 1].enabled
 
@@ -326,7 +331,7 @@ async def test_select_tab_overflow(widget, probe, on_select_handler):
         await probe.wait_for_tab("Inserted item bumped the last item")
 
         # Assert the properties of the last visible item
-        assert widget.content[probe.max_tabs - 1].text == f"Tab {probe.max_tabs - 1}"
+        assert_tab_text(widget.content[probe.max_tabs - 1], f"Tab {probe.max_tabs - 1}")
         probe.assert_tab_icon(probe.max_tabs - 1, None)
         assert widget.content[probe.max_tabs - 1].enabled
 
@@ -338,7 +343,7 @@ async def test_select_tab_overflow(widget, probe, on_select_handler):
         )
 
         # Assert the properties of the first invisible item
-        assert widget.content[probe.max_tabs].text == f"Tab {probe.max_tabs}"
+        assert_tab_text(widget.content[probe.max_tabs], f"Tab {probe.max_tabs}")
         probe.assert_tab_icon(probe.max_tabs, None)
         assert widget.content[probe.max_tabs].enabled
 
@@ -348,7 +353,7 @@ async def test_select_tab_overflow(widget, probe, on_select_handler):
 
         await probe.wait_for_tab("Deleting an item restores previously bumped item")
 
-        assert widget.content[probe.max_tabs - 1].text == f"Tab {probe.max_tabs}"
+        assert_tab_text(widget.content[probe.max_tabs - 1], f"Tab {probe.max_tabs}")
         probe.assert_tab_icon(probe.max_tabs - 1, None)
         assert widget.content[probe.max_tabs - 1].enabled
 
@@ -366,7 +371,7 @@ async def test_select_tab_overflow(widget, probe, on_select_handler):
 
         await probe.wait_for_tab("Deleting an item creates a previously excess item")
 
-        assert widget.content[probe.max_tabs - 1].text == "Extra Tab"
+        assert_tab_text(widget.content[probe.max_tabs - 1], "Extra Tab")
         probe.assert_tab_icon(probe.max_tabs - 1, "new-tab")
         assert not widget.content[probe.max_tabs - 1].enabled
 
@@ -427,7 +432,7 @@ async def test_enable_tab(widget, probe, on_select_handler):
     await probe.wait_for_tab("Tab 3 should be selected")
 
     assert widget.current_tab.index == 2
-    assert widget.current_tab.text == "Tab 3"
+    assert_tab_text(widget.current_tab, "Tab 3")
 
     # on_select has been invoked
     on_select_handler.assert_called_once_with(widget)
@@ -482,7 +487,7 @@ async def test_change_content(
     await probe.wait_for_tab("New tab has been added disabled")
 
     assert len(widget.content) == 4
-    assert widget.content[1].text == "New tab"
+    assert_tab_text(widget.content[1], "New tab")
     assert not widget.content[1].enabled
 
     # Enable the new content and select it
@@ -491,7 +496,7 @@ async def test_change_content(
     await probe.wait_for_tab("New tab has been enabled and selected")
 
     assert widget.current_tab.index == 1
-    assert widget.current_tab.text == "New tab"
+    assert_tab_text(widget.current_tab, "New tab")
 
     # The content should be the same size as the container; these dimensions can
     # be impacted by the size of tabs and other widget chrome. Test that the
@@ -508,7 +513,7 @@ async def test_change_content(
     widget.content["Tab 2"].text = "New 2"
     await probe.wait_for_tab("Tab 2 has been renamed")
 
-    assert widget.content[2].text == "New 2"
+    assert_tab_text(widget.content[2], "New 2")
 
     # Change the icon of Tab 2
     widget.content["New 2"].icon = "resources/new-tab"
@@ -535,7 +540,7 @@ async def test_change_content(
     await probe.wait_for_tab("Revised tab 2 has been selected")
 
     assert widget.current_tab.index == 3
-    assert widget.current_tab.text == "New Tab 2"
+    assert_tab_text(widget.current_tab, "New Tab 2")
     # The content should be the same size as the container; these dimensions can
     # be impacted by the size of tabs and other widget chrome. Test that the
     # content has expanded by asserting that the content is at least 80% the


### PR DESCRIPTION
Fixes #3672

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
