### PR TITLE
Android: use `MaterialButton` under a Material theme

### DIFF
--- a/android/src/toga_android/widgets/button.py
+++ b/android/src/toga_android/widgets/button.py
@@ -9,6 +9,13 @@ from toga.colors import TRANSPARENT
 
 from .label import TextViewWidget
 
+try:
+    from com.google.android.material.button import MaterialButton
+except ImportError:  # pragma: no cover
+    # Older projects that don't include the Material library; fall back to a plain
+    # android.widget.Button. Can't be validated in CI, so it's marked no-cover.
+    MaterialButton = None
+
 
 class TogaOnClickListener(dynamic_proxy(View.OnClickListener)):
     def __init__(self, button_impl):
@@ -22,12 +29,33 @@ class TogaOnClickListener(dynamic_proxy(View.OnClickListener)):
 class Button(TextViewWidget):
     focusable = False
 
+    # Tri-state cache of whether a MaterialButton can be created under the app's
+    # theme. MaterialButton requires a Material Components / Material 3 theme and
+    # raises if the theme doesn't qualify, so we probe once: None = not yet probed,
+    # True/False = the result. Cached on the class because the theme is app-wide.
+    _material_capable = None
+
     def create(self):
-        self.native = A_Button(self._native_activity)
+        self.native = self._create_native_button()
         self.native.setOnClickListener(TogaOnClickListener(button_impl=self))
         self.cache_textview_defaults()
 
         self._icon = None
+
+    def _create_native_button(self):
+        # Prefer a Material "filled" button (rounded, ripple, accent-tinted from the
+        # theme's colorPrimary) when the Material library is present AND the app theme
+        # supports it. A plain Button is used otherwise, so AppCompat-themed apps are
+        # unaffected. MaterialButton subclasses android.widget.Button, so the rest of
+        # this backend (and the probe's isinstance check) still applies.
+        if MaterialButton is not None and Button._material_capable is not False:
+            try:
+                button = MaterialButton(self._native_activity)
+                Button._material_capable = True
+                return button
+            except Exception:  # pragma: no cover - theme isn't Material-compatible
+                Button._material_capable = False
+        return A_Button(self._native_activity)
 
     def get_text(self):
         return str(self.native.getText())

--- a/changes/4461.feature.md
+++ b/changes/4461.feature.md
@@ -1,0 +1,1 @@
+On Android, buttons now render as Material ``MaterialButton``\ s (filled, rounded, tinted from the theme's ``colorPrimary``) when the app uses a Material Components / Material 3 theme and the Material library is available. Apps using an AppCompat theme are unaffected, falling back to the standard ``Button``.


### PR DESCRIPTION
Refs #4461.

### What this does

`toga_android` creates buttons programmatically as `android.widget.Button`, which
bypasses `AppCompatViewInflater` — so under a Material Components / Material 3 theme
the button never picks up the Material *filled-button* style (rounded, ripple,
`colorPrimary` tint), even though other widgets (`Switch`, etc.) and the chrome do.

When the Material library is present **and** the app theme supports it, this creates
`com.google.android.material.button.MaterialButton` instead; otherwise it falls back
to a plain `Button`, so AppCompat-themed apps are unchanged. `MaterialButton`
subclasses `android.widget.Button`, so the rest of the backend (and the probe's
`isinstance(self.native, android.widget.Button)` check) still applies. `MaterialButton`
requires a Material theme (it raises otherwise), so the swap is gated: it's attempted
once and the result cached, falling back if construction fails. There's precedent for
optional Material use in this backend — `OptionContainer` already uses
`BottomNavigationView`.

### Validation

Validated on a physical device:
- A Material-3-themed app (`base_theme = "Theme.Material3.DayNight"` + the material
  dependency): buttons become filled, rounded, accent-tinted Material buttons.
- An AppCompat-themed app: unchanged (plain `Button`; the probe-once falls back).

### Open questions / where I'd value direction (see #4461)

- This changes the default button appearance for **Material-themed apps, including the
  testbed** (`Theme.MaterialComponents.*`). I was **not able to run the testbed**
  locally (no emulator here), so probe assertions may need updates — notably Material
  button **min-width (~88dp)**, text appearance, and `background_color` readback.
  Guidance on how you'd like the testbed handled is very welcome.
- `set_background_color`: `MaterialButton` manages its own background; the existing
  `set_background_filter` (color filter on `getBackground()`) appears to work, but you
  may prefer `setBackgroundTintList`.

I split this from the issue so the design discussion can happen there; happy to adjust
scope (e.g. gate behind an explicit opt-in) based on your preference.

### Status
- [x] Changelog note added (`changes/4461.feature.md`).
- [ ] Testbed probe updates — needs an emulator/CI run (see above).

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
<!-- update or delete the next line to reflect your usage -->
Assisted-by: Claude Opus 4.8
