### PR TITLE
docs: add editable install workflow to AGENTS.md (#4380)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,27 @@ tox -e towncrier-check
 tox -e docs-lint
 ```
 
+### Editable installs
+
+Toga is split into separate packages (`core`, `dummy`, `travertino`, and one package per backend) that depend on each other. Installing them one-by-one with `pip install -e ./core`, `pip install -e ./dummy`, ... fails because each install resolves its dependencies before the next sibling package exists on disk. Agents that work around the failure with `--no-deps` end up with a partial environment that imports but misses the dev tooling.
+
+Install all the packages you need in a single command so pip sees the local sources together. Match your host platform:
+
+```console
+# macOS
+(.venv) $ python -m pip install -e ./core -e ./dummy -e ./cocoa -e ./travertino --group dev
+
+# Linux (GTK or Qt -- swap the backend as needed)
+(.venv) $ python -m pip install -e ./core -e ./dummy -e ./gtk -e ./travertino --group dev
+
+# Windows
+(.venv) C:\...>python -m pip install -e ./core -e ./dummy -e ./winforms -e ./travertino --group dev
+```
+
+`--group dev` pulls in the dev tooling (`tox`, `pre-commit`, `ruff`, ...) so `tox -m test` and `pre-commit run --all-files` work in the same venv. For backend-only work, swap the third `-e ./<backend>` in for `iOS`, `android`, `textual`, `web`, or `qt` -- you only need the backend you are changing plus the always-required `core`, `dummy`, and `travertino` packages.
+
+See `docs/en/how-to/contribute/how/dev-environment.md` for the full setup, including platform prerequisites.
+
 ### Testbed (backend validation)
 
 The core suite uses the Dummy backend. Real backend behaviour is validated through the testbed app. Install only the backend under test in your virtualenv, then:

--- a/changes/4380.doc.md
+++ b/changes/4380.doc.md
@@ -1,0 +1,1 @@
+Documented the editable-install workflow in AGENTS.md so coding agents install all required packages (`core`, `dummy`, the backend under test, and `travertino`) in a single `pip install -e` command instead of working around resolver errors with `--no-deps`.


### PR DESCRIPTION
## Summary

Adds an "Editable installs" subsection to `AGENTS.md` so agents working in this repo know to install all interdependent packages together rather than trying them one-by-one and bailing out with `--no-deps`.

Closes #4380.

## Why

Toga's per-package layout (`core` + `dummy` + `travertino` + one backend package per platform) means each package's dependencies reference its sibling packages. A serial `pip install -e ./core` followed by `pip install -e ./dummy` fails because pip resolves dependencies before the next sibling is on disk. Agents working around the failure with `--no-deps` end up with a partial environment that imports but misses the dev tooling (`tox`, `pre-commit`, `ruff`...), and the symptom is "tests can't find the toolchain" much later.

The fix is the single-command install per host platform from `docs/en/how-to/contribute/how/dev-environment.md`. The new subsection links to that doc and explains the swap-the-backend pattern for backend-only work.

## Change Type

- [x] Documentation

## Pre-commit / docs

The subsection lives under "Canonical commands" between the tox block and the testbed block to keep the install / test / validate sequence ordered. A `4380.doc.md` towncrier fragment is included.