### PR TITLE
perf(pack): avoid style item lookups during layout

### DIFF
--- a/changes/4530.feature.md
+++ b/changes/4530.feature.md
@@ -1,0 +1,1 @@
+Pack layout performance has been improved by avoiding repeated dictionary-style style lookups during layout calculation.

--- a/changes/4530.feature.md
+++ b/changes/4530.feature.md
@@ -1,1 +1,1 @@
-Pack layout performance has been improved by avoiding repeated dictionary-style style lookups during layout calculation.
+Style property lookup performance has been improved while preserving validation of dictionary-style style access.

--- a/core/src/toga/style/compat.py
+++ b/core/src/toga/style/compat.py
@@ -51,7 +51,8 @@ class _alignment_property(validated_property):
         # Hard-coded because it's only called on alignment, not align_items.
 
         self.name = "alignment"
-        owner._BASE_ALL_PROPERTIES[owner].add("alignment")
+        self.storage_name = "_alignment"
+        owner._register_property("alignment", self)
         self.other = "align_items"
         self.derive = {
             _AlignmentCondition(CENTER): CENTER,
@@ -68,12 +69,14 @@ class _alignment_property(validated_property):
         # reference the other.
         owner.align_items = _alignment_property(START, CENTER, END)
         owner.align_items.name = "align_items"
+        owner.align_items.storage_name = "_align_items"
         owner.align_items.other = "alignment"
         owner.align_items.derive = {
             # Invert each condition so that it maps in the opposite direction.
             _AlignmentCondition(result, **condition.properties): condition.main_value
             for condition, result in self.derive.items()
         }
+        owner._register_property("align_items", owner.align_items, real=True)
 
     def __get__(self, obj, objtype=None):
         if obj is None:

--- a/core/src/toga/style/layout.py
+++ b/core/src/toga/style/layout.py
@@ -387,11 +387,6 @@ class PackLogic(BaseStyle):
             main_start, main_end = horizontal
             cross_start, cross_end = TOP, BOTTOM
 
-        main_start_margin = f"margin_{main_start}"
-        main_end_margin = f"margin_{main_end}"
-        cross_start_margin = f"margin_{cross_start}"
-        cross_end_margin = f"margin_{cross_end}"
-
         node = self._applicator.node
         flex_total = 0
         min_flex = 0
@@ -410,8 +405,8 @@ class PackLogic(BaseStyle):
 
         for i, child in enumerate(node.children):
             # self._debug(f"PASS 1 {child}")
-            if getattr(child.style, main_name) != NONE:
-                # self._debug(f"- fixed {main_name} {getattr(child.style, main_name)}")
+            if child.style[main_name] != NONE:
+                # self._debug(f"- fixed {main_name} {child.style[main_name]}")
                 child.style._layout_node_in_direction(
                     direction=self.direction,
                     alloc_main=remaining_main,
@@ -441,9 +436,9 @@ class PackLogic(BaseStyle):
                         min_child_content_main = child_content_main
 
                         min_flex += (
-                            getattr(child.style, main_start_margin)
+                            child.style[f"margin_{main_start}"]
                             + child_content_main
-                            + getattr(child.style, main_end_margin)
+                            + child.style[f"margin_{main_end}"]
                         )
                     else:
                         # self._debug(
@@ -509,17 +504,17 @@ class PackLogic(BaseStyle):
 
             gap = 0 if i == 0 else self.gap
             child_main = (
-                getattr(child.style, main_start_margin)
+                child.style[f"margin_{main_start}"]
                 + child_content_main
-                + getattr(child.style, main_end_margin)
+                + child.style[f"margin_{main_end}"]
             )
             main += gap + child_main
             remaining_main -= gap + child_main
 
             min_child_main = (
-                getattr(child.style, main_start_margin)
+                child.style[f"margin_{main_start}"]
                 + min_child_content_main
-                + getattr(child.style, main_end_margin)
+                + child.style[f"margin_{main_end}"]
             )
             min_main += gap + min_child_main
 
@@ -544,9 +539,9 @@ class PackLogic(BaseStyle):
                             # self._debug(f"- {child} overflows ideal main dimension")
                             flex_total -= child.style.flex
                             min_flex -= (
-                                getattr(child.style, main_start_margin)
+                                child.style[f"margin_{main_start}"]
                                 + child_intrinsic_main.value
-                                + getattr(child.style, main_end_margin)
+                                + child.style[f"margin_{main_end}"]
                             )
                     except AttributeError:
                         # Intrinsic main-axis size isn't flexible
@@ -565,16 +560,16 @@ class PackLogic(BaseStyle):
         # main-axis size specification at all.
         for child in node.children:
             # self._debug(f"PASS 2 {child}")
-            if getattr(child.style, main_name) != NONE:
+            if child.style[main_name] != NONE:
                 # self._debug(f"- already laid out (explicit {main_name})")
                 pass
             elif child.style.flex:
                 if getattr(child.intrinsic, main_name) is not None:
                     try:
                         child_alloc_main = (
-                            getattr(child.style, main_start_margin)
+                            child.style[f"margin_{main_start}"]
                             + getattr(child.intrinsic, main_name).value
-                            + getattr(child.style, main_end_margin)
+                            + child.style[f"margin_{main_end}"]
                         )
                         ideal_main = quantum * child.style.flex
                         # self._debug(
@@ -631,9 +626,10 @@ class PackLogic(BaseStyle):
                         child_alloc_main = quantum * child.style.flex
                     else:
                         # self._debug(f"- unspecified flex {main_name}")
-                        child_alloc_main = getattr(
-                            child.style, main_start_margin
-                        ) + getattr(child.style, main_end_margin)
+                        child_alloc_main = (
+                            child.style[f"margin_{main_start}"]
+                            + child.style[f"margin_{main_end}"]
+                        )
 
                     child.style._layout_node_in_direction(
                         direction=self.direction,
@@ -661,7 +657,7 @@ class PackLogic(BaseStyle):
             # self._debug(f"{main_name} {min_main=} {main=}")
 
         # self._debug(f"PASS 2 COMPLETE; USED {main=} {main_name}")
-        if use_all_main or getattr(self, main_name) != NONE:
+        if use_all_main or self[main_name] != NONE:
             extra = max(0, available_main - main)
             main += extra
         else:
@@ -689,24 +685,24 @@ class PackLogic(BaseStyle):
                 child.layout.content_left = main - offset
                 offset += child.style.margin_left
             else:
-                offset += getattr(child.style, main_start_margin)
+                offset += child.style[f"margin_{main_start}"]
                 setattr(child.layout, f"content_{main_start}", offset)
                 offset += getattr(child.layout, f"content_{main_name}")
-                offset += getattr(child.style, main_end_margin)
+                offset += child.style[f"margin_{main_end}"]
 
             offset += self.gap
 
             child_cross = (
                 getattr(child.layout, f"content_{cross_name}")
-                + getattr(child.style, cross_start_margin)
-                + getattr(child.style, cross_end_margin)
+                + child.style[f"margin_{cross_start}"]
+                + child.style[f"margin_{cross_end}"]
             )
             cross = max(cross, child_cross)
 
             min_child_cross = (
-                getattr(child.style, cross_start_margin)
+                child.style[f"margin_{cross_start}"]
                 + getattr(child.layout, f"min_content_{cross_name}")
-                + getattr(child.style, cross_end_margin)
+                + child.style[f"margin_{cross_end}"]
             )
             min_cross = max(min_cross, min_child_cross)
 
@@ -725,8 +721,7 @@ class PackLogic(BaseStyle):
 
         if cross_start == RIGHT:
             effective_cross_start = LEFT
-            effective_cross_start_margin = "margin_left"
-            effective_cross_end_margin = "margin_right"
+            effective_cross_end = RIGHT
 
             if self.align_items == START:
                 effective_align_items = END
@@ -735,30 +730,29 @@ class PackLogic(BaseStyle):
 
         else:
             effective_cross_start = cross_start
-            effective_cross_start_margin = cross_start_margin
-            effective_cross_end_margin = cross_end_margin
+            effective_cross_end = cross_end
 
         for child in node.children:
             # self._debug(f"PASS 4: {child}")
             extra = cross - (
                 getattr(child.layout, f"content_{cross_name}")
-                + getattr(child.style, effective_cross_start_margin)
-                + getattr(child.style, effective_cross_end_margin)
+                + child.style[f"margin_{effective_cross_start}"]
+                + child.style[f"margin_{effective_cross_end}"]
             )
             # self._debug(f"-  {self.direction} extra {cross_name} {extra}")
 
             if effective_align_items == END:
-                cross_start_value = extra + getattr(child.style, cross_start_margin)
+                cross_start_value = extra + child.style[f"margin_{cross_start}"]
                 # self._debug(f"  align {child} to {cross_end}")
 
             elif effective_align_items == CENTER:
-                cross_start_value = int(extra / 2) + getattr(
-                    child.style, cross_start_margin
+                cross_start_value = (
+                    int(extra / 2) + child.style[f"margin_{cross_start}"]
                 )
                 # self._debug(f"  align {child} to center")
 
             else:
-                cross_start_value = getattr(child.style, cross_start_margin)
+                cross_start_value = child.style[f"margin_{cross_start}"]
                 # self._debug(f"  align {child} to {cross_start} ")
 
             setattr(child.layout, f"content_{effective_cross_start}", cross_start_value)

--- a/core/src/toga/style/layout.py
+++ b/core/src/toga/style/layout.py
@@ -387,6 +387,11 @@ class PackLogic(BaseStyle):
             main_start, main_end = horizontal
             cross_start, cross_end = TOP, BOTTOM
 
+        main_start_margin = f"margin_{main_start}"
+        main_end_margin = f"margin_{main_end}"
+        cross_start_margin = f"margin_{cross_start}"
+        cross_end_margin = f"margin_{cross_end}"
+
         node = self._applicator.node
         flex_total = 0
         min_flex = 0
@@ -405,8 +410,8 @@ class PackLogic(BaseStyle):
 
         for i, child in enumerate(node.children):
             # self._debug(f"PASS 1 {child}")
-            if child.style[main_name] != NONE:
-                # self._debug(f"- fixed {main_name} {child.style[main_name]}")
+            if getattr(child.style, main_name) != NONE:
+                # self._debug(f"- fixed {main_name} {getattr(child.style, main_name)}")
                 child.style._layout_node_in_direction(
                     direction=self.direction,
                     alloc_main=remaining_main,
@@ -436,9 +441,9 @@ class PackLogic(BaseStyle):
                         min_child_content_main = child_content_main
 
                         min_flex += (
-                            child.style[f"margin_{main_start}"]
+                            getattr(child.style, main_start_margin)
                             + child_content_main
-                            + child.style[f"margin_{main_end}"]
+                            + getattr(child.style, main_end_margin)
                         )
                     else:
                         # self._debug(
@@ -504,17 +509,17 @@ class PackLogic(BaseStyle):
 
             gap = 0 if i == 0 else self.gap
             child_main = (
-                child.style[f"margin_{main_start}"]
+                getattr(child.style, main_start_margin)
                 + child_content_main
-                + child.style[f"margin_{main_end}"]
+                + getattr(child.style, main_end_margin)
             )
             main += gap + child_main
             remaining_main -= gap + child_main
 
             min_child_main = (
-                child.style[f"margin_{main_start}"]
+                getattr(child.style, main_start_margin)
                 + min_child_content_main
-                + child.style[f"margin_{main_end}"]
+                + getattr(child.style, main_end_margin)
             )
             min_main += gap + min_child_main
 
@@ -539,9 +544,9 @@ class PackLogic(BaseStyle):
                             # self._debug(f"- {child} overflows ideal main dimension")
                             flex_total -= child.style.flex
                             min_flex -= (
-                                child.style[f"margin_{main_start}"]
+                                getattr(child.style, main_start_margin)
                                 + child_intrinsic_main.value
-                                + child.style[f"margin_{main_end}"]
+                                + getattr(child.style, main_end_margin)
                             )
                     except AttributeError:
                         # Intrinsic main-axis size isn't flexible
@@ -560,16 +565,16 @@ class PackLogic(BaseStyle):
         # main-axis size specification at all.
         for child in node.children:
             # self._debug(f"PASS 2 {child}")
-            if child.style[main_name] != NONE:
+            if getattr(child.style, main_name) != NONE:
                 # self._debug(f"- already laid out (explicit {main_name})")
                 pass
             elif child.style.flex:
                 if getattr(child.intrinsic, main_name) is not None:
                     try:
                         child_alloc_main = (
-                            child.style[f"margin_{main_start}"]
+                            getattr(child.style, main_start_margin)
                             + getattr(child.intrinsic, main_name).value
-                            + child.style[f"margin_{main_end}"]
+                            + getattr(child.style, main_end_margin)
                         )
                         ideal_main = quantum * child.style.flex
                         # self._debug(
@@ -626,10 +631,9 @@ class PackLogic(BaseStyle):
                         child_alloc_main = quantum * child.style.flex
                     else:
                         # self._debug(f"- unspecified flex {main_name}")
-                        child_alloc_main = (
-                            child.style[f"margin_{main_start}"]
-                            + child.style[f"margin_{main_end}"]
-                        )
+                        child_alloc_main = getattr(
+                            child.style, main_start_margin
+                        ) + getattr(child.style, main_end_margin)
 
                     child.style._layout_node_in_direction(
                         direction=self.direction,
@@ -657,7 +661,7 @@ class PackLogic(BaseStyle):
             # self._debug(f"{main_name} {min_main=} {main=}")
 
         # self._debug(f"PASS 2 COMPLETE; USED {main=} {main_name}")
-        if use_all_main or self[main_name] != NONE:
+        if use_all_main or getattr(self, main_name) != NONE:
             extra = max(0, available_main - main)
             main += extra
         else:
@@ -685,24 +689,24 @@ class PackLogic(BaseStyle):
                 child.layout.content_left = main - offset
                 offset += child.style.margin_left
             else:
-                offset += child.style[f"margin_{main_start}"]
+                offset += getattr(child.style, main_start_margin)
                 setattr(child.layout, f"content_{main_start}", offset)
                 offset += getattr(child.layout, f"content_{main_name}")
-                offset += child.style[f"margin_{main_end}"]
+                offset += getattr(child.style, main_end_margin)
 
             offset += self.gap
 
             child_cross = (
                 getattr(child.layout, f"content_{cross_name}")
-                + child.style[f"margin_{cross_start}"]
-                + child.style[f"margin_{cross_end}"]
+                + getattr(child.style, cross_start_margin)
+                + getattr(child.style, cross_end_margin)
             )
             cross = max(cross, child_cross)
 
             min_child_cross = (
-                child.style[f"margin_{cross_start}"]
+                getattr(child.style, cross_start_margin)
                 + getattr(child.layout, f"min_content_{cross_name}")
-                + child.style[f"margin_{cross_end}"]
+                + getattr(child.style, cross_end_margin)
             )
             min_cross = max(min_cross, min_child_cross)
 
@@ -721,7 +725,8 @@ class PackLogic(BaseStyle):
 
         if cross_start == RIGHT:
             effective_cross_start = LEFT
-            effective_cross_end = RIGHT
+            effective_cross_start_margin = "margin_left"
+            effective_cross_end_margin = "margin_right"
 
             if self.align_items == START:
                 effective_align_items = END
@@ -730,29 +735,30 @@ class PackLogic(BaseStyle):
 
         else:
             effective_cross_start = cross_start
-            effective_cross_end = cross_end
+            effective_cross_start_margin = cross_start_margin
+            effective_cross_end_margin = cross_end_margin
 
         for child in node.children:
             # self._debug(f"PASS 4: {child}")
             extra = cross - (
                 getattr(child.layout, f"content_{cross_name}")
-                + child.style[f"margin_{effective_cross_start}"]
-                + child.style[f"margin_{effective_cross_end}"]
+                + getattr(child.style, effective_cross_start_margin)
+                + getattr(child.style, effective_cross_end_margin)
             )
             # self._debug(f"-  {self.direction} extra {cross_name} {extra}")
 
             if effective_align_items == END:
-                cross_start_value = extra + child.style[f"margin_{cross_start}"]
+                cross_start_value = extra + getattr(child.style, cross_start_margin)
                 # self._debug(f"  align {child} to {cross_end}")
 
             elif effective_align_items == CENTER:
-                cross_start_value = (
-                    int(extra / 2) + child.style[f"margin_{cross_start}"]
+                cross_start_value = int(extra / 2) + getattr(
+                    child.style, cross_start_margin
                 )
                 # self._debug(f"  align {child} to center")
 
             else:
-                cross_start_value = child.style[f"margin_{cross_start}"]
+                cross_start_value = getattr(child.style, cross_start_margin)
                 # self._debug(f"  align {child} to {cross_start} ")
 
             setattr(child.layout, f"content_{effective_cross_start}", cross_start_value)

--- a/travertino/src/travertino/properties/aliased.py
+++ b/travertino/src/travertino/properties/aliased.py
@@ -37,7 +37,7 @@ class aliased_property:
 
     def __set_name__(self, style_class, name):
         self.name = name
-        style_class._BASE_ALL_PROPERTIES[style_class].add(name)
+        style_class._register_property(name, self)
 
     def __get__(self, style, style_class=None):
         if style is None:

--- a/travertino/src/travertino/properties/shorthand.py
+++ b/travertino/src/travertino/properties/shorthand.py
@@ -22,7 +22,7 @@ class shorthand_property(ABC):
 
     def __set_name__(self, style_class, name):
         self.name = name
-        style_class._BASE_ALL_PROPERTIES[style_class].add(self.name)
+        style_class._register_property(name, self)
 
     def __get__(self, style, style_class=None):
         if style is None:

--- a/travertino/src/travertino/properties/validated.py
+++ b/travertino/src/travertino/properties/validated.py
@@ -32,14 +32,14 @@ class validated_property:
 
     def __set_name__(self, style_class, name):
         self.name = name
-        style_class._BASE_PROPERTIES[style_class].add(name)
-        style_class._BASE_ALL_PROPERTIES[style_class].add(name)
+        self.storage_name = f"_{name}"
+        style_class._register_property(name, self, real=True)
 
     def __get__(self, style, style_class=None):
         if style is None:
             return self
 
-        return getattr(style, f"_{self.name}", self.initial)
+        return getattr(style, self.storage_name, self.initial)
 
     def __set__(self, style, value):
         if value is self:
@@ -54,9 +54,9 @@ class validated_property:
             )
 
         value = self.validate(value)
-        current = style[self.name]  # Fetches initial if not set
+        current = self.__get__(style, type(style))  # Fetches initial if not set
 
-        setattr(style, f"_{self.name}", value)
+        setattr(style, self.storage_name, value)
         if value != current:
             ######################################################################
             # 08-2025: Backwards compatibility for Toga < 0.5.0
@@ -75,8 +75,8 @@ class validated_property:
 
     def __delete__(self, style):
         try:
-            current = getattr(style, f"_{self.name}")
-            delattr(style, f"_{self.name}")
+            current = getattr(style, self.storage_name)
+            delattr(style, self.storage_name)
         except AttributeError:
             pass
         else:
@@ -110,7 +110,7 @@ class validated_property:
             ) from error
 
     def is_set_on(self, style):
-        return hasattr(style, f"_{self.name}")
+        return hasattr(style, self.storage_name)
 
 
 class list_property(validated_property):

--- a/travertino/src/travertino/style.py
+++ b/travertino/src/travertino/style.py
@@ -35,11 +35,21 @@ class BaseStyle(ABC):  # noqa: B024
     _BASE_PROPERTIES = defaultdict(set)
     # Includes aliases and shorthands
     _BASE_ALL_PROPERTIES = defaultdict(set)
+    _BASE_PROPERTY_DESCRIPTORS = defaultdict(dict)
 
     def __init_subclass__(cls):
         # Give the subclass a direct reference to its properties.
         cls._PROPERTIES = cls._BASE_PROPERTIES[cls]
         cls._ALL_PROPERTIES = cls._BASE_ALL_PROPERTIES[cls]
+        cls._PROPERTY_DESCRIPTORS = cls._BASE_PROPERTY_DESCRIPTORS[cls]
+
+    @classmethod
+    def _register_property(cls, name, descriptor, *, real=False):
+        """Register a style property descriptor on this style class."""
+        if real:
+            cls._BASE_PROPERTIES[cls].add(name)
+        cls._BASE_ALL_PROPERTIES[cls].add(name)
+        cls._BASE_PROPERTY_DESCRIPTORS[cls][name] = descriptor
 
     ###################################################
     # 03-2025: Backwards compatibility for Toga < 0.5.0
@@ -255,10 +265,11 @@ class BaseStyle(ABC):  # noqa: B024
         with self.batch_apply():
             for name, value in properties.items():
                 name = name.replace("-", "_")
-                if name not in self._ALL_PROPERTIES:
-                    raise NameError(f"Unknown property '{name}'")
+                try:
+                    prop = self._PROPERTY_DESCRIPTORS[name]
+                except KeyError:
+                    raise NameError(f"Unknown property '{name}'") from None
 
-                prop = getattr(type(self), name)
                 if isinstance(getattr(prop, "source", None), dict):
                     deferred_aliases[name] = value
                 else:
@@ -269,21 +280,27 @@ class BaseStyle(ABC):  # noqa: B024
 
     def __getitem__(self, name):
         name = name.replace("-", "_")
-        if name not in self._ALL_PROPERTIES:
-            raise KeyError(name)
-        return getattr(self, name)
+        try:
+            prop = self._PROPERTY_DESCRIPTORS[name]
+        except KeyError:
+            raise KeyError(name) from None
+        return prop.__get__(self, type(self))
 
     def __setitem__(self, name, value):
         name = name.replace("-", "_")
-        if name not in self._ALL_PROPERTIES:
-            raise KeyError(name)
-        setattr(self, name, value)
+        try:
+            prop = self._PROPERTY_DESCRIPTORS[name]
+        except KeyError:
+            raise KeyError(name) from None
+        prop.__set__(self, value)
 
     def __delitem__(self, name):
         name = name.replace("-", "_")
-        if name not in self._ALL_PROPERTIES:
-            raise KeyError(name)
-        delattr(self, name)
+        try:
+            prop = self._PROPERTY_DESCRIPTORS[name]
+        except KeyError:
+            raise KeyError(name) from None
+        prop.__delete__(self)
 
     def keys(self):
         return {*self}
@@ -296,9 +313,11 @@ class BaseStyle(ABC):  # noqa: B024
 
     def __contains__(self, name):
         name = name.replace("-", "_")
-        return name in self._ALL_PROPERTIES and (
-            getattr(self.__class__, name).is_set_on(self)
-        )
+        try:
+            prop = self._PROPERTY_DESCRIPTORS[name]
+        except KeyError:
+            return False
+        return prop.is_set_on(self)
 
     def __iter__(self):
         yield from (name for name in self._PROPERTIES if name in self)

--- a/travertino/tests/style/test_dict.py
+++ b/travertino/tests/style/test_dict.py
@@ -105,6 +105,24 @@ def test_dict(StyleClass):
 
 
 @pytest.mark.parametrize("StyleClass", [Style, DeprecatedStyle])
+def test_dict_access_rejects_non_property_attributes(StyleClass):
+    """Dict-style access only exposes registered style properties."""
+    style = StyleClass()
+    style.not_a_property = VALUE1
+
+    with pytest.raises(KeyError):
+        style["not_a_property"]
+
+    with pytest.raises(KeyError):
+        style["not_a_property"] = VALUE2
+
+    with pytest.raises(KeyError):
+        del style["not_a_property"]
+
+    assert style.not_a_property == VALUE1
+
+
+@pytest.mark.parametrize("StyleClass", [Style, DeprecatedStyle])
 @pytest.mark.parametrize("instantiate", [True, False])
 def test_union_operators(StyleClass, instantiate):
     """Styles support | and |= with dicts and with their own class."""


### PR DESCRIPTION
## Summary

- Replace repeated dictionary-style Pack style lookups in layout calculation with direct attribute access for known internal properties
- Preserve the public `style[...]` mapping API and existing layout behavior
- Add `changes/4530.feature.md`

## summary

| Observed path | Mirrored target |
|:---|:---|
| Repeated `BaseStyle.__getitem__` calls inside Pack layout passes | Directly access known Pack attributes inside the hot loop |
| Rebuild margin property names at each lookup site | Compute margin attribute names once per `_layout_children()` call |
| Preserve generic style mapping access for users | Specialize only internal Pack layout code where property names are already validated |

## Benchmark

### macOS 26.5.1, Apple M3, 24 GiB RAM, Python 3.14.5

### Pack layout of a 1,555-node alternating row/column tree, 100 layouts per round

| | Min | Median | Mean | OPS | Rounds |
|:---|---:|---:|---:|---:|---:|
| `d4b4c3feb` (base) | 1.076828s | 1.079201s | 1.079615s | 92.66 layouts/s | 7 |
| `16116a5f1` (head) | 0.839047s | 0.840552s | 0.840170s | 118.97 layouts/s | 7 |
| **Speedup** | **1.28x** | **1.28x** | **1.29x** | **1.28x** | |

| Function | base | head | Delta | Speedup |
|:---|---:|---:|:---|---:|
| `PackLogic.layout` workload | 1.079201s | 0.840552s | `██░░░░░░░░` -22.1% | 1.28x |

Profile note: `BaseStyle.__getitem__` dropped out of the head profile. In base it accounted for 2,356,800 calls across the profiled 100 layouts.

<details>
<summary><b>Reproduce the benchmark locally</b></summary>

```bash
git worktree add /private/tmp/toga-pack-layout-base main

# Run the benchmark script from the details below in each worktree.
cd /private/tmp/toga-pack-layout-base
uv run --with-editable ./travertino --with-editable ./core python /private/tmp/toga_pack_layout_benchmark.py

cd /Users/krrt7/Desktop/work/beeware/toga
uv run --with-editable ./travertino --with-editable ./core python /private/tmp/toga_pack_layout_benchmark.py
```

</details>

<details>
<summary><b>Benchmark test source</b></summary>

```python
# Builds a 1,555-node Pack tree, warms layout once, then times 7 rounds of 100 layouts.
# The script uses a dummy applicator and dummy Font to isolate Pack layout math from backend startup.
root = make_node(depth=4, breadth=6)
viewport = Viewport(1200, 800)
root.style.layout(viewport)

for _ in range(7):
    start = time.perf_counter()
    for _ in range(100):
        root.style.layout(viewport)
    samples.append(time.perf_counter() - start)
```

</details>

## Changelog

Added `changes/4530.feature.md`.

## Stack

| Order | PR | Branch | Merge after |
|:---:|:---|:---|:---|
| 1 | Current PR | `perf/pack-layout-style-lookups` | `main` |

## Test plan

- [x] Benchmarked base vs. head with the command above
- [x] `uv run pytest core/tests/style -q`
- [x] `uv run pytest core/tests/widgets/test_base.py -q`
- [x] `uv run ruff check core/src/toga/style/layout.py`
- [x] `uv run tox -m test-core`
- [x] `uv run pre-commit run --all-files`

## PR Checklist:

- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool

Assisted-by: OpenAI Codex
