### PR TITLE
Tweak iOS testbed configuration to account for GitHub Actions changes.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,7 +345,15 @@ jobs:
         - backend: "iOS"
           platform: "iOS"
           runs-on: "macos-latest"
-          briefcase-run-args: "--device 'iPhone SE (3rd generation)'"
+          pre-command: |
+            # 2025-08-15 - Github Actions are in the process of switching how they
+            # manage Xcode, so they can save disk space.
+            # See https://github.com/actions/runner-images/issues/12541
+            # and https://github.com/actions/runner-images/issues/12751; see
+            # also https://github.com/actions/runner-images/issues/12758 for
+            # a discussion of transition issues.
+            sudo xcode-select --switch /Applications/Xcode_16.4.app
+          briefcase-run-args: "--device 'iPhone SE (3rd generation)::iOS 18.5'"
           app-user-data-path: "$(xcrun simctl get_app_container booted org.beeware.toga.testbed data)/Documents"
 
         - backend: "android"


### PR DESCRIPTION
In an attempt to conserve disk space, GitHub Actions has stopped consistently providing iOS simulator images. See 
https://github.com/actions/runner-images/issues/12541 and https://github.com/actions/runner-images/issues/12751 for discussion of this transition.

This means the "default" configuration no longer works for iOS simulation; we need to pick an explicit Xcode version that provides the simulator images we need. We are also in a transition period where the default iOS simulator image is switching from iPhone SE to iPhone 16e; and the iOS version used can radically impact the boot up time of the simulator.

GitHub [recommends explicitly selecting the desired Xcode version](https://github.com/actions/runner-images/issues/12541#issuecomment-3083850140) on every workflow, so we might as well make this configurable; and the iOS simulator is already a configurable item, so we might as well expose it as such.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
