### PR TITLE
Add project-specific links for documentation to CONTRIBUTING.md.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ We require that all new code is exercised by automated tests. Our contribution g
 
 ### Documentation
 
-We require that all new features have full user documentation. We have a [documentation style guide](https://beeware.org/contributing/guide/style/docs-style-guide/) that all documentation should follow. Our contribution guide has details on [how to build and preview project documentation](https://beeware.org/contributing/guide/how/build-docs/).
+We require that all new features have full user documentation. We have a [documentation style guide](https://toga.beeware.org/en/latest/how-to/contribute/style/docs-style-guide/) that all documentation should follow. Our contribution guide has details on [how to build and preview project documentation](https://toga.beeware.org/en/latest/how-to/contribute/how/build-docs/).
 
 ### Pull Requests
 

--- a/changes/4345.misc.md
+++ b/changes/4345.misc.md
@@ -1,0 +1,1 @@
+Some links in CONTRIBUTING.md were updated.


### PR DESCRIPTION
Modified CONTRIBUTING.md to point at Briefcase contribution docs for documentation.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
<!-- update or delete the next line to reflect your usage -->
Assisted-by: <!--name of tool; e.g., Claude Opus 4.5-->
