### PR TITLE
cocoa: submit a follow-up event after shutting down Cocoa event loop

### DIFF
--- a/changes/4394.bugfix.md
+++ b/changes/4394.bugfix.md
@@ -1,0 +1,1 @@
+Fix programmatic application shutdown in macOS Cocoa backend when `rubicon-objc` >= 0.5.4 is used.

--- a/cocoa/src/toga_cocoa/app.py
+++ b/cocoa/src/toga_cocoa/app.py
@@ -28,6 +28,8 @@ from .libs import (
     NSBeep,
     NSBundle,
     NSCursor,
+    NSEvent,
+    NSMakePoint,
     NSMenu,
     NSMenuItem,
     NSPanel,
@@ -296,6 +298,21 @@ class App:
     # We can't call this under test conditions, because it would kill the test harness
     def exit(self):  # pragma: no cover
         self.loop.stop()
+
+        # Shutting down the Cooca event loop needs a follow-up event to ensure that
+        # post-stop processing occurs. See beeware/rubicon-objc#746
+        event = NSEvent.otherEventWithType(
+            15,
+            location=NSMakePoint(0, 0),
+            modifierFlags=0,
+            timestamp=0,
+            windowNumber=0,
+            context=None,
+            subtype=0,
+            data1=0,
+            data2=0,
+        )
+        self.native.postEvent(event, atStart=True)
 
     def main_loop(self):
         self.loop.run_forever(lifecycle=CocoaLifecycle(self.native))


### PR DESCRIPTION
Have `toga_coca.app.App.exit()` submit a follow-up event after shutting down the Cocoa event loop, to ensure that the post-stop processing occurs and that application can be closed without any user interaction.

This is necessary because `rubicon-objc` 0.5.4 changed `CocoaLifecycle.stop()` to call `NSApplication.stop()` instead of `NSApplication.terminate()`, and therefore the event loop does not exit until next event is received and processed.

Fixes #4394.

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
