### PR TITLE
Encode special characters for Android WebView

### DIFF
--- a/android/src/toga_android/widgets/webview.py
+++ b/android/src/toga_android/widgets/webview.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 import shutil
+import urllib
 from http.cookiejar import CookieJar
 
 from android.webkit import ValueCallback, WebView as A_WebView, WebViewClient
@@ -124,7 +125,7 @@ class WebView(Widget):
             # There is a loadDataWithBaseURL method, but it's inconsistent about
             # whether getUrl returns the given URL or a data: URL. Rather than support
             # this feature intermittently, it's better to not support it at all.
-            self.native.loadData(content, "text/html", "utf-8")
+            self.native.loadData(urllib.parse.quote(content), "text/html", "utf-8")
 
     def get_user_agent(self):
         return self.settings.getUserAgentString()

--- a/changes/2242.bugfix.md
+++ b/changes/2242.bugfix.md
@@ -1,1 +1,1 @@
-On Android, Webview widgets can now display static content that contains # characters (such as CSS color specifications).
+On Android, `WebView` widgets can now display static content that contains `#` characters (such as CSS color specifications).

--- a/changes/2242.bugfix.md
+++ b/changes/2242.bugfix.md
@@ -1,0 +1,1 @@
+Encode special characters for Android WebView

--- a/changes/2242.bugfix.md
+++ b/changes/2242.bugfix.md
@@ -1,1 +1,1 @@
-Encode special characters for Android WebView
+On Android, Webview widgets can now display static content that contains # characters (such as CSS color specifications).

--- a/testbed/tests/widgets/test_webview.py
+++ b/testbed/tests/widgets/test_webview.py
@@ -207,6 +207,25 @@ async def test_static_content(widget, probe, on_load):
 
 
 @pytest.mark.flaky(retries=5, delay=1)
+async def test_static_style_content(widget, probe, on_load):
+    """Static content with style tags can be loaded into the page."""
+    widget.set_content(
+        "https://example.com/",
+        "<style>h1 { color: #000000; }</style><h1>Nice page</h1>",
+    )
+
+    # DOM loads aren't instantaneous; wait for the URL to appear
+    await assert_content_change(
+        widget,
+        probe,
+        message="Webview has static content with style tags",
+        url="https://example.com/" if probe.content_supports_url else None,
+        content="<h1>Nice page</h1>",
+        on_load=on_load,
+    )
+
+
+@pytest.mark.flaky(retries=5, delay=1)
 async def test_static_large_content(widget, probe, on_load):
     """Static large content can be loaded into the page"""
     large_content = f"<p>{'lorem ipsum ' * 200000}</p>"


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Added `urllib.parse.quote(content)` in the android WebView
<!--- What problem does this change solve? -->
Blank pages when special characters appear (like `#` in html content)
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Fixes #2242 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
<!-- update or delete the next line to reflect your usage -->
Assisted-by: Claude Sonnet 4.6 to get the android emulator installed