### PR TITLE
Update Signature of Task Factory

### DIFF
--- a/changes/3744.misc.rst
+++ b/changes/3744.misc.rst
@@ -1,0 +1,1 @@
+The signature for task factories have been updated in the testbed.

--- a/testbed/src/testbed/app.py
+++ b/testbed/src/testbed/app.py
@@ -1,4 +1,3 @@
-import sys
 from unittest.mock import Mock
 
 import toga

--- a/testbed/src/testbed/app.py
+++ b/testbed/src/testbed/app.py
@@ -47,7 +47,9 @@ class Testbed(toga.App):
     _gc_protector = []
 
     def startup(self):
-        # Ensure that Toga's task factory is tracking all tasks
+        # Toga installs a custom task factory to ensure that a strong reference to
+        # long-lived tasks is retained until the task completes. This task factory is
+        # used to verify that the custom task factory has been installed.
         toga_task_factory = self.loop.get_task_factory()
 
         def task_factory(loop, coro, **kwargs):

--- a/testbed/src/testbed/app.py
+++ b/testbed/src/testbed/app.py
@@ -51,11 +51,8 @@ class Testbed(toga.App):
         # Ensure that Toga's task factory is tracking all tasks
         toga_task_factory = self.loop.get_task_factory()
 
-        def task_factory(loop, coro, context=None):
-            if sys.version_info < (3, 11):
-                task = toga_task_factory(loop, coro)
-            else:
-                task = toga_task_factory(loop, coro, context=context)
+        def task_factory(loop, coro, **kwargs):
+            task = toga_task_factory(loop, coro, **kwargs)
             assert task in self._running_tasks, f"missing task reference for {task}"
             return task
 


### PR DESCRIPTION
https://docs.python.org/3.13/library/asyncio-eventloop.html#asyncio.loop.set_task_factory

The new specification specifies that we must pass on ALL kwargs, since the older if doesn't error if you pass in context in <3.11 anyways, I assume that extra args is not a concern here, so I simplified the entire if out.

This inconsistency was discovered when using Python 3.13 to run unofficial Qt backend tests on Ubuntu 25.04 container because of missing PySide6 in earlier versions.

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
