### PR TITLE
Use updated build workflow with skip-sdist support.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,15 +72,16 @@ jobs:
 
           - wheel: "winforms"
             skip-wheel: "true"
-
           - wheel: "winforms-x64"
             subdir: "winforms"
             plat-name: "win_amd64"
             exclude-runtime: "win-arm64"
+            skip-sdist: "true"
           - wheel: "winforms-arm64"
             subdir: "winforms"
             plat-name: "win_arm64"
             exclude-runtime: "win-x64"
+            skip-sdist: "true"
 
     # On Windows, we need to produce py3-none-win_arm64 and py3-none-win_amd64 wheels
     # because the wheel includes a platform-specific binary to support WebView2. The
@@ -132,45 +133,13 @@ jobs:
 
       - name: Build Package & Upload Artifact
         id: package
-        uses: hynek/build-and-inspect-python-package@v2.17.0
+        uses: hynek/build-and-inspect-python-package@v2.18.0
         with:
           path: ${{ matrix.subdir || matrix.wheel }}
           upload-name-suffix: ${{ format('-{0}', matrix.wheel) }}
           attest-build-provenance-github: ${{ inputs.attest-package }}
           skip-wheel: ${{ matrix.skip-wheel || 'false' }}
-
-
-  # Both the platform-tagged winforms artefacts build an sdist, and the two
-  # sdists disagree with each other due to the platform changes that are made.
-  # Strip those tainted sdists from the wheel artifacts.
-  clean-packages:
-    name: Clean packages to remove redundant artefacts
-    needs: package
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        artifact:
-          - "Packages-winforms-x64"
-          - "Packages-winforms-arm64"
-    steps:
-      - name: Download artifact
-        uses: actions/download-artifact@v8.0.1
-        with:
-          name: ${{ matrix.artifact }}
-          path: dist
-
-      - name: Remove tainted sdist
-        run: rm -f dist/*.tar.gz
-
-      - name: Re-upload artifact
-        uses: actions/upload-artifact@v7.0.1
-        with:
-          name: ${{ matrix.artifact }}
-          path: dist
-          overwrite: true
-          if-no-files-found: error
-
+          skip-sdist: ${{ matrix.skip-sdist || 'false' }}
 
   docs-lint:
     name: Documentation linting
@@ -208,7 +177,7 @@ jobs:
   core-and-travertino:
     name: Test ${{ matrix.package }} (${{ matrix.platform }}, ${{ matrix.python-version }})
     runs-on: ${{ matrix.platform }}
-    needs: [ pre-commit, towncrier, clean-packages ]
+    needs: [ pre-commit, towncrier, package ]
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
@@ -316,7 +285,7 @@ jobs:
   travertino-backwards-compatibility:
     name: Test Travertino backwards compatibility with Toga 0.4.8
     runs-on: "ubuntu-latest"
-    needs: [ pre-commit, towncrier, clean-packages ]
+    needs: [ pre-commit, towncrier, package ]
 
     steps:
     - name: Checkout

--- a/changes/4392.misc.md
+++ b/changes/4392.misc.md
@@ -1,0 +1,1 @@
+The release packaging workflow was simplified with an update to hynek/build-and-inspect-python-package.


### PR DESCRIPTION
Thanks to a fast turnaround from @hynek on https://github.com/hynek/build-and-inspect-python-package/pull/228, we're now able to avoid the post-processing step and directly skip creation of an sdist.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
