### PR TITLE
Disable launchpad.net link checking

### DIFF
--- a/changes/4364.misc.md
+++ b/changes/4364.misc.md
@@ -1,0 +1,1 @@
+Link checking for launchpad.net has been temporarily disabled.

--- a/tox.ini
+++ b/tox.ini
@@ -108,7 +108,9 @@ deps =
 commands =
     !lint-!all-!live-!en : build_md_translations {posargs} en --source-code=core{/}src --source-code=travertino{/}src --source-code=android{/}src
     lint : pyspelling
-    lint : markdown-checker --dir {[docs]docs_dir} --func check_broken_urls
+    # 3-3-2026: launchpad.net seems to be affected by the Ubuntu web outage. Temporarily
+    # disabling link checking for it.
+    lint : markdown-checker --dir {[docs]docs_dir} --func check_broken_urls --skip-domains=launchpad.net
     live : live_serve_en {posargs} core{/}src --port=8038 --source-code=core{/}src --source-code=travertino{/}src --source-code=android{/}src
     all : build_md_translations {posargs} en --source-code=core{/}src --source-code=travertino{/}src --source-code=android{/}src
     en : build_md_translations {posargs} en --source-code=core{/}src --source-code=travertino{/}src --source-code=android{/}src


### PR DESCRIPTION
Fixes #4364

With [Ubuntu web sites down](https://arstechnica.com/security/2026/05/ubuntu-infrastructure-has-been-down-for-more-than-a-day/), launchpad.net seems to be affected. This temporarily disables link checking for the domain.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
<!-- update or delete the next line to reflect your usage -->

