### PR TITLE
Add custom `approx()` to help with floating point `<=` / `>=` testing

### DIFF
--- a/changes/4504.misc.md
+++ b/changes/4504.misc.md
@@ -1,1 +1,1 @@
-An iOS test assertion has been expanded to account for potential floating-point inaccuracy.
+A utility has been added to allow easier inequality testing of floating-point numbers in backend tests.

--- a/changes/4504.misc.md
+++ b/changes/4504.misc.md
@@ -1,0 +1,1 @@
+An iOS test assertion has been expanded to account for potential floating-point inaccuracy.

--- a/iOS/tests_backend/window.py
+++ b/iOS/tests_backend/window.py
@@ -1,6 +1,7 @@
 import asyncio
 
 import pytest
+from tests.conftest import approx
 
 from toga_iOS.libs import UIWindow
 
@@ -40,9 +41,9 @@ class WindowProbe(BaseProbe, DialogsMixin):
     def _assert_container_layout(self):
         # If the window has been laid out, the origin should be at least at the
         # position of the top bar height.
-        y = self.impl.container.content.native.frame.origin.y
-        top_bar_height = self.top_bar_height
-        assert y > top_bar_height or y == pytest.approx(top_bar_height)
+        assert self.impl.container.content.native.frame.origin.y >= approx(
+            self.top_bar_height
+        )
 
     def _assert_window_state(self, state):
         # Create an assertion function that the window's instantaneous state is a

--- a/iOS/tests_backend/window.py
+++ b/iOS/tests_backend/window.py
@@ -40,7 +40,9 @@ class WindowProbe(BaseProbe, DialogsMixin):
     def _assert_container_layout(self):
         # If the window has been laid out, the origin should be at least at the
         # position of the top bar height.
-        assert self.impl.container.content.native.frame.origin.y >= self.top_bar_height
+        y = self.impl.container.content.native.frame.origin.y
+        top_bar_height = self.top_bar_height
+        assert y > top_bar_height or y == pytest.approx(top_bar_height)
 
     def _assert_window_state(self, state):
         # Create an assertion function that the window's instantaneous state is a

--- a/testbed/tests/conftest.py
+++ b/testbed/tests/conftest.py
@@ -6,6 +6,12 @@ from importlib import import_module
 
 from pytest import fixture, register_assert_rewrite, skip
 
+try:
+    from _pytest.approx import ApproxScalar
+except ImportError:
+    # Location as of 9.1.1
+    from _pytest.python_api import ApproxScalar
+
 import toga
 from toga.colors import GOLDENROD
 from toga.constants import WindowState
@@ -214,3 +220,13 @@ class ProxyTask:
 
     def done(self):
         return False
+
+
+# pytest.approx doesn't support <= / >=
+# See https://github.com/pytest-dev/pytest/issues/2003
+class approx(ApproxScalar):
+    def __ge__(self, other):
+        return self.expected > other or self == other
+
+    def __le__(self, other):
+        return self.expected < other or self == other

--- a/testbed/tests/conftest.py
+++ b/testbed/tests/conftest.py
@@ -4,13 +4,8 @@ import inspect
 from dataclasses import dataclass
 from importlib import import_module
 
+from _pytest.python_api import ApproxScalar
 from pytest import fixture, register_assert_rewrite, skip
-
-try:
-    from _pytest.approx import ApproxScalar
-except ImportError:
-    # Location as of 9.1.1
-    from _pytest.python_api import ApproxScalar
 
 import toga
 from toga.colors import GOLDENROD

--- a/testbed/tests/test_approx.py
+++ b/testbed/tests/test_approx.py
@@ -1,0 +1,22 @@
+import pytest
+
+from .conftest import approx
+
+
+async def test_approx():
+    """Local subclass of pytest.approx handles <= / <= of floats as expected."""
+    a = 1.555555555555
+    b = 1.555555555554
+
+    with pytest.raises(TypeError):
+        _ = a > approx(b)
+
+    with pytest.raises(TypeError):
+        _ = a < approx(b)
+
+    assert a >= approx(b)
+    assert a <= approx(b)
+    assert a == approx(b)
+
+    assert not 1.4 >= approx(b)
+    assert not 1.6 <= approx(b)


### PR DESCRIPTION
For reference, this is my current setup:

- Python 3.12.13
- Briefcase 0.4.2
- Toga current main branch
- iOS 18.1 simulator
- macOS 14.8.7

I found that every single test in the iOS testbed was erroring out for me in setup:
```
__________________ ERROR at setup of test_unsupported_widget ___________________
Traceback (most recent call last):
[...]
  File "/Users/charles/Library/Developer/CoreSimulator/Devices/EF6E765C-63E6-483E-B45D-2217D4206454/data/Containers/Bundle/Application/2DF77722-55A1-4B8C-8034-5D92F1F3EBA5/Toga Testbed.app/app/tests_backend/window.py", line 43, in _assert_container_layout
    assert self.impl.container.content.native.frame.origin.y >= self.top_bar_height
AssertionError: assert 100.33333333333331 >= 100.33333333333334
 +  where 100.33333333333331 = <NSPoint(0.0, 100.33333333333331)>.y
 +    where <NSPoint(0.0, 100.33333333333331)> = <NSRect(NSPoint(0.0, 100.33333333333331), NSSize(402.0, 773.0))>.origin
 +      where <NSRect(NSPoint(0.0, 100.33333333333331), NSSize(402.0, 773.0))> = <ObjCInstance: TogaView at 0x13c2ba8a0: <TogaView: 0x13ca0e5c0; frame = (0 100.333; 402 773); backgroundColor = UIExtendedSRGBColorSpace 0.854902 0.647059 0.12549 1; layer = <CALayer: 0x600000267700>>>.frame
 +        where <ObjCInstance: TogaView at 0x13c2ba8a0: <TogaView: 0x13ca0e5c0; frame = (0 100.333; 402 773); backgroundColor = UIExtendedSRGBColorSpace 0.854902 0.647059 0.12549 1; layer = <CALayer: 0x600000267700>>> = <toga_iOS.widgets.box.Box object at 0x13b6f4f20>.native
 +          where <toga_iOS.widgets.box.Box object at 0x13b6f4f20> = <toga_iOS.container.NavigationContainer object at 0x13a44a0c0>.content
 +            where <toga_iOS.container.NavigationContainer object at 0x13a44a0c0> = <toga_iOS.window.MainWindow object at 0x13821c9b0>.container
 +              where <toga_iOS.window.MainWindow object at 0x13821c9b0> = <tests_backend.window.WindowProbe object at 0x13c2dfbf0>.impl
 +  and   100.33333333333334 = <tests_backend.window.WindowProbe object at 0x13c2dfbf0>.top_bar_height
---------------------------- Captured stdout setup -----------------------------
Resetting main_window
=========================== short test summary info ============================
ERROR tests/app/test_app.py::test_unsupported_widget - assert 100.33333333333331 >= 100.33333333333334
 +  where 100.33333333333331 = <NSPoint(0.0, 100.33333333333331)>.y
 +    where <NSPoint(0.0, 100.33333333333331)> = <NSRect(NSPoint(0.0, 100.33333333333331), NSSize(402.0, 773.0))>.origin
 +      where <NSRect(NSPoint(0.0, 100.33333333333331), NSSize(402.0, 773.0))> = <ObjCInstance: TogaView at 0x13c2ba8a0: <TogaView: 0x13ca0e5c0; frame = (0 100.333; 402 773); backgroundColor = UIExtendedSRGBColorSpace 0.854902 0.647059 0.12549 1; layer = <CALayer: 0x600000267700>>>.frame
 +        where <ObjCInstance: TogaView at 0x13c2ba8a0: <TogaView: 0x13ca0e5c0; frame = (0 100.333; 402 773); backgroundColor = UIExtendedSRGBColorSpace 0.854902 0.647059 0.12549 1; layer = <CALayer: 0x600000267700>>> = <toga_iOS.widgets.box.Box object at 0x13b6f4f20>.native
 +          where <toga_iOS.widgets.box.Box object at 0x13b6f4f20> = <toga_iOS.container.NavigationContainer object at 0x13a44a0c0>.content
 +            where <toga_iOS.container.NavigationContainer object at 0x13a44a0c0> = <toga_iOS.window.MainWindow object at 0x13821c9b0>.container
 +              where <toga_iOS.window.MainWindow object at 0x13821c9b0> = <tests_backend.window.WindowProbe object at 0x13c2dfbf0>.impl
 +  and   100.33333333333334 = <tests_backend.window.WindowProbe object at 0x13c2dfbf0>.top_bar_height
=============================== 1 error in 5.25s ===============================
```

Floating-point inaccuracy strikes again. Unfortunately, because `pytest.approx` [intentionally doesn't support inequalities](https://github.com/pytest-dev/pytest/issues/2003) (explained by a note in the docs that I [still find baffling](https://github.com/pytest-dev/pytest/discussions/14134)), we can't simply write `a >= approx(b)`; we instead need `a > b or a == approx(b)`.

This isn't the first time I've seen an issue like this crop up; I'm starting to wonder if it would be worth writing our own subclass or helper function to handle floating-point `<=` / `>=` comparisons.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
<!-- update or delete the next line to reflect your usage -->
