### PR TITLE
Improve handling for null values on GTK mapviews.

### DIFF
--- a/changes/4378.bugfix.md
+++ b/changes/4378.bugfix.md
@@ -1,0 +1,1 @@
+The handling of null return values on GTK `MapView` widgets has been corrected.

--- a/gtk/src/toga_gtk/widgets/mapview.py
+++ b/gtk/src/toga_gtk/widgets/mapview.py
@@ -122,18 +122,25 @@ class MapView(Widget):
                 value = webview.evaluate_javascript_finish(result)
                 if value.is_number():
                     value = value.to_double()
+                elif value.is_object():
+                    # JSON is as good a representation as any for an object.
+                    # The only usage we see in this widget is "None".
+                    value = value.to_json(0)
                 else:
+                    # Convert all other values to a string
                     value = value.to_string()
                     if value.startswith("LatLng("):
                         value = LatLng(*tuple(float(v) for v in value[7:-1].split(",")))
 
                 future.set_result(value)
             except Exception as e:
-                if e.code == WebKit2.JavascriptError.INVALID_RESULT:
-                    # The object returned can't be parsed; it's probably a
-                    # Javascript Object.
+                if e.code == WebKit2.JavascriptError.INVALID_RESULT:  # pragma: no cover
+                    # The object returned can't be parsed. We can't do anything
+                    # with that object, so return None. This used to happen on
+                    # older versions of WebKit, but doesn't any more in CI, so
+                    # the branch is marked no-cover.
                     future.set_result(None)
-                else:  # pragma: no cover
+                else:
                     exc = RuntimeError(str(e))
                     future.set_exception(exc)
 


### PR DESCRIPTION
Fixes #4378.

Evidently something has changed recently in the handling of Javascript `None` values in GTK's WebView2 implementation. Leaflet hasn't changed; I can only assume it's a minor change in WebKit2 versions.

Previously, None values were thrown as an "invalid result"; they're now being returned as "object". This doesn't change any operation of the MapView itself (as they're none values - we weren't using them) - but it does impact coverage, as the "none" values are now turned into `"[object Object]"` strings.

It also turns out we *are* exercising the "runtime error" branch now, due to the window reset triggering a "request for an infinite number of tiles", which is a [known failure mode of Leaflet 1.9.4](https://github.com/Leaflet/Leaflet/issues/7030). 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
