### PR TITLE
Turn Canvas transform methods into states

### DIFF
--- a/changes/4477.feature.md
+++ b/changes/4477.feature.md
@@ -1,0 +1,1 @@
+The Canvas widget's `rotate`, `scale`, and `translate` methods can now be used as context managers.

--- a/core/src/toga/widgets/canvas/__init__.py
+++ b/core/src/toga/widgets/canvas/__init__.py
@@ -14,19 +14,16 @@ from .drawingaction import (
     Rect,
     ResetTransform,
     Restore,
-    Rotate,
     RoundRect,
     Save,
-    Scale,
     SetFillStyle,
     SetLineDash,
     SetLineWidth,
     SetStrokeStyle,
-    Translate,
     WriteText,
 )
 from .geometry import arc_to_bezier, sweepangle
-from .state import BaseState, ClosePath, Fill, State, Stroke
+from .state import BaseState, ClosePath, Fill, Rotate, Scale, State, Stroke, Translate
 
 # Make sure deprecation warnings are shown by default
 warnings.filterwarnings("default", category=DeprecationWarning)
@@ -76,10 +73,7 @@ __all__ = [
     "QuadraticCurveTo",
     "Rect",
     "ResetTransform",
-    "Rotate",
     "RoundRect",
-    "Scale",
-    "Translate",
     "WriteText",
     # States
     "BaseState",
@@ -87,6 +81,9 @@ __all__ = [
     "Fill",
     "Stroke",
     "ClosePath",
+    "Rotate",
+    "Scale",
+    "Translate",
     # Geometry
     "arc_to_bezier",
     "sweepangle",

--- a/core/src/toga/widgets/canvas/drawingaction.py
+++ b/core/src/toga/widgets/canvas/drawingaction.py
@@ -443,44 +443,6 @@ class DrawImage(DrawingAction):
 ###########################################################################
 
 
-@dataclass(repr=False)
-class Rotate(DrawingAction):
-    """The [`DrawingAction`][toga.widgets.canvas.DrawingAction] representing the
-    [rotate()][toga.Canvas.rotate] method.
-    """
-
-    radians: float
-
-    def _draw(self, context: Any) -> None:
-        context.rotate(self.radians)
-
-
-@dataclass(repr=False)
-class Scale(DrawingAction):
-    """The [`DrawingAction`][toga.widgets.canvas.DrawingAction] representing the
-    [scale()][toga.Canvas.scale] method.
-    """
-
-    sx: float
-    sy: float
-
-    def _draw(self, context: Any) -> None:
-        context.scale(self.sx, self.sy)
-
-
-@dataclass(repr=False)
-class Translate(DrawingAction):
-    """The [`DrawingAction`][toga.widgets.canvas.DrawingAction] representing the
-    [translate()][toga.Canvas.translate] method.
-    """
-
-    tx: float
-    ty: float
-
-    def _draw(self, context: Any) -> None:
-        context.translate(self.tx, self.ty)
-
-
 class ResetTransform(DrawingAction):
     """The [`DrawingAction`][toga.widgets.canvas.DrawingAction] representing the
     [reset_transform()][toga.Canvas.reset_transform] method.

--- a/core/src/toga/widgets/canvas/state.py
+++ b/core/src/toga/widgets/canvas/state.py
@@ -25,10 +25,7 @@ from .drawingaction import (
     QuadraticCurveTo,
     Rect,
     ResetTransform,
-    Rotate,
     RoundRect,
-    Scale,
-    Translate,
     WriteText,
     color_property,
 )
@@ -464,6 +461,9 @@ class DrawingActionDispatch(ABC):
     def rotate(self, radians: float) -> Rotate:
         """Add a rotation.
 
+        If used as a context manager, this saves state and applies the rotation when
+        entering, then restores state upon exiting.
+
         :param radians: The angle to rotate clockwise in radians.
         :returns: The `Rotate` [`DrawingAction`][toga.widgets.canvas.DrawingAction]
             for the transformation.
@@ -475,6 +475,9 @@ class DrawingActionDispatch(ABC):
 
     def scale(self, sx: float, sy: float) -> Scale:
         """Add a scaling transformation.
+
+        If used as a context manager, this saves state and applies the scaling when
+        entering, then restores state upon exiting.
 
         :param sx: Scale factor for the X dimension. A negative value flips the
             image horizontally.
@@ -490,6 +493,9 @@ class DrawingActionDispatch(ABC):
 
     def translate(self, tx: float, ty: float) -> Translate:
         """Add a translation.
+
+        If used as a context manager, this saves state and applies the translation when
+        entering, then restores state upon exiting.
 
         :param tx: Translation for the X dimension.
         :param ty: Translation for the Y dimension.
@@ -691,7 +697,7 @@ class BaseState(DrawingAction, DrawingActionDispatch, ABC):
     [`Canvas.redraw()`][toga.Canvas.redraw] for the changes to be rendered.
     """
 
-    def __init__(self):
+    def __post_init__(self):
         self.drawing_actions = []
         self._can_be_entered = True
 
@@ -865,11 +871,8 @@ class BaseState(DrawingAction, DrawingActionDispatch, ABC):
 @dataclass(repr=False)
 class State(BaseState):
     """The [DrawingAction][toga.widgets.canvas.DrawingAction] representing the
-    [stateh()][toga.Canvas.state] method. Functions as a context manager.
+    [state()][toga.Canvas.state] method. Functions as a context manager.
     """
-
-    def __post_init__(self):
-        super().__init__()
 
     def _draw(self, context: Any) -> None:
         context.save()
@@ -883,9 +886,6 @@ class ClosePath(BaseState):
     """The [DrawingAction][toga.widgets.canvas.DrawingAction] representing the
     [close_path()][toga.Canvas.close_path] method. Can function as a context manager.
     """
-
-    def __post_init__(self):
-        super().__init__()
 
     # Backwards compatibility for Toga <= 0.5.4
     # See DrawingActionDispatch.ClosedPath for explanation
@@ -953,7 +953,7 @@ class Fill(BaseState):
     color: InitVar[ColorT | None | object] = color_property()
 
     def __post_init__(self, color):
-        super().__init__()
+        super().__post_init__()
         self.fill_style = _assign_style(self, "fill", color)
 
     def _draw(self, context: Any) -> None:
@@ -989,7 +989,7 @@ class Stroke(BaseState):
     line_dash: list[float] | None = None
 
     def __post_init__(self, color):
-        super().__init__()
+        super().__post_init__()
         self.stroke_style = _assign_style(self, "stroke", color)
 
     def _draw(self, context: Any) -> None:
@@ -1013,3 +1013,60 @@ class Stroke(BaseState):
 
         context.stroke()
         context.restore()
+
+
+class TransformState(BaseState, ABC):
+    @abstractmethod
+    def _call_method(self, context: Any) -> None: ...
+
+    def _draw(self, context: Any) -> None:
+        if not (hasattr(self, "_is_open") or self.drawing_actions):
+            # Wasn't used as a context manager (nor had drawing actions manually added)
+            self._call_method(context)
+            return
+
+        context.save()
+        self._call_method(context)
+
+        for action in self.drawing_actions:
+            action._draw(context)
+
+        context.restore()
+
+
+@dataclass(repr=False)
+class Rotate(TransformState):
+    """The [`DrawingAction`][toga.widgets.canvas.DrawingAction] representing the
+    [rotate()][toga.Canvas.rotate] method. Can function as a context manager.
+    """
+
+    radians: float
+
+    def _call_method(self, context: Any) -> None:
+        context.rotate(self.radians)
+
+
+@dataclass(repr=False)
+class Scale(TransformState):
+    """The [`DrawingAction`][toga.widgets.canvas.DrawingAction] representing the
+    [scale()][toga.Canvas.scale] method. Can function as a context manager.
+    """
+
+    sx: float
+    sy: float
+
+    def _call_method(self, context: Any) -> None:
+        context.scale(self.sx, self.sy)
+
+
+@dataclass(repr=False)
+class Translate(TransformState):
+    """The [`DrawingAction`][toga.widgets.canvas.DrawingAction] representing the
+    [translate()][toga.Canvas.translate] method. Can function as a context manager.
+    """
+
+    tx: float
+    ty: float
+
+    def _call_method(self, context: Any) -> None:
+        context.translate(self.tx, self.ty)

--- a/core/tests/widgets/canvas/test_state_objects.py
+++ b/core/tests/widgets/canvas/test_state_objects.py
@@ -246,8 +246,6 @@ def test_transforms(widget):
     assert repr(translate) == "Translate(tx=0, ty=10)"
     assert translate.tx == 0
     assert translate.ty == 10
-
-
     assert widget._impl.draw_instructions[1:-1] == [
         "save",
         ("rotate", {"radians": 3}),

--- a/core/tests/widgets/canvas/test_state_objects.py
+++ b/core/tests/widgets/canvas/test_state_objects.py
@@ -247,11 +247,6 @@ def test_transforms(widget):
     assert translate.tx == 0
     assert translate.ty == 10
 
-    # The first and last instructions can be ignored; they're the root canvas state
-    from pprint import pprint
-
-    print(rotate._is_open)
-    pprint(widget._impl.draw_instructions[1:-1])
 
     assert widget._impl.draw_instructions[1:-1] == [
         "save",

--- a/core/tests/widgets/canvas/test_state_objects.py
+++ b/core/tests/widgets/canvas/test_state_objects.py
@@ -5,9 +5,11 @@ from toga.constants import FillRule
 from toga.widgets.canvas import (
     ClosePath,
     Fill,
+    Rotate,
     Scale,
     State,
     Stroke,
+    Translate,
 )
 from toga_dummy.utils import assert_action_performed
 
@@ -217,6 +219,53 @@ def test_stroke(widget, kwargs, args_repr, properties):
     # The first and last instructions can be ignored; they're the root canvas state
     assert widget._impl.draw_instructions[1:-1] == [
         command for command in commands if command is not None
+    ]
+
+
+def test_transforms(widget):
+    """Rotate, scale, and translate can be used as context managers."""
+    with widget.rotate(3) as rotate:
+        widget.move_to(10, 10)
+
+    with widget.scale(2, 2) as scale:
+        with widget.translate(0, 10) as translate:
+            widget.move_to(0, 0)
+
+    widget.line_to(100, 100)
+
+    assert isinstance(rotate, Rotate)
+    assert repr(rotate) == "Rotate(radians=3)"
+    assert rotate.radians == 3
+
+    assert isinstance(scale, Scale)
+    assert repr(scale) == "Scale(sx=2, sy=2)"
+    assert scale.sx == 2
+    assert scale.sy == 2
+
+    assert isinstance(translate, Translate)
+    assert repr(translate) == "Translate(tx=0, ty=10)"
+    assert translate.tx == 0
+    assert translate.ty == 10
+
+    # The first and last instructions can be ignored; they're the root canvas state
+    from pprint import pprint
+
+    print(rotate._is_open)
+    pprint(widget._impl.draw_instructions[1:-1])
+
+    assert widget._impl.draw_instructions[1:-1] == [
+        "save",
+        ("rotate", {"radians": 3}),
+        ("move to", {"x": 10, "y": 10}),
+        "restore",
+        "save",
+        ("scale", {"sx": 2, "sy": 2}),
+        "save",
+        ("translate", {"tx": 0, "ty": 10}),
+        ("move to", {"x": 0, "y": 0}),
+        "restore",
+        "restore",
+        ("line to", {"x": 100, "y": 100}),
     ]
 
 

--- a/testbed/tests/widgets/canvas/test_canvas.py
+++ b/testbed/tests/widgets/canvas/test_canvas.py
@@ -706,6 +706,35 @@ async def test_transforms(canvas, probe, restore_method):
     assert_reference(probe, "transforms")
 
 
+async def test_transforms_as_context_managers(canvas, probe):
+    """Transforms can be used as context managers."""
+    # Draw the same image as test_transforms above, but using the transforms as context
+    # managers.
+    with canvas.translate(160, 20):
+        canvas.rect(0, 0, 20, 60)
+        canvas.fill(fill_style=CORNFLOWERBLUE)
+
+    with canvas.rotate(pi / 4):
+        canvas.begin_path()
+        canvas.rect(200, 0, 20, 60)
+        canvas.fill(fill_style=REBECCAPURPLE)
+
+    with canvas.scale(2, 5):
+        canvas.begin_path()
+        canvas.rect(10, 10, 10, 10)
+        canvas.fill(fill_style=GOLDENROD)
+
+    with canvas.translate(100, 60):
+        canvas.begin_path()
+        canvas.rotate(pi / 7 * 4)
+        canvas.scale(5, 2)
+        canvas.rect(2, 2, 10, 10)
+        canvas.fill()
+
+    await probe.redraw("Transforms can be applied")
+    assert_reference(probe, "transforms")
+
+
 async def test_transforms_mid_path(canvas, probe):
     """Transforms can be applied mid-path."""
 


### PR DESCRIPTION
Part of #3994 

This enables the `rotate`, `scale`, and `translate` methods to function as states when used as context managers.

Also slightly simplifies the initialization of `BaseState` subclasses by putting the code in `__post_init__` on the base class, and corrects a typo in `BaseState`'s docstring.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
<!-- update or delete the next line to reflect your usage -->
