### PR TITLE
Avoid temporary list copies during source find

### DIFF
--- a/changes/4528.misc.md
+++ b/changes/4528.misc.md
@@ -1,0 +1,1 @@
+Improved source lookup performance by avoiding a temporary list copy when searching from a starting item.

--- a/core/src/toga/sources/list_source.py
+++ b/core/src/toga/sources/list_source.py
@@ -33,7 +33,14 @@ def _find_item(
     if accessors is None and not isinstance(data, Mapping):
         raise ValueError(f"find() requires accessors for non-mapping {value_type} data")
 
-    for item in candidates[start_index:]:
+    if start_index:
+        search_candidates: Iterable[T] = (
+            candidates[index] for index in range(start_index, len(candidates))
+        )
+    else:
+        search_candidates = candidates
+
+    for item in search_candidates:
         try:
             match data:
                 case Mapping():


### PR DESCRIPTION
## Summary

- Avoid creating a temporary sliced list when source lookup searches from a starting item.
- Preserve existing lookup behavior while reducing allocation during repeated find() calls.

## Testing

- `uvx --with tox-uv tox -e py-cov -- core/tests/sources/test_list_source.py core/tests/sources/test_tree_source.py core/tests/sources/test_node.py`
- `uvx ruff check core/src/toga/sources/list_source.py`
- `uvx --with tox-uv tox -e towncrier-check`

## PR Checklist:

- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
- Assisted-by: OpenAI Codex
