### PR TITLE
Fix broken numbered list in canvas tutorial

### DIFF
--- a/changes/4333.doc.md
+++ b/changes/4333.doc.md
@@ -1,0 +1,1 @@
+The numbered list in the canvas tutorial now renders correctly as a single sequence.

--- a/docs/en/tutorial/tutorial-4.md
+++ b/docs/en/tutorial/tutorial-4.md
@@ -4,18 +4,16 @@ One of the main capabilities needed to create many types of GUI applications is 
 
 Utilizing the Canvas is as easy as determining the drawing operations you want to perform and then creating a new Canvas. All drawing actions that are created with one of the drawing operations are returned so that they can be modified or removed.
 
-<!-- rumdl-disable MD013 -->
 1. We first define the drawing operations we want to perform in a new function:
 
     ```python
     def draw_eyes(self):
-	    with self.canvas.Fill(color=WHITE) as eye_whites:
-		    eye_whites.arc(58, 92, 15)
-			    eye_whites.arc(88, 92, 15, math.pi, 3 * math.pi)
+        with self.canvas.Fill(color=WHITE) as eye_whites:
+            eye_whites.arc(58, 92, 15)
+                eye_whites.arc(88, 92, 15, math.pi, 3 * math.pi)
     ```
 
     Notice that we also created and used a new fill state called `eye_whites`. The `with` keyword that is used for the fill operation causes everything draw using the state to be filled with a color. In this example we filled two circular eyes with the color white.
-<!-- rumdl-enable MD013 -->
 
 2. Next we create a new Canvas:
 


### PR DESCRIPTION
Fixes #4333.

The numbered list in the canvas tutorial renders as `1. … 1.` because two standalone HTML comments (`<!-- rumdl-disable MD013 -->` / `<!-- rumdl-enable MD013 -->`) wrap the first code block and are treated as block separators by MkDocs, splitting the list in two.

The comments are no-ops: rumdl's MD013 is already disabled project-wide via `line_length = 999999` in `pyproject.toml`, so removing them cannot change the lint outcome.

The adjacent Python code block contained hard tabs that rumdl's MD010 pre-commit hook rejects. Each tab was replaced with four spaces — the width it expands to in the rendered output — so the block displays exactly as before and the hook now passes.

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct