### PR TITLE
Fix broken numbered list in canvas tutorial

### DIFF
--- a/changes/4333.doc.md
+++ b/changes/4333.doc.md
@@ -1,0 +1,1 @@
+The step numbering on the canvas tutorial (tutorial 4) has been corrected so the two steps are numbered sequentially.

--- a/docs/en/tutorial/tutorial-4.md
+++ b/docs/en/tutorial/tutorial-4.md
@@ -4,7 +4,6 @@ One of the main capabilities needed to create many types of GUI applications is 
 
 Utilizing the Canvas is as easy as determining the drawing operations you want to perform and then creating a new Canvas. All drawing actions that are created with one of the drawing operations are returned so that they can be modified or removed.
 
-<!-- rumdl-disable MD013 -->
 1. We first define the drawing operations we want to perform in a new function:
 
     ```python
@@ -15,7 +14,6 @@ Utilizing the Canvas is as easy as determining the drawing operations you want t
     ```
 
     Notice that we also created and used a new fill state called `eye_whites`. The `with` keyword that is used for the fill operation causes everything draw using the state to be filled with a color. In this example we filled two circular eyes with the color white.
-<!-- rumdl-enable MD013 -->
 
 2. Next we create a new Canvas:
 

--- a/docs/en/tutorial/tutorial-4.md
+++ b/docs/en/tutorial/tutorial-4.md
@@ -8,9 +8,9 @@ Utilizing the Canvas is as easy as determining the drawing operations you want t
 
     ```python
     def draw_eyes(self):
-	    with self.canvas.Fill(color=WHITE) as eye_whites:
-		    eye_whites.arc(58, 92, 15)
-			    eye_whites.arc(88, 92, 15, math.pi, 3 * math.pi)
+     with self.canvas.Fill(color=WHITE) as eye_whites:
+      eye_whites.arc(58, 92, 15)
+       eye_whites.arc(88, 92, 15, math.pi, 3 * math.pi)
     ```
 
     Notice that we also created and used a new fill state called `eye_whites`. The `with` keyword that is used for the fill operation causes everything draw using the state to be filled with a color. In this example we filled two circular eyes with the color white.


### PR DESCRIPTION
## Summary

The canvas tutorial ([Tutorial 4](https://toga.beeware.org/en/latest/tutorial/tutorial-4/)) currently renders its two-step list as `1. ... 1.` instead of `1. ... 2.`:

![Image](https://github.com/user-attachments/assets/1e0cde3e-879c-478b-a22d-a6089b6ec741)

The cause is two standalone HTML comments between the list items:

```
<!-- rumdl-disable MD013 -->
1. We first define the drawing operations...
    ...
    Notice that we also created...
<!-- rumdl-enable MD013 -->

2. Next we create a new Canvas:
```

Because the enabling comment sits at column 0 between the two items, MkDocs treats it as a block separator, so the markup is parsed as two distinct ordered lists — both restarting at 1.

The comments are no-ops in practice: `MD013` is already effectively disabled project-wide via `line_length = 999999` in `[tool.rumdl.MD013]` (`pyproject.toml`), so there is nothing to disable on these lines. This PR removes both comments.

## Fixes

- Fixes #4333 — Tutorial 4: List broken

## Change note

- `changes/4333.doc.md`

## Test plan

- [ ] Run the docs build (`tox -e docs`) and confirm the rendered tutorial 4 numbers its steps `1.` and `2.` sequentially.
- [ ] Confirm no new rumdl lint warnings appear for `docs/en/tutorial/tutorial-4.md`.