### PR TITLE
Add spec-kit files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,11 @@ mprofile_*.dat
 .specify/extensions.yml
 .specify/extensions
 .specify/init-options.json
+.specify/feature.json
+.github/copilot-instructions.md
+.github/agents/
+.github/prompts/
+specs/
 .specify/integration.json
 .specify/integrations
 .specify/workflows

--- a/.gitignore
+++ b/.gitignore
@@ -42,18 +42,18 @@ mprofile_*.dat
 .briefcase
 
 # AI tooling (SpecKit v0.8.0)
-.opencode/
-.specify/scripts
-.specify/templates
-.specify/extensions.yml
-.specify/extensions
-.specify/init-options.json
-.specify/feature.json
-.github/copilot-instructions.md
 .github/agents/
+.github/copilot-instructions.md
 .github/prompts/
-specs/
+.opencode/
+.specify/extensions
+.specify/extensions.yml
+.specify/feature.json
+.specify/init-options.json
 .specify/integration.json
 .specify/integrations
-.specify/workflows
+.specify/scripts
+.specify/templates
 .specify/workflow.yml
+.specify/workflows
+specs/

--- a/changes/4388.misc.md
+++ b/changes/4388.misc.md
@@ -1,0 +1,1 @@
+SpecKit and GitHub Copilot generated files are now ignored by Git.


### PR DESCRIPTION
Add SpecKit and GitHub Copilot generated files/directories to `.gitignore`, so local AI-tooling outputs do not show up as untracked project files.

Fixes #4388

## PR Checklist:
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool

Assisted-by: OpenAI Codex