### PR TITLE
Android: implement `App.exit()` and route the hardware back button to `on_exit`

### DIFF
--- a/android/src/toga_android/app.py
+++ b/android/src/toga_android/app.py
@@ -103,6 +103,16 @@ class TogaApp(dynamic_proxy(IPythonApp)):
     def onConfigurationChanged(self, new_config):
         pass  # pragma: no cover
 
+    def onBackPressed(self):
+        # The Android hardware/gesture "back" at the root of the task maps to a
+        # request to exit the app. Routing it through request_exit() means the
+        # app's (vetoable) on_exit handler is honored, instead of the activity
+        # being silently finished. Returning True tells MainActivity that Python
+        # has handled the event, so it must not invoke the default behavior.
+        print("Toga app: onBackPressed")
+        self._impl.interface.request_exit()
+        return True
+
     def onOptionsItemSelected(self, menuitem):
         itemid = menuitem.getItemId()
         if itemid == Menu.NONE:
@@ -248,7 +258,10 @@ class App:
     ######################################################################
 
     def exit(self):
-        pass  # pragma: no cover
+        # Finish the activity and remove its task from the recents list. This is
+        # the closest Android equivalent to a desktop app exit; there is no HIG
+        # concept of a process-level "quit".
+        self.native.finishAndRemoveTask()
 
     def main_loop(self):
         # In order to support user asyncio code, start the Python/Android cooperative

--- a/changes/1623.feature.md
+++ b/changes/1623.feature.md
@@ -1,0 +1,1 @@
+On Android, the hardware/gesture back button now triggers the application's exit handling. The button is routed through ``App.request_exit()``, so the ``App.on_exit`` handler is honored (and can veto the exit, e.g. to navigate within the app); ``App.exit()`` is now implemented, finishing the activity and removing its task.


### PR DESCRIPTION
Refs #1623.

### What this does

On Android, Toga currently never wires the hardware/gesture **Back** button to
any Toga handler — the activity is silently finished, so `App.on_exit` never
runs and an app can't use Back to navigate between its own screens (see #2419,
and the request in #1623 to implement `App.exit`/`App.on_exit` on mobile).

This PR:

- Implements `App.exit()` on Android as `finishAndRemoveTask()` (previously a
  no-op `pass`).
- Adds `TogaApp.onBackPressed()` to the activity listener, which routes the back
  button through `App.request_exit()`. That invokes the (vetoable) `on_exit`
  handler and only calls `App.exit()` if the handler allows it.

No new public API is added — per the maintainer note in #1623 that a dedicated
`on_back_pressed` handler isn't desirable, Back is mapped onto the existing
cross-platform `request_exit`/`on_exit`/`exit` concept. An app can therefore:

- veto the exit and navigate within itself (return `False` from `on_exit`), or
- run cleanup / confirmation before exiting (the standard `on_exit` contract).

For a simple single-screen app the default `on_exit` (returns `True`) reproduces
the previous behavior: Back exits the app.

### Companion change

This requires a one-line-ish hook in the Android template, submitted separately:
**beeware/briefcase-android-gradle-template#121** overrides
`MainActivity.onBackPressed()` to delegate to the Python app via
`userCode("onBackPressed")`, falling back to `super.onBackPressed()` when Python
doesn't consume the event. The template hook is a no-op for apps/backends that
don't implement `onBackPressed`, so it's safe independent of this PR.

### Testing

The two repos are coupled (the template provides the Java hook; this PR provides
the Python handler), so an automated `testbed` test for the back button can only
pass once the template hook ships in a Briefcase template release. I'm happy to
add a testbed case in a follow-up (or here, gated) once the template PR lands —
guidance welcome on how you'd prefer to sequence that.

Validated on a physical device (Android, API ≥ 26):

- Back on a sub-screen → `on_exit` returns `False` → app navigates and stays
  running.
- Back on the root screen → `on_exit` returns `True` → `finishAndRemoveTask()`
  → activity destroyed, launcher returns to foreground.

Logcat confirms the chain `MainActivity.onBackPressed()` → `Toga app:
onBackPressed` → either *handled* (no `super`) or the exit lifecycle.

### Status

- [x] Existing tests pass / change is backend-local.
- [x] Changelog note added (`changes/1623.feature.md`).
- [ ] Testbed coverage — pending template release (see above).

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
<!-- update or delete the next line to reflect your usage -->
Assisted-by: Claude Opus 4.8
