### PR TITLE
Expand testing of custom `approx()`

### DIFF
--- a/changes/4506.misc.md
+++ b/changes/4506.misc.md
@@ -1,0 +1,1 @@
+The testbed's custom `approx()` implementation is now more thoroughly tested.

--- a/testbed/tests/test_approx.py
+++ b/testbed/tests/test_approx.py
@@ -38,9 +38,9 @@ async def test_approx():
     assert approx(larger) <= smaller
     assert approx(larger) == smaller
 
-    assert approx(smaller) >= smaller
-    assert approx(smaller) <= smaller
-    assert approx(smaller) == smaller
+    assert approx(smaller) >= larger
+    assert approx(smaller) <= larger
+    assert approx(smaller) == larger
 
     # Significantly smaller values should behave as expected.
 

--- a/testbed/tests/test_approx.py
+++ b/testbed/tests/test_approx.py
@@ -5,18 +5,75 @@ from .conftest import approx
 
 async def test_approx():
     """Local subclass of pytest.approx handles <= / <= of floats as expected."""
-    a = 1.555555555555
-    b = 1.555555555554
+    much_smaller = 1.4
+    smaller = 1.555555555554
+    larger = 1.555555555555
+    much_larger = 1.6
+
+    # > and < raise a TypeError
+    with pytest.raises(TypeError):
+        _ = larger > approx(smaller)
 
     with pytest.raises(TypeError):
-        _ = a > approx(b)
+        _ = larger < approx(smaller)
 
     with pytest.raises(TypeError):
-        _ = a < approx(b)
+        _ = approx(smaller) < larger
 
-    assert a >= approx(b)
-    assert a <= approx(b)
-    assert a == approx(b)
+    with pytest.raises(TypeError):
+        _ = approx(smaller) > larger
 
-    assert not 1.4 >= approx(b)
-    assert not 1.6 <= approx(b)
+    # All ==, <=, and >= comparisons between the middle two should be true, regardless
+    # of which is on which side and which is in approx().
+
+    assert larger >= approx(smaller)
+    assert larger <= approx(smaller)
+    assert larger == approx(smaller)
+
+    assert smaller >= approx(larger)
+    assert smaller <= approx(larger)
+    assert smaller == approx(larger)
+
+    assert approx(larger) >= smaller
+    assert approx(larger) <= smaller
+    assert approx(larger) == smaller
+
+    assert approx(smaller) >= smaller
+    assert approx(smaller) <= smaller
+    assert approx(smaller) == smaller
+
+    # Significantly smaller values should behave as expected.
+
+    assert much_smaller <= approx(smaller)
+    assert not much_smaller >= approx(smaller)
+    assert not much_smaller == approx(smaller)
+
+    assert smaller >= approx(much_smaller)
+    assert not smaller <= approx(much_smaller)
+    assert not smaller == approx(much_smaller)
+
+    assert approx(much_smaller) <= smaller
+    assert not approx(much_smaller) >= smaller
+    assert not approx(much_smaller) == smaller
+
+    assert approx(smaller) >= much_smaller
+    assert not approx(smaller) <= much_smaller
+    assert not approx(smaller) == much_smaller
+
+    # Significantly larger values should behave as expected.
+
+    assert much_larger >= approx(smaller)
+    assert not much_larger <= approx(smaller)
+    assert not much_larger == approx(smaller)
+
+    assert smaller <= approx(much_larger)
+    assert not smaller >= approx(much_larger)
+    assert not smaller == approx(much_larger)
+
+    assert approx(much_larger) >= smaller
+    assert not approx(much_larger) <= smaller
+    assert not approx(much_larger) == smaller
+
+    assert approx(smaller) <= much_larger
+    assert not approx(smaller) >= much_larger
+    assert not approx(smaller) == much_larger


### PR DESCRIPTION
The tests from #4504 could stand to be a little more comprehensive. I just want to make sure nothing subtle catches us by surprise.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
<!-- update or delete the next line to reflect your usage -->
