### PR TITLE
Correct macOS screen origin calculation.

### DIFF
--- a/changes/3667.bugfix.rst
+++ b/changes/3667.bugfix.rst
@@ -1,0 +1,1 @@
+On macOS, the origin of non-primary screens is now correctly calculated when screens are not vertically aligned and the same size.

--- a/cocoa/src/toga_cocoa/screens.py
+++ b/cocoa/src/toga_cocoa/screens.py
@@ -29,9 +29,11 @@ class Screen:
         # macOS screen coordinates have the origin at the bottom left.
         frame_native = self.native.frame
         return Position(
-            frame_native.origin.x,
-            NSScreen.screens[0].frame.size.height
-            - (frame_native.origin.y + frame_native.size.height),
+            int(frame_native.origin.x),
+            int(
+                NSScreen.screens[0].frame.size.height
+                - (frame_native.origin.y + frame_native.size.height)
+            ),
         )
 
     def get_size(self) -> Size:

--- a/cocoa/src/toga_cocoa/screens.py
+++ b/cocoa/src/toga_cocoa/screens.py
@@ -4,6 +4,7 @@ from toga.screens import Screen as ScreenInterface
 from toga.types import Position, Size
 from toga_cocoa.libs import (
     NSImage,
+    NSScreen,
     core_graphics,
 )
 
@@ -25,8 +26,13 @@ class Screen:
         return str(self.native.localizedName)
 
     def get_origin(self) -> Position:
+        # macOS screen coordinates have the origin at the bottom left.
         frame_native = self.native.frame
-        return Position(int(frame_native.origin.x), int(frame_native.origin.y))
+        return Position(
+            frame_native.origin.x,
+            NSScreen.screens[0].frame.size.height
+            - (frame_native.origin.y + frame_native.size.height),
+        )
 
     def get_size(self) -> Size:
         frame_native = self.native.frame

--- a/cocoa/src/toga_cocoa/window.py
+++ b/cocoa/src/toga_cocoa/window.py
@@ -329,9 +329,11 @@ class Window:
         # macOS origin is bottom left of screen, and the screen might be
         # offset relative to other screens. Adjust for this.
         return Position(
-            window_frame.origin.x,
-            primary_screen.size.height
-            - (window_frame.origin.y + window_frame.size.height),
+            int(window_frame.origin.x),
+            int(
+                primary_screen.size.height
+                - (window_frame.origin.y + window_frame.size.height)
+            ),
         )
 
     def set_position(self, position):

--- a/testbed/tests/app/test_screens.py
+++ b/testbed/tests/app/test_screens.py
@@ -21,23 +21,19 @@ async def test_origin(app):
     """The origin of the screens can be retrieved"""
     for screen in app.screens:
         origin = screen.origin
-        assert (
-            isinstance(origin, tuple)
-            and len(origin) == 2
-            and all(isinstance(val, int) for val in origin)
-        )
+        assert isinstance(origin, tuple)
+        assert len(origin) == 2
+        assert all(isinstance(val, int) for val in origin)
 
 
 async def test_size(app):
     """The size of the screens can be retrieved"""
     for screen in app.screens:
         size = screen.size
-        assert (
-            isinstance(size, tuple)
-            and len(size) == 2
-            # Check that neither the width or height is zero.
-            and all(isinstance(val, int) and val > 0 for val in size)
-        )
+        assert isinstance(size, tuple)
+        assert len(size) == 2
+        # Check that neither the width or height is zero.
+        assert all(isinstance(val, int) and val > 0 for val in size)
 
 
 async def test_as_image(app):

--- a/testbed/tests/window/test_window.py
+++ b/testbed/tests/window/test_window.py
@@ -1106,9 +1106,12 @@ else:
         assert second_window.position != initial_position
 
         # `position` and `screen_position` will be same as the window will be in
-        # primary screen.
+        # primary screen. They are also 2-tuples of integers
         assert second_window.position == (200, 200)
+        assert all(isinstance(val, int) for val in second_window.position)
+
         assert second_window.screen_position == (200, 200)
+        assert all(isinstance(val, int) for val in second_window.screen_position)
 
         # Move the window between available screens and assert its `screen_position`
         for screen in second_window.app.screens:
@@ -1121,6 +1124,7 @@ else:
                 second_window.position[0] - screen.origin[0],
                 second_window.position[1] - screen.origin[1],
             )
+            assert all(isinstance(val, int) for val in second_window.screen_position)
 
 
 async def test_as_image(main_window, main_window_probe):


### PR DESCRIPTION
On macOS, the native screen origin is a the bottom left of the screen. As a result, if you have multiple screens, and those screens are not the same size, or the screens are not vertically aligned, the origin of the non-primary screens (and thus the value of `screen_position`) is incorrect.

This can't be easily tested in testbed because we don't have multiple screens on the testbed environment.

Thanks to @passportjal for the report and prototype fix.

Fixes #3677.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
