### PR TITLE
Clip and ellipsize GTK labels

### DIFF
--- a/changes/3780.bugfix.md
+++ b/changes/3780.bugfix.md
@@ -1,0 +1,1 @@
+Label widgets on GTK now clips its contents to its bounds if an explicit width less than what could accommodate the text is set on the widget, ellipsizing if possible during the process.

--- a/examples/layout/layout/app.py
+++ b/examples/layout/layout/app.py
@@ -24,6 +24,8 @@ class LayoutApp(toga.App):
         image = toga.Image("resources/tiberius.png")
         self.image_view = toga.ImageView(image, width=60, height=60)
 
+        self.label_clipped = toga.Label("Truncated text", width=80)
+
         # this tests adding children during init, before we have an implementation
         self.button_box = toga.Column(
             children=[
@@ -33,8 +35,9 @@ class LayoutApp(toga.App):
                 self.button_reparent,
                 self.button_remove,
                 self.button_add_to_scroll,
+                self.label_clipped,
             ],
-            width=120,
+            width=150,
             gap=20,
         )
 

--- a/gtk/src/toga_gtk/widgets/label.py
+++ b/gtk/src/toga_gtk/widgets/label.py
@@ -1,6 +1,6 @@
 from travertino.size import at_least
 
-from ..libs import GTK_VERSION, Gtk, gtk_text_align
+from ..libs import GTK_VERSION, Gdk, Gtk, Pango, gtk_text_align
 from .base import Widget
 
 
@@ -9,11 +9,26 @@ class Label(Widget):
         self.native = Gtk.Label()
         if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             self.native.set_line_wrap(False)
+            self.native.connect("size-allocate", self.gtk_on_size_allocate)
         else:  # pragma: no-cover-if-gtk3
             self.native.set_wrap(False)
+            self.native.set_overflow(Gtk.Overflow.HIDDEN)
+        self.native.set_ellipsize(Pango.EllipsizeMode.END)
+
+    if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4  # pragma: no branch
+
+        def gtk_on_size_allocate(self, widget, allocation):
+            clip = Gdk.Rectangle()
+            clip.x = allocation.x
+            clip.y = allocation.y
+            clip.width = allocation.width
+            clip.height = allocation.height
+
+            self.native.set_clip(clip)
 
     def set_text_align(self, value):
         xalign, justify = gtk_text_align(value)
+
         self.native.set_xalign(xalign)  # Aligns the whole text block within the widget.
         self.native.set_yalign(0.0)  # Aligns the text block to the top
         self.native.set_justify(
@@ -27,28 +42,16 @@ class Label(Widget):
         self.native.set_text(value)
 
     def rehint(self):
+        # We must use the preferred size rather than minimum size here, as the ellipsize
+        # mode makes the label possible to shrink to a minimum size of just 3 dots.
         if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
-            # print(
-            #     "REHINT",
-            #     self,
-            #     self.native.get_preferred_width(),
-            #     self.native.get_preferred_height(),
-            #     getattr(self, "_fixed_height", False),
-            #     getattr(self, "_fixed_width", False),
-            # )
-            width = self.native.get_preferred_width()
-            height = self.native.get_preferred_height()
+            _, preferred_width = self.native.get_preferred_width()
+            _, preferred_height = self.native.get_preferred_height()
 
-            self.interface.intrinsic.width = at_least(width[0])
-            self.interface.intrinsic.height = height[1]
+            self.interface.intrinsic.width = at_least(preferred_width)
+            self.interface.intrinsic.height = preferred_height
         else:  # pragma: no-cover-if-gtk3
-            # print(
-            #     "REHINT",
-            #     self,
-            #     self.native.get_preferred_size()[0].width,
-            #     self.native.get_preferred_size()[0].height,
-            # )
-            min_size, size = self.native.get_preferred_size()
+            _, preferred_size = self.native.get_preferred_size()
 
-            self.interface.intrinsic.width = at_least(min_size.width)
-            self.interface.intrinsic.height = size.height
+            self.interface.intrinsic.width = at_least(preferred_size.width)
+            self.interface.intrinsic.height = preferred_size.height


### PR DESCRIPTION
Fixes #3780.

GTK labels are not clipped to their bounds; there is a native ellipsize option on the widget we should enable to automatically put ellipsis at the end of the text if necessary.  Enabling this changes the way we use native functions to rehint, and the rehint code is modified accordingly.

We should still clip the widget to bounds, however, because the user may set a very very tiny label that can't even fit a single ellipsis, but still we have to clip the label properly to avoid overflow.

A drive-by fix to the example app involves bumping the width for the button box, as the buttons were hinted to >120px wide and was overlapping with the text.

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
<!-- update or delete the next line to reflect your usage -->
