### PR TITLE
Fix DrawingAction color aliasing logic

### DIFF
--- a/changes/4472.bugfix.md
+++ b/changes/4472.bugfix.md
@@ -1,0 +1,1 @@
+Providing the `color` parameter alias when instantiating a `Fill` or `Stroke` drawing action no longer throws an erroneous `TypeError`.

--- a/core/src/toga/widgets/canvas/state.py
+++ b/core/src/toga/widgets/canvas/state.py
@@ -925,10 +925,11 @@ class ClosePath(BaseState):
 
 def _assign_style(action, name, color):
     """Determine fill_style/stroke_style based on "actual" arg and color."""
-
-    # Normalize to NOT_PROVIDED if it's the property itself.
-    color = NOT_PROVIDED if color is type(action).color else color
     style = getattr(action, f"{name}_style")
+
+    # For each, normalize to NOT_PROVIDED if it's the property itself.
+    color = NOT_PROVIDED if isinstance(color, color_property) else color
+    style = NOT_PROVIDED if isinstance(style, color_property) else style
 
     if style is not NOT_PROVIDED and color is not NOT_PROVIDED:
         raise TypeError(f"Both {name}_style and color provided")

--- a/core/tests/widgets/canvas/test_draw_operations.py
+++ b/core/tests/widgets/canvas/test_draw_operations.py
@@ -66,6 +66,7 @@ def test_close_path(widget):
     assert widget._impl.draw_instructions[1:-1] == ["close path"]
 
 
+@pytest.mark.parametrize("use_method", [True, False])
 @pytest.mark.parametrize("alias_kwarg", [True, False])
 @pytest.mark.parametrize("alias_attr", [True, False])
 @pytest.mark.parametrize(
@@ -131,19 +132,33 @@ def test_close_path(widget):
         ),
     ],
 )
-def test_fill(widget, alias_kwarg, alias_attr, kwargs, args_repr, draw_objs, attrs):
+def test_fill(
+    widget,
+    use_method,
+    alias_kwarg,
+    alias_attr,
+    kwargs,
+    args_repr,
+    draw_objs,
+    attrs,
+):
     """A primitive fill operation can be added."""
     if alias_kwarg and "fill_style" in kwargs:
         kwargs["color"] = kwargs.pop("fill_style")
 
-    draw_op = widget.fill(**kwargs)
+    if use_method:
+        draw_op = widget.fill(**kwargs)
 
-    assert_action_performed(widget, "redraw")
+        assert_action_performed(widget, "redraw")
+
+        # The first and last instructions save/restore the root state, and can be
+        # ignored. But the fill itself also saves and then restores.
+        assert widget._impl.draw_instructions[1:-1] == ["save", *draw_objs, "restore"]
+
+    else:
+        draw_op = Fill(**kwargs)
+
     assert repr(draw_op) == f"Fill({args_repr})"
-
-    # The first and last instructions save/restore the root state, and can be ignored.
-    # But the fill itself also saves and then restores.
-    assert widget._impl.draw_instructions[1:-1] == ["save", *draw_objs, "restore"]
 
     # All the attributes can be retrieved.
     if alias_attr and "fill_style" in attrs:
@@ -162,6 +177,7 @@ def test_fill_kw_only(widget, use_method):
         fill(FillRule.EVENODD, REBECCAPURPLE)
 
 
+@pytest.mark.parametrize("use_method", [True, False])
 @pytest.mark.parametrize("alias_kwarg", [True, False])
 @pytest.mark.parametrize("alias_attr", [True, False])
 @pytest.mark.parametrize(
@@ -237,24 +253,37 @@ def test_fill_kw_only(widget, use_method):
         ),
     ],
 )
-def test_stroke(widget, alias_kwarg, alias_attr, kwargs, args_repr, draw_objs, attrs):
+def test_stroke(
+    widget,
+    use_method,
+    alias_kwarg,
+    alias_attr,
+    kwargs,
+    args_repr,
+    draw_objs,
+    attrs,
+):
     """A primitive stroke operation can be added."""
     if alias_kwarg and "stroke_style" in kwargs:
         kwargs["color"] = kwargs.pop("stroke_style")
 
-    draw_op = widget.stroke(**kwargs)
+    if use_method:
+        draw_op = widget.stroke(**kwargs)
 
-    assert_action_performed(widget, "redraw")
+        assert_action_performed(widget, "redraw")
+
+        # The first and last instructions save/restore the root state, and can be
+        # ignored. But the stroke itself also saves and then restores.
+        assert widget._impl.draw_instructions[1:-1] == [
+            "save",
+            *draw_objs,
+            "stroke",
+            "restore",
+        ]
+    else:
+        draw_op = Stroke(**kwargs)
+
     assert repr(draw_op) == f"Stroke({args_repr})"
-
-    # The first and last instructions save/restore the root state, and can be ignored.
-    # But the stroke itself also saves and then restores.
-    assert widget._impl.draw_instructions[1:-1] == [
-        "save",
-        *draw_objs,
-        "stroke",
-        "restore",
-    ]
 
     # All the attributes can be retrieved.
     if alias_attr and "stroke_style" in attrs:


### PR DESCRIPTION
#4330 gave the `fill` and `stroke` methods (and their corresponding drawing actions) `fill_style` and `stroke_style` parameters, respectively, but retained `color` as a user-friendly alias. This worked just fine when calling the methods, but I discovered (from running some [example code](https://github.com/beeware/toga/discussions/4397#discussioncomment-17081879) I'd typed up) that it *doesn't* work correctly for the drawing actions themselves. For example, `canvas.fill(color="blue")` works, but `Fill(color="blue")` throws a `TypeError`, claiming that both `color` and `fill_style` were provided.

This was because the method was explicitly passing `NOT_PROVIDED` for `fill_style` (or `stroke_style`), while if you actually omit the argument in the dataclass constructor, the property itself is assigned to the attribute.

I missed this because the tests being run on the fill and stroke methods weren't also being run on the classes directly. For now I've fixed that specifically. The fact that similar test mismatches are probably lurking elsewhere is one of the main reasons for #4368.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
<!-- update or delete the next line to reflect your usage -->
