### PR TITLE
Update links and link checker.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ If you'd like to contribute to Toga, our [contribution guide](https://toga.beewa
 
 ### Code of Conduct
 
-BeeWare operates under a [Code of Conduct](https://beeware.org/community/behavior/code-of-conduct/). All participation the BeeWare community is governed by this code.
+BeeWare operates under a [Code of Conduct](https://beeware.org/community/code-of-conduct/). All participation the BeeWare community is governed by this code.
 
 ### AI contributions
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The BeeWare project would not be possible without the generous support of our fi
 
 Anaconda Inc. - Advancing AI through open source.
 
-Plus individual contributions from [users like you](https://beeware.org/community/members/). If you find Toga, or other BeeWare tools useful, please consider becoming a financial member.
+Plus individual contributions from [users like you](https://beeware.org/membership/). If you find Toga, or other BeeWare tools useful, please consider becoming a financial member.
 
 ## Community
 
@@ -48,9 +48,9 @@ Toga is part of the [BeeWare suite](https://beeware.org). You can talk to the co
 
 - [@beeware@fosstodon.org on Mastodon](https://fosstodon.org/@beeware)
 - [Discord](https://beeware.org/bee/chat/)
-- The Toga [GitHub Discussions forum](https://github.com/beeware/toga/discussions)
+- The Toga [GitHub Discussions forum](https://github.com/beeware/toga/discussions/)
 
-We foster a welcoming and respectful community as described in our [BeeWare Community Code of Conduct](https://beeware.org/community/behavior/).
+We foster a welcoming and respectful community as described in our [BeeWare Community Code of Conduct](https://beeware.org/community/code-of-conduct/).
 
 ## Contributing
 

--- a/android/CONTRIBUTING.md
+++ b/android/CONTRIBUTING.md
@@ -2,6 +2,6 @@
 
 BeeWare <3's contributions!
 
-Please be aware that BeeWare operates under a [Code of Conduct](https://beeware.org/community/behavior/code-of-conduct/).
+Please be aware that BeeWare operates under a [Code of Conduct](https://beeware.org/community/code-of-conduct/).
 
 If you'd like to contribute to Toga development, our [contribution guide](https://toga.beeware.org/en/latest/how-to/contribute/) details how to set up a development environment, and other requirements we have as part of our contribution process.

--- a/android/README.md
+++ b/android/README.md
@@ -2,7 +2,7 @@
 
 <!-- rumdl-disable MD013 -->
 [![Python Versions](https://img.shields.io/pypi/pyversions/toga-android.svg)](https://pypi.python.org/pypi/toga-android)
-[![BSD-3-Clause License](https://img.shields.io/pypi/l/toga-android.svg)](https://github.com/beeware/toga-android/blob/main/LICENSE)
+[![BSD-3-Clause License](https://img.shields.io/pypi/l/toga-android.svg)](https://github.com/beeware/toga/blob/main/android/LICENSE)
 [![Project status](https://img.shields.io/pypi/status/toga-android.svg)](https://pypi.python.org/pypi/toga-android)
 <!-- rumdl-enable MD013 -->
 
@@ -20,12 +20,12 @@ Toga is part of the [BeeWare suite](https://beeware.org). You can talk to the co
 
 - [@beeware@fosstodon.org on Mastodon](https://fosstodon.org/@beeware)
 - [Discord](https://beeware.org/bee/chat/)
-- The Toga [GitHub Discussions forum](https://github.com/beeware/toga/discussions)
+- The Toga [GitHub Discussions forum](https://github.com/beeware/toga/discussions/)
 
-We foster a welcoming and respectful community as described in our [BeeWare Community Code of Conduct](https://beeware.org/community/behavior/).
+We foster a welcoming and respectful community as described in our [BeeWare Community Code of Conduct](https://beeware.org/community/code-of-conduct/).
 
 ## Contributing
 
-If you experience problems with Toga, [log them on GitHub](https://github.com/beeware/toga/issues).
+If you experience problems with Toga, [log them on GitHub](https://github.com/beeware/toga/issues/).
 
 If you'd like to contribute to Toga development, our [contribution guide](https://toga.beeware.org/en/latest/how-to/contribute/) details how to set up a development environment, and other requirements we have as part of our contribution process.

--- a/changes/4391.misc.md
+++ b/changes/4391.misc.md
@@ -1,0 +1,1 @@
+Some old and stale links were updated.

--- a/cocoa/CONTRIBUTING.md
+++ b/cocoa/CONTRIBUTING.md
@@ -2,6 +2,6 @@
 
 BeeWare <3's contributions!
 
-Please be aware that BeeWare operates under a [Code of Conduct](https://beeware.org/community/behavior/code-of-conduct/).
+Please be aware that BeeWare operates under a [Code of Conduct](https://beeware.org/community/code-of-conduct/).
 
 If you'd like to contribute to Toga development, our [contribution guide](https://toga.beeware.org/en/latest/how-to/contribute/) details how to set up a development environment, and other requirements we have as part of our contribution process.

--- a/cocoa/README.md
+++ b/cocoa/README.md
@@ -2,7 +2,7 @@
 
 <!-- rumdl-disable MD013 -->
 [![Python Versions](https://img.shields.io/pypi/pyversions/toga-cocoa.svg)](https://pypi.python.org/pypi/toga-cocoa)
-[![BSD-3-Clause License](https://img.shields.io/pypi/l/toga-cocoa.svg)](https://github.com/beeware/toga-cocoa/blob/main/LICENSE)
+[![BSD-3-Clause License](https://img.shields.io/pypi/l/toga-cocoa.svg)](https://github.com/beeware/toga/blob/main/cocoa/LICENSE)
 [![Project status](https://img.shields.io/pypi/status/toga-cocoa.svg)](https://pypi.python.org/pypi/toga-cocoa)
 <!-- rumdl-enable MD013 -->
 
@@ -20,12 +20,12 @@ Toga is part of the [BeeWare suite](https://beeware.org). You can talk to the co
 
 - [@beeware@fosstodon.org on Mastodon](https://fosstodon.org/@beeware)
 - [Discord](https://beeware.org/bee/chat/)
-- The Toga [GitHub Discussions forum](https://github.com/beeware/toga/discussions)
+- The Toga [GitHub Discussions forum](https://github.com/beeware/toga/discussions/)
 
-We foster a welcoming and respectful community as described in our [BeeWare Community Code of Conduct](https://beeware.org/community/behavior/).
+We foster a welcoming and respectful community as described in our [BeeWare Community Code of Conduct](https://beeware.org/community/code-of-conduct/).
 
 ## Contributing
 
-If you experience problems with Toga, [log them on GitHub](https://github.com/beeware/toga/issues).
+If you experience problems with Toga, [log them on GitHub](https://github.com/beeware/toga/issues/).
 
 If you'd like to contribute to Toga development, our [contribution guide](https://toga.beeware.org/en/latest/how-to/contribute/) details how to set up a development environment, and other requirements we have as part of our contribution process.

--- a/core/CONTRIBUTING.md
+++ b/core/CONTRIBUTING.md
@@ -2,6 +2,6 @@
 
 BeeWare <3's contributions!
 
-Please be aware that BeeWare operates under a [Code of Conduct](https://beeware.org/community/behavior/code-of-conduct/).
+Please be aware that BeeWare operates under a [Code of Conduct](https://beeware.org/community/code-of-conduct/).
 
 If you'd like to contribute to Toga development, our [contribution guide](https://toga.beeware.org/en/latest/how-to/#contributing-to-toga) details how to set up a development environment, and other requirements we have as part of our contribution process.

--- a/core/README.md
+++ b/core/README.md
@@ -2,7 +2,7 @@
 
 <!-- rumdl-disable MD013 -->
 [![Python Versions](https://img.shields.io/pypi/pyversions/toga-core.svg)](https://pypi.python.org/pypi/toga-core)
-[![BSD-3-Clause License](https://img.shields.io/pypi/l/toga-core.svg)](https://github.com/beeware/toga-core/blob/main/LICENSE)
+[![BSD-3-Clause License](https://img.shields.io/pypi/l/toga-core.svg)](https://github.com/beeware/toga/blob/main/core/LICENSE)
 [![Project status](https://img.shields.io/pypi/status/toga-core.svg)](https://pypi.python.org/pypi/toga-core)
 <!-- rumdl-enable MD013 -->
 
@@ -44,12 +44,12 @@ Toga is part of the [BeeWare suite](https://beeware.org). You can talk to the co
 
 - [@beeware@fosstodon.org on Mastodon](https://fosstodon.org/@beeware)
 - [Discord](https://beeware.org/bee/chat/)
-- The Toga [GitHub Discussions forum](https://github.com/beeware/toga/discussions)
+- The Toga [GitHub Discussions forum](https://github.com/beeware/toga/discussions/)
 
-We foster a welcoming and respectful community as described in our [BeeWare Community Code of Conduct](https://beeware.org/community/behavior/).
+We foster a welcoming and respectful community as described in our [BeeWare Community Code of Conduct](https://beeware.org/community/code-of-conduct/).
 
 ## Contributing
 
-If you experience problems with Toga, [log them on GitHub](https://github.com/beeware/toga/issues).
+If you experience problems with Toga, [log them on GitHub](https://github.com/beeware/toga/issues/).
 
 If you'd like to contribute to Toga development, our [contribution guide](https://toga.beeware.org/en/latest/how-to/contribute/) details how to set up a development environment, and other requirements we have as part of our contribution process.

--- a/demo/README.md
+++ b/demo/README.md
@@ -2,7 +2,7 @@
 
 <!-- rumdl-disable MD013 -->
 [![Python Versions](https://img.shields.io/pypi/pyversions/toga-demo.svg)](https://pypi.python.org/pypi/toga-demo)
-[![BSD-3-Clause License](https://img.shields.io/pypi/l/toga-demo.svg)](https://github.com/beeware/toga-demo/blob/main/LICENSE)
+[![BSD-3-Clause License](https://img.shields.io/pypi/l/toga-demo.svg)](https://github.com/beeware/toga/blob/main/demo/LICENSE)
 [![Project status](https://img.shields.io/pypi/status/toga-demo.svg)](https://pypi.python.org/pypi/toga-demo)
 <!-- rumdl-enable MD013 -->
 
@@ -49,12 +49,12 @@ Toga Demo is part of the [BeeWare suite](https://beeware.org). You can talk to t
 
 - [@beeware@fosstodon.org on Mastodon](https://fosstodon.org/@beeware)
 - [Discord](https://beeware.org/bee/chat/)
-- The Toga [GitHub Discussions forum](https://github.com/beeware/toga/discussions)
+- The Toga [GitHub Discussions forum](https://github.com/beeware/toga/discussions/)
 
-We foster a welcoming and respectful community as described in our [BeeWare Community Code of Conduct](https://beeware.org/community/behavior/).
+We foster a welcoming and respectful community as described in our [BeeWare Community Code of Conduct](https://beeware.org/community/code-of-conduct/).
 
 ## Contributing
 
-If you experience problems with Toga, [log them on GitHub](https://github.com/beeware/toga/issues).
+If you experience problems with Toga, [log them on GitHub](https://github.com/beeware/toga/issues/).
 
 If you'd like to contribute to Toga development, our [contribution guide](https://toga.beeware.org/en/latest/how-to/contribute/) details how to set up a development environment, and other requirements we have as part of our contribution process.

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -66,7 +66,7 @@ Toga is part of the [BeeWare suite](https://beeware.org). You can talk to the co
 
 - [@beeware@fosstodon.org on Mastodon](https://fosstodon.org/@beeware)
 - [Discord](https://beeware.org/bee/chat/)
-- The Toga [GitHub Discussions forum](https://github.com/beeware/Toga/discussions)
+- The Toga [GitHub Discussions forum](https://github.com/beeware/toga/discussions/)
 
 ### Code of conduct
 
@@ -76,4 +76,4 @@ If you have any concerns about this code of conduct, or you wish to report a vio
 
 ### Contributing
 
-If you experience problems with Toga, [log them on GitHub](https://github.com/beeware/toga/issues). If you want to contribute to Toga, you can read through the [Toga contribution guides](how-to/contribute/index.md).
+If you experience problems with Toga, [log them on GitHub](https://github.com/beeware/toga/issues/). If you want to contribute to Toga, you can read through the [Toga contribution guides](how-to/contribute/index.md).

--- a/dummy/CONTRIBUTING.md
+++ b/dummy/CONTRIBUTING.md
@@ -2,6 +2,6 @@
 
 BeeWare <3's contributions!
 
-Please be aware that BeeWare operates under a [Code of Conduct](https://beeware.org/community/behavior/code-of-conduct/).
+Please be aware that BeeWare operates under a [Code of Conduct](https://beeware.org/community/code-of-conduct/).
 
 If you'd like to contribute to Toga development, our [contribution guide](https://toga.beeware.org/en/latest/how-to/contribute/) details how to set up a development environment, and other requirements we have as part of our contribution process.

--- a/dummy/README.md
+++ b/dummy/README.md
@@ -2,7 +2,7 @@
 
 <!-- rumdl-disable MD013 -->
 [![Python Versions](https://img.shields.io/pypi/pyversions/toga-dummy.svg)](https://pypi.python.org/pypi/toga-dummy)
-[![BSD-3-Clause License](https://img.shields.io/pypi/l/toga-dummy.svg)](https://github.com/beeware/toga-dummy/blob/main/LICENSE)
+[![BSD-3-Clause License](https://img.shields.io/pypi/l/toga-dummy.svg)](https://github.com/beeware/toga/blob/main/dummy/LICENSE)
 [![Project status](https://img.shields.io/pypi/status/toga-dummy.svg)](https://pypi.python.org/pypi/toga-dummy)
 <!-- rumdl-enable MD013 -->
 
@@ -20,12 +20,12 @@ Toga is part of the [BeeWare suite](https://beeware.org). You can talk to the co
 
 - [@beeware@fosstodon.org on Mastodon](https://fosstodon.org/@beeware)
 - [Discord](https://beeware.org/bee/chat/)
-- The Toga [GitHub Discussions forum](https://github.com/beeware/toga/discussions)
+- The Toga [GitHub Discussions forum](https://github.com/beeware/toga/discussions/)
 
-We foster a welcoming and respectful community as described in our [BeeWare Community Code of Conduct](https://beeware.org/community/behavior/).
+We foster a welcoming and respectful community as described in our [BeeWare Community Code of Conduct](https://beeware.org/community/code-of-conduct/).
 
 ## Contributing
 
-If you experience problems with Toga, [log them on GitHub](https://github.com/beeware/toga/issues).
+If you experience problems with Toga, [log them on GitHub](https://github.com/beeware/toga/issues/).
 
 If you'd like to contribute to Toga development, our [contribution guide](https://toga.beeware.org/en/latest/how-to/contribute/) details how to set up a development environment, and other requirements we have as part of our contribution process.

--- a/gtk/CONTRIBUTING.md
+++ b/gtk/CONTRIBUTING.md
@@ -2,6 +2,6 @@
 
 BeeWare <3's contributions!
 
-Please be aware that BeeWare operates under a [Code of Conduct](https://beeware.org/community/behavior/code-of-conduct/).
+Please be aware that BeeWare operates under a [Code of Conduct](https://beeware.org/community/code-of-conduct/).
 
 If you'd like to contribute to Toga development, our [contribution guide](https://toga.beeware.org/en/latest/how-to/contribute/) details how to set up a development environment, and other requirements we have as part of our contribution process.

--- a/gtk/README.md
+++ b/gtk/README.md
@@ -2,7 +2,7 @@
 
 <!-- rumdl-disable MD013 -->
 [![Python Versions](https://img.shields.io/pypi/pyversions/toga-gtk.svg)](https://pypi.python.org/pypi/toga-gtk)
-[![BSD-3-Clause License](https://img.shields.io/pypi/l/toga-gtk.svg)](https://github.com/beeware/toga-gtk/blob/main/LICENSE)
+[![BSD-3-Clause License](https://img.shields.io/pypi/l/toga-gtk.svg)](https://github.com/beeware/toga/blob/main/gtk/LICENSE)
 [![Project status](https://img.shields.io/pypi/status/toga-gtk.svg)](https://pypi.python.org/pypi/toga-gtk)
 <!-- rumdl-enable MD013 -->
 
@@ -20,12 +20,12 @@ Toga is part of the [BeeWare suite](https://beeware.org). You can talk to the co
 
 - [@beeware@fosstodon.org on Mastodon](https://fosstodon.org/@beeware)
 - [Discord](https://beeware.org/bee/chat/)
-- The Toga [GitHub Discussions forum](https://github.com/beeware/toga/discussions)
+- The Toga [GitHub Discussions forum](https://github.com/beeware/toga/discussions/)
 
-We foster a welcoming and respectful community as described in our [BeeWare Community Code of Conduct](https://beeware.org/community/behavior/).
+We foster a welcoming and respectful community as described in our [BeeWare Community Code of Conduct](https://beeware.org/community/code-of-conduct/).
 
 ## Contributing
 
-If you experience problems with Toga, [log them on GitHub](https://github.com/beeware/toga/issues).
+If you experience problems with Toga, [log them on GitHub](https://github.com/beeware/toga/issues/).
 
 If you'd like to contribute to Toga development, our [contribution guide](https://toga.beeware.org/en/latest/how-to/contribute/) details how to set up a development environment, and other requirements we have as part of our contribution process.

--- a/iOS/CONTRIBUTING.md
+++ b/iOS/CONTRIBUTING.md
@@ -2,6 +2,6 @@
 
 BeeWare <3's contributions!
 
-Please be aware that BeeWare operates under a [Code of Conduct](https://beeware.org/community/behavior/code-of-conduct/).
+Please be aware that BeeWare operates under a [Code of Conduct](https://beeware.org/community/code-of-conduct/).
 
 If you'd like to contribute to Toga development, our [contribution guide](https://toga.beeware.org/en/latest/how-to/contribute/) details how to set up a development environment, and other requirements we have as part of our contribution process.

--- a/iOS/README.md
+++ b/iOS/README.md
@@ -2,7 +2,7 @@
 
 <!-- rumdl-disable MD013 -->
 [![Python Versions](https://img.shields.io/pypi/pyversions/toga-ios.svg)](https://pypi.python.org/pypi/toga-ios)
-[![BSD-3-Clause License](https://img.shields.io/pypi/l/toga-ios.svg)](https://github.com/beeware/toga-ios/blob/main/LICENSE)
+[![BSD-3-Clause License](https://img.shields.io/pypi/l/toga-ios.svg)](https://github.com/beeware/toga/blob/main/iOS/LICENSE)
 [![Project status](https://img.shields.io/pypi/status/toga-ios.svg)](https://pypi.python.org/pypi/toga-ios)
 <!-- rumdl-enable MD013 -->
 
@@ -20,12 +20,12 @@ Toga is part of the [BeeWare suite](https://beeware.org). You can talk to the co
 
 - [@beeware@fosstodon.org on Mastodon](https://fosstodon.org/@beeware)
 - [Discord](https://beeware.org/bee/chat/)
-- The Toga [GitHub Discussions forum](https://github.com/beeware/toga/discussions)
+- The Toga [GitHub Discussions forum](https://github.com/beeware/toga/discussions/)
 
-We foster a welcoming and respectful community as described in our [BeeWare Community Code of Conduct](https://beeware.org/community/behavior/).
+We foster a welcoming and respectful community as described in our [BeeWare Community Code of Conduct](https://beeware.org/community/code-of-conduct/).
 
 ## Contributing
 
-If you experience problems with Toga, [log them on GitHub](https://github.com/beeware/toga/issues).
+If you experience problems with Toga, [log them on GitHub](https://github.com/beeware/toga/issues/).
 
 If you'd like to contribute to Toga development, our [contribution guide](https://toga.beeware.org/en/latest/how-to/contribute/) details how to set up a development environment, and other requirements we have as part of our contribution process.

--- a/positron/CONTRIBUTING.md
+++ b/positron/CONTRIBUTING.md
@@ -2,6 +2,6 @@
 
 BeeWare <3's contributions!
 
-Please be aware that BeeWare operates under a [Code of Conduct](https://beeware.org/community/behavior/code-of-conduct/).
+Please be aware that BeeWare operates under a [Code of Conduct](https://beeware.org/community/code-of-conduct/).
 
 If you'd like to contribute to Toga development, our [contribution guide](https://toga.beeware.org/en/latest/how-to/contribute/) details how to set up a development environment, and other requirements we have as part of our contribution process.

--- a/positron/README.md
+++ b/positron/README.md
@@ -2,7 +2,7 @@
 
 <!-- rumdl-disable MD013 -->
 [![Python Versions](https://img.shields.io/pypi/pyversions/toga-positron.svg)](https://pypi.python.org/pypi/toga-positron)
-[![BSD-3-Clause License](https://img.shields.io/pypi/l/toga-positron.svg)](https://github.com/beeware/toga-positron/blob/main/LICENSE)
+[![BSD-3-Clause License](https://img.shields.io/pypi/l/toga-positron.svg)](https://github.com/beeware/toga/blob/main/positron/LICENSE)
 [![Project status](https://img.shields.io/pypi/status/toga-positron.svg)](https://pypi.python.org/pypi/toga-positron)
 <!-- rumdl-enable MD013 -->
 
@@ -87,12 +87,12 @@ Toga Positron is part of the [BeeWare suite](https://beeware.org). You can talk 
 
 * [@beeware@fosstodon.org on Mastodon](https://fosstodon.org/@beeware)
 * [Discord](https://beeware.org/bee/chat/)
-* [The Toga GitHub Discussions forum](https://github.com/beeware/toga/discussions)
+* [The Toga GitHub Discussions forum](https://github.com/beeware/toga/discussions/)
 
-We foster a welcoming and respectful community as described in our [BeeWare Community Code of Conduct](https://beeware.org/community/behavior/)
+We foster a welcoming and respectful community as described in our [BeeWare Community Code of Conduct](https://beeware.org/community/code-of-conduct/)
 
 ## Contributing
 
-If you experience problems with Toga, [log them on GitHub](https://github.com/beeware/toga/issues).
+If you experience problems with Toga, [log them on GitHub](https://github.com/beeware/toga/issues/).
 
 If you'd like to contribute to Toga development, our [contribution guide](https://toga.beeware.org/en/latest/how-to/contribute/) details how to set up a development environment, and other requirements we have as part of our contribution process.

--- a/qt/CONTRIBUTING.md
+++ b/qt/CONTRIBUTING.md
@@ -2,6 +2,6 @@
 
 BeeWare <3's contributions!
 
-Please be aware that BeeWare operates under a [Code of Conduct](https://beeware.org/community/behavior/code-of-conduct/).
+Please be aware that BeeWare operates under a [Code of Conduct](https://beeware.org/community/code-of-conduct/).
 
 If you'd like to contribute to Toga development, our [contribution guide](https://toga.beeware.org/en/latest/how-to/contribute/index.html) details how to set up a development environment, and other requirements we have as part of our contribution process.

--- a/qt/README.md
+++ b/qt/README.md
@@ -2,7 +2,7 @@
 
 <!-- rumdl-disable MD013 -->
 [![Python Versions](https://img.shields.io/pypi/pyversions/toga-qt.svg)](https://pypi.python.org/pypi/toga-qt)
-[![BSD-3-Clause License](https://img.shields.io/pypi/l/toga-qt.svg)](https://github.com/beeware/toga-qt/blob/main/LICENSE)
+[![BSD-3-Clause License](https://img.shields.io/pypi/l/toga-qt.svg)](https://github.com/beeware/toga/blob/main/qt/LICENSE)
 [![Project status](https://img.shields.io/pypi/status/toga-qt.svg)](https://pypi.python.org/pypi/toga-qt)
 <!-- rumdl-enable MD013 -->
 
@@ -20,12 +20,12 @@ Toga is part of the [BeeWare suite](https://beeware.org). You can talk to the co
 
 - [@beeware@fosstodon.org on Mastodon](https://fosstodon.org/@beeware)
 - [Discord](https://beeware.org/bee/chat/)
-- The Toga [GitHub Discussions forum](https://github.com/beeware/toga/discussions)
+- The Toga [GitHub Discussions forum](https://github.com/beeware/toga/discussions/)
 
-We foster a welcoming and respectful community as described in our [BeeWare Community Code of Conduct](https://beeware.org/community/behavior/).
+We foster a welcoming and respectful community as described in our [BeeWare Community Code of Conduct](https://beeware.org/community/code-of-conduct/).
 
 ## Contributing
 
-If you experience problems with Toga, [log them on GitHub](https://github.com/beeware/toga/issues).
+If you experience problems with Toga, [log them on GitHub](https://github.com/beeware/toga/issues/).
 
 If you'd like to contribute to Toga development, our [contribution guide](https://toga.beeware.org/en/latest/how-to/contribute) details how to set up a development environment, and other requirements we have as part of our contribution process.

--- a/textual/CONTRIBUTING.md
+++ b/textual/CONTRIBUTING.md
@@ -2,6 +2,6 @@
 
 BeeWare <3's contributions!
 
-Please be aware that BeeWare operates under a [Code of Conduct](https://beeware.org/community/behavior/code-of-conduct/).
+Please be aware that BeeWare operates under a [Code of Conduct](https://beeware.org/community/code-of-conduct/).
 
 If you'd like to contribute to Toga development, our [contribution guide](https://toga.beeware.org/en/latest/how-to/contribute/) details how to set up a development environment, and other requirements we have as part of our contribution process.

--- a/textual/README.md
+++ b/textual/README.md
@@ -2,7 +2,7 @@
 
 <!-- rumdl-disable MD013 -->
 [![Python Versions](https://img.shields.io/pypi/pyversions/toga-textual.svg)](https://pypi.python.org/pypi/toga-textual)
-[![BSD-3-Clause License](https://img.shields.io/pypi/l/toga-textual.svg)](https://github.com/beeware/toga-textual/blob/main/LICENSE)
+[![BSD-3-Clause License](https://img.shields.io/pypi/l/toga-textual.svg)](https://github.com/beeware/toga/blob/main/textual/LICENSE)
 [![Project status](https://img.shields.io/pypi/status/toga-textual.svg)](https://pypi.python.org/pypi/toga-textual)
 <!-- rumdl-enable MD013 -->
 
@@ -20,12 +20,12 @@ Toga is part of the [BeeWare suite](https://beeware.org). You can talk to the co
 
 - [@beeware@fosstodon.org on Mastodon](https://fosstodon.org/@beeware)
 - [Discord](https://beeware.org/bee/chat/)
-- The Toga [GitHub Discussions forum](https://github.com/beeware/toga/discussions)
+- The Toga [GitHub Discussions forum](https://github.com/beeware/toga/discussions/)
 
-We foster a welcoming and respectful community as described in our [BeeWare Community Code of Conduct](https://beeware.org/community/behavior/).
+We foster a welcoming and respectful community as described in our [BeeWare Community Code of Conduct](https://beeware.org/community/code-of-conduct/).
 
 ## Contributing
 
-If you experience problems with Toga, [log them on GitHub](https://github.com/beeware/toga/issues).
+If you experience problems with Toga, [log them on GitHub](https://github.com/beeware/toga/issues/).
 
 If you'd like to contribute to Toga development, our [contribution guide](https://toga.beeware.org/en/latest/how-to/contribute/) details how to set up a development environment, and other requirements we have as part of our contribution process.

--- a/toga/CONTRIBUTING.md
+++ b/toga/CONTRIBUTING.md
@@ -2,6 +2,6 @@
 
 BeeWare <3's contributions!
 
-Please be aware that BeeWare operates under a [Code of Conduct](https://beeware.org/community/behavior/code-of-conduct/).
+Please be aware that BeeWare operates under a [Code of Conduct](https://beeware.org/community/code-of-conduct/).
 
 If you'd like to contribute to Toga development, our [contribution guide](https://toga.beeware.org/en/latest/how-to/contribute/) details how to set up a development environment, and other requirements we have as part of our contribution process.

--- a/toga/README.md
+++ b/toga/README.md
@@ -2,7 +2,7 @@
 
 <!-- rumdl-disable MD013 -->
 [![Python Versions](https://img.shields.io/pypi/pyversions/toga.svg)](https://pypi.python.org/pypi/toga)
-[![BSD-3-Clause License](https://img.shields.io/pypi/l/toga.svg)](https://github.com/beeware/toga/blob/main/LICENSE)
+[![BSD-3-Clause License](https://img.shields.io/pypi/l/toga.svg)](https://github.com/beeware/toga/blob/main/toga/LICENSE)
 [![Project status](https://img.shields.io/pypi/status/toga.svg)](https://pypi.python.org/pypi/toga)
 <!-- rumdl-enable MD013 -->
 
@@ -29,12 +29,12 @@ Toga is part of the [BeeWare suite](https://beeware.org). You can talk to the co
 
 - [@beeware@fosstodon.org on Mastodon](https://fosstodon.org/@beeware)
 - [Discord](https://beeware.org/bee/chat/)
-- The Toga [GitHub Discussions forum](https://github.com/beeware/toga/discussions)
+- The Toga [GitHub Discussions forum](https://github.com/beeware/toga/discussions/)
 
-We foster a welcoming and respectful community as described in our [BeeWare Community Code of Conduct](https://beeware.org/community/behavior/).
+We foster a welcoming and respectful community as described in our [BeeWare Community Code of Conduct](https://beeware.org/community/code-of-conduct/).
 
 ## Contributing
 
-If you experience problems with Toga, [log them on GitHub](https://github.com/beeware/toga/issues).
+If you experience problems with Toga, [log them on GitHub](https://github.com/beeware/toga/issues/).
 
 If you'd like to contribute to Toga development, our [contribution guide](https://toga.beeware.org/en/latest/how-to/contribute/) details how to set up a development environment, and other requirements we have as part of our contribution process.

--- a/tox.ini
+++ b/tox.ini
@@ -109,7 +109,8 @@ deps =
 commands =
     !lint-!all-!live-!en : build_md_translations {posargs} en --source-code=core{/}src --source-code=travertino{/}src --source-code=android{/}src
     lint : pyspelling
-    lint : markdown-checker --dir {[docs]docs_dir} --func check_broken_urls
+    # Github, Wikipedia, Wiktionary and superuser.com have aggressive rate limiters
+    lint : markdown-checker --dir {[docs]docs_dir} --func check_broken_urls --skip-urls-containing=https://github.com/beeware,https://github.com/EddLabs,https://github.com/linuxmint,https://en.wikipedia.org/wiki/,https://en.wiktionary.org/wiki/,https://superuser.com/questions/284342/
     live : live_serve_en {posargs} core{/}src --port=8038 --source-code=core{/}src --source-code=travertino{/}src --source-code=android{/}src
     all : build_md_translations {posargs} en --source-code=core{/}src --source-code=travertino{/}src --source-code=android{/}src
     en : build_md_translations {posargs} en --source-code=core{/}src --source-code=travertino{/}src --source-code=android{/}src

--- a/travertino/CONTRIBUTING.md
+++ b/travertino/CONTRIBUTING.md
@@ -2,6 +2,6 @@
 
 BeeWare <3's contributions!
 
-Please be aware that BeeWare operates under a [Code of Conduct](https://beeware.org/community/behavior/code-of-conduct/).
+Please be aware that BeeWare operates under a [Code of Conduct](https://beeware.org/community/code-of-conduct/).
 
 If you'd like to contribute to Toga development, our [contribution guide](https://toga.beeware.org/en/latest/how-to/contribute/) details how to set up a development environment, and other requirements we have as part of our contribution process.

--- a/travertino/README.md
+++ b/travertino/README.md
@@ -45,10 +45,10 @@ Travertino is part of the [BeeWare suite](https://beeware.org). You can talk to 
 - [@beeware@fosstodon.org on Mastodon](https://fosstodon.org/@beeware)
 - [Discord](https://beeware.org/bee/chat/)
 
-We foster a welcoming and respectful community as described in our [BeeWare Community Code of Conduct](https://beeware.org/community/behavior/).
+We foster a welcoming and respectful community as described in our [BeeWare Community Code of Conduct](https://beeware.org/community/code-of-conduct/).
 
 ## Contributing
 
-If you experience problems with Toga, [log them on GitHub](https://github.com/beeware/toga/issues).
+If you experience problems with Toga, [log them on GitHub](https://github.com/beeware/toga/issues/).
 
 If you'd like to contribute to Toga development, our [contribution guide](https://toga.beeware.org/en/latest/how-to/contribute/) details how to set up a development environment, and other requirements we have as part of our contribution process.

--- a/web/CONTRIBUTING.md
+++ b/web/CONTRIBUTING.md
@@ -2,6 +2,6 @@
 
 BeeWare <3's contributions!
 
-Please be aware that BeeWare operates under a [Code of Conduct](https://beeware.org/community/behavior/code-of-conduct/).
+Please be aware that BeeWare operates under a [Code of Conduct](https://beeware.org/community/code-of-conduct/).
 
 If you'd like to contribute to Toga development, our [contribution guide](https://toga.beeware.org/en/latest/how-to/contribute/) details how to set up a development environment, and other requirements we have as part of our contribution process.

--- a/web/README.md
+++ b/web/README.md
@@ -2,7 +2,7 @@
 
 <!-- rumdl-disable MD013 -->
 [![Python Versions](https://img.shields.io/pypi/pyversions/toga-web.svg)](https://pypi.python.org/pypi/toga-web)
-[![BSD-3-Clause License](https://img.shields.io/pypi/l/toga-web.svg)](https://github.com/beeware/toga-web/blob/main/LICENSE)
+[![BSD-3-Clause License](https://img.shields.io/pypi/l/toga-web.svg)](https://github.com/beeware/toga/blob/main/web/LICENSE)
 [![Project status](https://img.shields.io/pypi/status/toga-web.svg)](https://pypi.python.org/pypi/toga-web)
 <!-- rumdl-enable MD013 -->
 
@@ -20,12 +20,12 @@ Toga is part of the [BeeWare suite](https://beeware.org). You can talk to the co
 
 - [@beeware@fosstodon.org on Mastodon](https://fosstodon.org/@beeware)
 - [Discord](https://beeware.org/bee/chat/)
-- The Toga [GitHub Discussions forum](https://github.com/beeware/toga/discussions)
+- The Toga [GitHub Discussions forum](https://github.com/beeware/toga/discussions/)
 
-We foster a welcoming and respectful community as described in our [BeeWare Community Code of Conduct](https://beeware.org/community/behavior/).
+We foster a welcoming and respectful community as described in our [BeeWare Community Code of Conduct](https://beeware.org/community/code-of-conduct/).
 
 ## Contributing
 
-If you experience problems with Toga, [log them on GitHub](https://github.com/beeware/toga/issues).
+If you experience problems with Toga, [log them on GitHub](https://github.com/beeware/toga/issues/).
 
 If you'd like to contribute to Toga development, our [contribution guide](https://toga.beeware.org/en/latest/how-to/contribute/) details how to set up a development environment, and other requirements we have as part of our contribution process.

--- a/winforms/CONTRIBUTING.md
+++ b/winforms/CONTRIBUTING.md
@@ -2,6 +2,6 @@
 
 BeeWare <3's contributions!
 
-Please be aware that BeeWare operates under a [Code of Conduct](https://beeware.org/community/behavior/code-of-conduct/).
+Please be aware that BeeWare operates under a [Code of Conduct](https://beeware.org/community/code-of-conduct/).
 
 If you'd like to contribute to Toga development, our [contribution guide](https://toga.beeware.org/en/latest/how-to/contribute/) details how to set up a development environment, and other requirements we have as part of our contribution process.

--- a/winforms/README.md
+++ b/winforms/README.md
@@ -2,7 +2,7 @@
 
 <!-- rumdl-disable MD013 -->
 [![Python Versions](https://img.shields.io/pypi/pyversions/toga-winforms.svg)](https://pypi.python.org/pypi/toga-winforms)
-[![BSD-3-Clause License](https://img.shields.io/pypi/l/toga-winforms.svg)](https://github.com/beeware/toga-winforms/blob/main/LICENSE)
+[![BSD-3-Clause License](https://img.shields.io/pypi/l/toga-winforms.svg)](https://github.com/beeware/toga/blob/main/winforms/LICENSE)
 [![Project status](https://img.shields.io/pypi/status/toga-winforms.svg)](https://pypi.python.org/pypi/toga-winforms)
 <!-- rumdl-enable MD013 -->
 
@@ -20,12 +20,12 @@ Toga is part of the [BeeWare suite](https://beeware.org). You can talk to the co
 
 - [@beeware@fosstodon.org on Mastodon](https://fosstodon.org/@beeware)
 - [Discord](https://beeware.org/bee/chat/)
-- The Toga [GitHub Discussions forum](https://github.com/beeware/toga/discussions)
+- The Toga [GitHub Discussions forum](https://github.com/beeware/toga/discussions/)
 
-We foster a welcoming and respectful community as described in our [BeeWare Community Code of Conduct](https://beeware.org/community/behavior/).
+We foster a welcoming and respectful community as described in our [BeeWare Community Code of Conduct](https://beeware.org/community/code-of-conduct/).
 
 ## Contributing
 
-If you experience problems with Toga, [log them on GitHub](https://github.com/beeware/toga/issues).
+If you experience problems with Toga, [log them on GitHub](https://github.com/beeware/toga/issues/).
 
 If you'd like to contribute to Toga development, our [contribution guide](https://toga.beeware.org/en/latest/how-to/contribute/) details how to set up a development environment, and other requirements we have as part of our contribution process.


### PR DESCRIPTION
Markdown-checker has historically ignored GitHub links; we now need to *explicitly* ignore GitHub links (and a few others) due to rate limits.

However, it did reveal a few stale and old links in our docs.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
