### PR TITLE
Fix DetailedList focus ring on Cocoa

### DIFF
--- a/changes/4270.bugfix.md
+++ b/changes/4270.bugfix.md
@@ -1,0 +1,1 @@
+To better match native styling, the focus border on macOS DetailedList has been removed.

--- a/cocoa/src/toga_cocoa/libs/appkit.py
+++ b/cocoa/src/toga_cocoa/libs/appkit.py
@@ -359,6 +359,13 @@ NSBackingStoreRetained = 0
 NSBackingStoreNonretained = 1
 NSBackingStoreBuffered = 2
 
+
+class NSFocusRingType(IntEnum):
+    Default = 0
+    None_ = 1
+    Exterior = 2
+
+
 ######################################################################
 # NSGraphicsContext.h
 NSGraphicsContext = ObjCClass("NSGraphicsContext")

--- a/cocoa/src/toga_cocoa/widgets/detailedlist.py
+++ b/cocoa/src/toga_cocoa/widgets/detailedlist.py
@@ -2,6 +2,7 @@ from rubicon.objc import SEL, objc_method, objc_property
 from travertino.size import at_least
 
 from toga_cocoa.libs import (
+    NSFocusRingType,
     NSIndexSet,
     NSMenu,
     NSTableColumn,
@@ -144,6 +145,7 @@ class DetailedList(Widget):
         self.native_detailedlist.columnAutoresizingStyle = (
             NSTableViewColumnAutoresizingStyle.Uniform
         )
+        self.native_detailedlist.focusRingType = NSFocusRingType.None_
         self.native_detailedlist.allowsMultipleSelection = False
 
         # Disable all actions by default.


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

As discussed in Discord, the focus ring style has been set to None for Cocoa in order to better match native style.

Disclosure: ChatGPT was used to find the correct API but was not used to author any of the code.  (In fact ChatGPT blindly assumed a value of 0 meant nothing and wasted hours of debugging before I realized the None value was actually 1.)

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
