### PR TITLE
Update conftest.py to Match Signature of shutdown_default_executor to…

### DIFF
--- a/changes/3723.misc.rst
+++ b/changes/3723.misc.rst
@@ -1,0 +1,1 @@
+A issue with mismatched signature in ProxyEventLoop vs. BaseEventLoop in the test configuration has been fixed.

--- a/testbed/tests/conftest.py
+++ b/testbed/tests/conftest.py
@@ -171,7 +171,7 @@ class ProxyEventLoop(asyncio.AbstractEventLoop):
         # underlying event loop will shut down its own async generators.
         pass
 
-    async def shutdown_default_executor(self, timeout):
+    async def shutdown_default_executor(self, timeout=None):
         # The proxy event loop doesn't need to shut anything down; the
         # underlying event loop will shut down its own executor.
         pass


### PR DESCRIPTION
… CPython Core

``shutdown_default_executor`` is implemented as ``shutdown_default_executor(self, timeout)`` in Toga, but BaseEventLoop implements ``timeout=None`` instead of just ``timeout``; stay consistent with the official signature.

REFERENCE:: https://github.com/python/cpython/blob/95d6e0b2830c8e6bfd861042f6df6343891d5843/Lib/asyncio/base_events.py#L595

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
