### PR TITLE
Ensure that image files aren't left open

### DIFF
--- a/testbed/tests/test_images.py
+++ b/testbed/tests/test_images.py
@@ -3,6 +3,7 @@ import os
 import re
 import shutil
 from importlib import import_module
+from pathlib import Path
 
 import pytest
 from PIL import Image as PIL_Image, ImageDraw as PIL_ImageDraw
@@ -16,14 +17,21 @@ def image_probe(app, image):
 
 
 async def test_local_image(app):
-    "An image can be specified by filename"
+    """An image can be specified by filename"""
     image = toga.Image("resources/sample.png")
     assert image.width == 144
     assert image.height == 72
 
 
+async def test_closed_file_handle(app):
+    """The local image file isn't left open once the Image is created."""
+    _ = toga.Image("resources/sample.png")
+    # If the file still has an open handle, this should raise an IOError.
+    _ = Path(app.paths.app / "resources/sample.png").read_bytes()
+
+
 async def test_raw_image(app):
-    "An image can be created from the platform's raw representation"
+    """An image can be created from the platform's raw representation"""
     original = toga.Image("resources/sample.png")
 
     image = toga.Image(original._impl.native)
@@ -33,7 +41,7 @@ async def test_raw_image(app):
 
 
 async def test_bad_image_file(app):
-    "If a file isn't a loadable image, an error is raised"
+    """If a file isn't a loadable image, an error is raised"""
     with pytest.raises(
         ValueError,
         match=rf"Unable to load image from {re.escape(__file__)}",
@@ -42,7 +50,7 @@ async def test_bad_image_file(app):
 
 
 async def test_buffer_image(app):
-    "An image can be constructed from buffer data"
+    """An image can be constructed from buffer data"""
     # Generate an image using pillow
     pil_image = PIL_Image.new("RGBA", size=(110, 30))
     draw_context = PIL_ImageDraw.Draw(pil_image)
@@ -86,7 +94,7 @@ async def test_pil_raw_and_data_image(app):
 
 
 async def test_bad_image_data(app):
-    "If data isn't a valid image, an error is raised"
+    """If data isn't a valid image, an error is raised"""
     with pytest.raises(
         ValueError,
         match=r"Unable to load image from data",


### PR DESCRIPTION
Currently, when core's Image() is given a path, it passes that path on to the backend. We've learned (from a report on Discord) that, at least on Windows, this results in the file being kept open even after the Image is created (presumably by something in Python.NET). This PR is to change the logic so that core handles reading the file's data, then passes that along to the backend. This way we can ensure the file is closed.

I'm uploading this first as just the test, because I'm curious to see which platforms currently suffer from this issue.

Also: this will obsolete the `path` parameter to each backend's Image class. Is that worth a deprecation, since it's internal and version-locked?

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
