### PR TITLE
Fix up the changenote for #2613

### DIFF
--- a/changes/2613.bugfix.md
+++ b/changes/2613.bugfix.md
@@ -1,1 +1,1 @@
-Performance of the `asyncio` event loop on WinForms when events are being added in an interval less than 5ms is resolved.
+Performance of the `asyncio` event loop on WinForms when events are being added in an interval less than 5ms is slightly improved.


### PR DESCRIPTION
As discussed at #3823 there is still significant performance gains on the table.

(sorry the extended description for the commit said #2613 in the message.  Make sure to edit it out, thanks!)

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
