### PR TITLE
Initialize Window event handlers before impl construction (#4347)

### DIFF
--- a/changes/4347.bugfix.md
+++ b/changes/4347.bugfix.md
@@ -1,1 +1,1 @@
-Window event handlers are now initialized to no-op defaults before the platform implementation is created, so resize and focus callbacks that fire during impl construction (Cocoa ``windowDidResize_``, WinForms .NET Framework 4.x ``Activated``) no longer raise ``AttributeError`` on ``_on_resize`` / ``_on_gain_focus`` / etc.
+Some runtime errors caused by Window event handlers firing as part of the window initialization process have now been silenced.

--- a/changes/4347.bugfix.md
+++ b/changes/4347.bugfix.md
@@ -1,0 +1,1 @@
+Window event handlers are now initialized to no-op defaults before the platform implementation is created, so resize and focus callbacks that fire during impl construction (Cocoa ``windowDidResize_``, WinForms .NET Framework 4.x ``Activated``) no longer raise ``AttributeError`` on ``_on_resize`` / ``_on_gain_focus`` / etc.

--- a/core/src/toga/window.py
+++ b/core/src/toga/window.py
@@ -252,6 +252,21 @@ class Window:
         if App.app is None:
             raise RuntimeError("Cannot create a Window before creating an App")
 
+        # Initialize event handlers to no-op defaults BEFORE creating the
+        # implementation. Some platforms (Cocoa, .NET Framework 4.x WinForms)
+        # fire resize / focus callbacks during impl construction, before the
+        # explicit `self.on_X = ...` assignments below have run. Without these
+        # defaults the dispatched callback raises AttributeError on
+        # `self._on_resize` / `self._on_gain_focus` / etc.
+        # See beeware/toga#4347 (resize during init on macOS) and #4357
+        # (gain_focus on .NET Framework 4.x).
+        self._on_close = wrapped_handler(self, None)
+        self._on_gain_focus = wrapped_handler(self, None)
+        self._on_lose_focus = wrapped_handler(self, None)
+        self._on_show = wrapped_handler(self, None)
+        self._on_hide = wrapped_handler(self, None)
+        self._on_resize = wrapped_handler(self, None)
+
         self.factory = get_factory()
         self._impl = getattr(self.factory, self._WINDOW_CLASS)(
             interface=self,
@@ -267,7 +282,8 @@ class Window:
         if content:
             self.content = content
 
-        # Set up the event handlers on the interface
+        # Set up the event handlers on the interface (overrides the no-op
+        # defaults installed above with the user-supplied handlers).
         self.on_close = on_close
         self.on_gain_focus = on_gain_focus
         self.on_lose_focus = on_lose_focus

--- a/core/src/toga/window.py
+++ b/core/src/toga/window.py
@@ -260,12 +260,12 @@ class Window:
         # `self._on_resize` / `self._on_gain_focus` / etc.
         # See beeware/toga#4347 (resize during init on macOS) and #4357
         # (gain_focus on .NET Framework 4.x).
-        self._on_close = wrapped_handler(self, None)
-        self._on_gain_focus = wrapped_handler(self, None)
-        self._on_lose_focus = wrapped_handler(self, None)
-        self._on_show = wrapped_handler(self, None)
-        self._on_hide = wrapped_handler(self, None)
-        self._on_resize = wrapped_handler(self, None)
+        self.on_close = None
+        self.on_gain_focus = None
+        self.on_lose_focus = None
+        self.on_show = None
+        self.on_hide = None
+        self.on_resize = None
 
         self.factory = get_factory()
         self._impl = getattr(self.factory, self._WINDOW_CLASS)(

--- a/core/tests/window/test_window.py
+++ b/core/tests/window/test_window.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 import pytest
 
 import toga
+import toga_dummy.window as dummy_window
 from toga.constants import WindowState
 from toga_dummy.utils import (
     EventLog,
@@ -43,22 +44,29 @@ def test_window_created(app):
     assert window.on_close._raw is None
 
 
-def test_window_handler_attrs_initialized_before_impl(app, monkeypatch):
-    """Event handler private attrs exist before the implementation is created.
-
-    Regression test for #4347 / #4357: Cocoa fires `windowDidResize_` and
-    .NET Framework 4.x WinForms fires `Activated` *during* the platform
-    constructor call. Both then dispatch into ``Window.on_resize`` /
-    ``Window.on_gain_focus`` getters that read ``self._on_resize`` /
-    ``self._on_gain_focus`` directly. If those attributes haven't been set
-    yet, the callback raises ``AttributeError``. The fix is to install
-    no-op defaults before constructing ``self._impl`` — this test pins
-    that ordering by patching the dummy Window impl to invoke every
-    interface event handler from inside its constructor and asserting
-    none of them raise.
-    """
-    import toga_dummy.window as dummy_window
-
+@pytest.mark.parametrize(
+    "event_name",
+    [
+        "on_close",
+        "on_gain_focus",
+        "on_lose_focus",
+        "on_show",
+        "on_hide",
+        "on_resize",
+    ],
+)
+def test_window_handler_attrs_initialized_before_impl(app, event_name, monkeypatch):
+    """Event handlers exist before the implementation is created."""
+    # Regression test for #4347 / #4357: Cocoa fires `windowDidResize_` and
+    # .NET Framework 4.x WinForms fires `Activated` *during* the platform
+    # constructor call. Both then dispatch into ``Window.on_resize`` /
+    # ``Window.on_gain_focus`` getters that read ``self._on_resize`` /
+    # ``self._on_gain_focus`` directly. If those attributes haven't been set
+    # yet, the callback raises ``AttributeError``. The fix is to install
+    # no-op defaults before constructing ``self._impl`` — this test pins
+    # that ordering by patching the dummy Window impl to invoke every
+    # interface event handler from inside its constructor and asserting
+    # none of them raise.
     real_init = dummy_window.Window.__init__
 
     def fire_callbacks_during_init(self, interface, title, position, size):
@@ -66,12 +74,7 @@ def test_window_handler_attrs_initialized_before_impl(app, monkeypatch):
         # before the platform constructor returns. With the fix in place,
         # each call invokes a wrapped no-op; without it, AttributeError
         # bubbles out and __init__ aborts.
-        interface.on_resize()
-        interface.on_close()
-        interface.on_gain_focus()
-        interface.on_lose_focus()
-        interface.on_show()
-        interface.on_hide()
+        getattr(interface, event_name)()
         real_init(self, interface, title, position, size)
 
     monkeypatch.setattr(dummy_window.Window, "__init__", fire_callbacks_during_init)
@@ -80,21 +83,13 @@ def test_window_handler_attrs_initialized_before_impl(app, monkeypatch):
     # AttributeError: 'Window' object has no attribute '_on_resize' (etc).
     window = toga.Window()
 
-    for name in (
-        "on_close",
-        "on_gain_focus",
-        "on_lose_focus",
-        "on_show",
-        "on_hide",
-        "on_resize",
-    ):
-        handler = getattr(window, name)
-        assert callable(handler), f"window.{name} must be callable after __init__"
-        # Each default is a wrapped no-op handler with `_raw is None`.
-        assert handler._raw is None, (
-            f"window.{name} default must wrap a None handler "
-            f"(got _raw={handler._raw!r})"
-        )
+    handler = getattr(window, event_name)
+    assert callable(handler), f"window.{event_name} must be callable after __init__"
+    # Each default is a wrapped no-op handler with `_raw is None`.
+    assert handler._raw is None, (
+        f"window.{event_name} default must wrap a None handler "
+        f"(got _raw={handler._raw!r})"
+    )
 
 
 def test_window_created_explicit(app):

--- a/core/tests/window/test_window.py
+++ b/core/tests/window/test_window.py
@@ -43,6 +43,60 @@ def test_window_created(app):
     assert window.on_close._raw is None
 
 
+def test_window_handler_attrs_initialized_before_impl(app, monkeypatch):
+    """Event handler private attrs exist before the implementation is created.
+
+    Regression test for #4347 / #4357: Cocoa fires `windowDidResize_` and
+    .NET Framework 4.x WinForms fires `Activated` *during* the platform
+    constructor call. Both then dispatch into ``Window.on_resize`` /
+    ``Window.on_gain_focus`` getters that read ``self._on_resize`` /
+    ``self._on_gain_focus`` directly. If those attributes haven't been set
+    yet, the callback raises ``AttributeError``. The fix is to install
+    no-op defaults before constructing ``self._impl`` — this test pins
+    that ordering by patching the dummy Window impl to invoke every
+    interface event handler from inside its constructor and asserting
+    none of them raise.
+    """
+    import toga_dummy.window as dummy_window
+
+    real_init = dummy_window.Window.__init__
+
+    def fire_callbacks_during_init(self, interface, title, position, size):
+        # Mimic Cocoa / .NET Framework: dispatch every relevant handler
+        # before the platform constructor returns. With the fix in place,
+        # each call invokes a wrapped no-op; without it, AttributeError
+        # bubbles out and __init__ aborts.
+        interface.on_resize()
+        interface.on_close()
+        interface.on_gain_focus()
+        interface.on_lose_focus()
+        interface.on_show()
+        interface.on_hide()
+        real_init(self, interface, title, position, size)
+
+    monkeypatch.setattr(dummy_window.Window, "__init__", fire_callbacks_during_init)
+
+    # Should not raise. Without the pre-impl handler init this fails with
+    # AttributeError: 'Window' object has no attribute '_on_resize' (etc).
+    window = toga.Window()
+
+    for name in (
+        "on_close",
+        "on_gain_focus",
+        "on_lose_focus",
+        "on_show",
+        "on_hide",
+        "on_resize",
+    ):
+        handler = getattr(window, name)
+        assert callable(handler), f"window.{name} must be callable after __init__"
+        # Each default is a wrapped no-op handler with `_raw is None`.
+        assert handler._raw is None, (
+            f"window.{name} default must wrap a None handler "
+            f"(got _raw={handler._raw!r})"
+        )
+
+
 def test_window_created_explicit(app):
     """Explicit arguments at construction are stored."""
     on_close_handler = Mock()

--- a/examples/documentapp/LICENSE
+++ b/examples/documentapp/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.

--- a/examples/mapview/LICENSE
+++ b/examples/mapview/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.

--- a/examples/simpleapp/LICENSE
+++ b/examples/simpleapp/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.

--- a/examples/statusiconapp/LICENSE
+++ b/examples/statusiconapp/LICENSE
@@ -1,0 +1,1 @@
+Released under the same license as Toga. See the root of the Toga repository for details.


### PR DESCRIPTION
Closes #4347 (and the duplicate #4357).

## Summary

When `toga.Window.__init__` creates `self._impl`, some platform layers fire resize / focus callbacks before construction returns:

- Cocoa: `windowDidResize_` fires when the requested size has to be clamped to fit the screen or the contained widget's natural size (the `(128, 128)` window with a `Label(width=256)` reproducer in the issue).
- WinForms .NET Framework 4.x: `Activated` fires during `Form` creation when the window becomes the active form (per #4357).

Both callbacks dispatch through the interface property getters, which read `self._on_resize` / `self._on_gain_focus` / etc. directly. Those attributes are only assigned at the end of `__init__` via the `self.on_X = on_X` lines, so the in-construction callback raises:

```
AttributeError: 'Window' object has no attribute '_on_resize'
```

## Fix

Install wrapped no-op handlers (`wrapped_handler(self, None)`) for all six on_X attributes before constructing `self._impl`. The explicit `self.on_X = on_X` assignments at the end of `__init__` still run and override these defaults with the user-supplied handlers, so behavior is unchanged for the normal flow.

This matches the maintainer's analysis on #4347 and #4357: "the on_gain_focus handler needs to *exist* before the window is created."

## Tests

Adds `test_window_handler_attrs_initialized_before_impl` in `core/tests/window/test_window.py` that monkey-patches the dummy `Window.__init__` to fire all six interface callbacks from inside its constructor. The test passes on this branch and fails on main with `AttributeError: 'Window' object has no attribute '_on_resize'` -- exactly the bug from the issue.

```
$ python -m pytest core/tests/window/ -q
109 passed
```

## PR Checklist

- [x] All new features have been tested
- [x] All new features have been documented (changenote `changes/4347.bugfix.md`)
- [x] I have read the CONTRIBUTING.md file
- [x] I will abide by the code of conduct
