### PR TITLE
Build: add dependency groups for tox/pyproject to simplify dev, docs,…

### DIFF
--- a/changes/3634.misc.rst
+++ b/changes/3634.misc.rst
@@ -1,0 +1,1 @@
+Added dependency groups to pyproject.toml and tox.ini for reproducible dev/docs/test environments.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,3 +108,40 @@ type = [
 # We're not doing anything Python-related at the root level of the repo, but if this
 # declaration isn't here, tox commands run from the root directory raise a warning that
 # pyproject.toml doesn't contain a setuptools_scm section.
+# -------------------------------------------------------------------
+# PEP 735 dependency groups (root): used by tox & contributors.
+# These do NOT ship in built wheels.
+# -------------------------------------------------------------------
+[dependency-groups]
+
+"pre-commit" = [
+    "pre-commit == 4.3.0",
+]
+
+"town-crier" = [
+    "towncrier == 24.8.0",
+]
+
+dev = [
+    "coverage[toml] == 7.10.6",
+    "coverage-conditional-plugin == 0.9.0",
+    "Pillow == 11.3.0",
+    "pytest == 8.4.1",
+    "pytest-asyncio == 1.1.0",
+    "pytest-freezer == 0.4.9",
+    "pytest-xdist == 3.8.0",
+    "setuptools-scm == 9.2.0",
+]
+
+docs = [
+    "sphinx == 8.2.3",
+    "furo == 2025.7.19",
+    "sphinx_tabs == 3.4.5",
+    "sphinx-autobuild == 2024.10.3",
+    "sphinx-csv-filter == 0.4.2",
+    "sphinx-copybutton == 0.5.2",
+    "sphinx-toolbox == 4.0.0",
+    "sphinxcontrib-spelling == 8.0.1",
+    "pyenchant == 3.2.2",
+    "Pillow == 11.3.0",
+]

--- a/tox.ini
+++ b/tox.ini
@@ -15,9 +15,10 @@ skip_missing_interpreters = True
 
 [testenv:pre-commit]
 skip_install = True
+dependency_groups = pre-commit
 deps =
-    {tox_root}{/}travertino
-    {tox_root}{/}core[dev]
+    -e{tox_root}{/}core
+    -e{tox_root}{/}travertino
 commands = pre-commit run --all-files --show-diff-on-failure --color=always
 
 # The leading comma generates the "py" environment
@@ -33,11 +34,10 @@ allowlist_externals =
     bash
 commands =
     # TOGA_INSTALL_COMMAND is set to a bash command by the CI workflow
-    {env:TOGA_INSTALL_COMMAND:python -m pip install {tox_root}{/}core[dev] {tox_root}{/}dummy {tox_root}{/}travertino}
+    {env:TOGA_INSTALL_COMMAND:python -m pip install -e {tox_root}{/}core -e {tox_root}{/}dummy -e {tox_root}{/}travertino}
     !fast-!cov : python -m pytest {posargs:-vv --color yes}
-    cov  : python -m coverage run -m pytest {posargs:-vv --color yes}
-    fast : python -m pytest {posargs:-vv --color yes -n auto}
-
+    cov        : python -m coverage run -m pytest {posargs:-vv --color yes}
+    fast       : python -m pytest {posargs:-vv --color yes -n auto}
 [testenv:coverage{,310,311,312,313,314}{,-trav}{,-html}{,-keep}{,-platform}]
 depends =
     !trav: pre-commit,py3{10-14}{,-cov}
@@ -61,10 +61,11 @@ setenv =
     PROJECT_RCFILE = --rcfile {tox_root}{/}pyproject.toml
     # disable conditional coverage exclusions for Python version
     {platform}: COVERAGE_EXCLUDE_PYTHON_VERSION=disable
+dependency_groups = dev
 commands_pre = python --version
 commands =
     # TOGA_INSTALL_COMMAND is set to a bash command by the CI workflow
-    {env:TOGA_INSTALL_COMMAND:python -m pip install {tox_root}{/}core[dev] {tox_root}{/}travertino}
+    {env:TOGA_INSTALL_COMMAND:python -m pip install -e {tox_root}{/}core -e {tox_root}{/}travertino}
     -python -m coverage combine {env:PACKAGE_RCFILE} {env:COMBINE_KEEP}
     html: python -m coverage html {env:PROJECT_RCFILE} --skip-covered --skip-empty
     python -m coverage report {env:PROJECT_RCFILE} --fail-under=100
@@ -85,8 +86,8 @@ commands =
 
 [testenv:towncrier{,-check}]
 skip_install = True
-deps =
-    towncrier==25.8.0
+dependency_groups =
+    town-crier
 commands =
     check  : python -m towncrier.check --compare-with origin/main
     !check : python -m towncrier {posargs}
@@ -102,9 +103,10 @@ base_python = py312
 skip_install = True
 # give sphinx-autobuild time to shutdown http server
 suicide_timeout = 1
+dependency_groups = docs
 deps =
     # editable install so docstrings can be updated for 'all' and 'live'
-    -e {tox_root}{/}core[docs]
+    -e {tox_root}{/}core
     -e {tox_root}{/}travertino
     # Docs requirements are *mostly* handled by the `docs` extra; but we can't include
     # the theme that way, so the theme is installed using a requirements.txt file,


### PR DESCRIPTION
<!--- Describe your changes in detail -->
This PR introduces PEP 735 dependency groups (`dev`, `docs`, `pre-commit`, `towncrier`) to both `pyproject.toml` and `tox.ini`.  

This ensures contributors can reproduce the exact development, testing, and docs environments with consistent tooling. It replaces ad-hoc dependency lists and centralizes them for clarity. I made sure, the styling of the files stay the same

<!--- What problem does this change solve? -->
Solves inconsistencies in developer environments and makes `tox` easier to run by mapping environments directly to dependency groups.

If merged, contributors can run:
- `pip install .[dev]` → dev/test tools
- `pip install .[docs]` → docs build
- `tox -e pre-commit` → linting hooks
- `tox -e towncrier-check` → changelog check

Refs #3634


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
