### PR TITLE
Restore use of macOS-latest for ARM64 testbed.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,7 +353,7 @@ jobs:
 
         - backend: "macOS-arm64"
           platform: "macOS"
-          runs-on: "macos-14"
+          runs-on: "macos-latest"
           app-user-data-path: "$HOME/Library/Application Support/org.beeware.toga.testbed"
 
         # We use a fixed Ubuntu version rather than `-latest` because at some point,

--- a/changes/4430.misc.md
+++ b/changes/4430.misc.md
@@ -1,0 +1,1 @@
+The use of the macOS-latest runner was restored for macOS ARM64 testbed testing.


### PR DESCRIPTION
#4424 reverted the use of the macOS-latest runner for the macOS ARM64 testbed because of focus-related issue. It's possible that issue was caused by a issue with the 20260520 image; this PR is a test to see if the newer 20260525 image has the same issue.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
