### PR TITLE
Document editable install guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,20 @@ Any PR failing one of these is rejected, not waived.
 
 Do not replace or bypass these tools. Add new dependencies only with a clear need and a compatible license (BSD-3-Clause friendly).
 
+### Editable installs
+
+For manual testing outside `tox`, install local packages explicitly in editable mode and always pass `--no-deps`. This repository's packages depend on each other, so normal dependency resolution can install released `toga-*` or `travertino` packages from PyPI instead of using the local checkout.
+
+```console
+# Core with the Dummy backend
+python -m pip install --no-deps -e ./travertino -e ./core -e ./dummy
+
+# Core with a production backend; replace ./gtk with the backend under test
+python -m pip install --no-deps -e ./travertino -e ./core -e ./gtk
+```
+
+Use the local backend path for the platform you are exercising: `./cocoa`, `./gtk`, `./winforms`, `./iOS`, `./android`, `./textual`, `./web`, or `./qt`. Install `./toga` only when you specifically need to test the platform-selecting `toga` meta package, and install `./positron` only when working on the Positron Briefcase plugin.
+
 ## Canonical commands
 
 Run from the repository root unless noted.

--- a/changes/4380.doc.md
+++ b/changes/4380.doc.md
@@ -1,0 +1,1 @@
+Documented editable install guidance for local Toga development.


### PR DESCRIPTION
This helps coding agents and contributors avoid accidentally resolving local BeeWare package dependencies from released PyPI packages instead of the local checkout.

Fixes #4380

Testing:

- `pre-commit run --files AGENTS.md changes/4380.doc.md`

## PR Checklist:
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool

Assisted-by: ChatGPT 5.5
Assisted-by: Codex