### PR TITLE
Use a standalone testbed app for Textual.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -472,22 +472,22 @@ jobs:
           platform: "linux"
           runs-on: "ubuntu-latest"
           setup-python: false  # Use the system Python packages
-          briefcase-run-args: --config 'requires=["toga-core", "toga-textual"]' --config 'console_app=true'
-          app-user-data-path: "$HOME/.local/share/testbed"
+          testbed-app: "testbed-textual"
+          app-user-data-path: "$HOME/.local/share/testbed-textual"
           # install the meta-package build-essential since Briefcase explicitly checks for it
           pre-command: sudo apt update -y && sudo apt install -y build-essential
 
         - backend: "textual-macOS"
           platform: "macOS"
           runs-on: "macos-latest"
-          briefcase-run-args: --config 'requires=["toga-core", "toga-textual"]' --config 'console_app=true'
-          app-user-data-path: "$HOME/Library/Application Support/org.beeware.toga.testbed"
+          testbed-app: "testbed-textual"
+          app-user-data-path: "$HOME/Library/Application Support/org.beeware.toga.testbed-textual"
 
         - backend: "textual-windows"
           platform: "windows"
           runs-on: "windows-latest"
-          briefcase-run-args: --config 'requires=["toga-core", "toga-textual"]' --config 'console_app=true'
-          app-user-data-path: '$HOME\AppData\Local\Tiberius Yak\Toga Testbed\Data'
+          testbed-app: "testbed-textual"
+          app-user-data-path: '$HOME\AppData\Local\Tiberius Yak\Toga Testbed (Textual)\Data'
 
         - backend: "windows"
           platform: "windows"

--- a/changes/4341.misc.md
+++ b/changes/4341.misc.md
@@ -1,0 +1,1 @@
+A separate testbed app was added for Textual.

--- a/testbed/pyproject.toml
+++ b/testbed/pyproject.toml
@@ -159,3 +159,22 @@ requires = [
     # Android identifies as Linux, and psutil isn't available for Android.
     "psutil==7.2.2 ; python_version < '3.13'",
 ]
+
+[tool.briefcase.app.testbed-textual]
+formal_name = "Toga Testbed (Textual)"
+console_app = true
+
+requires = [
+    "../travertino",
+    "../core",
+    "../textual",
+]
+
+sources = [
+    "src/testbed_textual",
+    "src/testbed",
+]
+
+test_sources = [
+    # "../textual/tests_backend",
+]

--- a/testbed/src/testbed_textual/__main__.py
+++ b/testbed/src/testbed_textual/__main__.py
@@ -1,0 +1,4 @@
+from testbed.app import main
+
+if __name__ == "__main__":
+    main("testbed-textual").main_loop()

--- a/testbed/tests/testbed_textual.py
+++ b/testbed/tests/testbed_textual.py
@@ -1,0 +1,4 @@
+from .testbed import main
+
+if __name__ == "__main__":
+    main("testbed-textual", backend_override="toga_textual")


### PR DESCRIPTION
When we added a standalone testbed app for Qt, we missed an opportunity to do a similar refactoring for Textual.

This introduces a test app for the Textual backend, allowing us to simplify the CI configuration and provide a consistent interface for Textual testing.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
