### PR TITLE
Fix WinForms button color rendering

### DIFF
--- a/changes/4342.bugfix.md
+++ b/changes/4342.bugfix.md
@@ -1,1 +1,1 @@
-WinForms buttons now render its interior region with the correct native background color.
+WinForms buttons now render its interior region with the correct native background color when none is set.

--- a/changes/4342.bugfix.md
+++ b/changes/4342.bugfix.md
@@ -1,0 +1,1 @@
+WinForms buttons now render its interior region with the correct native background color.

--- a/winforms/src/toga_winforms/widgets/activityindicator.py
+++ b/winforms/src/toga_winforms/widgets/activityindicator.py
@@ -5,10 +5,8 @@ from pathlib import Path
 
 import System.Windows.Forms as WinForms
 from PIL import Image, ImageSequence
-from System.Drawing import Image as WinImage
+from System.Drawing import Color, Image as WinImage
 from System.IO import MemoryStream
-
-from toga.colors import TRANSPARENT
 
 from .base import Widget
 
@@ -59,7 +57,7 @@ class ActivityIndicator(Widget):
         self.native = WinForms.PictureBox()
         self.native.SizeMode = WinForms.PictureBoxSizeMode.Zoom
         self._spinner_cache_key = None
-        self._default_background_color = TRANSPARENT
+        self._default_background_color = Color.Transparent
         self.set_spinner_image()
         self.running = False
 

--- a/winforms/src/toga_winforms/widgets/base.py
+++ b/winforms/src/toga_winforms/widgets/base.py
@@ -161,10 +161,8 @@ class Widget(Scalable, ABC):
         # to work properly.  System colors are opaque.
         if self._default_background_color.IsSystemColor and color is None:
             self.native.BackColor = self._default_background_color
-            try:
+            if hasattr(self.native, "UseVisualStyleBackColor"):
                 self.native.UseVisualStyleBackColor = True
-            except NameError:  # Not all winforms widgets have this property
-                pass
         else:
             # Either not resetting, or the default color is not a system color
             # (i.e. default color may be modified by us; in this case, there may

--- a/winforms/src/toga_winforms/widgets/base.py
+++ b/winforms/src/toga_winforms/widgets/base.py
@@ -154,6 +154,9 @@ class Widget(Scalable, ABC):
             self.native.ForeColor = native_color(color)
 
     def set_background_color(self, color):
+        # If a system color is being reset to, then use it directly,
+        # and set the appropriate semantics for Button-like widgets
+        # to work properly.  System colors are opaque.
         if self._default_background_color.IsSystemColor and color is None:
             self.native.BackColor = self._default_background_color
             try:
@@ -161,12 +164,22 @@ class Widget(Scalable, ABC):
             except NameError:  # Not all winforms widgets have this property
                 pass
         else:
+            # Either not resetting, or the default color is not a system color
+            # (i.e. default color may be modified by us; in this case, there may
+            # be alpha, so we must blend manually).
             if self.interface.parent:
                 parent_color = toga_color(self.interface.parent._impl.native.BackColor)
             else:
                 parent_color = toga_color(SystemColors.Control)
 
-            requested_color = toga_color(self._default_background_color)
+            toga_default_background_color = toga_color(self._default_background_color)
+            match color, toga_default_background_color:
+                case (colors.TRANSPARENT, _) | (None, colors.TRANSPARENT):
+                    requested_color = rgb(0, 0, 0, 0)
+                case None, _:
+                    requested_color = toga_default_background_color
+                case _:
+                    requested_color = color.rgb
 
             blended_color = requested_color.blend_over(parent_color)
             self.native.BackColor = native_color(blended_color)

--- a/winforms/src/toga_winforms/widgets/base.py
+++ b/winforms/src/toga_winforms/widgets/base.py
@@ -8,8 +8,6 @@ from System.Drawing import (
 )
 from travertino.size import at_least
 
-import toga.colors as colors
-from toga.colors import rgb
 from toga_winforms.colors import (
     native_color,
     toga_color,
@@ -50,16 +48,11 @@ class Widget(Scalable, ABC):
 
         # Widgets that need to set a different default background_color should override
         # the _default_background_color attribute.
-        #
-        # Note: On Winforms, _default_background_color is set in the form of toga color,
-        #       instead of the native Color. This is because we need to manually do the
-        #       alpha blending, and the native Color class does not directly handle the
-        #       alpha transparency in the same way.
         if not hasattr(self, "_default_background_color"):
             # If a widget hasn't specifically defined a default background color then
             # set the system assigned background color as the default background color
             # of the widget.
-            self._default_background_color = toga_color(self.native.BackColor)
+            self._default_background_color = self.native.BackColor
 
         # Obtain a Graphics object and immediately dispose of it. This is
         # done to trigger the control's Paint event and force it to redraw.
@@ -161,21 +154,22 @@ class Widget(Scalable, ABC):
             self.native.ForeColor = native_color(color)
 
     def set_background_color(self, color):
-        if self.interface.parent:
-            parent_color = toga_color(self.interface.parent._impl.native.BackColor)
+        if self._default_background_color.IsSystemColor and color is None:
+            self.native.BackColor = self._default_background_color
+            try:
+                self.native.UseVisualStyleBackColor = True
+            except NameError:  # Not all winforms widgets have this property
+                pass
         else:
-            parent_color = toga_color(SystemColors.Control)
+            if self.interface.parent:
+                parent_color = toga_color(self.interface.parent._impl.native.BackColor)
+            else:
+                parent_color = toga_color(SystemColors.Control)
 
-        match color, self._default_background_color:
-            case (colors.TRANSPARENT, _) | (None, colors.TRANSPARENT):
-                requested_color = rgb(0, 0, 0, 0)
-            case None, _:
-                requested_color = self._default_background_color.rgb
-            case _:
-                requested_color = color.rgb
+            requested_color = toga_color(self._default_background_color)
 
-        blended_color = requested_color.blend_over(parent_color)
-        self.native.BackColor = native_color(blended_color)
+            blended_color = requested_color.blend_over(parent_color)
+            self.native.BackColor = native_color(blended_color)
 
         for child in self.interface.children:
             child._impl.set_background_color(child.style.background_color)

--- a/winforms/src/toga_winforms/widgets/base.py
+++ b/winforms/src/toga_winforms/widgets/base.py
@@ -8,6 +8,8 @@ from System.Drawing import (
 )
 from travertino.size import at_least
 
+import toga.colors as colors
+from toga.colors import rgb
 from toga_winforms.colors import (
     native_color,
     toga_color,

--- a/winforms/src/toga_winforms/widgets/box.py
+++ b/winforms/src/toga_winforms/widgets/box.py
@@ -1,6 +1,5 @@
 import System.Windows.Forms as WinForms
-
-from toga.colors import TRANSPARENT
+from System.Drawing import Color
 
 from .base import Widget
 
@@ -8,4 +7,4 @@ from .base import Widget
 class Box(Widget):
     def create(self):
         self.native = WinForms.Panel()
-        self._default_background_color = TRANSPARENT
+        self._default_background_color = Color.Transparent

--- a/winforms/src/toga_winforms/widgets/button.py
+++ b/winforms/src/toga_winforms/widgets/button.py
@@ -59,9 +59,7 @@ class Button(Widget):
             )
 
     def set_background_color(self, color):
-        super().set_background_color(
-            self._default_background_color if color in {None, TRANSPARENT} else color
-        )
+        super().set_background_color(None if color in {None, TRANSPARENT} else color)
 
     def rehint(self):
         self.interface.intrinsic.width = self.scale_out(

--- a/winforms/src/toga_winforms/widgets/canvas.py
+++ b/winforms/src/toga_winforms/widgets/canvas.py
@@ -4,6 +4,7 @@ import System.Windows.Forms as WinForms
 from System import Array
 from System.Drawing import (
     Bitmap,
+    Color,
     Graphics,
     Pen,
     PointF,
@@ -23,7 +24,7 @@ from System.Drawing.Drawing2D import (
 from System.Drawing.Imaging import ImageFormat
 from System.IO import MemoryStream
 
-from toga.colors import TRANSPARENT, rgb
+from toga.colors import rgb
 from toga.constants import Baseline, FillRule
 from toga.handlers import WeakrefCallable
 from toga.widgets.canvas.geometry import arc_to_bezier, round_rect, sweepangle
@@ -365,7 +366,7 @@ class Context:
 class Canvas(Box):
     def create(self):
         super().create()
-        self._default_background_color = TRANSPARENT
+        self._default_background_color = Color.Transparent
         self.native.DoubleBuffered = True
         self.native.Paint += WeakrefCallable(self.winforms_paint)
         self.native.Resize += WeakrefCallable(self.winforms_resize)

--- a/winforms/src/toga_winforms/widgets/detailedlist.py
+++ b/winforms/src/toga_winforms/widgets/detailedlist.py
@@ -7,7 +7,6 @@ from System.Drawing import ColorTranslator, Size, SystemColors
 
 from toga.handlers import WeakrefCallable
 
-from ..colors import toga_color
 from ..libs import gdi32, user32 as u32, win32constants as wc, win32structures as ws
 from ..libs.comctl32 import (
     DefSubclassProc,
@@ -74,7 +73,7 @@ class DetailedList(Widget):
         self.native.HandleCreated += WeakrefCallable(self.winforms_handle_created)
         self.native.HandleDestroyed += WeakrefCallable(self.winforms_handle_destroyed)
 
-        self._default_background_color = toga_color(SystemColors.Window)
+        self._default_background_color = SystemColors.Window
         self._first_item = 0
         self._cache = []
 

--- a/winforms/src/toga_winforms/widgets/imageview.py
+++ b/winforms/src/toga_winforms/widgets/imageview.py
@@ -1,9 +1,8 @@
 from decimal import ROUND_UP
 
 import System.Windows.Forms as WinForms
-from System.Drawing import Bitmap
+from System.Drawing import Bitmap, Color
 
-from toga.colors import TRANSPARENT
 from toga.widgets.imageview import rehint_imageview
 
 from .base import Widget
@@ -12,7 +11,7 @@ from .base import Widget
 class ImageView(Widget):
     def create(self):
         self.native = WinForms.PictureBox()
-        self._default_background_color = TRANSPARENT
+        self._default_background_color = Color.Transparent
         self.native.SizeMode = WinForms.PictureBoxSizeMode.Zoom
 
         # If self.native.Image is None, Winforms renders it as a white square

--- a/winforms/src/toga_winforms/widgets/label.py
+++ b/winforms/src/toga_winforms/widgets/label.py
@@ -1,9 +1,9 @@
 from decimal import ROUND_UP
 
 import System.Windows.Forms as WinForms
+from System.Drawing import Color
 from travertino.size import at_least
 
-from toga.colors import TRANSPARENT
 from toga_winforms.libs.fonts import TextAlignment
 
 from .base import Widget
@@ -12,7 +12,7 @@ from .base import Widget
 class Label(Widget):
     def create(self):
         self.native = WinForms.Label()
-        self._default_background_color = TRANSPARENT
+        self._default_background_color = Color.Transparent
         self.native.AutoSizeMode = WinForms.AutoSizeMode.GrowAndShrink
 
     def set_text_align(self, value):

--- a/winforms/src/toga_winforms/widgets/slider.py
+++ b/winforms/src/toga_winforms/widgets/slider.py
@@ -1,7 +1,7 @@
 from decimal import ROUND_UP
 
 import System.Windows.Forms as WinForms
-from System.Windows.Drawing import Color
+from System.Drawing import Color
 
 from toga.handlers import WeakrefCallable
 from toga.widgets.slider import IntSliderImpl

--- a/winforms/src/toga_winforms/widgets/slider.py
+++ b/winforms/src/toga_winforms/widgets/slider.py
@@ -1,8 +1,8 @@
 from decimal import ROUND_UP
 
 import System.Windows.Forms as WinForms
+from System.Windows.Drawing import Color
 
-from toga.colors import TRANSPARENT
 from toga.handlers import WeakrefCallable
 from toga.widgets.slider import IntSliderImpl
 
@@ -24,7 +24,7 @@ class Slider(Widget, IntSliderImpl):
     def create(self):
         IntSliderImpl.__init__(self)
         self.native = WinForms.TrackBar()
-        self._default_background_color = TRANSPARENT
+        self._default_background_color = Color.Transparent
         self.native.AutoSize = False
 
         # Unlike Scroll, ValueChanged also fires when the value is changed

--- a/winforms/src/toga_winforms/widgets/switch.py
+++ b/winforms/src/toga_winforms/widgets/switch.py
@@ -1,9 +1,9 @@
 from decimal import ROUND_UP
 
 import System.Windows.Forms as WinForms
+from System.Drawing import Color
 from travertino.size import at_least
 
-from toga.colors import TRANSPARENT
 from toga.handlers import WeakrefCallable
 
 from .base import Widget
@@ -12,7 +12,7 @@ from .base import Widget
 class Switch(Widget):
     def create(self):
         self.native = WinForms.CheckBox()
-        self._default_background_color = TRANSPARENT
+        self._default_background_color = Color.Transparent
         self.native.CheckedChanged += WeakrefCallable(self.winforms_checked_changed)
 
     def winforms_checked_changed(self, sender, event):

--- a/winforms/src/toga_winforms/widgets/webview.py
+++ b/winforms/src/toga_winforms/widgets/webview.py
@@ -11,10 +11,10 @@ from System import (
     Uri,
 )
 from System.Collections.Generic import List  # Import List for generics
+from System.Drawing import Color
 from System.Threading.Tasks import Task, TaskScheduler
 
 import toga
-from toga.colors import TRANSPARENT
 from toga.handlers import WeakrefCallable
 from toga.widgets.webview import CookiesResult, JavaScriptResult
 from toga_winforms.libs.extensions import (
@@ -108,7 +108,7 @@ class WebView(Widget):
             toga.App.app.paths.cache / f"toga/webview-{self.interface.id}"
         )
 
-        self._default_background_color = TRANSPARENT
+        self._default_background_color = Color.Transparent
 
     def __del__(self):  # pragma: nocover
         """Cleaning up the cached files for large content"""


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

Fixes #4342.

This PR fixes the button rendering issue by taking the following approach:

- Storing native colors for defaults and converting on-demand instead, so system colors work.
- When resetting background color and when we're resetting to a predefined color for the widget, reset to default *and* set UseVisualStyleBackColor on the widget if it exists on the widget.
- All the bookkeeping changes from the above.

Draft for now to run CI.


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
<!-- update or delete the next line to reflect your usage -->
Assisted-by: <!--name of tool; e.g., Claude Opus 4.5-->
