### PR TITLE
Miscellaneous yak-shaving regarding actions and rendering in Cocoa DetailedList

### DIFF
--- a/changes/2412.bugfix.md
+++ b/changes/2412.bugfix.md
@@ -1,0 +1,1 @@
+macOS systems with scroll elasticity disabled can now access Refresh through a context menu item on a DetailedList.

--- a/changes/2506.bugfix.md
+++ b/changes/2506.bugfix.md
@@ -1,0 +1,1 @@
+VoiceOver hints for macOS DetailedList can now read the primary and secondary text of each item properly.

--- a/changes/4416.feature.md
+++ b/changes/4416.feature.md
@@ -1,0 +1,1 @@
+Rows of a DetailedList in Cocoa can now be swiped right and left to reveal the primary and secondary actions, respectively.

--- a/changes/4448.bugfix.md
+++ b/changes/4448.bugfix.md
@@ -1,0 +1,1 @@
+DetailedLists in Cocoa now match the native "white border" styling when a context menu is activated.

--- a/changes/4448.feature.md
+++ b/changes/4448.feature.md
@@ -1,0 +1,1 @@
+Cocoa can now activate context menus on DetailedList items that are not selected.

--- a/cocoa/src/toga_cocoa/libs/appkit.py
+++ b/cocoa/src/toga_cocoa/libs/appkit.py
@@ -644,9 +644,20 @@ NSTableCellView = ObjCClass("NSTableCellView")
 # NSTableView.h
 NSTableColumn = ObjCClass("NSTableColumn")
 NSTableView = ObjCClass("NSTableView")
+NSTableViewRowAction = ObjCClass("NSTableViewRowAction")
 
 
-class NSTableViewColumnAutoresizingStyle(Enum):
+class NSTableRowActionEdge(IntEnum):
+    Leading = 0
+    Trailing = 1
+
+
+class NSTableViewRowActionStyle(IntEnum):
+    Default = 0
+    Destructive = 1
+
+
+class NSTableViewColumnAutoresizingStyle(IntEnum):
     NoAutoresizing = 0
     Uniform = 1
     Sequential = 2
@@ -655,7 +666,7 @@ class NSTableViewColumnAutoresizingStyle(Enum):
     FirstColumnOnly = 5
 
 
-class NSTableViewAnimation(Enum):
+class NSTableViewAnimation(IntEnum):
     EffectNone = 0x0
     EffectFade = 0x1
     EffectGap = 0x2

--- a/cocoa/src/toga_cocoa/widgets/detailedlist.py
+++ b/cocoa/src/toga_cocoa/widgets/detailedlist.py
@@ -30,15 +30,15 @@ class TogaList(NSTableView):
     impl = objc_property(object, weak=True)
 
     @objc_method
-    def didCloseMenu_withEvent_(self, menu, event) -> None:
-        # When the menu closes, drop the reference to the menu object.
+    def menuDidClose_(self, menu) -> None:
         self.impl._popup = None
 
     @objc_method
     def menu(self):
-        if (
-            self.clickedRow == -1 or self.clickedColumn == -1
-        ):  # Somehow this happens in VoiceOver
+        # The below branch occurs when using VoiceOver, which calls
+        # for a menu even when there is no right click, which would have
+        # to occur on a specific row; thus it is no-covered.
+        if self.clickedRow == -1 or self.clickedColumn == -1:  # pragma: no cover
             return NSMenu(send_super(__class__, self, "menu"))
         # Create a popup menu to display the possible actions.
         popup = NSMenu.alloc().initWithTitle("popup")
@@ -57,6 +57,7 @@ class TogaList(NSTableView):
                 keyEquivalent="",
             )
             secondary_action_item.tag = self.clickedRow
+
         if self.impl.refresh_enabled:
             popup.addItem(NSMenuItem.separatorItem())
             refresh_action_item = popup.addItemWithTitle(
@@ -67,7 +68,9 @@ class TogaList(NSTableView):
             refresh_action_item.image = REFRESH_IMAGE
             refresh_action_item.tag = self.clickedRow
 
+        # Preserve reference to popup for testing purposes.
         self.impl._popup = popup
+        popup.delegate = self
         return popup
 
     @objc_method
@@ -108,7 +111,8 @@ class TogaList(NSTableView):
             def handler(action: c_void_p, index: int) -> None:
                 row = self.interface.data[index]
                 self.interface.on_secondary_action(row=row)
-                self.impl.leading_handler = handler
+
+            self.impl.leading_handler = handler
 
         if edge == NSTableRowActionEdge.Trailing and self.impl.primary_action_enabled:
             style = (
@@ -151,11 +155,19 @@ class TogaList(NSTableView):
         value = self.interface.data[row]
         try:
             title = getattr(value, self.interface.accessors[0])
+            if title is not None:
+                title = str(title)
+            else:
+                title = self.interface.missing_value
         except AttributeError:
             title = self.interface.missing_value
 
         try:
             subtitle = getattr(value, self.interface.accessors[1])
+            if subtitle is not None:
+                subtitle = str(subtitle)
+            else:
+                subtitle = self.interface.missing_value
         except AttributeError:
             subtitle = self.interface.missing_value
 
@@ -164,8 +176,8 @@ class TogaList(NSTableView):
         except AttributeError:
             icon = None
 
-        view.setTitle(str(title))
-        view.setSubtitle(str(subtitle))
+        view.setTitle(title)
+        view.setSubtitle(subtitle)
         view.setIcon(icon)
 
         return view

--- a/cocoa/src/toga_cocoa/widgets/detailedlist.py
+++ b/cocoa/src/toga_cocoa/widgets/detailedlist.py
@@ -91,14 +91,24 @@ class TogaList(NSTableView):
 
     @objc_method
     def tableView_rowActionsForRow_edge_(self, table, row: int, edge: int):
-        # This API needs a block, not a selector, hence the redefinition of a handler
-        # instead of using primaryActionOnRow: and secondaryActionOnRow:.
-        def handler(action: c_void_p, index: int) -> None:
-            row = self.interface.data[index]
-            if edge == NSTableRowActionEdge.Trailing:
+        # The native API needs a block, not a selector, hence the redefinition of a
+        # handler instead of using primaryActionOnRow: and secondaryActionOnRow:.
+        # The handlers are being preserved for testing purposes, as AppKit doesn't give
+        # us a way to get the handler back from the NSTableViewRowAction.
+        if edge == NSTableRowActionEdge.Trailing:
+
+            def handler(action: c_void_p, index: int) -> None:
+                row = self.interface.data[index]
                 self.interface.on_primary_action(row=row)
-            elif edge == NSTableRowActionEdge.Leading:
+
+            self.impl.trailing_handler = handler
+        # The elif is defensive; there should not be any other edges in practice.
+        elif edge == NSTableRowActionEdge.Leading:  # pragma: no branch
+
+            def handler(action: c_void_p, index: int) -> None:
+                row = self.interface.data[index]
                 self.interface.on_secondary_action(row=row)
+                self.impl.leading_handler = handler
 
         if edge == NSTableRowActionEdge.Trailing and self.impl.primary_action_enabled:
             style = (

--- a/cocoa/src/toga_cocoa/widgets/detailedlist.py
+++ b/cocoa/src/toga_cocoa/widgets/detailedlist.py
@@ -1,18 +1,28 @@
+from ctypes import c_void_p
+
 from rubicon.objc import SEL, objc_method, objc_property
+from rubicon.objc.runtime import send_super
 from travertino.size import at_least
 
 from toga_cocoa.libs import (
     NSFocusRingType,
-    NSIndexSet,
+    NSImage,
     NSMenu,
+    NSMenuItem,
     NSTableColumn,
+    NSTableRowActionEdge,
     NSTableView,
     NSTableViewColumnAutoresizingStyle,
+    NSTableViewRowAction,
+    NSTableViewRowActionStyle,
 )
 from toga_cocoa.widgets.base import Widget
-from toga_cocoa.widgets.internal.cells import TogaDetailedCell
-from toga_cocoa.widgets.internal.data import TogaData
+from toga_cocoa.widgets.internal.cells import TogaDetailedView
 from toga_cocoa.widgets.internal.refresh import RefreshableScrollView
+
+REFRESH_IMAGE = NSImage.imageWithSystemSymbolName_accessibilityDescription_(
+    "arrow.clockwise", "refresh"
+)
 
 
 class TogaList(NSTableView):
@@ -25,42 +35,44 @@ class TogaList(NSTableView):
         self.impl._popup = None
 
     @objc_method
-    def menuForEvent_(self, event):
-        if self.impl.primary_action_enabled or self.impl.secondary_action_enabled:
-            # Find the row under the mouse click
-            mousePoint = self.convertPoint(event.locationInWindow, fromView=None)
-            row = self.rowAtPoint(mousePoint)
-
-            # Ensure the row is selected.
-            self.selectRowIndexes(
-                NSIndexSet.indexSetWithIndex(row),
-                byExtendingSelection=False,
+    def menu(self):
+        if (
+            self.clickedRow == -1 or self.clickedColumn == -1
+        ):  # Somehow this happens in VoiceOver
+            return NSMenu(send_super(__class__, self, "menu"))
+        # Create a popup menu to display the possible actions.
+        popup = NSMenu.alloc().initWithTitle("popup")
+        if self.impl.primary_action_enabled:
+            primary_action_item = popup.addItemWithTitle(
+                self.interface._primary_action,
+                action=SEL("primaryActionOnRow:"),
+                keyEquivalent="",
             )
+            primary_action_item.tag = self.clickedRow
 
-            # Create a popup menu to display the possible actions.
-            popup = NSMenu.alloc().initWithTitle("popup")
-            if self.impl.primary_action_enabled:
-                primary_action_item = popup.addItemWithTitle(
-                    self.interface._primary_action,
-                    action=SEL("primaryActionOnRow:"),
-                    keyEquivalent="",
-                )
-                primary_action_item.tag = row
+        if self.impl.secondary_action_enabled:
+            secondary_action_item = popup.addItemWithTitle(
+                self.interface._secondary_action,
+                action=SEL("secondaryActionOnRow:"),
+                keyEquivalent="",
+            )
+            secondary_action_item.tag = self.clickedRow
+        if self.impl.refresh_enabled:
+            popup.addItem(NSMenuItem.separatorItem())
+            refresh_action_item = popup.addItemWithTitle(
+                "Refresh",
+                action=SEL("onInterfaceRefresh:"),
+                keyEquivalent="",
+            )
+            refresh_action_item.image = REFRESH_IMAGE
+            refresh_action_item.tag = self.clickedRow
 
-            if self.impl.secondary_action_enabled:
-                secondary_action_item = popup.addItemWithTitle(
-                    self.interface._secondary_action,
-                    action=SEL("secondaryActionOnRow:"),
-                    keyEquivalent="",
-                )
-                secondary_action_item.tag = row
-
-        else:
-            popup = None
-
-        # Preserve a Python reference to the popup for testing purposes.
         self.impl._popup = popup
         return popup
+
+    @objc_method
+    def onInterfaceRefresh_(self, menuitem):
+        self.interface.on_refresh()
 
     @objc_method
     def primaryActionOnRow_(self, menuitem):
@@ -78,29 +90,62 @@ class TogaList(NSTableView):
         return len(self.interface.data) if self.interface.data else 0
 
     @objc_method
-    def tableView_objectValueForTableColumn_row_(self, table, column, row: int):
+    def tableView_rowActionsForRow_edge_(self, table, row: int, edge: int):
+        # This API needs a block, not a selector, hence the redefinition of a handler
+        # instead of using primaryActionOnRow: and secondaryActionOnRow:.
+        def handler(action: c_void_p, index: int) -> None:
+            row = self.interface.data[index]
+            if edge == NSTableRowActionEdge.Trailing:
+                self.interface.on_primary_action(row=row)
+            elif edge == NSTableRowActionEdge.Leading:
+                self.interface.on_secondary_action(row=row)
+
+        if edge == NSTableRowActionEdge.Trailing and self.impl.primary_action_enabled:
+            style = (
+                NSTableViewRowActionStyle.Default
+                if self.interface._primary_action not in self.impl.DESTRUCTIVE_ACTIONS
+                else NSTableViewRowActionStyle.Destructive
+            )
+            return [
+                NSTableViewRowAction.rowActionWithStyle_title_handler_(
+                    style, self.interface._primary_action, handler
+                )
+            ]
+        if edge == NSTableRowActionEdge.Leading and self.impl.secondary_action_enabled:
+            style = (
+                NSTableViewRowActionStyle.Default
+                if self.interface._secondary_action not in self.impl.DESTRUCTIVE_ACTIONS
+                else NSTableViewRowActionStyle.Destructive
+            )
+            return [
+                NSTableViewRowAction.rowActionWithStyle_title_handler_(
+                    style, self.interface._secondary_action, handler
+                )
+            ]
+        return []
+
+    @objc_method
+    def tableView_viewForTableColumn_row_(self, table, column, row: int):
+        identifier = "DetailedCell"
+
+        view = table.makeViewWithIdentifier_owner_(
+            identifier,
+            self,
+        )
+
+        if view is None:
+            view = TogaDetailedView.alloc().init()
+            view.setup()
+            view.setIdentifier(identifier)
+
         value = self.interface.data[row]
         try:
-            data = value._impl
-        except AttributeError:
-            data = TogaData.alloc().init()
-            value._impl = data
-
-        try:
             title = getattr(value, self.interface.accessors[0])
-            if title is not None:
-                title = str(title)
-            else:
-                title = self.interface.missing_value
         except AttributeError:
             title = self.interface.missing_value
 
         try:
             subtitle = getattr(value, self.interface.accessors[1])
-            if subtitle is not None:
-                subtitle = str(subtitle)
-            else:
-                subtitle = self.interface.missing_value
         except AttributeError:
             subtitle = self.interface.missing_value
 
@@ -109,13 +154,11 @@ class TogaList(NSTableView):
         except AttributeError:
             icon = None
 
-        data.attrs = {
-            "title": title,
-            "subtitle": subtitle,
-            "icon": icon,
-        }
+        view.setTitle(str(title))
+        view.setSubtitle(str(subtitle))
+        view.setIcon(icon)
 
-        return data
+        return view
 
     # TableDelegate methods
     @objc_method
@@ -134,6 +177,8 @@ class TogaList(NSTableView):
 
 
 class DetailedList(Widget):
+    DESTRUCTIVE_ACTIONS = {"Delete", "Remove"}
+
     def create(self):
         # Create a List, and put it in a scroll view.
         # The scroll view is the _impl, because it's the outer container.
@@ -151,6 +196,7 @@ class DetailedList(Widget):
         # Disable all actions by default.
         self.primary_action_enabled = False
         self.secondary_action_enabled = False
+        self.refresh_enabled = False
 
         self.native = RefreshableScrollView.alloc().initWithDocument(
             self.native_detailedlist
@@ -162,9 +208,6 @@ class DetailedList(Widget):
         column = NSTableColumn.alloc().initWithIdentifier("data")
         self.native_detailedlist.addTableColumn(column)
         self.columns = [column]
-
-        cell = TogaDetailedCell.alloc().init()
-        column.dataCell = cell
 
         # Hide the column header.
         self.native_detailedlist.headerView = None
@@ -247,6 +290,7 @@ class DetailedList(Widget):
         self.native_detailedlist.reloadData()
 
     def set_refresh_enabled(self, enabled):
+        self.refresh_enabled = enabled
         self.native.setRefreshEnabled(enabled)
 
     def set_primary_action_enabled(self, enabled):

--- a/cocoa/src/toga_cocoa/widgets/detailedlist.py
+++ b/cocoa/src/toga_cocoa/widgets/detailedlist.py
@@ -1,7 +1,6 @@
 from ctypes import c_void_p
 
 from rubicon.objc import SEL, objc_method, objc_property
-from rubicon.objc.runtime import send_super
 from travertino.size import at_least
 
 from toga_cocoa.libs import (
@@ -35,14 +34,9 @@ class TogaList(NSTableView):
 
     @objc_method
     def menu(self):
-        # The below branch occurs when using VoiceOver, which calls
-        # for a menu even when there is no right click, which would have
-        # to occur on a specific row; thus it is no-covered.
-        if self.clickedRow == -1 or self.clickedColumn == -1:  # pragma: no cover
-            return NSMenu(send_super(__class__, self, "menu"))
         # Create a popup menu to display the possible actions.
         popup = NSMenu.alloc().initWithTitle("popup")
-        if self.impl.primary_action_enabled:
+        if self.clickedRow != -1 and self.impl.primary_action_enabled:
             primary_action_item = popup.addItemWithTitle(
                 self.interface._primary_action,
                 action=SEL("primaryActionOnRow:"),
@@ -50,7 +44,7 @@ class TogaList(NSTableView):
             )
             primary_action_item.tag = self.clickedRow
 
-        if self.impl.secondary_action_enabled:
+        if self.clickedRow != -1 and self.impl.secondary_action_enabled:
             secondary_action_item = popup.addItemWithTitle(
                 self.interface._secondary_action,
                 action=SEL("secondaryActionOnRow:"),

--- a/cocoa/src/toga_cocoa/widgets/internal/cells.py
+++ b/cocoa/src/toga_cocoa/widgets/internal/cells.py
@@ -1,30 +1,20 @@
-from rubicon.objc import at, objc_method
+from rubicon.objc import objc_method
 
 from toga_cocoa.libs import (
-    NSAffineTransform,
-    NSColor,
-    NSCompositingOperationSourceOver,
     NSFont,
-    NSFontAttributeName,
-    NSForegroundColorAttributeName,
-    NSGraphicsContext,
-    NSImageInterpolationHigh,
     NSImageView,
+    NSLayoutAttributeBottom,
     NSLayoutAttributeCenterY,
     NSLayoutAttributeLeft,
     NSLayoutAttributeNotAnAttribute,
     NSLayoutAttributeRight,
+    NSLayoutAttributeTop,
     NSLayoutAttributeWidth,
     NSLayoutConstraint,
     NSLayoutRelationEqual,
     NSLineBreakMode,
-    NSMutableDictionary,
-    NSPoint,
-    NSRect,
-    NSSize,
     NSTableCellView,
     NSTextField,
-    NSTextFieldCell,
 )
 
 
@@ -147,76 +137,141 @@ class TogaIconView(NSTableCellView):
         self.textField.stringValue = text
 
 
-# A TogaDetailedCell contains:
-# * an icon
-# * a main "title" label
-# * a secondary "subtitle" label
-class TogaDetailedCell(NSTextFieldCell):
+class TogaDetailedView(NSTableCellView):
     @objc_method
-    def drawInteriorWithFrame_inView_(self, cellFrame: NSRect, view) -> None:
-        # The data to display.
-        icon = self.objectValue.attrs["icon"]
-        title = self.objectValue.attrs["title"]
-        subtitle = self.objectValue.attrs["subtitle"]
+    def setup(self):
+        self.imageView = NSImageView.alloc().init()
 
-        # If there's an icon, draw it.
+        self.titleField = NSTextField.alloc().init()
+        self.subtitleField = NSTextField.alloc().init()
+
+        for field in (self.titleField, self.subtitleField):
+            field.editable = False
+            field.bordered = False
+            field.drawsBackground = False
+            field.selectable = False
+
+        self.titleField.font = NSFont.systemFontOfSize(15)
+        self.subtitleField.font = NSFont.systemFontOfSize(13)
+
+        self.titleField.cell.lineBreakMode = NSLineBreakMode.byTruncatingTail
+        self.subtitleField.cell.lineBreakMode = NSLineBreakMode.byTruncatingTail
+
+        self.addSubview(self.imageView)
+        self.addSubview(self.titleField)
+        self.addSubview(self.subtitleField)
+
+        self.imageView.translatesAutoresizingMaskIntoConstraints = False
+        self.titleField.translatesAutoresizingMaskIntoConstraints = False
+        self.subtitleField.translatesAutoresizingMaskIntoConstraints = False
+
+        self.padding_constraint = NSLayoutConstraint.constraintWithItem(
+            self.titleField,
+            attribute__1=NSLayoutAttributeLeft,
+            relatedBy=NSLayoutRelationEqual,
+            toItem=self.imageView,
+            attribute__2=NSLayoutAttributeRight,
+            multiplier=1,
+            constant=4,
+        )
+        self.width_constraint = NSLayoutConstraint.constraintWithItem(
+            self.imageView,
+            attribute__1=NSLayoutAttributeRight,
+            relatedBy=NSLayoutRelationEqual,
+            toItem=self,
+            attribute__2=NSLayoutAttributeLeft,
+            multiplier=1,
+            constant=40,
+        )
+        constraints = [
+            # icon
+            self.width_constraint,
+            NSLayoutConstraint.constraintWithItem(
+                self.imageView,
+                attribute__1=NSLayoutAttributeLeft,
+                relatedBy=NSLayoutRelationEqual,
+                toItem=self,
+                attribute__2=NSLayoutAttributeLeft,
+                multiplier=1,
+                constant=4,
+            ),
+            NSLayoutConstraint.constraintWithItem(
+                self.imageView,
+                attribute__1=NSLayoutAttributeCenterY,
+                relatedBy=NSLayoutRelationEqual,
+                toItem=self,
+                attribute__2=NSLayoutAttributeCenterY,
+                multiplier=1,
+                constant=0,
+            ),
+            # title
+            self.padding_constraint,
+            NSLayoutConstraint.constraintWithItem(
+                self.titleField,
+                attribute__1=NSLayoutAttributeTop,
+                relatedBy=NSLayoutRelationEqual,
+                toItem=self,
+                attribute__2=NSLayoutAttributeTop,
+                multiplier=1,
+                constant=4,
+            ),
+            NSLayoutConstraint.constraintWithItem(
+                self.titleField,
+                attribute__1=NSLayoutAttributeRight,
+                relatedBy=NSLayoutRelationEqual,
+                toItem=self,
+                attribute__2=NSLayoutAttributeRight,
+                multiplier=1,
+                constant=-4,
+            ),
+            # subtitle
+            NSLayoutConstraint.constraintWithItem(
+                self.subtitleField,
+                attribute__1=NSLayoutAttributeTop,
+                relatedBy=NSLayoutRelationEqual,
+                toItem=self.titleField,
+                attribute__2=NSLayoutAttributeBottom,
+                multiplier=1,
+                constant=2,
+            ),
+            NSLayoutConstraint.constraintWithItem(
+                self.subtitleField,
+                attribute__1=NSLayoutAttributeLeft,
+                relatedBy=NSLayoutRelationEqual,
+                toItem=self.titleField,
+                attribute__2=NSLayoutAttributeLeft,
+                multiplier=1,
+                constant=0,
+            ),
+            NSLayoutConstraint.constraintWithItem(
+                self.subtitleField,
+                attribute__1=NSLayoutAttributeRight,
+                relatedBy=NSLayoutRelationEqual,
+                toItem=self.titleField,
+                attribute__2=NSLayoutAttributeRight,
+                multiplier=1,
+                constant=0,
+            ),
+        ]
+
+        for constraint in constraints:
+            self.addConstraint(constraint)
+
+    @objc_method
+    def setTitle(self, title):
+        self.titleField.stringValue = title
+
+    @objc_method
+    def setSubtitle(self, subtitle):
+        self.subtitleField.stringValue = subtitle
+
+    @objc_method
+    def setIcon(self, icon):
         if icon:
-            NSGraphicsContext.currentContext.saveGraphicsState()
-            yOffset = cellFrame.origin.y
-
-            # Coordinate system is always flipped
-            xform = NSAffineTransform.transform()
-            xform.translateXBy(4, yBy=cellFrame.size.height)
-            xform.scaleXBy(1.0, yBy=-1.0)
-            xform.concat()
-            yOffset = 0.5 - cellFrame.origin.y
-
-            interpolation = NSGraphicsContext.currentContext.imageInterpolation
-            NSGraphicsContext.currentContext.imageInterpolation = (
-                NSImageInterpolationHigh
-            )
-
-            icon.drawInRect(
-                NSRect(NSPoint(cellFrame.origin.x, yOffset + 4), NSSize(40.0, 40.0)),
-                fromRect=NSRect(
-                    NSPoint(0, 0),
-                    NSSize(icon.size.width, icon.size.height),
-                ),
-                operation=NSCompositingOperationSourceOver,
-                fraction=1.0,
-            )
-
-            NSGraphicsContext.currentContext.imageInterpolation = interpolation
-            NSGraphicsContext.currentContext.restoreGraphicsState()
-
-        # Find the right color for the text
-        if (
-            self.controlView
-            and self.controlView.window
-            and self.controlView.window.firstResponder == self.controlView
-            and self.controlView.window.isKeyWindow()
-            and self.isHighlighted()
-        ):
-            primaryColor = NSColor.alternateSelectedControlTextColor
+            self.imageView.image = icon
+            self.width_constraint.constant = 40
+            self.padding_constraint.constant = 4
         else:
-            primaryColor = NSColor.textColor
-
-        # Draw the title
-        textAttributes = NSMutableDictionary.alloc().init()
-        textAttributes[NSForegroundColorAttributeName] = primaryColor
-        textAttributes[NSFontAttributeName] = NSFont.systemFontOfSize(15)
-
-        at(title).drawAtPoint(
-            NSPoint(cellFrame.origin.x + 48, cellFrame.origin.y + 4),
-            withAttributes=textAttributes,
-        )
-
-        # Draw the subtitle
-        textAttributes = NSMutableDictionary.alloc().init()
-        textAttributes[NSForegroundColorAttributeName] = primaryColor
-        textAttributes[NSFontAttributeName] = NSFont.systemFontOfSize(13)
-
-        at(subtitle).drawAtPoint(
-            NSPoint(cellFrame.origin.x + 48, cellFrame.origin.y + 24),
-            withAttributes=textAttributes,
-        )
+            self.imageView.image = None
+            self.width_constraint.constant = 0
+            self.padding_constraint.constant = 0

--- a/cocoa/src/toga_cocoa/widgets/internal/data.py
+++ b/cocoa/src/toga_cocoa/widgets/internal/data.py
@@ -2,8 +2,13 @@ from toga_cocoa.libs import NSObject, objc_method
 
 
 class TogaData(NSObject):
+    # This method is no-covered because different system APIs requiring
+    # a native wrapper object may or may not choose to copy the native
+    # objects involved; however, we should still preserve this method
+    # as a defensive measure and not remove it from the codebase, as
+    # future usages of a data object in native APIs may require copying.
     @objc_method
-    def copyWithZone_(self):
+    def copyWithZone_(self):  # pragma: no cover
         # TogaData is used as an immutable reference to a row
         # so the same object can be returned as a copy. We need
         # to manually `retain` the object before returning because

--- a/cocoa/tests_backend/widgets/detailedlist.py
+++ b/cocoa/tests_backend/widgets/detailedlist.py
@@ -1,5 +1,6 @@
 import asyncio
 from ctypes import c_int64, c_uint32, c_uint64
+from unittest.mock import Mock
 
 from rubicon.objc import CGPoint, NSPoint
 
@@ -179,13 +180,36 @@ class DetailedListProbe(SimpleProbe):
             # pull-to-refresh
             await asyncio.sleep(0.1)
             self.scroll_to_top()
+
+            def assert_popup(popup):
+                refresh_item = popup.itemAtIndex(popup.numberOfItems - 1)
+                assert refresh_item.title != "Refresh"
+
+            await self._context_menu(assert_popup, row=0)
         else:
             assert not self.native.refresh_indicator.isHidden()
+
             # Wait for the scroll to relax after reload completion
             while self.scroll_position < 0:  # noqa: ASYNC110
                 await asyncio.sleep(0.01)
 
-    async def _perform_action(self, row, index):
+            # Do refresh again to get coverage; but we mock the handler
+            # to prevent the testbed from getting 2 refresh events.
+            old_on_refresh = self.widget.on_refresh._raw
+            on_refresh_menu_mock = Mock() if active else None
+            self.widget.on_refresh = on_refresh_menu_mock
+
+            # Assert proper display in context menu
+            def refresh_with_popup(popup):
+                refresh_item = popup.itemAtIndex(popup.numberOfItems - 1)
+                assert refresh_item.title == "Refresh"
+                popup.performActionForItemAtIndex(popup.numberOfItems - 1)
+
+            await self._context_menu(refresh_with_popup, row=0)
+            on_refresh_menu_mock.assert_called_once_with(self.widget)
+            self.widget.on_refresh = old_on_refresh
+
+    async def _context_menu(self, action, row):
         point = self.row_position(row)
 
         # Click to show menu
@@ -198,30 +222,79 @@ class DetailedListProbe(SimpleProbe):
 
         popup = self.impl._popup
         if popup:
-            popup.performActionForItemAtIndex(index)
+            action(popup)
             popup.cancelTracking()
 
             # Wait until the popup menu is fully disposed.
             while self.impl._popup is not None:
                 await self.redraw("Action has been selected", delay=0.1)
 
-    def _perform_swipe_action(self, row, edge):
+    def _perform_swipe_action(self, row, edge, active):
         actions = self.native_detailedlist.tableView(
             self.native_detailedlist, rowActionsForRow=row, edge=edge
         )
-        assert len(actions) == 1, "Expected exactly one action for the row edge"
-        if edge == NSTableRowActionEdge.Trailing:
-            assert actions[0].title == self.widget._primary_action
-            self.impl.trailing_handler(None, row)
-        elif edge == NSTableRowActionEdge.Leading:
-            assert actions[0].title == self.widget._secondary_action
-            self.impl.leading_handler(None, row)
+        if active:
+            assert len(actions) == 1, "Expected exactly one action for the row edge"
+            if edge == NSTableRowActionEdge.Trailing:
+                assert actions[0].title == self.widget._primary_action
+                self.impl.trailing_handler(None, row)
+            elif edge == NSTableRowActionEdge.Leading:
+                assert actions[0].title == self.widget._secondary_action
+                self.impl.leading_handler(None, row)
+        else:
+            assert len(actions) == 0, "Expected no actions for the row edge"
 
     async def perform_primary_action(self, row, active=True):
-        # Test primary using swipe.
-        if self.impl.primary_action_enabled:
-            self._perform_swipe_action(row, NSTableRowActionEdge.Trailing)
+        self._perform_swipe_action(row, NSTableRowActionEdge.Trailing, active)
+
+        old_on_primary = self.widget.on_primary_action._raw
+        on_primary_menu_mock = Mock() if active else None
+        self.widget.on_primary_action = on_primary_menu_mock
+
+        def primary_with_popup(popup):
+            supposed_index = 0
+            item = popup.itemAtIndex(supposed_index)
+            if active:
+                assert item.title == self.widget._primary_action
+                popup.performActionForItemAtIndex(supposed_index)
+            else:
+                assert (
+                    popup.numberOfItems <= supposed_index
+                    or item.title != self.widget._primary_action
+                )
+
+        await self._context_menu(primary_with_popup, row=row)
+
+        if active:
+            on_primary_menu_mock.assert_called_once_with(
+                self.widget, row=self.widget.data[row]
+            )
+        self.widget.on_primary_action = old_on_primary
 
     async def perform_secondary_action(self, row, active=True):
-        # Test secondary using menu.
-        await self._perform_action(row, 1 if self.impl.primary_action_enabled else 0)
+        # Test secondary using swipe.
+        self._perform_swipe_action(row, NSTableRowActionEdge.Leading, active)
+
+        old_on_secondary = self.widget.on_secondary_action._raw
+        on_secondary_menu_mock = Mock() if active else None
+        self.widget.on_secondary_action = on_secondary_menu_mock
+
+        def secondary_with_popup(popup):
+            supposed_index = 0 if not self.impl.primary_action_enabled else 1
+            item = popup.itemAtIndex(supposed_index)
+            if active:
+                assert item.title == self.widget._secondary_action
+                popup.performActionForItemAtIndex(supposed_index)
+            else:
+                assert (
+                    popup.numberOfItems <= supposed_index
+                    or item.title != self.widget._secondary_action
+                )
+
+        await self._context_menu(secondary_with_popup, row=row)
+
+        if active:
+            on_secondary_menu_mock.assert_called_once_with(
+                self.widget, row=self.widget.data[row]
+            )
+        self.widget.on_secondary_action = old_on_secondary

--- a/cocoa/tests_backend/widgets/detailedlist.py
+++ b/cocoa/tests_backend/widgets/detailedlist.py
@@ -8,6 +8,7 @@ from toga_cocoa.libs import (
     NSEvent,
     NSEventType,
     NSScrollView,
+    NSTableRowActionEdge,
     NSTableView,
     core_graphics,
     kCGScrollEventUnitPixel,
@@ -53,18 +54,18 @@ class DetailedListProbe(SimpleProbe):
         )
 
     def assert_cell_content(self, row, title, subtitle, icon=None):
-        data = self.native_detailedlist.tableView(
+        row = self.native_detailedlist.tableView(
             self.native_detailedlist,
-            objectValueForTableColumn=self.native_detailedlist.tableColumns[0],
+            viewForTableColumn=self.native_detailedlist.tableColumns[0],
             row=row,
         )
-        assert str(data.attrs["title"]) == title
-        assert str(data.attrs["subtitle"]) == subtitle
+        assert str(row.titleField.stringValue) == title
+        assert str(row.subtitleField.stringValue) == subtitle
 
         if icon:
-            assert data.attrs["icon"] == icon._impl.native
+            assert row.imageView.image == icon._impl.native
         else:
-            assert data.attrs["icon"] is None
+            assert row.imageView.image is None
 
     @property
     def max_scroll_position(self):
@@ -204,8 +205,23 @@ class DetailedListProbe(SimpleProbe):
             while self.impl._popup is not None:
                 await self.redraw("Action has been selected", delay=0.1)
 
+    def _perform_swipe_action(self, row, edge):
+        actions = self.native_detailedlist.tableView(
+            self.native_detailedlist, rowActionsForRow=row, edge=edge
+        )
+        assert len(actions) == 1, "Expected exactly one action for the row edge"
+        if edge == NSTableRowActionEdge.Trailing:
+            assert actions[0].title == self.widget._primary_action
+            self.impl.trailing_handler(None, row)
+        elif edge == NSTableRowActionEdge.Leading:
+            assert actions[0].title == self.widget._secondary_action
+            self.impl.leading_handler(None, row)
+
     async def perform_primary_action(self, row, active=True):
-        await self._perform_action(row, 0)
+        # Test primary using swipe.
+        if self.impl.primary_action_enabled:
+            self._perform_swipe_action(row, NSTableRowActionEdge.Trailing)
 
     async def perform_secondary_action(self, row, active=True):
+        # Test secondary using menu.
         await self._perform_action(row, 1 if self.impl.primary_action_enabled else 0)

--- a/docs/en/reference/api/widgets/detailedlist.md
+++ b/docs/en/reference/api/widgets/detailedlist.md
@@ -64,7 +64,7 @@ Items in a DetailedList will respond to a primary and secondary action if the `o
 * On **Android**, a long press displays a menu with the primary and secondary actions.
 * On **iOS** and **macOS**, swiping left triggers the primary action, and swiping right triggers the secondary action.
 * On **GTK**, a right click displays buttons for the primary and secondary actions.
-* On **macOS** **Windows**, and **Qt**, a right click displays a context menu with the primary and secondary actions.
+* On **macOS**, **Windows**, and **Qt**, a right click displays a context menu with the primary and secondary actions.
 * On **Qt**, the primary and secondary actions are displayed as standalone buttons.
 
 By default, the primary and secondary action will be labeled as "Delete" and "Action", respectively. These names can be overridden by providing a `primary_action` and `secondary_action` argument when constructing the DetailedList. Although the primary action is labeled "Delete" by default, the DetailedList will not perform any data deletion as part of the UI interaction. It is the responsibility of the application to implement any data deletion behavior as part of the `on_primary_action` handler.
@@ -74,7 +74,7 @@ The DetailedList as a whole will also respond to a refresh UI action if an `on_r
 * On **Android**, **iOS** and **macOS**, pulling down at the top of the list triggers a refresh.
 * On **Qt**, a button bar displays a refresh button.
 * On **GTK**, a floating refresh button is displayed when scrolled to the top.
-* On **Windows** and **macOS**, a right click displays a context menu with a refresh option.
+* On **macOS**, **Windows**, and **Qt**, a right click displays a context menu with a refresh option.
 
 ## Notes
 

--- a/docs/en/reference/api/widgets/detailedlist.md
+++ b/docs/en/reference/api/widgets/detailedlist.md
@@ -59,12 +59,12 @@ If the value provided by the title or subtitle accessor is `None`, or the access
 
 The icon accessor should return an [`Icon`][toga.Icon]. If it returns `None`, or the accessor isn't defined, then no icon will be displayed, but space for the icon will remain in the layout.
 
-Items in a DetailedList will respond to a primary and secondary action if the `on_primary_action` and `on_secondary_action` handlers are set:
+Items in a DetailedList will respond to a primary and secondary action if the `on_primary_action` and `on_secondary_action` handlers are set. Each platform may support one or more methods of interaction with actions, as detailed below:
 
 * On **Android**, a long press displays a menu with the primary and secondary actions.
-* On **iOS**, swiping left triggers the primary action, and swiping right triggers the secondary action.
+* On **iOS** and **macOS**, swiping left triggers the primary action, and swiping right triggers the secondary action.
 * On **GTK**, a right click displays buttons for the primary and secondary actions.
-* On **macOS** and **Windows**, a right click displays a context menu with the primary and secondary actions.
+* On **macOS** **Windows**, and **Qt**, a right click displays a context menu with the primary and secondary actions.
 * On **Qt**, the primary and secondary actions are displayed as standalone buttons.
 
 By default, the primary and secondary action will be labeled as "Delete" and "Action", respectively. These names can be overridden by providing a `primary_action` and `secondary_action` argument when constructing the DetailedList. Although the primary action is labeled "Delete" by default, the DetailedList will not perform any data deletion as part of the UI interaction. It is the responsibility of the application to implement any data deletion behavior as part of the `on_primary_action` handler.
@@ -74,11 +74,11 @@ The DetailedList as a whole will also respond to a refresh UI action if an `on_r
 * On **Android**, **iOS** and **macOS**, pulling down at the top of the list triggers a refresh.
 * On **Qt**, a button bar displays a refresh button.
 * On **GTK**, a floating refresh button is displayed when scrolled to the top.
-* On **Windows**, a right click displays a context menu with a refresh option.
+* On **Windows** and **macOS**, a right click displays a context menu with a refresh option.
 
 ## Notes
 
-* The iOS Human Interface Guidelines differentiate between "Normal" and "Destructive" actions on a row. Toga will interpret any action with a name of "Delete" or "Remove" as destructive, and will render the action appropriately.
+* The Apple Human Interface Guidelines differentiate between "Normal" and "Destructive" actions on a row. Toga will interpret any action with a name of "Delete" or "Remove" as destructive, and will render the action appropriately.
 * Using DetailedList on Android requires the AndroidX SwipeRefreshLayout widget in your project's Gradle dependencies. Ensure your app declares a dependency on `androidx.swiperefreshlayout:swiperefreshlayout:1.1.0` or later.
 
 ## Reference

--- a/testbed/tests/widgets/test_detailedlist.py
+++ b/testbed/tests/widgets/test_detailedlist.py
@@ -319,8 +319,6 @@ async def test_actions(
     on_secondary_action_handler.assert_called_once_with(widget, row=widget.data[4])
     on_secondary_action_handler.reset_mock()
 
-    await probe.redraw("Before perform")
-
     # Disable secondary action
     widget.on_secondary_action = None
     await probe.perform_secondary_action(5, active=False)


### PR DESCRIPTION
Multiple yaks shaved in Cocoa DetailedList, since this is a case where a small number of lines that can do a lot of things.

Bugs fixed:

- #4416 is an issue where swiping left and right doesn't reveal actions.  However, some digging in the header file points at a broader issue that we're using the old "cell-based" renderers, rather than the new "view-based" renders.  Significant amounts of this PR is switching to the new mechanism; there's also a function (`tableView_rowActionsForRow_edge_`) for adding the new actions.
- #2506 gets fixed free using the above view-based rendering; worked well in my testing, as the layout auto-reads the texts in the correct order.
- I noticed spontaneously that the popup mechanism is way too complex; we do not need to handle mouse clicks -- the `menu` proprety of the DetailedList automatically displays on any right click in any item — we can just override the `menu` attribute, which is technically a getter; however, overriding getter for `menu` is an established pattern (see https://stackoverflow.com/questions/72367017/implementing-context-menu-for-nstablecellview), and makes the code simpler as we don't have to rebuild the menu every time primary/secondary is enabled and disabled in the future.
As a side effect of using the native property, we get the ability to perform actions on a nonselected item, and also get the proper border styling on context menu click on an item we *do* select:
- Since I'm touching the context menu anyways, might as well fix #2412 by just adding an extra divider and menu item -- see screenshot above.

Screenshot demo (swipe to reveal actions, correct menu styling and menu on unselected, and refresh menu item):

<img width="708" height="548" alt="image" src="https://github.com/user-attachments/assets/45f26ba8-7a28-4cc0-8c15-405c30f34bb6" />


TODO:  Tests

- Fixes #2412
- Fixes #4416
- Fixes #2506

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
<!-- update or delete the next line to reflect your usage -->
Assisted-by: ChatGPT, GitHub Copilot
