### PR TITLE
Fix ScrollContainer and OptionContainer refresh when event loop blocked on Cocoa

### DIFF
--- a/changes/3787.bugfix.rst
+++ b/changes/3787.bugfix.rst
@@ -1,0 +1,1 @@
+OptionContainer and ScrollContainer widgets will now resize continuously during the drag of a parent SplitContainer on macOS.

--- a/cocoa/src/toga_cocoa/widgets/optioncontainer.py
+++ b/cocoa/src/toga_cocoa/widgets/optioncontainer.py
@@ -1,6 +1,6 @@
 import warnings
 
-from rubicon.objc import SEL, objc_method
+from rubicon.objc import objc_method
 from travertino.size import at_least
 
 from toga_cocoa.container import Container
@@ -58,11 +58,10 @@ class OptionContainer(Widget):
         super().set_bounds(x, y, width, height)
 
         # Setting the bounds changes the constraints, but that doesn't mean
-        # the constraints have been fully applied. Schedule a refresh to be done
-        # as soon as possible in the future
-        self.native.performSelector(
-            SEL("refreshContent"), withObject=None, afterDelay=0
-        )
+        # the constraints have been fully applied. Force realization of the
+        # new layout, and then refresh the content.
+        self.interface.window._impl.native.layoutIfNeeded()
+        self.native.refreshContent()
 
     def content_refreshed(self, container):
         container.min_width = container.content.interface.layout.min_width

--- a/cocoa/src/toga_cocoa/widgets/scrollcontainer.py
+++ b/cocoa/src/toga_cocoa/widgets/scrollcontainer.py
@@ -75,11 +75,10 @@ class ScrollContainer(Widget):
         super().set_bounds(x, y, width, height)
 
         # Setting the bounds changes the constraints, but that doesn't mean
-        # the constraints have been fully applied. Schedule a refresh to be done
-        # as soon as possible in the future
-        self.native.performSelector(
-            SEL("refreshContent"), withObject=None, afterDelay=0
-        )
+        # the constraints have been fully applied. Force realization of the
+        # new layout, and then refresh the content.
+        self.interface.window._impl.native.layoutIfNeeded()
+        self.native.refreshContent()
 
     def content_refreshed(self, container):
         width = self.native.frame.size.width

--- a/testbed/tests/widgets/test_optioncontainer.py
+++ b/testbed/tests/widgets/test_optioncontainer.py
@@ -551,3 +551,16 @@ async def test_change_content(
     # on_select has been invoked
     on_select_handler.assert_called_once_with(widget)
     on_select_handler.reset_mock()
+
+
+async def test_blocking_refresh(widget, probe):
+    """
+    Widget will be resized immediately upon relayout without delay when event
+    loop is blocked
+    """
+    widget.width = 100
+    assert probe.width == 100
+    widget.width = 101
+    assert probe.width == 101
+    widget.width = 102
+    assert probe.width == 102

--- a/testbed/tests/widgets/test_optioncontainer.py
+++ b/testbed/tests/widgets/test_optioncontainer.py
@@ -556,7 +556,7 @@ async def test_change_content(
 async def test_blocking_refresh(widget, probe):
     """
     Widget will be resized immediately upon relayout without delay when event
-    loop is blocked
+    loop is blocked (#3787)
     """
     widget.width = 100
     assert probe.width == 100

--- a/testbed/tests/widgets/test_scrollcontainer.py
+++ b/testbed/tests/widgets/test_scrollcontainer.py
@@ -510,3 +510,16 @@ async def test_no_content(widget, probe, content):
     widget.parent.remove(other)
     await probe.redraw("Scroll container size has been restored")
     assert probe.width == original_width
+
+
+async def test_blocking_refresh(widget, probe):
+    """
+    Widget will be resized immediately upon relayout without delay when event
+    loop is blocked (#3787)
+    """
+    widget.width = 100
+    assert probe.width == 100
+    widget.width = 101
+    assert probe.width == 101
+    widget.width = 102
+    assert probe.width == 102


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

Fixes #3787.  Uses the patch as described there, and add a test manually initiating a few width change events to make sure they are kept up with immediately.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
