### PR TITLE
Clarify font variant note in resources/font docs

### DIFF
--- a/changes/4479.doc.md
+++ b/changes/4479.doc.md
@@ -1,0 +1,1 @@
+Clarified the font notes to explain that Toga only guarantees the faces, variants and weights actually defined in a font file, rather than implying iOS and macOS can't use variant fonts.

--- a/changes/4479.doc.md
+++ b/changes/4479.doc.md
@@ -1,1 +1,0 @@
-Clarified the font notes to explain that Toga only guarantees the faces, variants and weights actually defined in a font file, rather than implying iOS and macOS can't use variant fonts.

--- a/changes/4479.misc.md
+++ b/changes/4479.misc.md
@@ -1,0 +1,1 @@
+Details of variant font usage has been clarified.

--- a/docs/en/reference/api/resources/font.md
+++ b/docs/en/reference/api/resources/font.md
@@ -61,7 +61,7 @@ When constructing your own [`Font`][toga.Font] instance, ensure that the font fa
 
 ## Notes
 
-- iOS and macOS do not support the use of variant font files (that is, fonts that contain the details of multiple weights/variants in a single file). Variant font files can be registered; however, only the "normal" variant will be used.
+- Some platforms allow the use of font weights and variants that aren't explicitly provided by altering the rendering of a normal font (e.g., using a thick pen to render a normal font to render a fake bold, or applying a skew to render a fake italic). Toga only guarantees that the font faces, variants and weights that are actually defined in a font file will be available for use.
 - Android and Windows do not support the oblique font style. If an oblique font is specified, Toga will attempt to use an italic style of the same font.
 - Android and Windows do not support the small caps font variant. If a Small Caps font is specified, Toga will use the normal variant of the same font.
 


### PR DESCRIPTION
Replaces the misleading note that implied iOS and macOS cannot use variant fonts. The wording now explains that Toga only guarantees the faces, variants and weights actually defined in a font file, matching the clarification suggested in the issue.

Refs #4479.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
<!-- update or delete the next line to reflect your usage -->
Assisted-by: <!--name of tool; e.g., Claude Opus 4.5-->
