### PR TITLE
Turn `DrawingAction` subclasses into data classes

### DIFF
--- a/core/src/toga/constants/__init__.py
+++ b/core/src/toga/constants/__init__.py
@@ -22,18 +22,12 @@ class Baseline(Enum):
     BOTTOM = auto()
     """Bottom of text"""
 
-    def __repr__(self):
-        return str(self)
-
 
 class FillRule(Enum):
     """The rule to use when filling paths."""
 
     EVENODD = 0
     NONZERO = 1
-
-    def __repr__(self):
-        return str(self)
 
 
 ##########################################################################

--- a/core/src/toga/widgets/canvas/drawingaction.py
+++ b/core/src/toga/widgets/canvas/drawingaction.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from dataclasses import InitVar, dataclass
+from dataclasses import InitVar, dataclass, fields, is_dataclass
+from enum import Enum
 from math import pi
 from typing import TYPE_CHECKING, Any
 from warnings import filterwarnings, warn
@@ -86,7 +87,24 @@ class DrawingAction(ABC):
     # the link content is split on two lines.
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}()"
+        if is_dataclass(self):
+            str_fields = []
+            for field in fields(self):
+                match value := getattr(self, field.name):
+                    case float():
+                        str_value = f"{value:.3f}"
+                    case Enum():
+                        str_value = str(value)
+                    case _:
+                        str_value = repr(value)
+                str_fields.append(f"{field.name}={str_value}")
+
+            parenthetical = ", ".join(str_fields)
+
+        else:
+            parenthetical = ""
+
+        return f"{type(self).__name__}({parenthetical})"
 
     @abstractmethod
     def _draw(self, context: Any) -> None: ...
@@ -120,7 +138,7 @@ class ClosePath(DrawingAction):
         context.close_path()
 
 
-@dataclass
+@dataclass(repr=False)
 class Fill(DrawingAction):
     color: ColorT | None = color_property()
     fill_rule: FillRule = FillRule.NONZERO
@@ -133,7 +151,7 @@ class Fill(DrawingAction):
         context.restore()
 
 
-@dataclass
+@dataclass(repr=False)
 class Stroke(DrawingAction):
     color: ColorT | None = color_property()
     line_width: float | None = None
@@ -151,7 +169,7 @@ class Stroke(DrawingAction):
         context.restore()
 
 
-@dataclass
+@dataclass(repr=False)
 class MoveTo(DrawingAction):
     x: float
     y: float
@@ -160,7 +178,7 @@ class MoveTo(DrawingAction):
         context.move_to(self.x, self.y)
 
 
-@dataclass
+@dataclass(repr=False)
 class LineTo(DrawingAction):
     x: float
     y: float
@@ -169,7 +187,7 @@ class LineTo(DrawingAction):
         context.line_to(self.x, self.y)
 
 
-@dataclass
+@dataclass(repr=False)
 class BezierCurveTo(DrawingAction):
     cp1x: float
     cp1y: float
@@ -184,7 +202,7 @@ class BezierCurveTo(DrawingAction):
         )
 
 
-@dataclass
+@dataclass(repr=False)
 class QuadraticCurveTo(DrawingAction):
     cpx: float
     cpy: float
@@ -195,7 +213,7 @@ class QuadraticCurveTo(DrawingAction):
         context.quadratic_curve_to(self.cpx, self.cpy, self.x, self.y)
 
 
-@dataclass
+@dataclass(repr=False)
 class Arc(DrawingAction):
     x: float
     y: float
@@ -229,7 +247,7 @@ class Arc(DrawingAction):
         )
 
 
-@dataclass
+@dataclass(repr=False)
 class Ellipse(DrawingAction):
     x: float
     y: float
@@ -268,7 +286,7 @@ class Ellipse(DrawingAction):
         )
 
 
-@dataclass
+@dataclass(repr=False)
 class Rect(DrawingAction):
     x: float
     y: float
@@ -279,7 +297,7 @@ class Rect(DrawingAction):
         context.rect(self.x, self.y, self.width, self.height)
 
 
-@dataclass
+@dataclass(repr=False)
 class WriteText(DrawingAction):
     text: str
     x: float = 0.0
@@ -303,7 +321,7 @@ class WriteText(DrawingAction):
         )
 
 
-@dataclass
+@dataclass(repr=False)
 class DrawImage(DrawingAction):
     image: Image
     x: float = 0.0
@@ -321,7 +339,7 @@ class DrawImage(DrawingAction):
         )
 
 
-@dataclass
+@dataclass(repr=False)
 class Rotate(DrawingAction):
     radians: float
 
@@ -329,7 +347,7 @@ class Rotate(DrawingAction):
         context.rotate(self.radians)
 
 
-@dataclass
+@dataclass(repr=False)
 class Scale(DrawingAction):
     sx: float
     sy: float
@@ -338,7 +356,7 @@ class Scale(DrawingAction):
         context.scale(self.sx, self.sy)
 
 
-@dataclass
+@dataclass(repr=False)
 class Translate(DrawingAction):
     tx: float
     ty: float

--- a/core/tests/widgets/canvas/test_draw_operations.py
+++ b/core/tests/widgets/canvas/test_draw_operations.py
@@ -148,7 +148,7 @@ def test_fill(widget, kwargs, args_repr, draw_objs, attrs):
         # Line width
         (
             {"line_width": 4.5},
-            "color=None, line_width=4.5, line_dash=None",
+            "color=None, line_width=4.500, line_dash=None",
             [("set line width", 4.5)],
             {"color": None, "line_width": 4.5, "line_dash": None},
         ),
@@ -162,7 +162,7 @@ def test_fill(widget, kwargs, args_repr, draw_objs, attrs):
         # All args
         (
             {"color": REBECCAPURPLE, "line_width": 4.5, "line_dash": [2, 7]},
-            f"color={REBECCA_PURPLE_COLOR!r}, line_width=4.5, line_dash=[2, 7]",
+            f"color={REBECCA_PURPLE_COLOR!r}, line_width=4.500, line_dash=[2, 7]",
             [
                 ("set stroke style", REBECCA_PURPLE_COLOR),
                 ("set line width", 4.5),
@@ -282,8 +282,8 @@ def test_quadratic_curve_to(widget):
         (
             {"x": 10, "y": 20, "radius": 30},
             (
-                "x=10, y=20, radius=30, startangle=0.0, "
-                "endangle=6.283185307179586, counterclockwise=False"
+                "x=10, y=20, radius=30, startangle=0.000, "
+                "endangle=6.283, counterclockwise=False"
             ),
             {
                 "x": 10,
@@ -299,7 +299,7 @@ def test_quadratic_curve_to(widget):
             {"x": 10, "y": 20, "radius": 30, "startangle": 1.234},
             (
                 "x=10, y=20, radius=30, startangle=1.234, "
-                "endangle=6.283185307179586, counterclockwise=False"
+                "endangle=6.283, counterclockwise=False"
             ),
             {
                 "x": 10,
@@ -319,7 +319,7 @@ def test_quadratic_curve_to(widget):
                 "endangle": 2.345,
             },
             (
-                "x=10, y=20, radius=30, startangle=0.0, "
+                "x=10, y=20, radius=30, startangle=0.000, "
                 "endangle=2.345, counterclockwise=False"
             ),
             {
@@ -340,8 +340,8 @@ def test_quadratic_curve_to(widget):
                 "counterclockwise": False,
             },
             (
-                "x=10, y=20, radius=30, startangle=0.0, "
-                "endangle=6.283185307179586, counterclockwise=False"
+                "x=10, y=20, radius=30, startangle=0.000, "
+                "endangle=6.283, counterclockwise=False"
             ),
             {
                 "x": 10,
@@ -361,8 +361,8 @@ def test_quadratic_curve_to(widget):
                 "counterclockwise": True,
             },
             (
-                "x=10, y=20, radius=30, startangle=0.0, "
-                "endangle=6.283185307179586, counterclockwise=True"
+                "x=10, y=20, radius=30, startangle=0.000, "
+                "endangle=6.283, counterclockwise=True"
             ),
             {
                 "x": 10,
@@ -423,7 +423,7 @@ def test_arc(widget, kwargs, args_repr, draw_kwargs):
             {"x": 10, "y": 20, "radiusx": 30, "radiusy": 40},
             (
                 "x=10, y=20, radiusx=30, radiusy=40, "
-                "rotation=0.0, startangle=0.0, endangle=6.283185307179586, "
+                "rotation=0.000, startangle=0.000, endangle=6.283, "
                 "counterclockwise=False"
             ),
             {
@@ -442,7 +442,7 @@ def test_arc(widget, kwargs, args_repr, draw_kwargs):
             {"x": 10, "y": 20, "radiusx": 30, "radiusy": 40, "rotation": 1.234},
             (
                 "x=10, y=20, radiusx=30, radiusy=40, "
-                "rotation=1.234, startangle=0.0, endangle=6.283185307179586, "
+                "rotation=1.234, startangle=0.000, endangle=6.283, "
                 "counterclockwise=False"
             ),
             {
@@ -461,7 +461,7 @@ def test_arc(widget, kwargs, args_repr, draw_kwargs):
             {"x": 10, "y": 20, "radiusx": 30, "radiusy": 40, "startangle": 2.345},
             (
                 "x=10, y=20, radiusx=30, radiusy=40, "
-                "rotation=0.0, startangle=2.345, endangle=6.283185307179586, "
+                "rotation=0.000, startangle=2.345, endangle=6.283, "
                 "counterclockwise=False"
             ),
             {
@@ -480,7 +480,7 @@ def test_arc(widget, kwargs, args_repr, draw_kwargs):
             {"x": 10, "y": 20, "radiusx": 30, "radiusy": 40, "endangle": 3.456},
             (
                 "x=10, y=20, radiusx=30, radiusy=40, "
-                "rotation=0.0, startangle=0.0, endangle=3.456, "
+                "rotation=0.000, startangle=0.000, endangle=3.456, "
                 "counterclockwise=False"
             ),
             {
@@ -499,7 +499,7 @@ def test_arc(widget, kwargs, args_repr, draw_kwargs):
             {"x": 10, "y": 20, "radiusx": 30, "radiusy": 40, "counterclockwise": False},
             (
                 "x=10, y=20, radiusx=30, radiusy=40, "
-                "rotation=0.0, startangle=0.0, endangle=6.283185307179586, "
+                "rotation=0.000, startangle=0.000, endangle=6.283, "
                 "counterclockwise=False"
             ),
             {
@@ -518,7 +518,7 @@ def test_arc(widget, kwargs, args_repr, draw_kwargs):
             {"x": 10, "y": 20, "radiusx": 30, "radiusy": 40, "counterclockwise": True},
             (
                 "x=10, y=20, radiusx=30, radiusy=40, "
-                "rotation=0.0, startangle=0.0, endangle=6.283185307179586, "
+                "rotation=0.000, startangle=0.000, endangle=6.283, "
                 "counterclockwise=True"
             ),
             {
@@ -691,7 +691,7 @@ SYSTEM_FONT_IMPL = Font(SYSTEM, SYSTEM_DEFAULT_FONT_SIZE)._impl
             },
             (
                 "text='Hello world', x=10, y=20, font=None, "
-                "baseline=Baseline.ALPHABETIC, line_height=1.5"
+                "baseline=Baseline.ALPHABETIC, line_height=1.500"
             ),
             {
                 "text": "Hello world",


### PR DESCRIPTION
(This is based off #4089 for now, to avoid/minimize merge conflicts. I keep submitting PRs that depend on or conflict with each other, but hopefully that's less inconvenient than giant, monolithic PRs.)

This is not as *directly* related to #3994's project of rearranging the Canvas API. The main purpose is to cut down on boilerplate in the code; this not only helps with general maintainability, it will also make it a little easier to see (and review) when things start changing more substantially.

This should have minimal — but not zero — impact on functionality. One advantage that comes to mind is that data classes support `copy()` out of the box. Once `fill`, `stroke`, `rotate` et. all become context managers that can each hold a list of sub-actions, one may want to reuse them, and insert them into various other actions, without carrying their referred children along (and potentially even causing infinite loops). However, I'm not sure this alone warrants a non-misc change note, especially amidst all the other Canvas changes.

Some hiccups:
- Getting autogenerated `__repr__` methods is part of the point. However...

  - The default implementation calls `repr()` on all field values, and for enums, that results in things like `<Baseline.ALPHABETIC: 1>`. This, of course, isn't valid Python, and the resulting representation of the data class can't be pasted directly into a REPL to create an identical instance. This is honestly kind of a weird aspect of enums. The best workaround I've found is simply defining custom `__repr__` methods on `Baseline` and `FillRule` which call their `__str__`, thus preserving existing behavior.
 
  - Floats are also displayed with more precision than we were doing, except in the case of zero, which is displayed with less. In this case I just updated the expected test values.
  
- The existing code used lots of properties, but aside from precluding deletion, most of them don't *do* anything; they simply set and access a hidden attribute as-is. The only things being altered or validated at all are two colors and a font — the latter of which isn't needed after #4089. For now, I've tossed in a quick-and-dirty validating descriptor that maintains the existing behavior for colors, but...

  - We should probably extend the validation / coercion to all other `Action` attributes.
  
  - One potential advantage of data classes here would be to set `slots=True`, and decrease (potentially by a lot) the amount of memory consumed by large sets of Canvas instructions. However, data classes don't seem to have a particularly elegant way to combine this with data descriptors, since the `_{name}` hidden attributes need slots too. (I guess the descriptor itself could store values, in a dictionary of weakrefs to objects? That sounds messy.)
 
  - All of this makes me wonder if we should split the non-style-specific behavior of Travertino's validated properties out into a base class of some sort... or whether the time may be approaching to adopt a library that handles validation out of the box, like Pydantic or attrs.
 
For now at least, I've not dataclassified the drawing actions that have no parameters, like `BeginPath` and `Context`, since currently there's no advantage in that (other than being able to freeze and/or slot them). Perhaps this will make sense in the (near?) future.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
