### PR TITLE
Add workaround for flaky and broken testbed tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,7 +353,7 @@ jobs:
 
         - backend: "macOS-arm64"
           platform: "macOS"
-          runs-on: "macos-latest"
+          runs-on: "macos-14"
           app-user-data-path: "$HOME/Library/Application Support/org.beeware.toga.testbed"
 
         # We use a fixed Ubuntu version rather than `-latest` because at some point,

--- a/changes/4415.misc.md
+++ b/changes/4415.misc.md
@@ -1,0 +1,1 @@
+A workaround was added for a flaky Qt webview test.

--- a/changes/4427.bugfix.md
+++ b/changes/4427.bugfix.md
@@ -1,0 +1,1 @@
+Initial application focus on macOS is now more reliable on macOS 26.

--- a/cocoa/src/toga_cocoa/app.py
+++ b/cocoa/src/toga_cocoa/app.py
@@ -1,7 +1,9 @@
 import asyncio
+import platform
 import sys
 from pathlib import Path
 
+from packaging.version import Version
 from rubicon.objc import (
     SEL,
     NSMutableDictionary,
@@ -312,6 +314,11 @@ class App:
             self.native.setActivationPolicy(NSApplicationActivationPolicyAccessory)
         else:
             self.native.setActivationPolicy(NSApplicationActivationPolicyRegular)
+
+        # macOS 14 introduced a new API for giving focus to the app
+        # We can't run CI on earlier versions, so this is no-branch.
+        if Version(platform.mac_ver()[0]) >= Version("14.0"):  # pragma: no branch
+            self.native.activate()
 
     ######################################################################
     # App resources

--- a/cocoa/tests_backend/probe.py
+++ b/cocoa/tests_backend/probe.py
@@ -55,8 +55,8 @@ class BaseProbe:
         if toga.App.app.run_slow or wait_for:
             delay = max(1, delay)
 
+        print("Waiting for redraw" if message is None else message)
         if delay or wait_for:
-            print("Waiting for redraw" if message is None else message)
             if toga.App.app.run_slow or wait_for is None:
                 await asyncio.sleep(delay)
             else:

--- a/iOS/tests_backend/probe.py
+++ b/iOS/tests_backend/probe.py
@@ -12,8 +12,8 @@ class BaseProbe:
         if toga.App.app.run_slow or wait_for:
             delay = max(1, delay)
 
+        print("Waiting for redraw" if message is None else message)
         if delay or wait_for:
-            print("Waiting for redraw" if message is None else message)
             if toga.App.app.run_slow or wait_for is None:
                 await asyncio.sleep(delay)
             else:

--- a/qt/tests_backend/widgets/webview.py
+++ b/qt/tests_backend/widgets/webview.py
@@ -8,7 +8,13 @@ from .base import SimpleProbe
 
 class WebViewProbe(SimpleProbe):
     native_class = QWebEngineView
-    content_supports_url = True
+
+    # See #4415. Qt's Webview *does* support content URLs; however, there appears to be
+    # a bug with Qt's WebView that causes the URL to be returned as a `data:text/html`
+    # content URL rather than the requested URL. As a workaround for test reliability,
+    # disable tests for content URLs.
+    # content_supports_url = True
+    content_supports_url = False
     javascript_supports_exception = True
     supports_on_load = True
 

--- a/testbed/tests/widgets/test_webview.py
+++ b/testbed/tests/widgets/test_webview.py
@@ -62,7 +62,9 @@ async def assert_content_change(
         new_url = widget.url
         new_content = await get_content(widget)
 
-        changed = (new_url == url) and (new_content == content)
+        changed = (new_content == content) and (
+            not probe.content_supports_url or (new_url == url)
+        )
         if not changed:
             timer -= 0.05
             await asyncio.sleep(0.05)
@@ -210,7 +212,7 @@ async def test_static_content(widget, probe, on_load):
         widget,
         probe,
         message="Webview has static content",
-        url="https://example.com/" if probe.content_supports_url else None,
+        url="https://example.com/",
         content="<h1>Nice page</h1>",
         on_load=on_load,
         timeout=JS_TIMEOUT,
@@ -458,9 +460,10 @@ async def test_on_navigation_starting_sync(widget, probe, on_load):
         widget,
         probe,
         message="Webview has static content",
-        url="https://example.com/" if probe.content_supports_url else None,
+        url="https://example.com/",
         content="<h1>Nice page</h1>",
         on_load=on_load,
+        timeout=JS_TIMEOUT,
     )
 
     # test static content can be set with no URL
@@ -534,9 +537,10 @@ async def test_on_navigation_starting_async(widget, probe, on_load):
         widget,
         probe,
         message="Webview has static content",
-        url="https://example.com/" if probe.content_supports_url else None,
+        url="https://example.com/",
         content="<h1>Nice page</h1>",
         on_load=on_load,
+        timeout=JS_TIMEOUT,
     )
     # test url allowed by code
     await wait_for(

--- a/testbed/tests/widgets/test_webview.py
+++ b/testbed/tests/widgets/test_webview.py
@@ -35,7 +35,15 @@ async def get_content(widget):
     )
 
 
-async def assert_content_change(widget, probe, message, url, content, on_load):
+async def assert_content_change(
+    widget,
+    probe,
+    message,
+    url,
+    content,
+    on_load,
+    timeout=LOAD_TIMEOUT,
+):
     # Web views aren't instantaneous. Even for simple static changes of page
     # content, the DOM won't be immediately rendered. As a result, even though a
     # page loaded signal has been received, it doesn't mean the accessors for
@@ -45,7 +53,7 @@ async def assert_content_change(widget, probe, message, url, content, on_load):
     # *and* content to change in any way before asserting the new values.
 
     changed = False
-    timer = LOAD_TIMEOUT
+    timer = timeout
 
     await probe.redraw(message)
 
@@ -54,7 +62,7 @@ async def assert_content_change(widget, probe, message, url, content, on_load):
         new_url = widget.url
         new_content = await get_content(widget)
 
-        changed = new_url == url and new_content == content
+        changed = (new_url == url) and (new_content == content)
         if not changed:
             timer -= 0.05
             await asyncio.sleep(0.05)
@@ -150,6 +158,7 @@ async def test_clear_url(widget, probe, on_load):
         url=None,
         content="",
         on_load=on_load,
+        timeout=JS_TIMEOUT,
     )
 
 
@@ -168,6 +177,7 @@ async def test_load_empty_url(widget, probe, on_load):
         url=None,
         content="",
         on_load=on_load,
+        timeout=JS_TIMEOUT,
     )
 
 
@@ -203,6 +213,7 @@ async def test_static_content(widget, probe, on_load):
         url="https://example.com/" if probe.content_supports_url else None,
         content="<h1>Nice page</h1>",
         on_load=on_load,
+        timeout=JS_TIMEOUT,
     )
 
 
@@ -224,6 +235,7 @@ async def test_static_large_content(widget, probe, on_load):
         url=url,
         content=large_content,
         on_load=on_load,
+        timeout=JS_TIMEOUT,
     )
 
 


### PR DESCRIPTION
Two improvements to testbed operation:

1. Temporarily disable content URL checks on the Qt backend. The Qt backend *does* support content URLs, but there's an intermittent bug in Qt that causes URLs to be returned as data URLs, rather than the requested page base URL. Also reduces the timeout for some web tests to speed up these failures when they do occur.

2. Reverts to running on macOS-14 runners. The 20260520 ARM64 image for macOS-15 appears to have a change in configuration that causes the app to resign focus as soon as the application event loop starts. The 20260427 image didn't do this. The macOS-14 images appear unaffected. There's a 20260525 release for macOS-15 that might correct things, but for now, we need CI to pass, so reverting is the easy solution.
 
This also moves the print statement for macOS/iOS probe redraws outside the if statement so that console output *always* contains the debug statements; and adds a call to the newer macOS-14 `NSApplication.activate()` call, which seems to improve window focus behaviour.

Fixes #4415
Fixes #4427

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
