### PR TITLE
Fix update table in background

### DIFF
--- a/changes/3900.bugfix.md
+++ b/changes/3900.bugfix.md
@@ -1,0 +1,1 @@
+On Windows, updating table data from a background task now triggers a repaint of the data.

--- a/winforms/src/toga_winforms/widgets/table.py
+++ b/winforms/src/toga_winforms/widgets/table.py
@@ -261,6 +261,8 @@ class Table(Widget):
 
     def change(self, item):
         self.update_data()
+        index = self._data.index(item)
+        self.native.RedrawItems(index, index, True)
 
     def remove(self, index, item):
         self.update_data()


### PR DESCRIPTION
This requests a redraw on the table when updating data from a background task.

Refs #3046

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
