### PR TITLE
Catch errors when the locale is unknown or invalid.

### DIFF
--- a/changes/3984.bugfix.md
+++ b/changes/3984.bugfix.md
@@ -1,0 +1,1 @@
+Apps now log an error instead of crashing if the system locale value is set to an unknown or invalid value.

--- a/core/src/toga/app.py
+++ b/core/src/toga/app.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import importlib.metadata
 import locale
+import os
 import signal
 import sys
 import warnings
@@ -202,7 +203,14 @@ class App:
             app can manage.
         """
         # Sets Python's locale settings to the language settings of the system.
-        locale.setlocale(locale.LC_ALL, "")
+        # If the local is unknown (e.g. en-FR), catch the error, log and ignore,
+        # as there's not much else we can do.
+        try:
+            locale.setlocale(locale.LC_ALL, "")
+        except locale.Error:  # pragma: no cover
+            print(
+                f"Unable to set locale to match system value of {os.getenv('LANG')!r}"
+            )
 
         # Initialize empty widgets registry
         self._widgets = WidgetRegistry()


### PR DESCRIPTION
Fixes #3984 

If the locale is unknown or invalid, catch the error raised when the locale is set.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
