### PR TITLE
Optional accessors in Sources

### DIFF
--- a/changes/4221.feature.md
+++ b/changes/4221.feature.md
@@ -1,0 +1,1 @@
+ListSource and TreeSource now allow mapping-based data to be used without explicitly providing accessors.

--- a/core/src/toga/sources/list_source.py
+++ b/core/src/toga/sources/list_source.py
@@ -21,6 +21,7 @@ def _find_item(
     accessors: Sequence[str] | None,
     start: T | None,
     error: str,
+    value_type: str,
 ) -> T:
     """Find-by-value implementation helper; find an item matching `data` in
     `candidates`, starting with item `start`."""
@@ -30,7 +31,7 @@ def _find_item(
         start_index = 0
 
     if accessors is None and not isinstance(data, Mapping):
-        raise ValueError("Cannot search for non-mapping data without accessors")
+        raise ValueError(f"find() requires accessors for non-mapping {value_type} data")
 
     for item in candidates[start_index:]:
         try:
@@ -109,13 +110,14 @@ class ListSource(Source):
     _accessors: list[str] | None
 
     def __init__(
-        self, accessors: Iterable[str] | None = None, data: Iterable | None = None
+        self,
+        accessors: Iterable[str] | None = None,
+        data: Iterable | None = None,
     ):
         """A data source to store an ordered list of multiple data values.
 
-        :param accessors: A list of attribute names for accessing the value
-            in each column of the row. If omitted, only mapping row data can be
-            converted.
+        :param accessors: A list of attribute names for accessing the value in each
+            column of the row. If omitted, only row data must be specified as a mapping.
         :param data: The initial list of items in the source. Items are converted as
             shown [above][listsource-item].
         """
@@ -126,8 +128,7 @@ class ListSource(Source):
             raise ValueError("accessors should be a list of attribute names")
         else:
             # Copy the list of accessors
-            accessors = list(accessors)
-            self._accessors = accessors if len(accessors) > 0 else None
+            self._accessors = list(accessors)
 
         # Convert the data into row objects
         if data is not None:
@@ -270,6 +271,7 @@ class ListSource(Source):
                 accessors=self._accessors,
                 start=start,
                 error=f"No row matching {data!r} in data",
+                value_type="row",
             )
         except ValueError:
             if default is UNDEFINED:

--- a/core/src/toga/sources/list_source.py
+++ b/core/src/toga/sources/list_source.py
@@ -29,6 +29,9 @@ def _find_item(
     else:
         start_index = 0
 
+    if len(accessors) == 0 and not isinstance(data, Mapping):
+        raise ValueError("Cannot search for non-mapping data without accessors")
+
     for item in candidates[start_index:]:
         try:
             if isinstance(data, Mapping):
@@ -104,22 +107,25 @@ class Row(Generic[T]):
 class ListSource(Source):
     _data: list[Row]
 
-    def __init__(self, accessors: Iterable[str], data: Iterable | None = None):
+    def __init__(
+        self, accessors: Iterable[str] | None = None, data: Iterable | None = None
+    ):
         """A data source to store an ordered list of multiple data values.
 
         :param accessors: A list of attribute names for accessing the value
-            in each column of the row.
+            in each column of the row. If omitted, only mapping row data can be
+            converted.
         :param data: The initial list of items in the source. Items are converted as
             shown [above][listsource-item].
         """
         super().__init__()
-        if isinstance(accessors, str) or not hasattr(accessors, "__iter__"):
+        if accessors is None:
+            self._accessors = []
+        elif isinstance(accessors, str) or not hasattr(accessors, "__iter__"):
             raise ValueError("accessors should be a list of attribute names")
-
-        # Copy the list of accessors
-        self._accessors = list(accessors)
-        if len(self._accessors) == 0:
-            raise ValueError("ListSource must be provided a list of accessors")
+        else:
+            # Copy the list of accessors
+            self._accessors = list(accessors)
 
         # Convert the data into row objects
         if data is not None:
@@ -159,8 +165,12 @@ class ListSource(Source):
         if isinstance(data, Mapping):
             row = Row(**data)
         elif hasattr(data, "__iter__") and not isinstance(data, str):
+            if len(self._accessors) == 0:
+                raise ValueError("ListSource requires accessors for non-mapping row data")
             row = Row(**dict(zip(self._accessors, data, strict=False)))
         else:
+            if len(self._accessors) == 0:
+                raise ValueError("ListSource requires accessors for non-mapping row data")
             row = Row(**{self._accessors[0]: data})
         row._source = self
         return row

--- a/core/src/toga/sources/list_source.py
+++ b/core/src/toga/sources/list_source.py
@@ -166,11 +166,15 @@ class ListSource(Source):
             row = Row(**data)
         elif hasattr(data, "__iter__") and not isinstance(data, str):
             if len(self._accessors) == 0:
-                raise ValueError("ListSource requires accessors for non-mapping row data")
+                raise ValueError(
+                    "ListSource requires accessors for non-mapping row data"
+                )
             row = Row(**dict(zip(self._accessors, data, strict=False)))
         else:
             if len(self._accessors) == 0:
-                raise ValueError("ListSource requires accessors for non-mapping row data")
+                raise ValueError(
+                    "ListSource requires accessors for non-mapping row data"
+                )
             row = Row(**{self._accessors[0]: data})
         row._source = self
         return row

--- a/core/src/toga/sources/list_source.py
+++ b/core/src/toga/sources/list_source.py
@@ -18,7 +18,7 @@ A type describing any object adhering to the same interface as
 def _find_item(
     candidates: Sequence[T],
     data: object,
-    accessors: Sequence[str],
+    accessors: Sequence[str] | None,
     start: T | None,
     error: str,
 ) -> T:
@@ -29,7 +29,7 @@ def _find_item(
     else:
         start_index = 0
 
-    if len(accessors) == 0 and not isinstance(data, Mapping):
+    if accessors is None and not isinstance(data, Mapping):
         raise ValueError("Cannot search for non-mapping data without accessors")
 
     for item in candidates[start_index:]:
@@ -106,6 +106,7 @@ class Row(Generic[T]):
 
 class ListSource(Source):
     _data: list[Row]
+    _accessors: list[str] | None
 
     def __init__(
         self, accessors: Iterable[str] | None = None, data: Iterable | None = None
@@ -120,12 +121,13 @@ class ListSource(Source):
         """
         super().__init__()
         if accessors is None:
-            self._accessors = []
+            self._accessors = None
         elif isinstance(accessors, str) or not hasattr(accessors, "__iter__"):
             raise ValueError("accessors should be a list of attribute names")
         else:
             # Copy the list of accessors
-            self._accessors = list(accessors)
+            accessors = list(accessors)
+            self._accessors = accessors if len(accessors) > 0 else None
 
         # Convert the data into row objects
         if data is not None:
@@ -134,8 +136,10 @@ class ListSource(Source):
             self._data = []
 
     @property
-    def accessors(self) -> list[str]:
+    def accessors(self) -> list[str] | None:
         """The attribute names for accessing the value in each column of a row."""
+        if self._accessors is None:
+            return None
         return self._accessors.copy()
 
     ######################################################################
@@ -164,18 +168,13 @@ class ListSource(Source):
     def _create_row(self, data: object) -> Row:
         if isinstance(data, Mapping):
             row = Row(**data)
-        elif hasattr(data, "__iter__") and not isinstance(data, str):
-            if len(self._accessors) == 0:
-                raise ValueError(
-                    "ListSource requires accessors for non-mapping row data"
-                )
-            row = Row(**dict(zip(self._accessors, data, strict=False)))
+        elif self._accessors is not None:
+            if hasattr(data, "__iter__") and not isinstance(data, str):
+                row = Row(**dict(zip(self._accessors, data, strict=False)))
+            else:
+                row = Row(**{self._accessors[0]: data})
         else:
-            if len(self._accessors) == 0:
-                raise ValueError(
-                    "ListSource requires accessors for non-mapping row data"
-                )
-            row = Row(**{self._accessors[0]: data})
+            raise ValueError("ListSource requires accessors for non-mapping row data")
         row._source = self
         return row
 

--- a/core/src/toga/sources/tree_source.py
+++ b/core/src/toga/sources/tree_source.py
@@ -199,6 +199,7 @@ class Node(Row[T]):
             accessors=self._source._accessors,
             start=start,
             error=f"No child matching {data!r} in {self}",
+            value_type="node",
         )
 
 
@@ -207,7 +208,9 @@ class TreeSource(Source):
     _accessors: list[str] | None
 
     def __init__(
-        self, accessors: Iterable[str] | None = None, data: object | None = None
+        self,
+        accessors: Iterable[str] | None = None,
+        data: object | None = None,
     ):
         super().__init__()
         if accessors is None:
@@ -215,9 +218,8 @@ class TreeSource(Source):
         elif isinstance(accessors, str) or not hasattr(accessors, "__iter__"):
             raise ValueError("accessors should be a list of attribute names")
         else:
-            # Copy the list of accessors, in case of [] its None.
-            accessors = list(accessors)
-            self._accessors = accessors if len(accessors) > 0 else None
+            # Copy the list of accessors.
+            self._accessors = list(accessors)
 
         if data is not None:
             self._roots = self._create_nodes(parent=None, value=data)
@@ -404,4 +406,5 @@ class TreeSource(Source):
             accessors=self._accessors,
             start=start,
             error=f"No root node matching {data!r} in {self}",
+            value_type="node",
         )

--- a/core/src/toga/sources/tree_source.py
+++ b/core/src/toga/sources/tree_source.py
@@ -204,18 +204,20 @@ class Node(Row[T]):
 
 class TreeSource(Source):
     _roots: list[Node]
+    _accessors: list[str] | None
 
     def __init__(
         self, accessors: Iterable[str] | None = None, data: object | None = None
     ):
         super().__init__()
         if accessors is None:
-            self._accessors = []
+            self._accessors = None
         elif isinstance(accessors, str) or not hasattr(accessors, "__iter__"):
             raise ValueError("accessors should be a list of attribute names")
         else:
-            # Copy the list of accessors
-            self._accessors = list(accessors)
+            # Copy the list of accessors, in case of [] its None.
+            accessors = list(accessors)
+            self._accessors = accessors if len(accessors) > 0 else None
 
         if data is not None:
             self._roots = self._create_nodes(parent=None, value=data)
@@ -223,8 +225,10 @@ class TreeSource(Source):
             self._roots = []
 
     @property
-    def accessors(self) -> list[str]:
+    def accessors(self) -> list[str] | None:
         """The attribute names for accessing the value in each column of a row."""
+        if self._accessors is None:
+            return None
         return self._accessors.copy()
 
     ######################################################################
@@ -255,18 +259,13 @@ class TreeSource(Source):
     ) -> Node:
         if isinstance(data, Mapping):
             node = Node(**data)
-        elif hasattr(data, "__iter__") and not isinstance(data, str):
-            if len(self._accessors) == 0:
-                raise ValueError(
-                    "TreeSource requires accessors for non-mapping node data"
-                )
-            node = Node(**dict(zip(self._accessors, data, strict=False)))
+        elif self._accessors is not None:
+            if hasattr(data, "__iter__") and not isinstance(data, str):
+                node = Node(**dict(zip(self._accessors, data, strict=False)))
+            else:
+                node = Node(**{self._accessors[0]: data})
         else:
-            if len(self._accessors) == 0:
-                raise ValueError(
-                    "TreeSource requires accessors for non-mapping node data"
-                )
-            node = Node(**{self._accessors[0]: data})
+            raise ValueError("TreeSource requires accessors for non-mapping node data")
 
         node._parent = parent
         node._source = self

--- a/core/src/toga/sources/tree_source.py
+++ b/core/src/toga/sources/tree_source.py
@@ -205,15 +205,17 @@ class Node(Row[T]):
 class TreeSource(Source):
     _roots: list[Node]
 
-    def __init__(self, accessors: Iterable[str], data: object | None = None):
+    def __init__(
+        self, accessors: Iterable[str] | None = None, data: object | None = None
+    ):
         super().__init__()
-        if isinstance(accessors, str) or not hasattr(accessors, "__iter__"):
+        if accessors is None:
+            self._accessors = []
+        elif isinstance(accessors, str) or not hasattr(accessors, "__iter__"):
             raise ValueError("accessors should be a list of attribute names")
-
-        # Copy the list of accessors
-        self._accessors = list(accessors)
-        if len(self._accessors) == 0:
-            raise ValueError("TreeSource must be provided a list of accessors")
+        else:
+            # Copy the list of accessors
+            self._accessors = list(accessors)
 
         if data is not None:
             self._roots = self._create_nodes(parent=None, value=data)
@@ -254,8 +256,12 @@ class TreeSource(Source):
         if isinstance(data, Mapping):
             node = Node(**data)
         elif hasattr(data, "__iter__") and not isinstance(data, str):
+            if len(self._accessors) == 0:
+                raise ValueError("TreeSource requires accessors for non-mapping node data")
             node = Node(**dict(zip(self._accessors, data, strict=False)))
         else:
+            if len(self._accessors) == 0:
+                raise ValueError("TreeSource requires accessors for non-mapping node data")
             node = Node(**{self._accessors[0]: data})
 
         node._parent = parent

--- a/core/src/toga/sources/tree_source.py
+++ b/core/src/toga/sources/tree_source.py
@@ -257,11 +257,15 @@ class TreeSource(Source):
             node = Node(**data)
         elif hasattr(data, "__iter__") and not isinstance(data, str):
             if len(self._accessors) == 0:
-                raise ValueError("TreeSource requires accessors for non-mapping node data")
+                raise ValueError(
+                    "TreeSource requires accessors for non-mapping node data"
+                )
             node = Node(**dict(zip(self._accessors, data, strict=False)))
         else:
             if len(self._accessors) == 0:
-                raise ValueError("TreeSource requires accessors for non-mapping node data")
+                raise ValueError(
+                    "TreeSource requires accessors for non-mapping node data"
+                )
             node = Node(**{self._accessors[0]: data})
 
         node._parent = parent

--- a/core/tests/sources/test_list_source.py
+++ b/core/tests/sources/test_list_source.py
@@ -38,7 +38,7 @@ def test_accessors_optional_for_mapping_data():
     source = ListSource(data=[{"value": 1}], accessors=[])
 
     assert len(source) == 1
-    assert source.accessors == []
+    assert source.accessors is None
     assert source[0].value == 1
 
 
@@ -47,7 +47,7 @@ def test_accessors_omitted_for_mapping_data():
     source = ListSource(data=[{"value": 1}])
 
     assert len(source) == 1
-    assert source.accessors == []
+    assert source.accessors is None
     assert source[0].value == 1
 
 

--- a/core/tests/sources/test_list_source.py
+++ b/core/tests/sources/test_list_source.py
@@ -35,11 +35,20 @@ def test_invalid_accessors(value):
 
 def test_accessors_optional_for_mapping_data():
     """A list source can omit accessors if rows are mapping-based."""
-    source = ListSource(data=[{"value": 1}], accessors=[])
+    source = ListSource(data=[{"value": 1}])
 
     assert len(source) == 1
     assert source.accessors is None
     assert source[0].value == 1
+
+
+def test_empty_accessors_for_sequence_data():
+    """If there is an empty accessor list, rows have no attributes."""
+    source = ListSource(data=[[1, "a"], [2, "b"]], accessors=[])
+
+    assert len(source) == 2
+    assert source.accessors == []
+    assert not hasattr(source[0], "value")
 
 
 def test_accessors_omitted_for_mapping_data():
@@ -57,7 +66,7 @@ def test_non_mapping_data_requires_accessors():
         ValueError,
         match=r"ListSource requires accessors for non-mapping row data",
     ):
-        ListSource(accessors=[], data=[1, 2, 3])
+        ListSource(data=[1, 2, 3])
 
 
 def test_non_mapping_setitem_requires_accessors():
@@ -77,7 +86,7 @@ def test_non_mapping_find_requires_accessors():
 
     with pytest.raises(
         ValueError,
-        match=r"Cannot search for non-mapping data without accessors",
+        match=r"find\(\) requires accessors for non-mapping row data",
     ):
         source.find(1)
 

--- a/core/tests/sources/test_list_source.py
+++ b/core/tests/sources/test_list_source.py
@@ -20,7 +20,6 @@ def source():
 @pytest.mark.parametrize(
     "value",
     [
-        None,
         42,
         "not a list",
     ],
@@ -34,13 +33,53 @@ def test_invalid_accessors(value):
         ListSource(accessors=value)
 
 
-def test_accessors_required():
-    """A list source must specify *some* accessors."""
+def test_accessors_optional_for_mapping_data():
+    """A list source can omit accessors if rows are mapping-based."""
+    source = ListSource(data=[{"value": 1}], accessors=[])
+
+    assert len(source) == 1
+    assert source.accessors == []
+    assert source[0].value == 1
+
+
+def test_accessors_omitted_for_mapping_data():
+    """A list source defaults to no accessors when omitted."""
+    source = ListSource(data=[{"value": 1}])
+
+    assert len(source) == 1
+    assert source.accessors == []
+    assert source[0].value == 1
+
+
+def test_non_mapping_data_requires_accessors():
+    """A list source without accessors rejects non-mapping row data."""
     with pytest.raises(
         ValueError,
-        match=r"ListSource must be provided a list of accessors",
+        match=r"ListSource requires accessors for non-mapping row data",
     ):
         ListSource(accessors=[], data=[1, 2, 3])
+
+
+def test_non_mapping_setitem_requires_accessors():
+    """Setting non-mapping row data requires accessors."""
+    source = ListSource(data=[{"value": 1}])
+
+    with pytest.raises(
+        ValueError,
+        match=r"ListSource requires accessors for non-mapping row data",
+    ):
+        source[0] = ("new", 2)
+
+
+def test_non_mapping_find_requires_accessors():
+    """Finding non-mapping row data requires accessors."""
+    source = ListSource(data=[{"value": 1}])
+
+    with pytest.raises(
+        ValueError,
+        match=r"Cannot search for non-mapping data without accessors",
+    ):
+        source.find(1)
 
 
 def test_accessors_copied():

--- a/core/tests/sources/test_tree_source.py
+++ b/core/tests/sources/test_tree_source.py
@@ -87,7 +87,7 @@ def test_accessors_optional_for_mapping_data():
     )
 
     assert len(source) == 1
-    assert source.accessors == []
+    assert source.accessors is None
     assert source[0].value == "root"
     assert source[0][0].value == "child"
 
@@ -97,7 +97,7 @@ def test_accessors_omitted_for_mapping_data():
     source = TreeSource(data=[({"value": "root"}, None)])
 
     assert len(source) == 1
-    assert source.accessors == []
+    assert source.accessors is None
     assert source[0].value == "root"
 
 

--- a/core/tests/sources/test_tree_source.py
+++ b/core/tests/sources/test_tree_source.py
@@ -59,7 +59,6 @@ def source(listener):
 @pytest.mark.parametrize(
     "value",
     [
-        None,
         42,
         "not a list",
     ],
@@ -73,13 +72,64 @@ def test_invalid_accessors(value):
         TreeSource(accessors=value)
 
 
-def test_accessors_required():
-    """A list source must specify *some* accessors."""
+def test_accessors_optional_for_mapping_data():
+    """A tree source can omit accessors if node data is mapping-based."""
+    source = TreeSource(
+        accessors=[],
+        data=[
+            (
+                {"value": "root"},
+                [
+                    ({"value": "child"}, None),
+                ],
+            )
+        ],
+    )
+
+    assert len(source) == 1
+    assert source.accessors == []
+    assert source[0].value == "root"
+    assert source[0][0].value == "child"
+
+
+def test_accessors_omitted_for_mapping_data():
+    """A tree source defaults to no accessors when omitted."""
+    source = TreeSource(data=[({"value": "root"}, None)])
+
+    assert len(source) == 1
+    assert source.accessors == []
+    assert source[0].value == "root"
+
+
+def test_non_mapping_data_requires_accessors():
+    """A tree source without accessors rejects non-mapping node data."""
     with pytest.raises(
         ValueError,
-        match=r"TreeSource must be provided a list of accessors",
+        match=r"TreeSource requires accessors for non-mapping node data",
     ):
-        TreeSource(accessors=[], data=[1, 2, 3])
+        TreeSource(accessors=[], data=[(("root", 1), None)])
+
+
+def test_non_mapping_insert_requires_accessors():
+    """Inserting non-mapping node data requires accessors."""
+    source = TreeSource(data=[({"value": "root"}, None)])
+
+    with pytest.raises(
+        ValueError,
+        match=r"TreeSource requires accessors for non-mapping node data",
+    ):
+        source.insert(0, ("new", 2))
+
+
+def test_scalar_insert_requires_accessors():
+    """Inserting scalar node data requires accessors."""
+    source = TreeSource(data=[({"value": "root"}, None)])
+
+    with pytest.raises(
+        ValueError,
+        match=r"TreeSource requires accessors for non-mapping node data",
+    ):
+        source.insert(0, "new")
 
 
 def test_accessors_copied():

--- a/core/tests/sources/test_tree_source.py
+++ b/core/tests/sources/test_tree_source.py
@@ -75,7 +75,6 @@ def test_invalid_accessors(value):
 def test_accessors_optional_for_mapping_data():
     """A tree source can omit accessors if node data is mapping-based."""
     source = TreeSource(
-        accessors=[],
         data=[
             (
                 {"value": "root"},
@@ -90,6 +89,15 @@ def test_accessors_optional_for_mapping_data():
     assert source.accessors is None
     assert source[0].value == "root"
     assert source[0][0].value == "child"
+
+
+def test_empty_accessors_for_sequence_data():
+    """If there is an empty accessor list, rows have no attributes."""
+    source = TreeSource(accessors=[], data=[(("root", 1), None)])
+
+    assert len(source) == 1
+    assert source.accessors == []
+    assert not hasattr(source[0], "value")
 
 
 def test_accessors_omitted_for_mapping_data():
@@ -107,7 +115,7 @@ def test_non_mapping_data_requires_accessors():
         ValueError,
         match=r"TreeSource requires accessors for non-mapping node data",
     ):
-        TreeSource(accessors=[], data=[(("root", 1), None)])
+        TreeSource(data=[(("root", 1), None)])
 
 
 def test_non_mapping_insert_requires_accessors():
@@ -662,3 +670,22 @@ def test_find(source):
 
     # Find the child by a full match of values, starting at the first match
     assert source.find({"val1": "group1", "val2": 333}) == root2
+
+
+def test_non_mapping_find_requires_accessors():
+    """Finding non-mapping row data requires accessors."""
+    source = TreeSource(data=[({"value": "root"}, [({"value": "child"}, None)])])
+
+    # Find on a source
+    with pytest.raises(
+        ValueError,
+        match=r"find\(\) requires accessors for non-mapping node data",
+    ):
+        source.find(1)
+
+    # Find on a node
+    with pytest.raises(
+        ValueError,
+        match=r"find\(\) requires accessors for non-mapping node data",
+    ):
+        source[0].find(1)

--- a/docs/en/reference/api/data-representation/listsource.md
+++ b/docs/en/reference/api/data-representation/listsource.md
@@ -4,7 +4,7 @@
 
 Data sources are abstractions that allow you to define the data being managed by your application independent of the GUI representation of that data. For details on the use of data sources, see the [topic guide](/topics/data-sources.md).
 
-ListSource is an implementation of an ordered list of data. When a ListSource is created, it is given a list of `accessors` - these are the attributes that all items managed by the ListSource will have. If no accessors are provided, or an empty sequence is given, the source stores `None`. The API provided by ListSource is [`list`][]-like; the operations you'd expect on a normal Python list, such as `insert`, `remove`, `index`, and indexing with `[]`, are also possible on a ListSource:
+ListSource is an implementation of an ordered list of data. When a ListSource is created, it can be provided a list of `accessors` - these are the attributes that all items managed by the ListSource will have. The API provided by ListSource is [`list`][]-like; the operations you'd expect on a normal Python list, such as `insert`, `remove`, `index`, and indexing with `[]`, are also possible on a ListSource:
 
 ```python
 from toga.sources import ListSource
@@ -34,11 +34,13 @@ source.insert(0, {"name": "Bettong", "weight": 1.2})
 
 [](){ #listsource-item }
 
-The ListSource manages a list of [`Row`][toga.sources.Row] objects. Each Row has all the attributes described by the source's `accessors`. If accessors are omitted, or an empty sequence is provided, `accessors` will be `None`. A Row object will be constructed for each item that is added to the ListSource, and each item can be:
+The ListSource manages a list of [`Row`][toga.sources.Row] objects. Each Row has all the attributes described by the source's `accessors`. A Row object will be constructed for each item that is added to the ListSource, and each item can be:
 
-- A dictionary, with the accessors mapping to the keys in the dictionary.
-- Any other iterable object (except for a string), with the accessors being mapped onto the items in the iterable in order of definition.
+- A dictionary; or
+- Any other iterable object (except for a string), with the accessors being mapped onto the items in the iterable in order of definition; or
 - Any other object, which will be mapped onto the *first* accessor.
+
+If the ListSource was constructed *without* specifying accessors, item data *must* be in dictionary form.
 
 Although Toga provides ListSource, you are not required to create one directly. A ListSource will be transparently constructed if you provide an iterable object to a GUI widget that displays list-like data (i.e., [`toga.Table`][], [`toga.Selection`][], or [`toga.DetailedList`][]).
 

--- a/docs/en/reference/api/data-representation/listsource.md
+++ b/docs/en/reference/api/data-representation/listsource.md
@@ -4,7 +4,7 @@
 
 Data sources are abstractions that allow you to define the data being managed by your application independent of the GUI representation of that data. For details on the use of data sources, see the [topic guide](/topics/data-sources.md).
 
-ListSource is an implementation of an ordered list of data. When a ListSource is created, it is given a list of `accessors` - these are the attributes that all items managed by the ListSource will have. The API provided by ListSource is [`list`][]-like; the operations you'd expect on a normal Python list, such as `insert`, `remove`, `index`, and indexing with `[]`, are also possible on a ListSource:
+ListSource is an implementation of an ordered list of data. When a ListSource is created, it is given a list of `accessors` - these are the attributes that all items managed by the ListSource will have. If no accessors are provided, or an empty sequence is given, the source stores `None`. The API provided by ListSource is [`list`][]-like; the operations you'd expect on a normal Python list, such as `insert`, `remove`, `index`, and indexing with `[]`, are also possible on a ListSource:
 
 ```python
 from toga.sources import ListSource
@@ -34,7 +34,7 @@ source.insert(0, {"name": "Bettong", "weight": 1.2})
 
 [](){ #listsource-item }
 
-The ListSource manages a list of [`Row`][toga.sources.Row] objects. Each Row has all the attributes described by the source's `accessors`. A Row object will be constructed for each item that is added to the ListSource, and each item can be:
+The ListSource manages a list of [`Row`][toga.sources.Row] objects. Each Row has all the attributes described by the source's `accessors`. If accessors are omitted, or an empty sequence is provided, `accessors` will be `None`. A Row object will be constructed for each item that is added to the ListSource, and each item can be:
 
 - A dictionary, with the accessors mapping to the keys in the dictionary.
 - Any other iterable object (except for a string), with the accessors being mapped onto the items in the iterable in order of definition.

--- a/docs/en/reference/api/data-representation/treesource.md
+++ b/docs/en/reference/api/data-representation/treesource.md
@@ -4,7 +4,7 @@
 
 Data sources are abstractions that allow you to define the data being managed by your application independent of the GUI representation of that data. For details on the use of data sources, see the [topic guide](/topics/data-sources.md).
 
-TreeSource is an implementation of an ordered hierarchical tree of values. When a TreeSource is created, it is given a list of `accessors` - these are the attributes that all items managed by the TreeSource will have. The API provided by TreeSource is [`list`][]-like; the operations you'd expect on a normal Python list, such as `insert`, `remove`, `index`, and indexing with `[]`, are also possible on a TreeSource. These methods are available on the TreeSource itself to manipulate root nodes, and also on each node within the tree.
+TreeSource is an implementation of an ordered hierarchical tree of values. When a TreeSource is created, it is given a list of `accessors` - these are the attributes that all items managed by the TreeSource will have. If no accessors are provided, or an empty sequence is given, the source stores `None`. The API provided by TreeSource is [`list`][]-like; the operations you'd expect on a normal Python list, such as `insert`, `remove`, `index`, and indexing with `[]`, are also possible on a TreeSource. These methods are available on the TreeSource itself to manipulate root nodes, and also on each node within the tree.
 
 ```python
 from toga.sources import TreeSource
@@ -54,9 +54,9 @@ Each Node object in the TreeSource can have children; those children can in turn
 
 When creating a single Node for a TreeSource (e.g., when inserting a new item), the data for the Node can be specified as:
 
-- A dictionary, with the accessors mapping to the keys in the dictionary
-- Any iterable object (except for a string), with the accessors being mapped onto the items in the iterable in order of definition.
-- Any other object, which will be mapped onto the *first* accessor.
+- A dictionary, with the accessors mapping to the keys in the dictionary. If accessors are omitted, or an empty sequence is given, the keys are used directly and `accessors` will be `None`.
+- Any iterable object (except for a string), with the accessors being mapped onto the items in the iterable in order of definition. Accessors are required for this type of data.
+- Any other object, which will be mapped onto the *first* accessor. Accessors are required for this type of data.
 
 When constructing an entire TreeSource, the data can be specified as:
 

--- a/docs/en/reference/api/data-representation/treesource.md
+++ b/docs/en/reference/api/data-representation/treesource.md
@@ -4,7 +4,7 @@
 
 Data sources are abstractions that allow you to define the data being managed by your application independent of the GUI representation of that data. For details on the use of data sources, see the [topic guide](/topics/data-sources.md).
 
-TreeSource is an implementation of an ordered hierarchical tree of values. When a TreeSource is created, it is given a list of `accessors` - these are the attributes that all items managed by the TreeSource will have. If no accessors are provided, or an empty sequence is given, the source stores `None`. The API provided by TreeSource is [`list`][]-like; the operations you'd expect on a normal Python list, such as `insert`, `remove`, `index`, and indexing with `[]`, are also possible on a TreeSource. These methods are available on the TreeSource itself to manipulate root nodes, and also on each node within the tree.
+TreeSource is an implementation of an ordered hierarchical tree of values. When a TreeSource is created, it can be given a list of `accessors` - these are the attributes that all items managed by the TreeSource will have. The API provided by TreeSource is [`list`][]-like; the operations you'd expect on a normal Python list, such as `insert`, `remove`, `index`, and indexing with `[]`, are also possible on a TreeSource. These methods are available on the TreeSource itself to manipulate root nodes, and also on each node within the tree.
 
 ```python
 from toga.sources import TreeSource
@@ -54,15 +54,19 @@ Each Node object in the TreeSource can have children; those children can in turn
 
 When creating a single Node for a TreeSource (e.g., when inserting a new item), the data for the Node can be specified as:
 
-- A dictionary, with the accessors mapping to the keys in the dictionary. If accessors are omitted, or an empty sequence is given, the keys are used directly and `accessors` will be `None`.
-- Any iterable object (except for a string), with the accessors being mapped onto the items in the iterable in order of definition. Accessors are required for this type of data.
-- Any other object, which will be mapped onto the *first* accessor. Accessors are required for this type of data.
+- A dictionary; or
+- Any iterable object (except for a string), with the accessors being mapped onto the items in the iterable in order of definition; or
+- Any other object, which will be mapped onto the *first* accessor.
+
+If the TreeSource was constructed *without* specifying accessors, node data *must* be in dictionary form.
 
 When constructing an entire TreeSource, the data can be specified as:
 
 - A dictionary. The keys of the dictionary will be converted into Nodes, and used as parents; the values of the dictionary will become the children of their corresponding parent.
 - Any other iterable object (except a string). Each value in the iterable will be treated as a 2-item tuple, with the first item being data for the parent Node, and the second item being the child data.
 - Any other object will be converted into a single node with no children.
+
+If the TreeSource was constructed *without* specifying accessors, value data for each node *must* be in dictionary form.
 
 When specifying children, a value of [`None`][] for the children will result in the creation of a leaf node. Any other value will be processed recursively - so, a child specifier can itself be a dictionary, an iterable of 2-tuples, or data for a single child, and so on.
 


### PR DESCRIPTION
Fixes #4221

This PR updates ListSource and TreeSource so accessors are optional when the input data is mapping-based (for example, dictionaries). Previously, accessors were effectively required for all non-Row inputs, which made mapping-based usage more restrictive than necessary.

Changes:
* Accepts accessors as optional (None defaults to an empty accessor list).
* Preserves strict validation for non-mapping data, which still requires explicit accessors.
* Applies the same behavior in both list and tree sources.
* Add test for valid and invalid scenarios.

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
