### PR TITLE
Clarify font variant documentation

### DIFF
--- a/changes/4479.misc.md
+++ b/changes/4479.misc.md
@@ -1,0 +1,1 @@
+The Font documentation now clarifies that only font faces, variants, and weights actually defined in a font file are guaranteed to be available.

--- a/docs/en/reference/api/resources/font.md
+++ b/docs/en/reference/api/resources/font.md
@@ -61,7 +61,7 @@ When constructing your own [`Font`][toga.Font] instance, ensure that the font fa
 
 ## Notes
 
-- iOS and macOS do not support the use of variant font files (that is, fonts that contain the details of multiple weights/variants in a single file). Variant font files can be registered; however, only the "normal" variant will be used.
+- Some platforms allow the use of font weights and variants that aren't explicitly provided by altering the rendering of a normal font (e.g., using a thick pen to render a normal font to render a fake bold, or applying a skew to render a fake italic). Toga only guarantees that the font faces, variants and weights that are actually defined in a font file will be available for use.
 - Android and Windows do not support the oblique font style. If an oblique font is specified, Toga will attempt to use an italic style of the same font.
 - Android and Windows do not support the small caps font variant. If a Small Caps font is specified, Toga will use the normal variant of the same font.
 


### PR DESCRIPTION
Fixes #4479.

This updates the Font notes to clarify that Toga only guarantees the font faces, variants, and weights that are actually defined in a font file, instead of saying iOS and macOS do not support variant font files. It also adds the required change note.

Verification:
- Compared the branch against upstream `main`; the diff is limited to `docs/en/reference/api/resources/font.md` and `changes/4479.misc.md`.
- Did not run the docs build because this change was applied through the GitHub Contents API after local Git transport to GitHub failed in this environment.

## PR Checklist:
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool

Assisted-by: OpenAI Codex
