### PR TITLE
Add system PySide6 support for Qt backend theme integration

### DIFF
--- a/docs/en/reference/platforms/linux/qt.md
+++ b/docs/en/reference/platforms/linux/qt.md
@@ -39,3 +39,15 @@ This will install the full `PySide6` package, which includes both `PySide6-Essen
 The `toga-qt` backend uses Qt 6.
 
 The native APIs are accessed using the [PySide6 bindings](https://www.qt.io/development/qt-framework/python-bindings).
+
+## Using System Qt
+
+If you want to use the system Qt runtime installed through your system package manager (which provides better integration with system-provided themes), you can install `toga-qt` with the `system` extra:
+
+```console
+$ python -m pip install toga-qt[system]
+```
+
+This installs `system-pyside6`, which allows using the system-provided PySide6 runtime. Since PySide6 bindings are static and specific to one version of Qt, they need to be provided through the system package manager to use the system Qt runtime. This approach enables integration with system-provided themes.
+
+To use this option, you must also install the PySide6 system packages. The PySide6 system packages, with minimum distribution versions, may be found in the [system-pyside6 README](https://github.com/beeware/system-pyside6).

--- a/docs/en/snippets/qt-prerequisites.md
+++ b/docs/en/snippets/qt-prerequisites.md
@@ -60,3 +60,7 @@ You can use a Python version other than the system default by replacing `python3
 ### Other distributions
 
 If you're not using one of these, you'll need to work out how to install the developer libraries for `python3`, [Qt's X11 dependencies](https://doc.qt.io/qt-6/linux-requirements.html), [Qt's Wayland dependencies](https://doc.qt.io/qt-6/wayland-requirements.html), and the executable ``canberra-gtk-play`` (and please let us know so we can improve this documentation!)
+
+### Using System PySide6
+
+To integrate with system themes, you can use the system PySide6 runtime instead of installing PySide6 through pip. This requires installing PySide6 through your system package manager, which automatically installs Qt as a dependency. The available PySide6 system packages, along with minimum distribution versions, can be found in the [system-pyside6 README](https://github.com/beeware/system-pyside6).

--- a/qt/pyproject.toml
+++ b/qt/pyproject.toml
@@ -66,6 +66,9 @@ pyside6-essentials = [
 pyside6 = [
     "PySide6 == 6.10.2",
 ]
+system = [
+    "system-pyside6 == 0.1.0",
+]
 
 [tool.coverage.run]
 parallel = true


### PR DESCRIPTION
Fixes #3995

## Summary

This PR adds support for using the system PySide6 runtime with the Qt backend, enabling better integration with system-provided themes on Linux. This is achieved by adding a new `system` optional extra that installs the `system-pyside6` package instead of the regular PySide6 packages from PyPI.

## Changes

- **qt/pyproject.toml**: Added a `system` optional extra that installs `system-pyside6 == 0.1.0`
- **docs/en/reference/platforms/linux/qt.md**: Added a new "Using System Qt" section explaining how to use `toga-qt[system]` to integrate with system themes, including installation instructions and rationale
- **docs/en/snippets/qt-prerequisites.md**: Added a "Using System PySide6" section explaining that PySide6 can be installed through the system package manager to enable theme integration

## Testing

The changes have been verified to:
- Parse correctly in pyproject.toml format
- Render properly in markdown documentation
- Follow existing documentation structure and style

## Implementation Details

Since PySide6 bindings are static and specific to one version of Qt, they need to be provided through the system package manager to use the system Qt runtime. This approach enables applications built with Toga to:
- Use the system Qt runtime installed through the system package manager
- Integrate with system-provided themes (resolving the main issue)
- Match the look and feel of other native applications on the system

The system-pyside6 package (https://github.com/beeware/system-pyside6) provides the necessary integration layer.

## Diff Stats

```
 docs/en/reference/platforms/linux/qt.md | 12 ++++++++++++
 docs/en/snippets/qt-prerequisites.md    |  4 ++++
 qt/pyproject.toml                       |  3 +++
 3 files changed, 19 insertions(+)
```