### PR TITLE
[Qt] Font support for Qt backend.

### DIFF
--- a/changes/3914.feature.6.md
+++ b/changes/3914.feature.6.md
@@ -1,0 +1,1 @@
+Fonts are now supported in the Qt backend.

--- a/docs/en/reference/data/apis_by_platform.yaml
+++ b/docs/en/reference/data/apis_by_platform.yaml
@@ -276,7 +276,6 @@ Resources:
     unsupported:
       - web
       - textual
-      - qt
 
   Icon:
     description: A small, square image used to provide easily identifiable visual context to a widget.

--- a/qt/src/toga_qt/fonts.py
+++ b/qt/src/toga_qt/fonts.py
@@ -1,11 +1,127 @@
-# Not yet implemented
+from pathlib import Path
+
+from PySide6.QtGui import QFont, QFontDatabase
+
+from toga.fonts import (
+    _IMPL_CACHE,
+    _REGISTERED_FONT_CACHE,
+    BOLD,
+    CURSIVE,
+    FANTASY,
+    ITALIC,
+    MESSAGE,
+    MONOSPACE,
+    NORMAL,
+    OBLIQUE,
+    SANS_SERIF,
+    SERIF,
+    SMALL_CAPS,
+    SYSTEM,
+    SYSTEM_DEFAULT_FONT_SIZE,
+    SYSTEM_DEFAULT_FONTS,
+    UnknownFontError,
+)
+
+QT_FONT_STYLE_HINTS = {
+    SYSTEM: QFont.StyleHint.System,
+    MESSAGE: QFont.StyleHint.System,
+    CURSIVE: QFont.StyleHint.Cursive,
+    FANTASY: QFont.StyleHint.Fantasy,
+    MONOSPACE: QFont.StyleHint.Monospace,
+    SANS_SERIF: QFont.StyleHint.SansSerif,
+    SERIF: QFont.StyleHint.Serif,
+}
+QT_FONT_STYLES = {
+    NORMAL: QFont.Style.StyleNormal,
+    ITALIC: QFont.Style.StyleItalic,
+    OBLIQUE: QFont.Style.StyleOblique,
+}
+QT_FONT_WEIGHTS = {
+    NORMAL: QFont.Weight.Normal,
+    BOLD: QFont.Weight.Bold,
+}
+
+# Names of user-registered fonts loaded into QFontDatabase
+_CUSTOM_FONT_NAMES = {}
 
 
 class Font:
-    def __init__(self, interface): ...
+    def __init__(self, interface):
+        self.interface = interface
 
-    def load_predefined_system_font(self): ...
+    def load_predefined_system_font(self):
+        """Use one of the system font names Toga predefines."""
+        if self.interface.family not in SYSTEM_DEFAULT_FONTS:
+            raise UnknownFontError(f"{self.interface} not a predefined system font")
 
-    def load_user_registered_font(self): ...
+        if self.interface.family in {SYSTEM, MESSAGE}:
+            font = QFontDatabase.systemFont(QFontDatabase.SystemFont.GeneralFont)
+        elif self.interface.family == MONOSPACE:
+            font = QFontDatabase.systemFont(QFontDatabase.SystemFont.FixedFont)
+        else:
+            font = QFont()
+            # Qt recognises standard predefined font names.
+            font.setFamily(self.interface.family)
+            font.setStyleHint(QT_FONT_STYLE_HINTS[self.interface.family])
 
-    def load_arbitrary_system_font(self): ...
+        self._assign_native(font)
+
+    def load_user_registered_font(self):
+        """Use a font that the user has registered in their code."""
+        font_key = self.interface._registered_font_key(
+            family=self.interface.family,
+            weight=self.interface.weight,
+            style=self.interface.style,
+            variant=self.interface.variant,
+        )
+        try:
+            font_path = _REGISTERED_FONT_CACHE[font_key]
+        except KeyError as exc:
+            msg = f"{self.interface} not a user-registered font"
+            raise UnknownFontError(msg) from exc
+
+        # Find the font family name to use for this font.
+        try:
+            family_name = _CUSTOM_FONT_NAMES[font_key]
+        except KeyError as exc:
+            # Font isn't yet loaded into QFontDatabase.
+            if not Path(font_path).is_file():
+                msg = f"Font file {font_path} could not be found"
+                raise ValueError(msg) from exc
+
+            id = QFontDatabase.addApplicationFont(font_path)
+            if id == -1:
+                msg = f"Unable to load font file {font_path}"
+                raise ValueError(msg) from exc
+
+            # Get the family name of the font we just loaded, and remember it.
+            family_name = QFontDatabase.applicationFontFamilies(id)[0]
+            _CUSTOM_FONT_NAMES[font_path] = family_name
+
+        # Create the font query.
+        font = QFont()
+        font.setFamily(family_name)
+        self._assign_native(font)
+
+    def load_arbitrary_system_font(self):
+        """Use a font available on the system."""
+        if self.interface.family not in QFontDatabase.families():
+            msg = f"{self.interface} not a registered font"
+            raise UnknownFontError(msg)
+        font = QFont()
+        font.setFamily(self.interface.family)
+        self._assign_native(font)
+
+    def _assign_native(self, font):
+        # Given a minimally initialized QFont, set all the other features
+        font.setStyle(QT_FONT_STYLES[self.interface.style])
+        weight = QT_FONT_WEIGHTS.get(self.interface.weight, self.interface.weight)
+        font.setWeight(weight)
+        if self.interface.variant == SMALL_CAPS:
+            font.setCapitalization(QFont.Capitalization.SmallCaps)
+        if self.interface.size != SYSTEM_DEFAULT_FONT_SIZE:
+            font.setPointSize(self.interface.size)
+
+        # Set the native font and remember it
+        self.native = font
+        _IMPL_CACHE[self.interface] = self

--- a/qt/src/toga_qt/widgets/base.py
+++ b/qt/src/toga_qt/widgets/base.py
@@ -106,8 +106,7 @@ class Widget:
         self.native.setPalette(palette)
 
     def set_font(self, font):
-        # Not implemented yet
-        pass
+        self.native.setFont(font._impl.native)
 
     ######################################################################
     # INTERFACE

--- a/qt/tests_backend/fonts.py
+++ b/qt/tests_backend/fonts.py
@@ -1,20 +1,61 @@
-import pytest
+from PySide6.QtGui import QFont, QFontDatabase
 
-from toga.fonts import NORMAL
+from toga.fonts import (
+    BOLD,
+    ITALIC,
+    MESSAGE,
+    MONOSPACE,
+    NORMAL,
+    OBLIQUE,
+    SMALL_CAPS,
+    SYSTEM,
+    SYSTEM_DEFAULT_FONT_SIZE,
+)
 
 
 class FontMixin:
-    supports_custom_fonts = False
-    supports_custom_variable_fonts = False
+    supports_custom_fonts = True
+    supports_custom_variable_fonts = True
 
     def preinstalled_font(self):
-        pytest.skip("Qt backend doesn't implement fonts")
+        # grab a known font family
+        return QFontDatabase.families()[0]
 
     def assert_font_family(self, expected):
-        pytest.skip("Qt backend doesn't implement fonts")
+        assert self.font.family() == {
+            # System fonts supplied by QFontDatabase
+            SYSTEM: QFontDatabase.systemFont(
+                QFontDatabase.SystemFont.GeneralFont
+            ).family(),
+            MESSAGE: QFontDatabase.systemFont(
+                QFontDatabase.SystemFont.GeneralFont
+            ).family(),
+            MONOSPACE: QFontDatabase.systemFont(
+                QFontDatabase.SystemFont.FixedFont
+            ).family(),
+            # Most other fonts we can just use the family name;
+            # however, the Font Awesome font has a different
+            # internal Postscript name, which *doesn't* include
+            # the "solid" weight component.
+            "Font Awesome 5 Free Solid": "Font Awesome 5 Free",
+        }.get(expected, expected)
 
     def assert_font_size(self, expected):
-        pytest.skip("Qt backend doesn't implement fonts")
+        if expected != SYSTEM_DEFAULT_FONT_SIZE:
+            assert self.font.pointSize() == expected
 
     def assert_font_options(self, weight=NORMAL, style=NORMAL, variant=NORMAL):
-        pytest.skip("Qt backend doesn't implement fonts")
+        assert (
+            self.font.weight() == QFont.Weight.Bold
+            if weight == BOLD
+            else QFont.Weight.Normal
+        )
+        assert self.font.style() == {
+            ITALIC: QFont.Style.StyleItalic,
+            OBLIQUE: QFont.Style.StyleOblique,
+        }.get(style, QFont.Style.StyleNormal)
+        assert self.font.capitalization() == (
+            QFont.Capitalization.SmallCaps
+            if variant == SMALL_CAPS
+            else QFont.Capitalization.MixedCase
+        )

--- a/qt/tests_backend/widgets/base.py
+++ b/qt/tests_backend/widgets/base.py
@@ -48,6 +48,11 @@ class SimpleProbe(BaseProbe, FontMixin):
         return toga_color(self.native.palette().color(self.native.backgroundRole()))
 
     @property
+    def font(self):
+        # This is checking what we ask for, not what we get
+        return self.native.font()
+
+    @property
     def hidden(self):
         return not self.native.isVisible()
 


### PR DESCRIPTION
This *should* be complete. To test the fonts example app, need to have the MultilineTextInput widget available (see #3964).

Ref #3914.

<img width="752" height="680" alt="Screenshot 2025-12-11 at 11 44 07 am" src="https://github.com/user-attachments/assets/cccff8f2-c091-41ed-9ffe-1d4d1706ada6" />

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
