### PR TITLE
Correct failure winforms show/hide cursor test.

### DIFF
--- a/winforms/src/toga_winforms/app.py
+++ b/winforms/src/toga_winforms/app.py
@@ -251,14 +251,22 @@ class App:
     ######################################################################
 
     def hide_cursor(self):
+        print("HIDE CURSOR")
         if self._cursor_visible:
+            print("- is visible")
             WinForms.Cursor.Hide()
+            print("- hide called ")
         self._cursor_visible = False
+        print("- now hidden")
 
     def show_cursor(self):
+        print("SHOW CURSOR")
         if not self._cursor_visible:
+            print("- is visible")
             WinForms.Cursor.Show()
+            print("- show called ")
         self._cursor_visible = True
+        print("- now visible")
 
     ######################################################################
     # Window control

--- a/winforms/tests_backend/app.py
+++ b/winforms/tests_backend/app.py
@@ -52,6 +52,8 @@ class AppProbe(BaseProbe, DialogsMixin):
         # The following code is based on https://stackoverflow.com/a/12467292, but it
         # only works when the cursor is over the window.
         form = self.main_window._impl.native
+        print("CURSOR POSITION", Cursor.Position)
+        print("FORM POSITION", form.Location, form.Size)
         Cursor.Position = Point(
             form.Location.X + (form.Size.Width // 2),
             form.Location.Y + (form.Size.Height // 2),
@@ -59,6 +61,7 @@ class AppProbe(BaseProbe, DialogsMixin):
 
         # A small delay is apparently required for the new position to take effect.
         sleep(0.1)
+        print("AFTER CURSOR POSITION", Cursor.Position)
 
         class POINT(ctypes.Structure):
             _fields_ = [
@@ -81,6 +84,10 @@ class AppProbe(BaseProbe, DialogsMixin):
         info.cbSize = ctypes.sizeof(info)
         if not GetCursorInfo(ctypes.byref(info)):
             raise RuntimeError("GetCursorInfo failed")
+
+        print("IS CURSOR VISIBLE?")
+        print(f"- {info.hCursor=}")
+        print(f"- {info.flags=}")
 
         # `flags` is 0 or 1 in local testing, but the GitHub Actions runner always
         # returns 2 ("the system is not drawing the cursor because the user is providing


### PR DESCRIPTION
At some point in the last week, the Winforms backend started failing a cursor show/hide test.

Still investigating the cause; This is a draft PR for investigation purposes.

Fixes #3783.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
