### PR TITLE
Fix link to Textual's FAQ about macOS Terminal.app limitations

### DIFF
--- a/changes/4234.misc.md
+++ b/changes/4234.misc.md
@@ -1,0 +1,1 @@
+A link to Textual's docs was corrected.

--- a/docs/en/reference/platforms/terminal.md
+++ b/docs/en/reference/platforms/terminal.md
@@ -22,4 +22,4 @@ The `toga-textual` backend uses the [Textual API](https://textual.textualize.io)
 
 ### macOS Terminal.app limitations  { #macos-terminal.app-limitations }
 
-There are some [known issues with the default macOS Terminal.app](https://github.com/Textualize/textual/blob/main/docs/FAQ.md#why-doesnt-textual-look-good-on-macos). In some layouts, box outlines render badly; this can *sometimes* be resolved by altering the line spacing of the font used in the terminal. The default Terminal.app also has a limited color palette. The maintainers of Textual recommend using an alternative terminal application to avoid these problems.
+There are some [known issues with the default macOS Terminal.app](https://textual.textualize.io/FAQ/#why-doesnt-textual-look-good-on-macos). In some layouts, box outlines render badly; this can *sometimes* be resolved by altering the line spacing of the font used in the terminal. The default Terminal.app also has a limited color palette. The maintainers of Textual recommend using an alternative terminal application to avoid these problems.


### PR DESCRIPTION
I've fixed the link to the Textual FAQ because they now have their docs inside the `docs/` subfolder.
