### PR TITLE
Clarify uniqueness requirement for table/tree accessors.

### DIFF
--- a/changes/3693.misc.rst
+++ b/changes/3693.misc.rst
@@ -1,0 +1,1 @@
+Table and example documentation was clarified.

--- a/docs/reference/api/widgets/table-values.rst
+++ b/docs/reference/api/widgets/table-values.rst
@@ -1,3 +1,7 @@
+Accessor names (whether explicitly provided, or automatically generated from the header
+names) should be unique. If they are not, column data will be duplicated, as Toga has no
+way to tell which version of an accessor to use when populating data for a column.
+
 The value provided by an accessor is interpreted as follows:
 
 * If the value is a :any:`Widget`, that widget will be displayed in the cell. Note that

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,11 +7,10 @@ It also contains working copies of the tutorial code.
 
 # Running the examples
 
-Each of the examples should run by installing Toga, and running the
-application as a Python module:
-
+Each of the examples can run by copying the example code to your computer
+(either by cloning this repository, or by manually duplicating the specific
+files), installing Toga, and running the application as a Python module:
 ```
-$ python -m pip install toga
 $ cd <example name>
 $ python -m <example name>
 ```


### PR DESCRIPTION
If accessors in a tree or table  aren't unique, columns will display duplicated data. While this may be obvious when you understand how the internals work, it's not necessarily obvious from the outside, so a clarification in the docs is called for.

Also adds a clarification about running the examples.

Fixes #3693.
Refs #3692.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
