### PR TITLE
Work around Cocoa multiline label layout bug.

### DIFF
--- a/changes/4315.bugfix.md
+++ b/changes/4315.bugfix.md
@@ -1,0 +1,1 @@
+Right-aligned, multi-line strings that contain an empty line are now correctly sized on macOS.

--- a/cocoa/src/toga_cocoa/widgets/label.py
+++ b/cocoa/src/toga_cocoa/widgets/label.py
@@ -1,7 +1,7 @@
 from travertino.size import at_least
 
 from toga_cocoa.colors import native_color
-from toga_cocoa.libs import NSTextAlignment, NSTextField
+from toga_cocoa.libs import NSLeftTextAlignment, NSTextAlignment, NSTextField
 
 from .base import Widget
 
@@ -34,8 +34,16 @@ class Label(Widget):
 
     def rehint(self):
         # Width & height of a label is known and fixed.
+
+        # 2026-04-08 A right-aligned multiline string that contains "\n\n" confuses
+        # Cocoa's layout algorithm. Temporarily switch to left alignment to perform the
+        # size measurement, then switch back to the original value. See #4315.
+        orig_alignment = self.native.alignment
+        self.native.alignment = NSLeftTextAlignment
         content_size = self.native.intrinsicContentSize()
         # print("REHINT label", self, content_size.width, content_size.height)
+        self.native.alignment = orig_alignment
+
         # 2020-05-11 The +1 is a hack; the label "X Translate:" gets truncated
         # without the extra pixel.
         self.interface.intrinsic.width = at_least(content_size.width + 1)

--- a/cocoa/src/toga_cocoa/widgets/label.py
+++ b/cocoa/src/toga_cocoa/widgets/label.py
@@ -35,16 +35,16 @@ class Label(Widget):
     def rehint(self):
         # Width & height of a label is known and fixed.
 
-        # 2026-04-08 A right-aligned multiline string that contains "\n\n" confuses
-        # Cocoa's layout algorithm. Temporarily switch to left alignment to perform the
-        # size measurement, then switch back to the original value. See #4315.
+        # A right-aligned multiline string that contains "\n\n" confuses Cocoa's layout
+        # algorithm. Temporarily switch to left alignment to perform the size
+        # measurement, then switch back to the original value. See #4315.
         orig_alignment = self.native.alignment
         self.native.alignment = NSLeftTextAlignment
         content_size = self.native.intrinsicContentSize()
         # print("REHINT label", self, content_size.width, content_size.height)
         self.native.alignment = orig_alignment
 
-        # 2020-05-11 The +1 is a hack; the label "X Translate:" gets truncated
-        # without the extra pixel.
+        # The +1 is a hack; the label "X Translate:" gets truncated without it.
+        # See comments on #891.
         self.interface.intrinsic.width = at_least(content_size.width + 1)
         self.interface.intrinsic.height = content_size.height

--- a/testbed/tests/widgets/test_label.py
+++ b/testbed/tests/widgets/test_label.py
@@ -1,4 +1,4 @@
-from pytest import approx, fixture
+import pytest
 
 import toga
 
@@ -20,7 +20,7 @@ from .properties import (  # noqa: F401
 )
 
 
-@fixture
+@pytest.fixture
 async def widget():
     return toga.Label("hello, this is a label")
 
@@ -28,11 +28,18 @@ async def widget():
 test_cleanup = build_cleanup_test(toga.Label, args=("hello, this is a label",))
 
 
-async def test_multiline(widget, probe):
+@pytest.mark.parametrize(
+    "alignment",
+    ["left", "right", "justify", "center"],
+)
+async def test_multiline(widget, probe, alignment):
     """If the label contains multiline text, it resizes vertically."""
+    # Bug #4315: check all alignments
+    widget.style.text_align = alignment
 
     def make_lines(n):
-        return "\n".join(f"This is line {i}" for i in range(n))
+        # Bug #4315: Ensure that at least one line is empty.
+        return "\n".join(("" if i == 3 else f"This is line {i}") for i in range(n))
 
     widget.text = make_lines(1)
     await probe.redraw("Label should be resized vertically")
@@ -50,14 +57,14 @@ async def test_multiline(widget, probe):
 
     widget.text = make_lines(2)
     await probe.redraw("Label text should be changed to 2 lines")
-    assert probe.height == approx(line_height * 2, rel=0.1)
+    assert probe.height == pytest.approx(line_height * 2, rel=0.1)
     line_spacing = probe.height - (line_height * 2)
 
     for n in range(3, 6):
         widget.text = make_lines(n)
         await probe.redraw(f"Label text should be changed to {n} lines")
         # Label height should reflect the number of lines
-        assert probe.height == approx(
+        assert probe.height == pytest.approx(
             (line_height * n) + (line_spacing * (n - 1)),
             rel=0.1,
         )

--- a/testbed/tests/widgets/test_label.py
+++ b/testbed/tests/widgets/test_label.py
@@ -38,8 +38,11 @@ async def test_multiline(widget, probe, alignment):
     widget.style.text_align = alignment
 
     def make_lines(n):
-        # Bug #4315: Ensure that at least one line is empty.
-        return "\n".join(("" if i == 3 else f"This is line {i}") for i in range(n))
+        # Bug #4315: Ensure that at least one line is empty. It can't be the *last*
+        # line, because that might be truncated in display calculations
+        return "\n".join(
+            ("" if i == 2 and n > 3 else f"This is line {i}") for i in range(n)
+        )
 
     widget.text = make_lines(1)
     await probe.redraw("Label should be resized vertically")


### PR DESCRIPTION
If a multi-line label contains an empty line, and the label is right aligned, Cocoa incorrectly evaluates the intrinsic width of the label as "-1" (or cannot compute). 

Work around this by temporarily switching text alignment to LEFT before computing intrinsic size.

Fixes #4315.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
