### PR TITLE
Docs: Restore header spacing

### DIFF
--- a/changes/3860.misc.md
+++ b/changes/3860.misc.md
@@ -1,1 +1,1 @@
-Margins were adjusted in code reference documentation to more clearly separate and organize class and their attributes.
+Margins on top of class headings in documentation were restored.

--- a/docs/en/stylesheets/toga.css
+++ b/docs/en/stylesheets/toga.css
@@ -2,10 +2,6 @@
     color-scheme: light dark;
 }
 
-/* Indent class/method/etc. contents */
-
-.doc-contents, .doc-signature { margin-left: 2em; }
-
 /* Title for platform availability tables */
 .availability-title {
     text-align: center;


### PR DESCRIPTION
This is two different but conceptually related changes, aiming to improve visual organization and separation in the code reference.

## Removed top margin

I've removed this rule:

```css
/* Override margins on the signatures of items with no docstring on pages where headings are not included */
h3.doc-heading {
    margin-top: 0;
    margin-bottom: 0.5rem;
}
```
This was intended to shrink spacing between attributes of Keys and Constants, but was instead shrinking the margin above each class on every page. (The spacing issue must've been fixed in some other, possibly ineffable way. The CSS gods move in mysterious ways.)

Removing it helps give a little more visual separation between classes:

<img width="400" alt="Current" src="https://github.com/user-attachments/assets/195943d3-142d-4447-9ec8-b4863bb8c30d" /> 
<img width="400" alt="With margin restored" src="https://github.com/user-attachments/assets/52f1d011-2e71-4bae-bed6-1c037bc23f24" />

## Added indentation (left margin)

However — and this may just be me — I still find this docs style difficult to parse, with everything justified uniformly to the left. The prior Sphinx indentation makes it much easier to see what contains what:

<img width="693" height="318" alt="Sphinx's indentation" src="https://github.com/user-attachments/assets/677c20e4-ed01-4f3f-a989-5f7027bf2765" />

I've inserted a 2em left margin to the subsections, so that it looks like this:

<img width="861" height="636" alt="Added indentation" src="https://github.com/user-attachments/assets/9853638a-9c67-498e-be57-36205a7d8503" />

I realize this is entirely subjective, both whether to indent as well as, if so, how much. More indentation makes the hierarchy more visually obvious, but also eats into line length. Thoughts?

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
