### PR TITLE
Add handling for the non-existence of __package__ under PDB.

### DIFF
--- a/changes/3686.bugfix.rst
+++ b/changes/3686.bugfix.rst
@@ -1,0 +1,1 @@
+Running a single-file app without an explicit app name under PDB no longer crashes.

--- a/core/src/toga/app.py
+++ b/core/src/toga/app.py
@@ -214,12 +214,13 @@ class App:
             # `python -m appname`, then __main__.__package__ will be an empty string.
             #
             # If the code is contained in appname.py, and you start the app using
-            # `python appname.py`, then __main__.__package__ will be None.
+            # `python appname.py`, then __main__.__package__ will be None - unless
+            # the app has been run under pdb, in which case `__package__` not exist.
             #
             # If the code is contained in appname/__main__.py, and you start the app
             # using `python -m appname`, then __main__.__package__ will be "appname".
             try:
-                main_module_pkg = sys.modules["__main__"].__package__
+                main_module_pkg = getattr(sys.modules["__main__"], "__package__", None)
                 if main_module_pkg:
                     app_name = main_module_pkg
             except KeyError:

--- a/core/src/toga/app.py
+++ b/core/src/toga/app.py
@@ -215,7 +215,7 @@ class App:
             #
             # If the code is contained in appname.py, and you start the app using
             # `python appname.py`, then __main__.__package__ will be None - unless
-            # the app has been run under pdb, in which case `__package__` not exist.
+            # the app has been run under pdb, in which case `__package__` doesn't exist.
             #
             # If the code is contained in appname/__main__.py, and you start the app
             # using `python -m appname`, then __main__.__package__ will be "appname".

--- a/core/tests/app/test_app.py
+++ b/core/tests/app/test_app.py
@@ -209,6 +209,19 @@ async def test_unsupported_widget(app):
             "org.beeware.explicit-app",
             "override-app",
         ),
+        ###########################################################################
+        # Invoking as python -m pdb my_app.py.
+        # This causes a main module of "my_app", but `__package__` isn't set.
+        ###########################################################################
+        # No app name provided; falls back to app_id
+        (
+            EXPLICIT_MIN_APP_KWARGS,
+            None,
+            Mock(),
+            "Explicit App",
+            "org.beeware.explicit-app",
+            "explicit-app",
+        ),
     ],
 )
 async def test_create(


### PR DESCRIPTION
When running as a single file under PDB (e.g., `python -m pdb myapp.py`), `app_name` logic fails because `__package__` isn't defined (as opposed to *existing*, but having a value of `None` when run outside PDB). This PR adds a fallback to ensure that if `__package__` doesn't exist on the main module, a fallback to app ID-based logic is still possible.

Thanks to @JustCommitRandomness for the report and draft fix.

Fixes #3686.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
