### PR TITLE
Add dependency on `packaging` for cocoa

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ gtk/cairo
 pip-selfcheck.json
 pyvenv.cfg
 .vscode
+.zed
 .envrc
 bin/
 lib/

--- a/changes/4446.misc.md
+++ b/changes/4446.misc.md
@@ -1,0 +1,1 @@
+An implied dependency on Packaging was corrected in the cocoa backend.

--- a/cocoa/pyproject.toml
+++ b/cocoa/pyproject.toml
@@ -116,6 +116,7 @@ dependencies = [
     "fonttools >= 4.42.1, < 5.0.0",
     "rubicon-objc >= 0.5.1, < 0.6.0",
     "toga-core == {version}",
+    "packaging >= 24.2",
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
In #4424, Cocoa inadvertently added a dependency on `packaging` that wasn't explicitly declared. This dependency is pulled in transitively by other dependencies in the testbed, so it wasn't picked up. The minimum version number is somewhat arbitrary; it's the same base version used by Briefcase.

Also adds a .gitignore exclusion for the `zed` editor.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
