### PR TITLE
Use explicit solid background color for WebView on WinForms

### DIFF
--- a/changes/3264.bugfix.md
+++ b/changes/3264.bugfix.md
@@ -1,0 +1,1 @@
+1-pixel black streaks no longer appear on high DPI screens on WebViews whose content has a transparent background on WinForms.

--- a/winforms/src/toga_winforms/widgets/webview.py
+++ b/winforms/src/toga_winforms/widgets/webview.py
@@ -11,10 +11,10 @@ from System import (
     Uri,
 )
 from System.Collections.Generic import List  # Import List for generics
-from System.Drawing import Color
 from System.Threading.Tasks import Task, TaskScheduler
 
 import toga
+from toga.colors import TRANSPARENT
 from toga.handlers import WeakrefCallable
 from toga.widgets.webview import CookiesResult, JavaScriptResult
 from toga_winforms.libs.extensions import (
@@ -98,7 +98,6 @@ class WebView(Widget):
         self.corewebview2_available = None
         self.pending_tasks = []
         self.native.EnsureCoreWebView2Async(None)
-        self.native.DefaultBackgroundColor = Color.Transparent
 
         # attribute to store the URL allowed by user interaction or
         # user on_navigation_starting handler
@@ -108,6 +107,8 @@ class WebView(Widget):
         self._large_content_dir = (
             toga.App.app.paths.cache / f"toga/webview-{self.interface.id}"
         )
+
+        self._default_background_color = TRANSPARENT
 
     def __del__(self):  # pragma: nocover
         """Cleaning up the cached files for large content"""
@@ -309,3 +310,7 @@ class WebView(Widget):
 
         self.run_after_initialization(execute)
         return result
+
+    def set_background_color(self, color):
+        super().set_background_color(color)
+        self.native.DefaultBackgroundColor = self.native.BackColor


### PR DESCRIPTION
Fixes #3264 by repainting the background that the WebView is blended behind explicitly using the WebView's APIs, rather than assuming a transparent background; although this does not uncover the root cause of #3264, it is a full fix for the reported issue, as the background is always painted immediately on resizing, and thus no artifacts are ever visible.

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
<!-- update or delete the next line to reflect your usage -->
Assisted-by: <!--name of tool; e.g., Claude Opus 4.5-->
