### PR TITLE
Fix scrolling API support tables

### DIFF
--- a/changes/3989.misc.md
+++ b/changes/3989.misc.md
@@ -1,0 +1,1 @@
+API support table width was adjusted to avoid scroll bars.

--- a/docs/en/stylesheets/toga.css
+++ b/docs/en/stylesheets/toga.css
@@ -37,10 +37,6 @@
     font-size: 0.7rem;
 }
 
-.widgets_by_platform ~ .md-typeset__scrollwrap .md-typeset__table table:not([class]) thead tr th:first-of-type {
-    min-width: 11rem;
-}
-
 .widgets_by_platform ~ .md-typeset__scrollwrap .md-typeset__table table:not([class]) thead tr th,
 .widgets_by_platform ~ .md-typeset__scrollwrap .md-typeset__table table:not([class]) tbody tr td:first-of-type {
     padding: 0.4em 0.63em;


### PR DESCRIPTION
With the addition of the Qt backend, the "APIs by platform" tables now have horizontal scrollbars.

<img width="847" height="296" alt="Before" src="https://github.com/user-attachments/assets/565b0342-e8e0-439d-97c5-02ac67ddd3f1" />

If I remove this min-width rule on the first column, the columns resize as needed. It could still end up scrolling if someone has text set really large, but this at least makes it less likely.

<img width="846" height="279" alt="After" src="https://github.com/user-attachments/assets/daf8a008-32b6-4854-a877-bab0b5de749d" />


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
