### PR TITLE
fix: assert uniqueness by origin (#3298)

### DIFF
--- a/changes/3298.misc.md
+++ b/changes/3298.misc.md
@@ -1,1 +1,1 @@
-The Linux testbed screen assertions were stabilized to avoid assuming unique monitor names, assert uniqueness by origin, and only require a `(0, 0)` primary origin on other platforms (not Linux Wayland).
+The testbed assertions on screens were corrected to remove assumptions that aren't always true on multiple-monitor setups.

--- a/changes/3298.misc.md
+++ b/changes/3298.misc.md
@@ -1,0 +1,1 @@
+The Linux testbed screen assertions were stabilized to avoid assuming unique monitor names, assert uniqueness by origin, and only require a `(0, 0)` primary origin on other platforms (not Linux Wayland).

--- a/testbed/tests/app/test_app.py
+++ b/testbed/tests/app/test_app.py
@@ -1,5 +1,3 @@
-import os
-import sys
 from types import NoneType
 from unittest.mock import Mock
 
@@ -260,10 +258,6 @@ async def test_screens(app, app_probe):
     # Identical monitors can share the same name, so assert uniqueness on origin
     # since every screen must occupy a distinct position.
     assert len(origins) == len(set(origins))
-
-    # Wayland does not guarantee screen[0] is at (0, 0); skip on Linux Wayland only.
-    if not (sys.platform == "linux" and os.environ.get("WAYLAND_DISPLAY")):
-        assert app.screens[0].origin == (0, 0)
 
 
 async def test_app_icon(app, app_probe):

--- a/testbed/tests/app/test_app.py
+++ b/testbed/tests/app/test_app.py
@@ -1,3 +1,5 @@
+import os
+import sys
 from types import NoneType
 from unittest.mock import Mock
 
@@ -242,19 +244,26 @@ async def test_beep(app, app_probe):
 
 
 async def test_screens(app, app_probe):
-    """Screens must have unique origins and names, with the primary screen at (0,0)."""
+    """Screens must have unique origins; on Linux Wayland,
+    identical monitors may share names so uniqueness is checked by origin, not name."""
+    assert app.screens
+    # Collect origins to verify each monitor occupies a unique position
+    origins = []
+    for screen in app.screens:
+        assert isinstance(screen.name, str)
+        # Origin is an (x, y) tuple of integers representing screen position
+        assert isinstance(screen.origin, tuple)
+        assert len(screen.origin) == 2
+        assert all(isinstance(value, int) for value in screen.origin)
+        origins.append(screen.origin)
 
-    # Get the origin of screen 0
-    assert app.screens[0].origin == (0, 0)
+    # Identical monitors can share the same name, so assert uniqueness on origin
+    # since every screen must occupy a distinct position.
+    assert len(origins) == len(set(origins))
 
-    # Check for unique names
-    screen_names = [s.name for s in app.screens]
-    unique_names = set(screen_names)
-    assert len(screen_names) == len(unique_names)
-
-    # Check that the origin of every other screen is not "0,0"
-    origins_not_zero = all(screen.origin != (0, 0) for screen in app.screens[1:])
-    assert origins_not_zero is True
+    # Wayland does not guarantee screen[0] is at (0, 0); skip on Linux Wayland only.
+    if not (sys.platform == "linux" and os.environ.get("WAYLAND_DISPLAY")):
+        assert app.screens[0].origin == (0, 0)
 
 
 async def test_app_icon(app, app_probe):

--- a/testbed/tests/app/test_app.py
+++ b/testbed/tests/app/test_app.py
@@ -242,8 +242,7 @@ async def test_beep(app, app_probe):
 
 
 async def test_screens(app, app_probe):
-    """Screens must have unique origins; on Linux Wayland,
-    identical monitors may share names so uniqueness is checked by origin, not name."""
+    """Screens must have unique origins, and a (not necessarily unique) name."""
     assert app.screens
     # Collect origins to verify each monitor occupies a unique position
     origins = []


### PR DESCRIPTION
Fix `test_screens` to handle duplicate monitor names on Linux Wayland by asserting  uniqueness on origin instead of name, and skip the `screen[0] == (0, 0)` check on Linux Wayland since it is not guaranteed.

Fixes #3298

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool.
<!-- update or delete the next line to reflect your usage -->
