### PR TITLE
Enable focus table tree

### DIFF
--- a/android/src/toga_android/widgets/table.py
+++ b/android/src/toga_android/widgets/table.py
@@ -45,6 +45,7 @@ class TogaOnLongClickListener(dynamic_proxy(View.OnLongClickListener)):
 
 
 class Table(Widget):
+    focusable = False
     table_layout = None
     color_selected = None
     _font_impl = None

--- a/android/tests_backend/widgets/table.py
+++ b/android/tests_backend/widgets/table.py
@@ -95,5 +95,5 @@ class TableProbe(SimpleProbe):
     def text_size(self):
         return self._row_view(0).getChildAt(0).getTextSize()
 
-    async def acquire_keyboard_focus(self):
+    async def select_first_row_keyboard(self):
         pytest.skip("test not implemented for this platform")

--- a/cocoa/tests_backend/widgets/table.py
+++ b/cocoa/tests_backend/widgets/table.py
@@ -32,6 +32,10 @@ class TableProbe(SimpleProbe):
             return None
 
     @property
+    def has_focus(self):
+        return self.native.window.firstResponder == self.native_table
+
+    @property
     def row_count(self):
         return int(self.native_table.numberOfRowsInTableView(self.native_table))
 
@@ -145,10 +149,7 @@ class TableProbe(SimpleProbe):
             clickCount=2,
         )
 
-    async def acquire_keyboard_focus(self):
-        self.native_table.window.makeFirstResponder(
-            self.native_table
-        )  # switch to widget.focus() when possible (#2972).
-        # Insure first row is selected.
+    async def select_first_row_keyboard(self):
+        # Use the keyboard to ensure first row is selected.
         await self.type_character("<down>")
         await self.type_character("<up>")

--- a/cocoa/tests_backend/widgets/tree.py
+++ b/cocoa/tests_backend/widgets/tree.py
@@ -31,6 +31,10 @@ class TreeProbe(SimpleProbe):
         else:
             return None
 
+    @property
+    def has_focus(self):
+        return self.native.window.firstResponder == self.native_tree
+
     async def expand_tree(self):
         self.native_tree.expandItem(None, expandChildren=True)
         await asyncio.sleep(0.1)

--- a/core/src/toga/widgets/table.py
+++ b/core/src/toga/widgets/table.py
@@ -122,10 +122,6 @@ class Table(Widget):
     def enabled(self, value: object) -> None:
         pass
 
-    def focus(self) -> None:
-        """No-op; Table cannot accept input focus."""
-        pass
-
     @property
     def data(self) -> SourceT | ListSource:
         """The data to display in the table.

--- a/core/src/toga/widgets/tree.py
+++ b/core/src/toga/widgets/tree.py
@@ -120,10 +120,6 @@ class Tree(Widget):
     def enabled(self, value: object) -> None:
         pass
 
-    def focus(self) -> None:
-        """No-op; Tree cannot accept input focus."""
-        pass
-
     @property
     def data(self) -> SourceT | TreeSource:
         """The data to display in the tree.

--- a/core/tests/widgets/test_table.py
+++ b/core/tests/widgets/test_table.py
@@ -136,13 +136,6 @@ def test_disable_no_op(table):
     assert table.enabled
 
 
-def test_focus_noop(table):
-    """Focus is a no-op."""
-
-    table.focus()
-    assert_action_not_performed(table, "focus")
-
-
 @pytest.mark.parametrize(
     "data, all_attributes, extra_attributes",
     [

--- a/core/tests/widgets/test_tree.py
+++ b/core/tests/widgets/test_tree.py
@@ -5,7 +5,6 @@ import pytest
 import toga
 from toga.sources import TreeSource
 from toga_dummy.utils import (
-    assert_action_not_performed,
     assert_action_performed,
     assert_action_performed_with,
 )
@@ -166,13 +165,6 @@ def test_disable_no_op(tree):
 
     # Still enabled.
     assert tree.enabled
-
-
-def test_focus_noop(tree):
-    """Focus is a no-op."""
-
-    tree.focus()
-    assert_action_not_performed(tree, "focus")
 
 
 @pytest.mark.parametrize(

--- a/gtk/tests_backend/widgets/table.py
+++ b/gtk/tests_backend/widgets/table.py
@@ -24,6 +24,10 @@ class TableProbe(SimpleProbe):
         pytest.skip("Can't set background color on GTK Tables")
 
     @property
+    def has_focus(self):
+        return self.native_table.has_focus()
+
+    @property
     def row_count(self):
         return len(self.native_table.get_model())
 
@@ -88,5 +92,5 @@ class TableProbe(SimpleProbe):
             self.native_table.get_columns()[0],
         )
 
-    async def acquire_keyboard_focus(self):
+    async def select_first_row_keyboard(self):
         pytest.skip("test not implemented for this platform")

--- a/gtk/tests_backend/widgets/tree.py
+++ b/gtk/tests_backend/widgets/tree.py
@@ -24,6 +24,10 @@ class TreeProbe(SimpleProbe):
     def background_color(self):
         pytest.skip("Can't set background color on GTK Tables")
 
+    @property
+    def has_focus(self):
+        return self.native_tree.has_focus()
+
     async def expand_tree(self):
         self.native_tree.expand_all()
         await asyncio.sleep(0.1)

--- a/testbed/tests/widgets/test_table.py
+++ b/testbed/tests/widgets/test_table.py
@@ -15,7 +15,7 @@ from .properties import (  # noqa: F401
     test_background_color_reset,
     test_enable_noop,
     test_flex_widget_size,
-    test_focus_noop,
+    test_focus,
     test_font,
 )
 
@@ -161,7 +161,11 @@ async def test_scroll(widget, probe):
 
 async def test_keyboard_navigation(widget, source, probe):
     """The list can be navigated using a keyboard."""
-    await probe.acquire_keyboard_focus()
+
+    widget.focus()
+    assert probe.has_focus
+
+    await probe.select_first_row_keyboard()
     await probe.redraw("First row selected")
     assert widget.selection == widget.data[0]
 
@@ -321,9 +325,11 @@ async def test_multiselect_keyboard_control(
     assert multiselect_widget.selection == []
     on_select_handler.assert_not_called()
 
-    await multiselect_probe.acquire_keyboard_focus()
+    multiselect_widget.focus()
+    assert multiselect_probe.has_focus
 
     # A single row can be added to the selection
+    await multiselect_probe.select_first_row_keyboard()
     await multiselect_probe.redraw("First row selected")
     assert multiselect_widget.selection == [source[0]]
 

--- a/testbed/tests/widgets/test_tree.py
+++ b/testbed/tests/widgets/test_tree.py
@@ -15,7 +15,7 @@ from .properties import (  # noqa: F401
     test_background_color_reset,
     test_enable_noop,
     test_flex_widget_size,
-    test_focus_noop,
+    test_focus,
     test_font,
 )
 

--- a/winforms/tests_backend/widgets/table.py
+++ b/winforms/tests_backend/widgets/table.py
@@ -100,8 +100,6 @@ class TableProbe(SimpleProbe):
             )
         )
 
-    async def acquire_keyboard_focus(self):
-        await self.type_character(
-            "\t"
-        )  # switch to widget.focus() when possible (#2972)
-        await self.type_character(" ")  # select first row
+    async def select_first_row_keyboard(self):
+        # Use the keyboard to ensure first row is selected.
+        await self.type_character(" ")


### PR DESCRIPTION
I enabled the focus method on Table and Tree widgets (except on Android)

It works fine with cocoa. Flying blind regarding winforms and gtk, I'm hoping that the CI run will be enlightening.  

Fixes #2972 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
