### PR TITLE
Add Waits for Window Show and Hide Before Checking for Current

### DIFF
--- a/changes/3724.misc.rst
+++ b/changes/3724.misc.rst
@@ -1,0 +1,1 @@
+Visual separation is added when showing and hiding window when testing for current window in slow mode.

--- a/testbed/tests/app/test_desktop.py
+++ b/testbed/tests/app/test_desktop.py
@@ -531,9 +531,11 @@ async def test_current_window(app, app_probe, main_window, main_window_probe):
             assert app.current_window == main_window
 
         main_window.hide()
+        await main_window_probe.wait_for_window("Hiding main window")
         assert app.current_window is None
 
         main_window.show()
+        await main_window_probe.wait_for_window("Showing main window")
         assert app.current_window == main_window
     finally:
         main_window.show()


### PR DESCRIPTION
This ensures the window don't just flash and the user can visualize the state change in slow mode; in addition, this is required for proper functioning of the still-unofficial Qt backend.

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [ ] I will abide by the code of conduct
