### PR TITLE
Fix an important, functional mistype in Cocoa backend

### DIFF
--- a/changes/4370.misc.md
+++ b/changes/4370.misc.md
@@ -1,0 +1,1 @@
+A mistype in Cocoa is fixed.

--- a/cocoa/src/toga_cocoa/widgets/scrollcontainer.py
+++ b/cocoa/src/toga_cocoa/widgets/scrollcontainer.py
@@ -37,7 +37,7 @@ class TogaScrollView(NSScrollView):
     # This cannot be covered in CI because the function used to emit
     # a scrolling event is unreliable.
     @objc_method
-    def wantsForwardedScrollEventsForAxis_(self, axis: int) -> None:  # pragma: no cover
+    def wantsForwardedScrollEventsForAxis_(self, axis: int) -> bool:  # pragma: no cover
         return True
 
 


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

Like the title says.  This issue invalidates the fix in #4034, and this PR corrects the oversight.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
<!-- update or delete the next line to reflect your usage -->
Assisted-by: <!--name of tool; e.g., Claude Opus 4.5-->
