### PR TITLE
fix(canvas): Change default stroke line_width from 2.0 to 1.0

### DIFF
--- a/cocoa/src/toga_cocoa/widgets/canvas.py
+++ b/cocoa/src/toga_cocoa/widgets/canvas.py
@@ -41,7 +41,7 @@ class State:
     # onto these values in order to fill or stroke text.
     fill_style: Color = Color.parse(BLACK)
     line_dash: Sequence[float] = ()
-    line_width: float = 2.0
+    line_width: float = 1.0
     stroke_style: Color = Color.parse(BLACK)
 
 
@@ -50,7 +50,7 @@ class Context:
         self.impl = impl
         self.native = NSGraphicsContext.currentContext.CGContext
         self.states = [State()]
-        self.set_line_width(2.0)
+        self.set_line_width(1.0)
 
         # Backwards compatibility for Toga <= 0.5.3
         self.in_fill = False
@@ -344,7 +344,7 @@ class Canvas(Widget):
         font,
         fill_style=None,
         stroke_style=None,
-        line_width=2.0,
+        line_width=1.0,
     ):
         textAttributes = NSMutableDictionary.alloc().init()
         textAttributes[NSFontAttributeName] = font.native

--- a/core/src/toga/widgets/canvas/canvas.py
+++ b/core/src/toga/widgets/canvas/canvas.py
@@ -232,7 +232,7 @@ class Canvas(Widget, DrawingActionDispatch):
     """The current fill color."""
     stroke_style: ColorT = drawing_context_property(SetStrokeStyle, BLACK_COLOR)
     """The current stroke color."""
-    line_width: float = drawing_context_property(SetLineWidth, 2.0)
+    line_width: float = drawing_context_property(SetLineWidth, 1.0)
     """The current width of the stroke."""
     line_dash: list[float] = drawing_context_property(SetLineDash, [])
     """The current dash pattern to follow when drawing the line, expressed as

--- a/iOS/src/toga_iOS/widgets/canvas.py
+++ b/iOS/src/toga_iOS/widgets/canvas.py
@@ -49,7 +49,7 @@ class State:
     # onto these values in order to fill or stroke text.
     fill_style: Color = Color.parse(BLACK)
     line_dash: Sequence[float] = ()
-    line_width: float = 2.0
+    line_width: float = 1.0
     stroke_style: Color = Color.parse(BLACK)
 
 
@@ -58,7 +58,7 @@ class Context:
         self.impl = impl
         self.native = uikit.UIGraphicsGetCurrentContext()
         self.states = [State()]
-        self.set_line_width(2.0)
+        self.set_line_width(1.0)
 
         # Backwards compatibility for Toga <= 0.5.3
         self.in_fill = False
@@ -342,7 +342,7 @@ class Canvas(Widget):
         font,
         fill_style=None,
         stroke_style=None,
-        line_width=2.0,
+        line_width=1.0,
     ):
         textAttributes = NSMutableDictionary.alloc().init()
         textAttributes[NSFontAttributeName] = font.native


### PR DESCRIPTION
Fixes #4381

The HTML5 Canvas specification defines lineWidth = 1.0 as the default.
Toga's Canvas API is intended to mirror the HTML5 Canvas API, so the
default line_width should match.

Changed the default from 2.0 to 1.0 in:
- core/src/toga/widgets/canvas/canvas.py
- cocoa/src/toga_cocoa/widgets/canvas.py
- iOS/src/toga_iOS/widgets/canvas.py