### PR TITLE
Add keyword parameters to Canvas.state()

### DIFF
--- a/changes/4485.feature.md
+++ b/changes/4485.feature.md
@@ -1,0 +1,1 @@
+The canvas widget's `state()` context manager now accepts optional keyword parameters to set drawing context attributes upon entering.

--- a/changes/4485.misc.md
+++ b/changes/4485.misc.md
@@ -1,0 +1,1 @@
+The `repr` for `DrawingAction` no longer displays attributes that haven't been set.

--- a/core/src/toga/widgets/canvas/canvas.py
+++ b/core/src/toga/widgets/canvas/canvas.py
@@ -103,6 +103,8 @@ class drawing_context_property:
                     if (value := getattr(action, self.name)) is not None:
                         # This is a state we're currently in, and it sets the attribute.
                         return value
+                    else:  # no-cover-if-lt-py311
+                        pass
                 case self.ActionClass() if restores <= 0:
                     return getattr(action, self.name)
 

--- a/core/src/toga/widgets/canvas/canvas.py
+++ b/core/src/toga/widgets/canvas/canvas.py
@@ -99,6 +99,10 @@ class drawing_context_property:
                     restores += 1
                 case Save():
                     restores -= 1
+                case State() if getattr(action, "_is_open", False):
+                    if (value := getattr(action, self.name)) is not None:
+                        # This is a state we're currently in, and it sets the attribute.
+                        return value
                 case self.ActionClass() if restores <= 0:
                     return getattr(action, self.name)
 

--- a/core/src/toga/widgets/canvas/drawingaction.py
+++ b/core/src/toga/widgets/canvas/drawingaction.py
@@ -74,6 +74,9 @@ class DrawingAction(ABC):
             str_fields = []
             for field in fields(self):
                 match value := getattr(self, field.name):
+                    case None:
+                        # Leave None (unset attributes) out of the repr
+                        continue
                     case float():
                         str_value = f"{value:.3f}"
                     case Enum():

--- a/core/src/toga/widgets/canvas/drawingaction.py
+++ b/core/src/toga/widgets/canvas/drawingaction.py
@@ -106,17 +106,27 @@ NOT_PROVIDED = object()
 
 
 class color_property:
+    def __init__(self, aliased=False):
+        self.aliased = aliased
+
+    def __set_name__(self, action_class, name):
+        self.name = name
+
     def __get__(self, action, action_class=None):
         if action is None:
             return self
 
-        return action._color
+        return action._color if self.aliased else getattr(action, f"_{self.name}")
 
     def __set__(self, action, value):
         if value not in {None, NOT_PROVIDED, self}:
             value = Color.parse(value)
 
-        action._color = value
+        if self.aliased:
+            action._color = value
+        else:
+            value = None if value is self else value
+            setattr(action, f"_{self.name}", value)
 
 
 ###########################################################################

--- a/core/src/toga/widgets/canvas/state.py
+++ b/core/src/toga/widgets/canvas/state.py
@@ -536,10 +536,10 @@ class DrawingActionDispatch(ABC):
         All parameters to `state()` are optional. If provided, they will set the
         corresponding drawing context attribute upon entering the context manager.
 
-        :param fill_style: Sets the [`fill_style`](toga.Canvas.fill_style).
-        :param stroke_style: Sets the [`stroke_style`](toga.Canvas.stroke_style).
-        :param line_width: Sets the [`line_width`](toga.Canvas.line_width)
-        :param line_dash: Sets the [`line_dash`](toga.Canvas.line_dash).
+        :param fill_style: Sets the [`fill_style`][toga.Canvas.fill_style].
+        :param stroke_style: Sets the [`stroke_style`][toga.Canvas.stroke_style].
+        :param line_width: Sets the [`line_width`][toga.Canvas.line_width].
+        :param line_dash: Sets the [`line_dash`][toga.Canvas.line_dash].
 
         :return: Yields the new `State`
           [`DrawingAction`][toga.widgets.canvas.DrawingAction].

--- a/core/src/toga/widgets/canvas/state.py
+++ b/core/src/toga/widgets/canvas/state.py
@@ -522,14 +522,34 @@ class DrawingActionDispatch(ABC):
     # Sub-states of this state
     ###########################################################################
 
-    def state(self) -> AbstractContextManager[State]:
+    def state(
+        self,
+        *,
+        fill_style: ColorT | None = None,
+        stroke_style: ColorT | None = None,
+        line_width: float | None = None,
+        line_dash: list[float] | None = None,
+    ) -> AbstractContextManager[State]:
         """A context manager that saves the current state of the Canvas context, and
         restores it upon exiting.
+
+        All parameters to `state()` are optional. If provided, they will set the
+        corresponding drawing context attribute upon entering the context manager.
+
+        :param fill_style: Sets the [`fill_style`](toga.Canvas.fill_style).
+        :param stroke_style: Sets the [`stroke_style`](toga.Canvas.stroke_style).
+        :param line_width: Sets the [`line_width`](toga.Canvas.line_width)
+        :param line_dash: Sets the [`line_dash`](toga.Canvas.line_dash).
 
         :return: Yields the new `State`
           [`DrawingAction`][toga.widgets.canvas.DrawingAction].
         """
-        state = State()
+        state = State(
+            fill_style=fill_style,
+            stroke_style=stroke_style,
+            line_width=line_width,
+            line_dash=line_dash,
+        )
         self._add_to_target(state)
         self._redraw_with_warning_if_state()
         return state
@@ -874,10 +894,27 @@ class State(BaseState):
     [state()][toga.Canvas.state] method. Functions as a context manager.
     """
 
+    _: KW_ONLY
+    fill_style: ColorT | None = color_property()
+    stroke_style: ColorT | None = color_property()
+    line_width: float | None = None
+    line_dash: list[float] | None = None
+
     def _draw(self, context: Any) -> None:
         context.save()
+
+        if self.fill_style is not None:
+            context.set_fill_style(self.fill_style)
+        if self.stroke_style is not None:
+            context.set_stroke_style(self.stroke_style)
+        if self.line_width is not None:
+            context.set_line_width(self.line_width)
+        if self.line_dash is not None:
+            context.set_line_dash(self.line_dash)
+
         for action in self.drawing_actions:
             action._draw(context)
+
         context.restore()
 
 
@@ -949,8 +986,8 @@ class Fill(BaseState):
     # (path), (fill_rule), or (path, fill_rule) usage as in JavaScript.
     fill_rule: FillRule = FillRule.NONZERO
     _: KW_ONLY
-    fill_style: ColorT | None | object = color_property()
-    color: InitVar[ColorT | None | object] = color_property()
+    fill_style: ColorT | None | object = color_property(aliased=True)
+    color: InitVar[ColorT | None | object] = color_property(aliased=True)
 
     def __post_init__(self, color):
         super().__post_init__()
@@ -983,8 +1020,8 @@ class Stroke(BaseState):
 
     # Path parameter (positional/keyword) will go here.
     _: KW_ONLY
-    stroke_style: ColorT | None | object = color_property()
-    color: InitVar[ColorT | None | object] = color_property()
+    stroke_style: ColorT | None | object = color_property(aliased=True)
+    color: InitVar[ColorT | None | object] = color_property(aliased=True)
     line_width: float | None = None
     line_dash: list[float] | None = None
 

--- a/core/tests/widgets/canvas/test_draw_operations.py
+++ b/core/tests/widgets/canvas/test_draw_operations.py
@@ -75,7 +75,7 @@ def test_close_path(widget):
         # Defaults
         (
             {},
-            "fill_rule=FillRule.NONZERO, fill_style=None",
+            "fill_rule=FillRule.NONZERO",
             [("fill", {"fill_rule": FillRule.NONZERO})],
             {"fill_rule": FillRule.NONZERO, "fill_style": None},
         ),
@@ -102,21 +102,21 @@ def test_close_path(widget):
         # Color explicitly not set
         (
             {"fill_style": None},
-            "fill_rule=FillRule.NONZERO, fill_style=None",
+            "fill_rule=FillRule.NONZERO",
             [("fill", {"fill_rule": FillRule.NONZERO})],
             {"fill_rule": FillRule.NONZERO, "fill_style": None},
         ),
         # Explicit Non-Zero winding
         (
             {"fill_rule": FillRule.NONZERO},
-            "fill_rule=FillRule.NONZERO, fill_style=None",
+            "fill_rule=FillRule.NONZERO",
             [("fill", {"fill_rule": FillRule.NONZERO})],
             {"fill_rule": FillRule.NONZERO, "fill_style": None},
         ),
         # Even-Odd winding
         (
             {"fill_rule": FillRule.EVENODD},
-            "fill_rule=FillRule.EVENODD, fill_style=None",
+            "fill_rule=FillRule.EVENODD",
             [("fill", {"fill_rule": FillRule.EVENODD})],
             {"fill_rule": FillRule.EVENODD, "fill_style": None},
         ),
@@ -186,14 +186,14 @@ def test_fill_kw_only(widget, use_method):
         # Defaults
         (
             {},
-            "stroke_style=None, line_width=None, line_dash=None",
+            "",
             [],
             {"stroke_style": None, "line_width": None, "line_dash": None},
         ),
         # Color as string name
         (
             {"stroke_style": REBECCAPURPLE},
-            f"stroke_style={REBECCA_PURPLE_COLOR!r}, line_width=None, line_dash=None",
+            f"stroke_style={REBECCA_PURPLE_COLOR!r}",
             [("set stroke style", REBECCA_PURPLE_COLOR)],
             {
                 "stroke_style": REBECCA_PURPLE_COLOR,
@@ -204,7 +204,7 @@ def test_fill_kw_only(widget, use_method):
         # Color as RGB object
         (
             {"stroke_style": REBECCA_PURPLE_COLOR},
-            f"stroke_style={REBECCA_PURPLE_COLOR!r}, line_width=None, line_dash=None",
+            f"stroke_style={REBECCA_PURPLE_COLOR!r}",
             [("set stroke style", REBECCA_PURPLE_COLOR)],
             {
                 "stroke_style": REBECCA_PURPLE_COLOR,
@@ -215,21 +215,21 @@ def test_fill_kw_only(widget, use_method):
         # Color explicitly not set
         (
             {"stroke_style": None},
-            "stroke_style=None, line_width=None, line_dash=None",
+            "",
             [],
             {"stroke_style": None, "line_width": None, "line_dash": None},
         ),
         # Line width
         (
             {"line_width": 4.5},
-            "stroke_style=None, line_width=4.500, line_dash=None",
+            "line_width=4.500",
             [("set line width", 4.5)],
             {"stroke_style": None, "line_width": 4.5, "line_dash": None},
         ),
         # Line dash
         (
             {"line_dash": [2, 7]},
-            "stroke_style=None, line_width=None, line_dash=[2, 7]",
+            "line_dash=[2, 7]",
             [("set line dash", [2, 7])],
             {"stroke_style": None, "line_width": None, "line_dash": [2, 7]},
         ),
@@ -792,10 +792,7 @@ SYSTEM_FONT_IMPL = Font(SYSTEM, SYSTEM_DEFAULT_FONT_SIZE)._impl
                 "line_height": None,
                 "font": SYSTEM_FONT_IMPL,
             },
-            (
-                "text='Hello world', x=10, y=20, font=None, "
-                "baseline=Baseline.ALPHABETIC, line_height=None"
-            ),
+            "text='Hello world', x=10, y=20, baseline=Baseline.ALPHABETIC",
             {
                 "text": "Hello world",
                 "x": 10,
@@ -816,10 +813,7 @@ SYSTEM_FONT_IMPL = Font(SYSTEM, SYSTEM_DEFAULT_FONT_SIZE)._impl
                 "line_height": None,
                 "font": SYSTEM_FONT_IMPL,
             },
-            (
-                "text='Hello world', x=10, y=20, font=None, "
-                "baseline=Baseline.TOP, line_height=None"
-            ),
+            "text='Hello world', x=10, y=20, baseline=Baseline.TOP",
             {
                 "text": "Hello world",
                 "x": 10,
@@ -842,7 +836,7 @@ SYSTEM_FONT_IMPL = Font(SYSTEM, SYSTEM_DEFAULT_FONT_SIZE)._impl
             },
             (
                 "text='Hello world', x=10, y=20, font=<Font: 42pt Cutive>, "
-                "baseline=Baseline.ALPHABETIC, line_height=None"
+                "baseline=Baseline.ALPHABETIC"
             ),
             {
                 "text": "Hello world",
@@ -865,7 +859,7 @@ SYSTEM_FONT_IMPL = Font(SYSTEM, SYSTEM_DEFAULT_FONT_SIZE)._impl
                 "font": SYSTEM_FONT_IMPL,
             },
             (
-                "text='Hello world', x=10, y=20, font=None, "
+                "text='Hello world', x=10, y=20, "
                 "baseline=Baseline.ALPHABETIC, line_height=1.500"
             ),
             {
@@ -970,7 +964,7 @@ def test_reset_transform(widget):
             # When width and height aren't specified, the image's true dimensions are
             # supplied to the backend.
             {"x": 10, "y": 20, "width": 32, "height": 32},
-            "x=10, y=20, width=None, height=None",
+            "x=10, y=20",
             {
                 "x": 10,
                 "y": 20,

--- a/core/tests/widgets/canvas/test_state_objects.py
+++ b/core/tests/widgets/canvas/test_state_objects.py
@@ -1,6 +1,6 @@
 import pytest
 
-from toga.colors import REBECCAPURPLE, rgb
+from toga.colors import BLUE, REBECCAPURPLE, rgb
 from toga.constants import FillRule
 from toga.widgets.canvas import (
     ClosePath,
@@ -14,6 +14,8 @@ from toga.widgets.canvas import (
 from toga_dummy.utils import assert_action_performed
 
 REBECCA_PURPLE_COLOR = rgb(102, 51, 153)
+BLACK_COLOR = rgb(0, 0, 0)
+BLUE_COLOR = rgb(0, 0, 255)
 
 
 def test_sub_state(widget):
@@ -33,6 +35,49 @@ def test_sub_state(widget):
         ("line to", {"x": 30, "y": 40}),
         "restore",
     ]
+
+
+def test_state_parameters(widget):
+    """Drawing context attributes can be set as parameters to state()."""
+
+    def assert_attrs(canvas, fill_style, stroke_style, line_width, line_dash):
+        assert canvas.fill_style == fill_style
+        assert canvas.stroke_style == stroke_style
+        assert canvas.line_width == line_width
+        assert canvas.line_dash == line_dash
+
+    # Can't hurt to double-check the defaults.
+    assert_attrs(widget, BLACK_COLOR, BLACK_COLOR, 1.0, [])
+
+    with widget.state(fill_style=REBECCAPURPLE) as state_1:
+        assert repr(state_1) == f"State(fill_style={REBECCA_PURPLE_COLOR!r})"
+        assert_attrs(widget, REBECCA_PURPLE_COLOR, BLACK_COLOR, 1.0, [])
+
+        with widget.state(line_width=3.0, line_dash=[1, 2]) as state_2:
+            assert repr(state_2) == "State(line_width=3.000, line_dash=[1, 2])"
+            assert_attrs(widget, REBECCA_PURPLE_COLOR, BLACK_COLOR, 3.0, [1, 2])
+
+            # Override one that's already been set.
+            with widget.state(fill_style=BLUE) as state_3:
+                assert repr(state_3) == f"State(fill_style={BLUE_COLOR!r})"
+                assert_attrs(widget, BLUE_COLOR, BLACK_COLOR, 3.0, [1, 2])
+
+            with widget.state(stroke_style=BLUE) as state_4:
+                assert_attrs(widget, REBECCA_PURPLE_COLOR, BLUE_COLOR, 3.0, [1, 2])
+                assert repr(state_4) == f"State(stroke_style={BLUE_COLOR!r})"
+
+    # Set all at once
+    with widget.state(
+        fill_style=BLUE,
+        stroke_style=REBECCAPURPLE,
+        line_dash=[3, 2, 1],
+        line_width=10.0,
+    ) as state_5:
+        assert_attrs(widget, BLUE_COLOR, REBECCA_PURPLE_COLOR, 10.000, [3, 2, 1])
+        assert repr(state_5) == (
+            f"State(fill_style={BLUE_COLOR!r}, stroke_style={REBECCA_PURPLE_COLOR!r}, "
+            "line_width=10.000, line_dash=[3, 2, 1])"
+        )
 
 
 def test_closed_path(widget):
@@ -328,16 +373,16 @@ NON_REENTRANT_MATCH = (
 )
 
 
-def test_enter_open_context(widget):
-    """Attempting to enter a currently open context is an error."""
+def test_enter_open_state(widget):
+    """Attempting to enter a currently open state is an error."""
     with widget.stroke() as stroke:
         with pytest.raises(RuntimeError, match=NON_REENTRANT_MATCH):
             with stroke:
                 pass
 
 
-def test_enter_closed_context(widget):
-    """Attempting to enter a previously open (now closed) context is an error."""
+def test_enter_closed_state(widget):
+    """Attempting to enter a previously open (now closed) state is an error."""
     with widget.stroke() as stroke:
         pass
 
@@ -346,8 +391,8 @@ def test_enter_closed_context(widget):
             pass
 
 
-def test_enter_context_out_of_order(widget):
-    """Attempting to enter a context manager after making other actions is an error."""
+def test_enter_state_out_of_order(widget):
+    """Attempting to enter a state manager after making other actions is an error."""
     stroke = widget.stroke()
     widget.rect(0, 0, 0, 0)
 

--- a/core/tests/widgets/canvas/test_state_objects.py
+++ b/core/tests/widgets/canvas/test_state_objects.py
@@ -64,7 +64,7 @@ def test_closed_path(widget):
         # Defaults
         (
             {},
-            "fill_rule=FillRule.NONZERO, fill_style=None",
+            "fill_rule=FillRule.NONZERO",
             {
                 "fill_rule": FillRule.NONZERO,
                 "fill_style": None,
@@ -79,13 +79,13 @@ def test_closed_path(widget):
         # Explicitly don't set fill style
         (
             {"fill_style": None},
-            "fill_rule=FillRule.NONZERO, fill_style=None",
+            "fill_rule=FillRule.NONZERO",
             {"fill_rule": FillRule.NONZERO, "fill_style": None},
         ),
         # Fill Rule
         (
             {"fill_rule": FillRule.EVENODD},
-            "fill_rule=FillRule.EVENODD, fill_style=None",
+            "fill_rule=FillRule.EVENODD",
             {"fill_style": None, "fill_rule": FillRule.EVENODD},
         ),
         # All args
@@ -134,13 +134,13 @@ def test_fill(widget, kwargs, args_repr, properties):
         # Defaults
         (
             {},
-            "stroke_style=None, line_width=None, line_dash=None",
+            "",
             {"stroke_style": None, "line_width": None, "line_dash": None},
         ),
         # Color
         (
             {"stroke_style": REBECCAPURPLE},
-            f"stroke_style={REBECCA_PURPLE_COLOR!r}, line_width=None, line_dash=None",
+            f"stroke_style={REBECCA_PURPLE_COLOR!r}",
             {
                 "stroke_style": REBECCA_PURPLE_COLOR,
                 "line_width": None,
@@ -150,19 +150,19 @@ def test_fill(widget, kwargs, args_repr, properties):
         # Explicitly don't set stroke_style
         (
             {"stroke_style": None},
-            "stroke_style=None, line_width=None, line_dash=None",
+            "",
             {"stroke_style": None, "line_width": None, "line_dash": None},
         ),
         # Line width
         (
             {"line_width": 4.5},
-            "stroke_style=None, line_width=4.500, line_dash=None",
+            "line_width=4.500",
             {"stroke_style": None, "line_width": 4.5, "line_dash": None},
         ),
         # Line dash
         (
             {"line_dash": [2, 7]},
-            "stroke_style=None, line_width=None, line_dash=[2, 7]",
+            "line_dash=[2, 7]",
             {"stroke_style": None, "line_width": None, "line_dash": [2, 7]},
         ),
         # All args

--- a/testbed/tests/widgets/canvas/test_canvas.py
+++ b/testbed/tests/widgets/canvas/test_canvas.py
@@ -1102,29 +1102,31 @@ async def test_miter_join(canvas, probe):
     assert_reference(probe, "miter_join", threshold=0.025)
 
 
+class RectDrawer:
+    SIDE = 40
+    GAP = 15
+
+    def __init__(self):
+        self.x = self.y = self.GAP
+
+    def draw(self, canvas):
+        with canvas.stroke():
+            with canvas.fill():
+                canvas.rect(self.x, self.y, self.SIDE, self.SIDE)
+
+        self.x += self.SIDE + self.GAP
+        if self.x >= 150:
+            self.x = self.GAP
+            self.y += self.SIDE + self.GAP
+
+
 @pytest.mark.parametrize("restore_method", [state_context_manager, save_and_restore])
 async def test_attributes(canvas, probe, restore_method):
     """Context attributes can be set and restored."""
-    side = 40
-    gap = 15
-    x = gap
-    y = gap
-
-    def draw_rect(canvas):
-        nonlocal x
-        nonlocal y
-
-        with canvas.stroke():
-            with canvas.fill():
-                canvas.rect(x, y, side, side)
-
-        x += side + gap
-        if x >= 150:
-            x = gap
-            y += side + gap
+    rect = RectDrawer()
 
     # 1. Black on black
-    draw_rect(canvas)
+    rect.draw(canvas)
 
     canvas.fill_style = CORNFLOWERBLUE
     canvas.stroke_style = REBECCAPURPLE
@@ -1132,7 +1134,7 @@ async def test_attributes(canvas, probe, restore_method):
     canvas.line_dash = [2, 2]
 
     # 2. Purple on blue
-    draw_rect(canvas)
+    rect.draw(canvas)
 
     with restore_method(canvas):
         canvas.fill_style = GOLDENROD
@@ -1141,7 +1143,7 @@ async def test_attributes(canvas, probe, restore_method):
         canvas.line_dash = [5, 1]
 
         # 3. Red on goldenrod
-        draw_rect(canvas)
+        rect.draw(canvas)
 
         with restore_method(canvas):
             canvas.fill_style = RED
@@ -1150,10 +1152,10 @@ async def test_attributes(canvas, probe, restore_method):
             canvas.line_dash = []
 
             # 4. Blue on red
-            draw_rect(canvas)
+            rect.draw(canvas)
 
         # 5. Restore to red on goldenrod
-        draw_rect(canvas)
+        rect.draw(canvas)
 
         with restore_method(canvas):
             canvas.fill_style = CORNFLOWERBLUE
@@ -1162,13 +1164,69 @@ async def test_attributes(canvas, probe, restore_method):
             canvas.line_dash = [1, 4]
 
             # 6. Black on blue
-            draw_rect(canvas)
+            rect.draw(canvas)
 
         # 7. Restore to red on goldenrod
-        draw_rect(canvas)
+        rect.draw(canvas)
 
     # 8. Restore to purple on blue
-    draw_rect(canvas)
+    rect.draw(canvas)
 
     await probe.redraw("Image should be drawn")
     assert_reference(probe, "attributes")
+
+
+async def test_state_parameters(canvas, probe):
+    """Context attributes can be set via parameters to state()."""
+    # Draw the same image as test_attributes above.
+    rect = RectDrawer()
+
+    # 1. Black on black
+    rect.draw(canvas)
+
+    canvas.fill_style = CORNFLOWERBLUE
+    canvas.stroke_style = REBECCAPURPLE
+    canvas.line_width = 4
+    canvas.line_dash = [2, 2]
+
+    # 2. Purple on blue
+    rect.draw(canvas)
+
+    with canvas.state(
+        fill_style=GOLDENROD,
+        stroke_style=RED,
+        line_width=8,
+        line_dash=[5, 1],
+    ):
+        # 3. Red on goldenrod
+        rect.draw(canvas)
+
+        with canvas.state(
+            fill_style=RED,
+            stroke_style=CORNFLOWERBLUE,
+            line_width=3,
+            line_dash=[],
+        ):
+            # 4. Blue on red
+            rect.draw(canvas)
+
+        # 5. Restore to red on goldenrod
+        rect.draw(canvas)
+
+        with canvas.state(
+            fill_style=CORNFLOWERBLUE,
+            stroke_style=BLACK,
+            line_width=5,
+            line_dash=[1, 4],
+        ):
+            # 6. Black on blue
+            rect.draw(canvas)
+
+        # 7. Restore to red on goldenrod
+        rect.draw(canvas)
+
+    # 8. Restore to purple on blue
+    rect.draw(canvas)
+
+    await probe.redraw("Image should be drawn")
+    assert_reference(probe, "attributes", threshold=0.02)


### PR DESCRIPTION
One of the last few pieces of #3994. We're getting there...

The primary thing here is giving `state()` (and the `State` class) optional keyword-only parameters that can set drawing context attributes.

Other bits and bobs:
- To make the resulting class's `repr` a little less ridiculous, I realized there's no need for us to list attributes that haven't been set; I've applied this to all drawing actions.
- This the first `DrawingAction` class that's had to track a `fill_style` *and* a `stroke_style` independently; they can't both live on `_color`. I've added a switch to `color_property` to accommodate this.
- I noticed some tests were still named `context` instead of `state`, so I updated those.
- Because the testbed test reuses the `test_attributes` reference image, I factored the box-drawing logic out into a class that both tests can use.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
<!-- update or delete the next line to reflect your usage -->

