### PR TITLE
Fix "e.g. i.e." in 0.5.3 release notes

### DIFF
--- a/changes/4002.misc.md
+++ b/changes/4002.misc.md
@@ -1,0 +1,1 @@
+Another sentence's grammar has been fixed in the 0.5.3 release notes.

--- a/docs/en/about/releases.md
+++ b/docs/en/about/releases.md
@@ -37,7 +37,7 @@
 * On GTK, the scroll position will now be correctly reflected if a `MultilineTextInput` is programmatically scrolled immediately after changing text content. ([#3658](https://github.com/beeware/toga/issues/3658))
 * On GTK, mouse drag events are now triggered when modifier keys (e.g. NumLock, Shift) are active. ([#3661](https://github.com/beeware/toga/issues/3661))
 * On macOS, the origin of non-primary screens is now correctly calculated when screens are not vertically aligned and the same size. ([#3667](https://github.com/beeware/toga/issues/3667))
-* App path attributes were unintentionally made writable in 0.5.2 (e.g. i.e., `app.paths.config = <something>` was permitted). This has been fixed. ([#3669](https://github.com/beeware/toga/issues/3669))
+* App path attributes were unintentionally made writable in 0.5.2 (e.g. `app.paths.config = <something>` was permitted). This has been fixed. ([#3669](https://github.com/beeware/toga/issues/3669))
 * The text of `OptionContainer` tab labels is now guaranteed to be `str` on macOS, instead of an Objective C String. ([#3672](https://github.com/beeware/toga/issues/3672))
 * On macOS, pressing Enter or Tab when a row is selected on a table no longer starts row editing mode. ([#3673](https://github.com/beeware/toga/issues/3673))
 * Backwards compatibility code in Travertino that allows it to function with pre-0.5 versions of Toga has been made more specific, to prevent it from masking other, unrelated errors. ([#3683](https://github.com/beeware/toga/issues/3683))


### PR DESCRIPTION
Found another one...

I could see either "i.e." (in other words) or "e.g." (for example) working here... but not both.

Will need manual fixing in the GitHub release notes.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
