### PR TITLE
Avoid refreshes for widget parenting no-ops

### DIFF
--- a/changes/4529.feature.md
+++ b/changes/4529.feature.md
@@ -1,0 +1,1 @@
+Performance has been improved by avoiding layout refreshes when add and insert operations are redundant and don't move widgets to new parents.

--- a/changes/4529.misc.md
+++ b/changes/4529.misc.md
@@ -1,0 +1,1 @@
+Improved widget parenting performance by avoiding layout refreshes when add and insert operations do not change child parentage.

--- a/changes/4529.misc.md
+++ b/changes/4529.misc.md
@@ -1,1 +1,0 @@
-Improved widget parenting performance by avoiding layout refreshes when add and insert operations do not change child parentage.

--- a/core/src/toga/widgets/base.py
+++ b/core/src/toga/widgets/base.py
@@ -186,6 +186,7 @@ class Widget(Node, PackMixin, ABC):
         :raises ValueError: If this widget cannot have children.
         """
         self._assert_can_have_children()
+        added = False
         for child in children:
             if child.parent is not self:
                 # remove from old parent
@@ -203,9 +204,11 @@ class Widget(Node, PackMixin, ABC):
                 super().add(child)
 
                 self._impl.add_child(child._impl)
+                added = True
 
         # Whatever layout we're a part of needs to be refreshed
-        self.refresh()
+        if added:
+            self.refresh()
 
     def insert(self, index: int, child: Widget) -> None:
         """Insert a widget as a child of this widget.
@@ -237,8 +240,8 @@ class Widget(Node, PackMixin, ABC):
 
             self._impl.insert_child(index, child._impl)
 
-        # Whatever layout we're a part of needs to be refreshed
-        self.refresh()
+            # Whatever layout we're a part of needs to be refreshed
+            self.refresh()
 
     def index(self, child: Widget) -> int:
         """Get the index of a widget in the list of children of this widget.

--- a/core/tests/widgets/test_base.py
+++ b/core/tests/widgets/test_base.py
@@ -349,8 +349,9 @@ def test_reparent_child_to_self(widget):
     # as the widget was already a child
     assert_action_not_performed(widget, "add child")
 
-    # The widget's layout has been refreshed
-    assert_action_performed_with(widget, "refresh")
+    # The widget's layout has *not* been refreshed,
+    # as the widget was already a child
+    assert_action_not_performed(widget, "refresh")
 
 
 def test_insert_child_into_leaf():
@@ -643,8 +644,9 @@ def test_insert_reparent_child_to_self(widget):
     # as the widget was already a child
     assert_action_not_performed(widget, "insert child")
 
-    # The widget's layout has been refreshed
-    assert_action_performed_with(widget, "refresh")
+    # The widget's layout has *not* been refreshed,
+    # as the widget was already a child
+    assert_action_not_performed(widget, "refresh")
 
 
 def test_remove_child_from_leaf():


### PR DESCRIPTION
## Summary

- Avoid refreshing widget layout when `add()` is called with children that already belong to the target widget.
- Avoid refreshing widget layout when `insert()` is called with a child that already belongs to the target widget.
- Update base widget tests to assert the documented no-op behavior.

## Testing

- `uvx --with tox-uv tox -e py-cov -- core/tests/widgets/test_base.py`
- `uvx ruff check core/src/toga/widgets/base.py core/tests/widgets/test_base.py`
- `uvx --with tox-uv tox -e towncrier-check`

## PR Checklist:

- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
- Assisted-by: Claude
