### PR TITLE
Fix `AndroidEventLoop` to handle a `fileobj`correctly

### DIFF
--- a/changes/4083.bugfix.md
+++ b/changes/4083.bugfix.md
@@ -1,0 +1,1 @@
+Fixed `AndroidEventLoop` to correctly handle `fileobj`. This fixes the usage of e.g. `grpcio` in a Toga app.


### PR DESCRIPTION
<!--- Describe your changes in detail -->
In `AndroidEventLoop` the `fileobj` handling was wrong. A `fileobj` can be not only an integer, but also, for example, a `socket` object. These must first be converted to an integer, otherwise an exception will occur.

<!--- What problem does this change solve? -->
I noticed this when I tried to use `grpcio` (v1.67.0) in conjunction with toga's `AndroidEventLoop`. I got the following error message:

```
W/python.stderr: 23:00:43.225 E asyncio: Task exception was never retrieved
W/python.stderr: future: <Task finished name='Task-1' coro=<_wrap_asyncgen_fixture.<locals>._asyncgen_fixture_wrapper.<locals>.setup() done, defined at /data/data/com.bleak.briefcaseexample.bleak_example/files/chaquopy/AssetFinder/requirements/pytest_asyncio/plugin.py:308> exception=TypeError('Cannot convert socket object to int')>
W/python.stderr: Traceback (most recent call last):
W/python.stderr:   File "/data/data/com.bleak.briefcaseexample.bleak_example/files/chaquopy/AssetFinder/requirements/pytest_asyncio/plugin.py", line 309, in setup
W/python.stderr:     res = await gen_obj.__anext__()
W/python.stderr:           ^^^^^^^^^^^^^^^^^^^^^^^^^
W/python.stderr:   File "/data/data/com.bleak.briefcaseexample.bleak_example/files/chaquopy/AssetFinder/app/tests/integration/conftest.py", line 27, in hci_transport
W/python.stderr:     async with create_hci_transport(request) as hci_transport:
W/python.stderr:                ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
W/python.stderr:   File "stdlib/contextlib.py", line 214, in __aenter__
W/python.stderr:   File "/data/data/com.bleak.briefcaseexample.bleak_example/files/chaquopy/AssetFinder/app/tests/integration/conftest.py", line 51, in create_hci_transport
W/python.stderr:     async with await open_transport(hci_transport_name) as hci_transport:
W/python.stderr:                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
W/python.stderr:   File "/data/data/com.bleak.briefcaseexample.bleak_example/files/chaquopy/AssetFinder/requirements/bumble/transport/__init__.py", line 100, in open_transport
W/python.stderr:     transport = await _open_transport(scheme, spec)
W/python.stderr:                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
W/python.stderr:   File "/data/data/com.bleak.briefcaseexample.bleak_example/files/chaquopy/AssetFinder/requirements/bumble/transport/__init__.py", line 188, in _open_transport
W/python.stderr:     return await open_android_netsim_transport(spec)
W/python.stderr:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
W/python.stderr:   File "/data/data/com.bleak.briefcaseexample.bleak_example/files/chaquopy/AssetFinder/requirements/bumble/transport/android_netsim.py", line 477, in open_android_netsim_transport
W/python.stderr:     return await open_android_netsim_host_transport_with_address(
W/python.stderr:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
W/python.stderr:         host, port, options
W/python.stderr:         ^^^^^^^^^^^^^^^^^^^
W/python.stderr:     )
W/python.stderr:     ^
W/python.stderr:   File "/data/data/com.bleak.briefcaseexample.bleak_example/files/chaquopy/AssetFinder/requirements/bumble/transport/android_netsim.py", line 320, in open_android_netsim_host_transport_with_address
W/python.stderr:     channel = grpc.aio.insecure_channel(server_address)
W/python.stderr:   File "/data/data/com.bleak.briefcaseexample.bleak_example/files/chaquopy/AssetFinder/requirements/grpc/aio/_channel.py", line 590, in insecure_channel
W/python.stderr:     return Channel(
W/python.stderr:         target,
W/python.stderr:     ...<3 lines>...
W/python.stderr:         interceptors,
W/python.stderr:     )
W/python.stderr:   File "/data/data/com.bleak.briefcaseexample.bleak_example/files/chaquopy/AssetFinder/requirements/grpc/aio/_channel.py", line 368, in __init__
W/python.stderr:     self._channel = cygrpc.AioChannel(
W/python.stderr:                     ~~~~~~~~~~~~~~~~~^
W/python.stderr:         _common.encode(target),
W/python.stderr:         ^^^^^^^^^^^^^^^^^^^^^^^
W/python.stderr:     ...<2 lines>...
W/python.stderr:         self._loop,
W/python.stderr:         ^^^^^^^^^^^
W/python.stderr:     )
W/python.stderr:     ^
W/python.stderr:   File "src/python/grpcio/grpc/_cython/_cygrpc/aio/channel.pyx.pxi", line 30, in grpc._cython.cygrpc.AioChannel.__cinit__
W/python.stderr:   File "src/python/grpcio/grpc/_cython/_cygrpc/aio/grpc_aio.pyx.pxi", line 97, in grpc._cython.cygrpc.init_grpc_aio
W/python.stderr:   File "src/python/grpcio/grpc/_cython/_cygrpc/aio/grpc_aio.pyx.pxi", line 101, in grpc._cython.cygrpc.init_grpc_aio
W/python.stderr:   File "src/python/grpcio/grpc/_cython/_cygrpc/aio/grpc_aio.pyx.pxi", line 88, in grpc._cython.cygrpc._initialize_per_loop
W/python.stderr:   File "src/python/grpcio/grpc/_cython/_cygrpc/aio/completion_queue.pyx.pxi", line 95, in grpc._cython.cygrpc.PollerCompletionQueue.bind_loop
W/python.stderr:   File "src/python/grpcio/grpc/_cython/_cygrpc/aio/completion_queue.pyx.pxi", line 60, in grpc._cython.cygrpc._BoundEventLoop.__cinit__
W/python.stderr:   File "stdlib/asyncio/selector_events.py", line 347, in add_reader
W/python.stderr:   File "stdlib/asyncio/selector_events.py", line 279, in _add_reader
W/python.stderr:   File "/data/data/com.bleak.briefcaseexample.bleak_example/files/chaquopy/AssetFinder/requirements/toga_android/libs/events.py", line 297, in register
W/python.stderr:     self.register_with_android(fileobj, events)
W/python.stderr:     ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
W/python.stderr:   File "/data/data/com.bleak.briefcaseexample.bleak_example/files/chaquopy/AssetFinder/requirements/toga_android/libs/events.py", line 331, in register_with_android
W/python.stderr:     _create_java_fd(fileobj),
W/python.stderr:     ~~~~~~~~~~~~~~~^^^^^^^^^
W/python.stderr:   File "/data/data/com.bleak.briefcaseexample.bleak_example/files/chaquopy/AssetFinder/requirements/toga_android/libs/events.py", line 420, in _create_java_fd
W/python.stderr:     getattr(java_fd, "setInt$")(int_fd)
W/python.stderr:     ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
W/python.stderr:   File "class.pxi", line 775, in java.chaquopy.JavaMethod.__get__.lambda2
W/python.stderr:   File "class.pxi", line 785, in java.chaquopy.JavaMethod.__call__
W/python.stderr:   File "conversion.pxi", line 249, in java.chaquopy.p2j
W/python.stderr: TypeError: Cannot convert socket object to int
```


<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
