### PR TITLE
Bump rumdl-pre-commit from v0.1.87 to v0.1.91

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
       additional_dependencies: ['.[toml]']
       args: ["--skip=CODE_OF_CONDUCT.md"]
   - repo: https://github.com/rvben/rumdl-pre-commit
-    rev: v0.1.87
+    rev: v0.1.91
     hooks:
       - id: rumdl
       - id: rumdl-fmt

--- a/changes/4387.misc.md
+++ b/changes/4387.misc.md
@@ -1,0 +1,1 @@
+The `pre-commit` hook for `rumdl-pre-commit` was updated to its latest version.


### PR DESCRIPTION
Bumps `pre-commit` hook for `rumdl-pre-commit` from v0.1.87 to v0.1.91 and ran the update against the repo.