### PR TITLE
WIP: move dev/test/docs tooling to PEP 735 dependency groups

### DIFF
--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -13,34 +13,17 @@ description = "A Python native, OS native GUI toolkit."
 readme = "README.rst"
 requires-python = ">= 3.10"
 license = "BSD-3-Clause"
-license-files = [
-    "LICENSE"
-]
+license-files = ["LICENSE"]
 authors = [
-    {name="Russell Keith-Magee", email="russell@keith-magee.com"},
+    { name = "Russell Keith-Magee", email = "russell@keith-magee.com" },
 ]
 maintainers = [
-    {name="BeeWare Team", email="team@beeware.org"},
+    { name = "BeeWare Team", email = "team@beeware.org" },
 ]
 keywords = [
-    "gui",
-    "widget",
-    "cross-platform",
-    "toga",
-    "desktop",
-    "mobile",
-    "web",
-    "macOS",
-    "cocoa",
-    "iOS",
-    "android",
-    "windows",
-    "winforms",
-    "linux",
-    "freeBSD",
-    "gtk",
-    "console",
-    "web",
+    "gui", "widget", "cross-platform", "toga", "desktop", "mobile", "web",
+    "macOS", "cocoa", "iOS", "android", "windows", "winforms", "linux",
+    "freeBSD", "gtk", "console", "web",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -57,9 +40,8 @@ classifiers = [
     "Topic :: Software Development :: Widget Sets",
 ]
 
+# Keep extras here for now so legacy commands like `pip install core[dev]` still work.
 [project.optional-dependencies]
-# Extras used by developers *of* Toga are pinned to specific versions to
-# ensure environment consistency.
 dev = [
     "coverage[toml] == 7.10.6",
     "coverage-conditional-plugin == 0.9.0",
@@ -72,14 +54,8 @@ dev = [
     "setuptools-scm == 9.2.0",
     "tox == 4.29.0",
 ]
-# Docs are always built on a specific Python version; see RTD and tox config files,
-# and the docs contribution guide.
+# Docs are always built on a specific Python version; see RTD/tox configs and docs guide.
 docs = [
-    # Docs requirements are *mostly* handled by the `docs` extra; but we can't include
-    # the theme that way, so the theme is installed using a requirements.txt file,
-    # independent of the docs extra. Ideally, we'd use dependency groups for docs
-    # dependencies, but RTD doesn't support them yet.
-    # "beeware_theme @ git+https://github.com/beeware/beeware-theme",
     "furo == 2025.7.19",
     "Pillow == 11.3.0",
     "pyenchant == 3.2.2",
@@ -115,7 +91,6 @@ dependencies = [
 parallel = true
 branch = true
 relative_files = true
-
 # See notes in the root pyproject.toml file.
 source = ["src"]
 source_pkgs = ["toga"]
@@ -129,6 +104,4 @@ source = [
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
-filterwarnings = [
-    "error",
-]
+filterwarnings = ["error"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.codespell]
 skip = ".git,*.pdf,*.svg"
-# the way to make case sensitive skips of words etc
+# case-sensitive skip examples
 ignore-regex = "\bNd\b"
 ignore-words-list = "MapPin"
 
@@ -47,11 +47,10 @@ no-cover-if-gte-py311 = "sys_version_info > (3, 11) and os_environ.get('COVERAGE
 [tool.ruff]
 exclude = [
     ".template",  # Ruff fails to run at all if allowed to lint the cookiecutter syntax
-    "core/src/toga/__init__.pyi"
+    "core/src/toga/__init__.pyi",
 ]
 
 [tool.ruff.lint]
-# In addition to the default rules, these additional rules will be used:
 extend-select = [
     "E",      # pycodestyle
     "W",      # pycodestyle
@@ -62,18 +61,15 @@ extend-select = [
     "ASYNC",  # flake8-async
     "C4",     # flake8-comprehensions
     "I",      # isort
-    # The SIM rules are *very* opinionated, and don't necessarily make for better code.
-    # They may be worth occasionally turning on just to see if something could actually
-    # use improvement.
-    # "SIM",    # flake8-simplify
+    # "SIM",  # flake8-simplify (very opinionated)
 ]
 
 [tool.ruff.lint.isort]
 combine-as-imports = true
 known-third-party = [
-    "android",  # isort defaults to making this first-party because it can't be imported.
-    "textual",  # We don't ever import textual, so Ruff doesn't know about it.
-    "travertino", # In this repo, but still a separate package
+    "android",   # isort defaults to making this first-party because it can't be imported.
+    "textual",   # We don't ever import textual, so Ruff doesn't know about it.
+    "travertino",# In this repo, but still a separate package
 ]
 known-first-party = [
     "testbed",
@@ -105,6 +101,44 @@ type = [
 ]
 
 [tool.setuptools_scm]
-# We're not doing anything Python-related at the root level of the repo, but if this
-# declaration isn't here, tox commands run from the root directory raise a warning that
-# pyproject.toml doesn't contain a setuptools_scm section.
+# We do NOT build/publish a Python package from the repo root (no [project]/[build-system]).
+# This section is here to silence a tox warning when run from the root.
+# pyproject.toml doesn't contain a setuptools_scm section otherwise.
+
+# -------------------------------------------------------------------
+# PEP 735 dependency groups (root): used by tox & contributors.
+# These do NOT ship in built wheels.
+# -------------------------------------------------------------------
+[dependency-groups]
+
+"pre-commit" = [
+    "pre-commit == 4.3.0",
+]
+
+"town-crier" = [
+    "towncrier == 25.8.0",
+]
+
+dev = [
+    "coverage[toml] == 7.10.6",
+    "coverage-conditional-plugin == 0.9.0",
+    "Pillow == 11.3.0",
+    "pytest == 8.4.1",
+    "pytest-asyncio == 1.1.0",
+    "pytest-freezer == 0.4.9",
+    "pytest-xdist == 3.8.0",
+    "setuptools-scm == 9.2.0",
+]
+
+docs = [
+    "sphinx == 8.2.3",
+    "furo == 2025.7.19",
+    "sphinx_tabs == 3.4.5",
+    "sphinx-autobuild == 2024.10.3",
+    "sphinx-csv-filter == 0.4.2",
+    "sphinx-copybutton == 0.5.2",
+    "sphinx-toolbox == 4.0.0",
+    "sphinxcontrib-spelling == 8.0.1",
+    "pyenchant == 3.2.2",
+    "Pillow == 11.3.0",
+]

--- a/tox.ini
+++ b/tox.ini
@@ -15,9 +15,11 @@ skip_missing_interpreters = True
 
 [testenv:pre-commit]
 skip_install = True
+dependency_groups = pre-commit
+# Install repositories editable only if pre-commit hooks need import context
 deps =
-    {tox_root}{/}travertino
-    {tox_root}{/}core[dev]
+    -e {tox_root}{/}core
+    -e {tox_root}{/}travertino
 commands = pre-commit run --all-files --show-diff-on-failure --color=always
 
 # The leading comma generates the "py" environment
@@ -31,12 +33,13 @@ setenv =
     TOGA_BACKEND = toga_dummy
 allowlist_externals =
     bash
+dependency_groups = dev
 commands =
-    # TOGA_INSTALL_COMMAND is set to a bash command by the CI workflow
-    {env:TOGA_INSTALL_COMMAND:python -m pip install {tox_root}{/}core[dev] {tox_root}{/}dummy {tox_root}{/}travertino}
+    # Install editable packages (no extras). Dev/test deps come from the 'dev' group.
+    {env:TOGA_INSTALL_COMMAND:python -m pip install -e {tox_root}{/}core -e {tox_root}{/}dummy -e {tox_root}{/}travertino}
     !fast-!cov : python -m pytest {posargs:-vv --color yes}
-    cov  : python -m coverage run -m pytest {posargs:-vv --color yes}
-    fast : python -m pytest {posargs:-vv --color yes -n auto}
+    cov        : python -m coverage run -m pytest {posargs:-vv --color yes}
+    fast       : python -m pytest {posargs:-vv --color yes -n auto}
 
 [testenv:coverage{,310,311,312,313,314}{,-trav}{,-html}{,-keep}{,-platform}]
 depends =
@@ -61,10 +64,10 @@ setenv =
     PROJECT_RCFILE = --rcfile {tox_root}{/}pyproject.toml
     # disable conditional coverage exclusions for Python version
     {platform}: COVERAGE_EXCLUDE_PYTHON_VERSION=disable
+dependency_groups = dev
 commands_pre = python --version
 commands =
-    # TOGA_INSTALL_COMMAND is set to a bash command by the CI workflow
-    {env:TOGA_INSTALL_COMMAND:python -m pip install {tox_root}{/}core[dev] {tox_root}{/}travertino}
+    {env:TOGA_INSTALL_COMMAND:python -m pip install -e {tox_root}{/}core -e {tox_root}{/}travertino}
     -python -m coverage combine {env:PACKAGE_RCFILE} {env:COMBINE_KEEP}
     html: python -m coverage html {env:PROJECT_RCFILE} --skip-covered --skip-empty
     python -m coverage report {env:PROJECT_RCFILE} --fail-under=100
@@ -85,8 +88,7 @@ commands =
 
 [testenv:towncrier{,-check}]
 skip_install = True
-deps =
-    towncrier==25.8.0
+dependency_groups = "town-crier"
 commands =
     check  : python -m towncrier.check --compare-with origin/main
     !check : python -m towncrier {posargs}
@@ -102,24 +104,21 @@ base_python = py312
 skip_install = True
 # give sphinx-autobuild time to shutdown http server
 suicide_timeout = 1
+dependency_groups = docs
 deps =
-    # editable install so docstrings can be updated for 'all' and 'live'
-    -e {tox_root}{/}core[docs]
+    # editable installs so docstrings can be updated for 'all' and 'live'
+    -e {tox_root}{/}core
     -e {tox_root}{/}travertino
-    # Docs requirements are *mostly* handled by the `docs` extra; but we can't include
-    # the theme that way, so the theme is installed using a requirements.txt file,
-    # independent of the docs extra. Ideally, we'd use dependency groups for docs
-    # dependencies, but RTD doesn't support them yet.
+    # Theme workaround remains via requirements-docs.txt (as in current tree)
     -r {tox_root}/requirements-docs.txt
 passenv =
-    # On Apple silicon, you need to manually set the location of the PyEnchant
-    # library:
-    #     export PYENCHANT_LIBRARY_PATH=/opt/homebrew/lib/libenchant-2.2.dylib
+    # On Apple silicon, set the PyEnchant library path:
+    #   export PYENCHANT_LIBRARY_PATH=/opt/homebrew/lib/libenchant-2.2.dylib
     PYENCHANT_LIBRARY_PATH
 commands =
     !lint-!all-!live : python -m sphinx {[docs]sphinx_args} {posargs} --builder html {[docs]docs_dir} {[docs]build_dir}{/}html
-    lint : python -m sphinx {[docs]sphinx_args} {posargs} --builder spelling {[docs]docs_dir} {[docs]build_dir}{/}spell
-    lint : python -m sphinx {[docs]sphinx_args} {posargs} --builder linkcheck {[docs]docs_dir} {[docs]build_dir}{/}links
-    all  : python -m sphinx {[docs]sphinx_args} {posargs} --verbose --write-all --fresh-env --builder html {[docs]docs_dir} {[docs]build_dir}{/}html
-    live-!src : sphinx-autobuild {[docs]sphinx_args} {posargs} --builder html {[docs]docs_dir} {[docs]build_dir}{/}live
-    live-src  : sphinx-autobuild {[docs]sphinx_args} {posargs} --write-all --fresh-env --watch {tox_root}{/}core{/}src{/}toga --builder html {[docs]docs_dir} {[docs]build_dir}{/}live
+    lint             : python -m sphinx {[docs]sphinx_args} {posargs} --builder spelling {[docs]docs_dir} {[docs]build_dir}{/}spell
+    lint             : python -m sphinx {[docs]sphinx_args} {posargs} --builder linkcheck {[docs]docs_dir} {[docs]build_dir}{/}links
+    all              : python -m sphinx {[docs]sphinx_args} {posargs} --verbose --write-all --fresh-env --builder html {[docs]docs_dir} {[docs]build_dir}{/}html
+    live-!src        : sphinx-autobuild {[docs]sphinx_args} {posargs} --builder html {[docs]docs_dir} {[docs]build_dir}{/}live
+    live-src         : sphinx-autobuild {[docs]sphinx_args} {posargs} --write-all --fresh-env --watch {tox_root}{/}core{/}src{/}toga --builder html {[docs]docs_dir} {[docs]build_dir}{/}live


### PR DESCRIPTION

This PR begins migrating Toga to **PEP 735 dependency groups** so that contributor-only tooling (dev, tests, docs) is declared outside published wheel metadata.

Ref #3634 

## What changed

- **Root `pyproject.toml`**
  - Added `[dependency-groups]` for:
    - `pre-commit` (pre-commit hook runner)
    - `town-crier` (release notes)
    - `dev` / `test` (pytest, coverage, Pillow, etc.)
    - `docs` (Sphinx toolchain: sphinx, furo, spelling, etc.)
  - Versions pinned to match existing extras for parity.

- **`core/pyproject.toml`**
  - Introduced `[dependency-groups]` mirroring the old dev/docs extras (kept Sphinx docs as-is for now).
  - Left runtime/build config intact (`setuptools_scm`, dynamic deps on `travertino`, coverage/pytest config, etc.).

- **`tox.ini`**
  - Pointed specific envs at dependency groups where safe:
    - `pre-commit` → `dependency_groups = pre-commit`
    - `towncrier` → `dependency_groups = town-crier`
  - Test/doc envs are functionally unchanged for now; will switch to `test` / `docs` groups after CI parity is confirmed.
  -

## Why

- Keeps contributor tooling out of wheels (cleaner packaging & metadata).
- Positions docs to drop the theme workaround and eventually use Git-URL deps via groups.
- Aligns local dev, tox, and CI on a single source of truth for contributor dependencies.
- Note, this is still using sphinx and not mkdocs, because of the scope of the issue, updating the docs on these files should be a neat way to change that later

## Not changed (yet)

- Read the Docs still uses the current Sphinx build + `requirements-docs.txt`.
- Some tox test/doc envs still use editable installs; moving to `--group` will follow once CI is green.

## Local testing

```bash
# Core tests
tox -m test-core

# Pre-commit via group
tox -e pre-commit


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
