### PR TITLE
fix(core): make toga submodules accessible after bare import toga

### DIFF
--- a/changes/4418.bugfix.md
+++ b/changes/4418.bugfix.md
@@ -1,0 +1,1 @@
+`toga.platform` (and other Toga submodules) can now be accessed directly after a bare `import toga`, without having to import another submodule first as a side effect.

--- a/core/src/toga/__init__.py
+++ b/core/src/toga/__init__.py
@@ -25,7 +25,18 @@ def __getattr__(name):
     try:
         module_name = toga_core_imports[name]
     except KeyError:
-        raise AttributeError(f"module '{__name__}' has no attribute '{name}'") from None
+        # Fall back to importing `name` as a submodule of toga so that
+        # `toga.<submodule>.<attr>` works after a bare `import toga`
+        # (e.g. `toga.platform.current_platform`). Without this fallback,
+        # the user has to import another submodule first as a side effect.
+        try:
+            module = importlib.import_module(f"{__name__}.{name}")
+        except ImportError:
+            raise AttributeError(
+                f"module '{__name__}' has no attribute '{name}'"
+            ) from None
+        globals()[name] = module
+        return module
     else:
         module = importlib.import_module(module_name)
         value = getattr(module, name)

--- a/core/tests/test_import.py
+++ b/core/tests/test_import.py
@@ -36,3 +36,21 @@ def test_lazy_fail():
         AttributeError, match="module 'toga' has no attribute 'nonexistent'"
     ):
         _ = toga.nonexistent
+
+
+def test_submodule_access(monkeypatch):
+    """Submodules can be accessed directly after a bare `import toga`."""
+    for mod_name in ["toga", "toga.platform"]:
+        monkeypatch.delitem(sys.modules, mod_name, raising=False)
+
+    # A clean import of toga, without touching anything else.
+    import toga
+
+    # Accessing `toga.platform` should load the submodule on demand and
+    # expose its attributes, without needing to import a sibling submodule
+    # first as a side effect.
+    assert toga.platform is sys.modules["toga.platform"]
+    assert hasattr(toga.platform, "current_platform")
+
+    # Repeat access should return the same module object.
+    assert toga.platform is toga.platform


### PR DESCRIPTION
## Summary

Closes #4418. After a bare `import toga`, accessing `toga.platform.current_platform` raised `AttributeError: module 'toga' has no attribute 'platform'`. The reported workaround (`from toga.style.pack import COLUMN`) only worked by side effect: importing any other toga submodule pulled `toga.platform` into the module cache, which then made the attribute lookup succeed.

## Why this matters

The root cause is `__getattr__` in `core/src/toga/__init__.py:24-33`. It only resolves names backed by entries in `toga_core_imports`, which is built from the `from toga.X import Y as Y` lines in `__init__.pyi`. Submodules like `toga.platform` are not in that table, because the table maps re-exported names (like `Button` -> `toga.widgets.button`), not submodule names. So `toga.platform` had no resolution path at all.

The reporter's example (`if toga.platform.current_platform == "android"`) is a natural way for app code to gate behavior. Asking users to add an unrelated `from toga.style.pack import COLUMN` to make it work, the documented workaround, is a foot-gun: that import is silent dependency-by-side-effect and could be removed by a "remove unused imports" pass.

The fix is a fallback in `__getattr__`: when the name is not in the table, try `importlib.import_module(f'{__name__}.{name}')` and return the resolved submodule. `ImportError` is converted back to the same `AttributeError` message, so the negative case (truly nonexistent attribute, exercised by `test_lazy_fail`) is unchanged. The resolved submodule is cached in `globals()` so repeated access returns the same module object. Submodules remain lazy: only accessed names get imported, the existing `test_lazy_succeed` invariant.

## Testing

- New `test_submodule_access` covers the issue's reproducer: bare `import toga`, then `toga.platform.current_platform` works without any other import as a side effect. Also asserts `toga.platform is sys.modules['toga.platform']`.
- Existing `test_lazy_succeed` still passes: submodules are still imported lazily, not eagerly on `import toga`.
- Existing `test_lazy_fail` still passes: `toga.nonexistent` still raises `AttributeError` with the unchanged message.

```
$ python -m pytest tests/test_import.py -v
tests/test_import.py::test_lazy_succeed PASSED
tests/test_import.py::test_lazy_fail PASSED
tests/test_import.py::test_submodule_access PASSED
```

Fixes #4418

AI-assisted.
