### PR TITLE
Ensure `Window.size` returns integers

### DIFF
--- a/changes/4505.bugfix.md
+++ b/changes/4505.bugfix.md
@@ -1,0 +1,1 @@
+The `size` attribute of a window is now guaranteed to return the width and height as integers.

--- a/cocoa/src/toga_cocoa/window.py
+++ b/cocoa/src/toga_cocoa/window.py
@@ -317,7 +317,7 @@ class Window:
             native_frame = self.container.native.frame
         else:
             native_frame = self.native.frame
-        return Size(native_frame.size.width, native_frame.size.height)
+        return Size(int(native_frame.size.width), int(native_frame.size.height))
 
     def set_size(self, size):
         frame = self.native.frame

--- a/iOS/src/toga_iOS/window.py
+++ b/iOS/src/toga_iOS/window.py
@@ -135,8 +135,8 @@ class Window:
 
     def get_size(self) -> Size:
         return Size(
-            UIScreen.mainScreen.bounds.size.width,
-            UIScreen.mainScreen.bounds.size.height,
+            int(UIScreen.mainScreen.bounds.size.width),
+            int(UIScreen.mainScreen.bounds.size.height),
         )
 
     def set_size(self, size):

--- a/testbed/tests/window/test_window.py
+++ b/testbed/tests/window/test_window.py
@@ -38,6 +38,13 @@ async def second_window_probe(app, app_probe, second_window):
     return probe
 
 
+def assert_size(window, expected):
+    size = window.size
+    assert isinstance(size.width, int)
+    assert isinstance(size.height, int)
+    assert size == expected
+
+
 async def test_title(main_window, app_probe, main_window_probe):
     """The title of a window can be changed"""
     formal_name = getattr(app_probe, "formal_name", "Toga Testbed")
@@ -93,12 +100,12 @@ if toga.platform.current_platform in {"iOS", "android"}:
 
         main_window.position = (150, 50)
         await main_window_probe.wait_for_window("Main window can't be moved")
-        assert main_window.size == initial_size
+        assert_size(main_window, initial_size)
         assert main_window.position == (0, 0)
 
         main_window.size = (200, 150)
         await main_window_probe.wait_for_window("Main window cannot be resized")
-        assert main_window.size == initial_size
+        assert_size(main_window, initial_size)
         assert main_window.position == (0, 0)
 
         orig_content = main_window.content
@@ -113,7 +120,7 @@ if toga.platform.current_platform in {"iOS", "android"}:
                 style=Pack(direction=COLUMN, background_color=CORNFLOWERBLUE),
             )
             await main_window_probe.wait_for_window("Main window content has been set")
-            assert main_window.size == initial_size
+            assert_size(main_window, initial_size)
             assert main_window_probe.content_size == content_size
 
             # Alter the content width to exceed window width
@@ -121,7 +128,7 @@ if toga.platform.current_platform in {"iOS", "android"}:
             await main_window_probe.wait_for_window(
                 "Content is too wide for the window"
             )
-            assert main_window.size == initial_size
+            assert_size(main_window, initial_size)
             assert main_window_probe.content_size == content_size
 
             space_warning = (
@@ -133,7 +140,7 @@ if toga.platform.current_platform in {"iOS", "android"}:
             # Resize content to fit
             box1.style.width = 100
             await main_window_probe.wait_for_window("Content fits in window")
-            assert main_window.size == initial_size
+            assert_size(main_window, initial_size)
             assert main_window_probe.content_size == content_size
             assert not re.search(space_warning, capsys.readouterr().out)
 
@@ -142,7 +149,7 @@ if toga.platform.current_platform in {"iOS", "android"}:
             await main_window_probe.wait_for_window(
                 "Content is too tall for the window"
             )
-            assert main_window.size == initial_size
+            assert_size(main_window, initial_size)
             assert main_window_probe.content_size == content_size
             assert re.search(space_warning, capsys.readouterr().out)
 
@@ -318,7 +325,7 @@ if toga.platform.current_platform in {"iOS", "android"}:
         initial_size = main_window.size
         main_window.position = (150, 50)
         await main_window_probe.wait_for_window("Main window can't be moved")
-        assert main_window.size == initial_size
+        assert_size(main_window, initial_size)
         assert main_window.position == (0, 0)
         assert main_window.screen_position == (0, 0)
 
@@ -339,7 +346,7 @@ else:
 
         assert second_window.title == formal_name
         # Qt rendering results in a small change in window size
-        assert second_window.size == approx((640, 480), abs=2)
+        assert_size(second_window, approx((640, 480), abs=2))
         # Position should be cascaded; the exact position depends on the platform,
         # and how many windows have been created. As long as it's not at (100,100).
         if second_window_probe.supports_placement:
@@ -382,7 +389,7 @@ else:
 
         assert second_window.title == "Secondary Window"
         # Qt rendering can result in a small change in window size
-        assert second_window.size == approx((300, 200), abs=2)
+        assert_size(second_window, approx((300, 200), abs=2))
         if second_window_probe.supports_placement:
             assert second_window.position == (200, 300)
 
@@ -571,7 +578,7 @@ else:
 
         assert second_window.visible
         # Qt rendering can result in a small change in window size
-        assert second_window.size == approx((640, 480), abs=2)
+        assert_size(second_window, approx((640, 480), abs=2))
         if second_window_probe.supports_placement:
             assert second_window.position == (200, 150)
 
@@ -579,7 +586,7 @@ else:
         second_window.position = (250, 200)
 
         await second_window_probe.wait_for_window("Secondary window has been moved")
-        assert second_window.size == approx((640, 480), abs=2)
+        assert_size(second_window, approx((640, 480), abs=2))
         if second_window_probe.supports_placement:
             assert second_window.position == (250, 200)
 
@@ -590,7 +597,7 @@ else:
             "Secondary window has been resized; position has not changed"
         )
 
-        assert second_window.size == approx((300, 250), abs=2)
+        assert_size(second_window, approx((300, 250), abs=2))
         # We can't confirm position here, because it may have changed. macOS rescales
         # windows relative to the bottom-left corner, which means the position of the
         # window has changed relative to the Toga coordinate frame.
@@ -610,7 +617,7 @@ else:
         )
 
         assert second_window.visible
-        assert second_window.size == approx((250, 200), abs=2)
+        assert_size(second_window, approx((250, 200), abs=2))
         if (
             second_window_probe.supports_move_while_hidden
             and second_window_probe.supports_placement
@@ -637,7 +644,7 @@ else:
 
             assert not second_window_probe.is_minimized
             # Window size hasn't changed as a result of min/unmin cycle
-            assert second_window.size == approx((250, 200), abs=2)
+            assert_size(second_window, approx((250, 200), abs=2))
 
         second_window_probe.close()
         await second_window_probe.wait_for_window("Secondary window has been closed")
@@ -672,7 +679,7 @@ else:
         second_window.size = (200, 150)
         await second_window_probe.wait_for_window("Secondary window has been resized")
         # Qt rendering can result in a small change in window size
-        assert second_window.size == approx((200, 150), abs=2)
+        assert_size(second_window, approx((200, 150), abs=2))
         assert second_window_probe.content_size == approx(
             (
                 200 - extra_width,
@@ -690,7 +697,7 @@ else:
         await second_window_probe.wait_for_window(
             "Secondary window has had height adjusted due to content"
         )
-        assert second_window.size == approx((200, 210 + extra_height), abs=2)
+        assert_size(second_window, approx((200, 210 + extra_height), abs=2))
         assert second_window_probe.content_size == approx(
             (200 - extra_width, 210), abs=2
         )
@@ -700,8 +707,9 @@ else:
         await second_window_probe.wait_for_window(
             "Secondary window has had width adjusted due to content"
         )
-        assert second_window.size == approx(
-            (250 + extra_width, 210 + extra_height), abs=2
+        assert_size(
+            second_window,
+            approx((250 + extra_width, 210 + extra_height), abs=2),
         )
 
         # Alter both height and width to exceed window size at once
@@ -710,8 +718,9 @@ else:
         await second_window_probe.wait_for_window(
             "Secondary window has had width and height adjusted due to content"
         )
-        assert second_window.size == approx(
-            (300 + extra_width, 300 + extra_height), abs=2
+        assert_size(
+            second_window,
+            approx((300 + extra_width, 300 + extra_height), abs=2),
         )
         assert second_window_probe.content_size == approx((300, 300), abs=2)
 
@@ -720,8 +729,9 @@ else:
         await second_window_probe.wait_for_window(
             "Secondary window forced resize fails"
         )
-        assert second_window.size == approx(
-            (300 + extra_width, 300 + extra_height), abs=2
+        assert_size(
+            second_window,
+            approx((300 + extra_width, 300 + extra_height), abs=2),
         )
         assert second_window_probe.content_size == approx((300, 300), abs=2)
 
@@ -885,7 +895,7 @@ else:
             second_window_on_resize_handler.assert_not_called()
             second_window_on_resize_handler.reset_mock()
             # Window size should remain the same
-            assert second_window.size == previous_state_window_size
+            assert_size(second_window, previous_state_window_size)
         else:
             second_window_on_resize_handler.assert_called_with(second_window)
             second_window_on_resize_handler.reset_mock()
@@ -934,7 +944,7 @@ else:
             second_window_on_resize_handler.assert_not_called()
             second_window_on_resize_handler.reset_mock()
             # Window size should remain the same
-            assert second_window.size == previous_state_window_size
+            assert_size(second_window, previous_state_window_size)
 
         # Check for visibility event notification
         if initial_state == WindowState.MINIMIZED:
@@ -1246,7 +1256,7 @@ else:
         expected_window_size = None
 
         def check_new_size_on_resize(window):
-            assert window.size == expected_window_size
+            assert_size(window, expected_window_size)
 
         second_window_on_resize_handler = Mock()
         second_window_on_resize_handler.side_effect = check_new_size_on_resize
@@ -1259,7 +1269,7 @@ else:
         expected_window_size = (200, 150)
         second_window.size = (200, 150)
         await second_window_probe.wait_for_window("Second window has been resized")
-        assert second_window.size == (200, 150)
+        assert_size(second_window, (200, 150))
         second_window_on_resize_handler.assert_called_with(second_window)
         second_window_on_resize_handler.reset_mock()
 
@@ -1267,14 +1277,14 @@ else:
         expected_window_size = initial_size
         second_window.size = initial_size
         await second_window_probe.wait_for_window("Second window has been resized")
-        assert second_window.size == initial_size
+        assert_size(second_window, initial_size)
         second_window_on_resize_handler.assert_called_with(second_window)
         second_window_on_resize_handler.reset_mock()
 
         # Again resize to initial size, on_resize() will not be triggered
         second_window.size = initial_size
         await second_window_probe.wait_for_window("Second window has been resized")
-        assert second_window.size == initial_size
+        assert_size(second_window, initial_size)
         second_window_on_resize_handler.assert_not_called()
 
     @pytest.mark.parametrize(

--- a/tox.ini
+++ b/tox.ini
@@ -110,7 +110,7 @@ commands =
     !lint-!all-!live-!en : build_md_translations {posargs} en --source-code=core{/}src --source-code=travertino{/}src --source-code=android{/}src
     lint : pyspelling
     # Github, Wikipedia, Wiktionary and superuser.com have aggressive rate limiters
-    lint : markdown-checker --dir {[docs]docs_dir} --func check_broken_urls --skip-urls-containing=https://github.com/beeware,https://github.com/EddLabs,https://github.com/linuxmint,https://en.wikipedia.org/wiki/,https://en.wiktionary.org/wiki/,https://superuser.com/questions/284342/
+    lint : markdown-checker --dir {[docs]docs_dir} --func check_broken_urls --skip-urls-containing=https://github.com/beeware,https://github.com/EddLabs,https://github.com/linuxmint,https://en.wikipedia.org/wiki/,https://en.wiktionary.org/wiki/,https://superuser.com/questions/284342/,https://hacks.mozilla.org/2013/09/css-length-explained/
     live : live_serve_en {posargs} core{/}src --port=8038 --source-code=core{/}src --source-code=travertino{/}src --source-code=android{/}src
     all : build_md_translations {posargs} en --source-code=core{/}src --source-code=travertino{/}src --source-code=android{/}src
     en : build_md_translations {posargs} en --source-code=core{/}src --source-code=travertino{/}src --source-code=android{/}src

--- a/tox.ini
+++ b/tox.ini
@@ -95,7 +95,7 @@ commands =
 [docs]
 docs_dir = {tox_root}{/}docs{/}en
 
-[testenv:docs{,-lint,-all,-live,-en}]
+[testenv:docs{,-lint,-links,-all,-live,-en}]
 # Docs are always built on Python 3.12. See also the RTD config and contribution docs.
 base_python = py312
 setenv =
@@ -107,10 +107,10 @@ deps =
     ./travertino
     ./core
 commands =
-    !lint-!all-!live-!en : build_md_translations {posargs} en --source-code=core{/}src --source-code=travertino{/}src --source-code=android{/}src
+    !lint-!links-!all-!live-!en : build_md_translations {posargs} en --source-code=core{/}src --source-code=travertino{/}src --source-code=android{/}src
     lint : pyspelling
     # Github, Wikipedia, Wiktionary and superuser.com have aggressive rate limiters
-    lint : markdown-checker --dir {[docs]docs_dir} --func check_broken_urls --skip-urls-containing=https://github.com/beeware,https://github.com/EddLabs,https://github.com/linuxmint,https://en.wikipedia.org/wiki/,https://en.wiktionary.org/wiki/,https://superuser.com/questions/284342/,https://hacks.mozilla.org/2013/09/css-length-explained/
+    links : markdown-checker --dir {[docs]docs_dir} --func check_broken_urls --skip-urls-containing=https://github.com/beeware,https://github.com/EddLabs,https://github.com/linuxmint,https://en.wikipedia.org/wiki/,https://en.wiktionary.org/wiki/,https://superuser.com/questions/284342/,https://hacks.mozilla.org/2013/09/css-length-explained/
     live : live_serve_en {posargs} core{/}src --port=8038 --source-code=core{/}src --source-code=travertino{/}src --source-code=android{/}src
     all : build_md_translations {posargs} en --source-code=core{/}src --source-code=travertino{/}src --source-code=android{/}src
     en : build_md_translations {posargs} en --source-code=core{/}src --source-code=travertino{/}src --source-code=android{/}src


### PR DESCRIPTION
I noticed that, at least on Cocoa and iOS, `Window.size` returned floats, not integers as documented. This is generally innocuous, but it's not as intended, and it'll throw an exception if you provide it as an argument to any of Pillow's resizing or cropping methods.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
<!-- update or delete the next line to reflect your usage -->
