### PR TITLE
Fix buttons in ScrollContainer in Qt backend

### DIFF
--- a/changes/4096.misc.md
+++ b/changes/4096.misc.md
@@ -1,0 +1,1 @@
+Buttons in ScrollContainers in the Qt backend when ran using the Fusion theme now correctly draws borders.

--- a/qt/src/toga_qt/widgets/base.py
+++ b/qt/src/toga_qt/widgets/base.py
@@ -1,6 +1,7 @@
 from abc import abstractmethod
 
 from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QApplication
 
 from ..colors import native_color, toga_color
 
@@ -13,6 +14,7 @@ class Widget:
         self.create()
         self.native.hide()
         self._hidden = True
+        self.native.setPalette(QApplication.style().standardPalette())
 
         if not hasattr(self, "_background_color_role"):
             self._background_color_role = self.native.backgroundRole()


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

Fixes #4096 (yay!! 2^12 tickets)

Issue is related to color management -- QPalettes cascade...so we need to make Qt think that we've overridden all values, which we can accomplish by simply setting the palette explicitly to follow the application style.

Misc changenote because natively-parenting widgets were not added before the last release cut.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
