### PR TITLE
Add system-pyside6 integration for Qt system themes

### DIFF
--- a/changes/3995.feature.md
+++ b/changes/3995.feature.md
@@ -1,0 +1,1 @@
+The Qt backend can now integrate properly with system themes, including Breeze on KDE.

--- a/docs/en/reference/platforms/linux/qt.md
+++ b/docs/en/reference/platforms/linux/qt.md
@@ -20,19 +20,33 @@ Although Qt *can* be installed on Windows and macOS, and the `toga-qt` backend *
 
 Most Qt testing occurs with Qt 6.10 as this is the version that is installable through `pip`.
 
-The system packages that provide Qt must be installed manually:
+The system packages that provide Qt, its dependencies, and/or PySide6 must be installed manually:
 
 -8<- "snippets/qt-prerequisites.md"
 
 ## Installation
 
-`toga-qt` must be installed directly using `pip`. The `pyside6` optional extra is used to request the installation of the Python language bindings for Qt.
+`toga-qt` must be installed directly using `pip` in a virtual environment. The exact options used will depend on whether you choose to integrate your application with the system PySide6 runtime.
+
+### Without System Integration
+
+The `pyside6` optional extra is used to request the installation of the Python language bindings for Qt directly in the virtual environment.
 
 ```console
 $ python -m pip install toga-qt[pyside6]
 ```
 
-This will install the full `PySide6` package, which includes both `PySide6-Essentials` and `PySide6-Addons`. The `PySide6-Addons` package is required to support the [WebView][] widget. If your app does not use [WebView][], you can specify a requirement of `toga-qt[pyside6-essentials]` to only install the `PySide6-Essentials` package.
+This will install the full `PySide6` package, which includes both `PySide6-Essentials` and `PySide6-Addons`. The `PySide6-Addons` package is required to support the [WebView][] widget. If your app does not use [WebView][], you can specify a requirement of `toga-qt[pyside6-essentials]` to only install the `PySide6-Essentials` package. These will also bundle a full copy of Qt into the virtual environment.
+
+### With System Integration
+
+The `system` optional extra is used to request the integration of the system PySide6 runtime into the virtual environment.
+
+```console
+$ python -m pip install toga-qt[system]
+```
+
+This will install a shim to redirect imports of `PySide6`-relevant packages from system-installed Python packages into the current virtual environment. The instructions to install `PySide6` at the system level is included in the [prerequisites][qt-prerequisites] section.
 
 ## Implementation details
 

--- a/docs/en/reference/platforms/linux/qt.md
+++ b/docs/en/reference/platforms/linux/qt.md
@@ -4,12 +4,6 @@ The Toga backend for Linux (and other Unix-like operating systems) running KDE i
 
 `toga-qt` requires Python 3.10+, and Qt 6.8 or newer.
 
-/// warning | Experimental Backend
-
-While the GTK 3 backend is mostly completed in functionality, the Qt backend is currently a pre-alpha prototype.
-
-///
-
 /// admonition | Qt on Windows and macOS
 
 Although Qt *can* be installed on Windows and macOS, and the `toga-qt` backend *may* work on those platforms, this is not officially supported by Toga. We recommend using `toga-winforms` on [Windows][], and `toga-cocoa` on [macOS][].
@@ -18,17 +12,25 @@ Although Qt *can* be installed on Windows and macOS, and the `toga-qt` backend *
 
 ## Prerequisites { #qt-prerequisites }
 
-Most Qt testing occurs with Qt 6.10 as this is the version that is installable through `pip`.
-
-The system packages that provide Qt, its dependencies, and/or PySide6 must be installed manually:
-
 -8<- "snippets/qt-prerequisites.md"
 
 ## Installation
 
-`toga-qt` must be installed directly using `pip` in a virtual environment. The exact options used will depend on whether you choose to integrate your application with the system PySide6 runtime.
+`toga-qt` can be installed directly using `pip` in a virtual environment.
 
-### Without System Integration
+/// tab | System integration
+
+The `system` optional extra is used to request the integration of the system PySide6 runtime into the virtual environment.
+
+```console
+$ python -m pip install toga-qt[system]
+```
+
+This will install a shim to redirect imports of `PySide6`-relevant packages from system-installed Python packages into the current virtual environment.
+
+///
+
+/// tab | Standalone bindings
 
 The `pyside6` optional extra is used to request the installation of the Python language bindings for Qt directly in the virtual environment.
 
@@ -38,18 +40,10 @@ $ python -m pip install toga-qt[pyside6]
 
 This will install the full `PySide6` package, which includes both `PySide6-Essentials` and `PySide6-Addons`. The `PySide6-Addons` package is required to support the [WebView][] widget. If your app does not use [WebView][], you can specify a requirement of `toga-qt[pyside6-essentials]` to only install the `PySide6-Essentials` package. These will also bundle a full copy of Qt into the virtual environment.
 
-### With System Integration
-
-The `system` optional extra is used to request the integration of the system PySide6 runtime into the virtual environment.
-
-```console
-$ python -m pip install toga-qt[system]
-```
-
-This will install a shim to redirect imports of `PySide6`-relevant packages from system-installed Python packages into the current virtual environment. The instructions to install `PySide6` at the system level is included in the [prerequisites][qt-prerequisites] section.
+///
 
 ## Implementation details
 
-The `toga-qt` backend uses Qt 6.
+The `toga-qt` backend uses Qt 6. Most testing occurs with Qt 6.10 as this is the version that is installable through `pip`.
 
 The native APIs are accessed using the [PySide6 bindings](https://www.qt.io/development/qt-framework/python-bindings).

--- a/docs/en/snippets/qt-prerequisites.md
+++ b/docs/en/snippets/qt-prerequisites.md
@@ -1,14 +1,50 @@
 <!-- rumdl-disable-line MD041 -->
 
-These instructions are different on almost every version of Linux and Unix, in addition to whether Wayland or X11 is used; here are some of the common alternatives:
+The Qt backend can operate either using an installation of PySide6 in the virtual environment used, or using integration with the system-installed PySide6. The latter is required to properly integrate with system themes, which will be important if you run your application under KDE. System integration is only available on recent distribution versions.
 
-### Ubuntu 24.04 / Debian 11+
+These instructions are different on almost every version of Linux and Unix, in addition to whether Wayland or X11 is used, or whether the system PySide6 integration is used; here are some of the common alternatives:
+
+#### Ubuntu 24.10+ / Debian 13+ (with system integration)
 
 /// tab | Wayland
 
 ```console
 (venv) $ sudo apt install git python3-dev build-essential \
-             libwayland-dev libwayland-egl1-mesa libwayland-server0 \
+             python3-pyside6.qtcore python3-pyside6.qtwidgets \
+             python3-pyside6.qtgui python3-pyside6.qtquickwidgets \
+             python3-pyside6.qtpositioning python3-pyside6.qtwebenginecore \
+             python3-pyside6.qtwebenginewidgets \
+             libwayland-dev libwayland-server0 libwayland-egl1 \
+             libgles2-mesa-dev libxkbcommon-dev gnome-session-canberra \
+             qt6-wayland
+```
+
+///
+
+/// tab | X11
+
+```console
+(venv) $ sudo apt install git python3-dev build-essential \
+             python3-pyside6.qtcore python3-pyside6.qtwidgets \
+             python3-pyside6.qtgui python3-pyside6.qtquickwidgets \
+             python3-pyside6.qtpositioning python3-pyside6.qtwebenginecore \
+             python3-pyside6.qtwebenginewidgets \
+             libfontconfig1-dev libfreetype-dev libgtk-3-dev \
+             libx11-dev libx11-xcb-dev libxext-dev \
+             libxfixes-dev libxi-dev libxkbcommon-dev \
+             libxkbcommon-x11-dev libxrender-dev 'libxcb*-dev' \
+             gnome-session-canberra
+```
+
+///
+
+### Ubuntu 24.04 / Debian 11+ (without system integration)
+
+/// tab | Wayland
+
+```console
+(venv) $ sudo apt install git python3-dev build-essential \
+             libwayland-dev libwayland-server0 libwayland-egl1 \
              libgles2-mesa-dev libxkbcommon-dev gnome-session-canberra
 ```
 
@@ -29,7 +65,35 @@ These instructions are different on almost every version of Linux and Unix, in a
 
 You can use [deadsnakes](https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa) (or a similar third-party source) to install a Python version other than the system default by replacing `python3-dev` with the `-dev` package matching the desired Python version. For example, to use Python 3.12, replace `python3-dev` with `python3.12-dev`.
 
-### Fedora 41+
+### Fedora 41+ (with system integration)
+
+/// tab | Wayland
+
+```console
+(venv) $ sudo dnf install git python3-devel \
+             libcanberra-gtk3 wayland-devel libwayland-server \
+             mesa-libEGL libxkbcommon-devel python3-pyside6 \
+             qt6-qtwayland
+(venv) $ sudo dnf upgrade --refresh
+```
+
+///
+
+/// tab | X11
+
+```console
+(venv) $ sudo dnf install git python3-devel \
+             libcanberra-gtk3 fontconfig-devel freetype-devel \
+             gtk3-devel libX11-devel libX11-xcb libXext-devel \
+             libXfixes-devel libXi-devel libxkbcommon-devel \
+             libxkbcommon-x11-devel libXrender-devel 'xcb-util*devel' \
+             python3-pyside6
+(venv) $ sudo dnf upgrade --refresh
+```
+
+///
+
+### Fedora 41+ (without system integration)
 
 /// tab | Wayland
 
@@ -49,7 +113,7 @@ You can use [deadsnakes](https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa) 
              libcanberra-gtk3 fontconfig-devel freetype-devel \
              gtk3-devel libX11-devel libX11-xcb libXext-devel \
              libXfixes-devel libXi-devel libxkbcommon-devel \
-             libxkbcommon-x11-devel libXrender-devel 'xcb-util*devel' \
+             libxkbcommon-x11-devel libXrender-devel 'xcb-util*devel'
 (venv) $ sudo dnf upgrade --refresh
 ```
 
@@ -59,4 +123,4 @@ You can use a Python version other than the system default by replacing `python3
 
 ### Other distributions
 
-If you're not using one of these, you'll need to work out how to install the developer libraries for `python3`, [Qt's X11 dependencies](https://doc.qt.io/qt-6/linux-requirements.html), [Qt's Wayland dependencies](https://doc.qt.io/qt-6/wayland-requirements.html), and the executable ``canberra-gtk-play`` (and please let us know so we can improve this documentation!)
+If you're not using one of these, you'll need to work out how to install the developer libraries for `python3`, PySide6, Qt 6, [Qt's X11 dependencies](https://doc.qt.io/qt-6/linux-requirements.html), [Qt's Wayland dependencies](https://doc.qt.io/qt-6/wayland-requirements.html), and the executable ``canberra-gtk-play`` (and please let us know so we can improve this documentation!)

--- a/docs/en/snippets/qt-prerequisites.md
+++ b/docs/en/snippets/qt-prerequisites.md
@@ -1,12 +1,14 @@
 <!-- rumdl-disable-line MD041 -->
 
-The Qt backend can operate either using an installation of PySide6 in the virtual environment used, or using integration with the system-installed PySide6. The latter is required to properly integrate with system themes, which will be important if you run your application under KDE. System integration is only available on recent distribution versions.
+`toga-qt` depends on the PySide6 Qt bindings. However, there are 2 ways to access these bindings: using the bindings provided by your operating system; or by installing the bindings that are published on PyPI.
 
-These instructions are different on almost every version of Linux and Unix, in addition to whether Wayland or X11 is used, or whether the system PySide6 integration is used; here are some of the common alternatives:
+If you install the PySide6 bindings from PyPI, your application will *not* integrate with any themes provided by your operating system. If you are using a Qt-based desktop environment (such as KDE), this will result in an application that doesn't match the appearance of the rest of your system. An app using the system-provided bindings will also be significantly smaller than one using standalone bindings, as the standalone bindings contain a complete copy of Qt.
 
-#### Ubuntu 24.10+ / Debian 13+ (with system integration)
+The process of installing pre-requisites is different on almost every version of Linux and Unix, and is affected by the use of Wayland or X11, and whether the system PySide6 bindings are used. Here are some of the common alternatives:
 
-/// tab | Wayland
+### Ubuntu 24.10+ / Debian 13+
+
+/// tab | Wayland (System)
 
 ```console
 (venv) $ sudo apt install git python3-dev build-essential \
@@ -21,7 +23,7 @@ These instructions are different on almost every version of Linux and Unix, in a
 
 ///
 
-/// tab | X11
+/// tab | X11 (System)
 
 ```console
 (venv) $ sudo apt install git python3-dev build-essential \
@@ -38,9 +40,7 @@ These instructions are different on almost every version of Linux and Unix, in a
 
 ///
 
-### Ubuntu 24.04 / Debian 11+ (without system integration)
-
-/// tab | Wayland
+/// tab | Wayland (Standalone)
 
 ```console
 (venv) $ sudo apt install git python3-dev build-essential \
@@ -50,7 +50,7 @@ These instructions are different on almost every version of Linux and Unix, in a
 
 ///
 
-/// tab | X11
+/// tab | X11 (Standalone)
 
 ```console
 (venv) $ sudo apt install git python3-dev build-essential \
@@ -65,9 +65,9 @@ These instructions are different on almost every version of Linux and Unix, in a
 
 You can use [deadsnakes](https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa) (or a similar third-party source) to install a Python version other than the system default by replacing `python3-dev` with the `-dev` package matching the desired Python version. For example, to use Python 3.12, replace `python3-dev` with `python3.12-dev`.
 
-### Fedora 41+ (with system integration)
+### Fedora 41+
 
-/// tab | Wayland
+/// tab | Wayland (System)
 
 ```console
 (venv) $ sudo dnf install git python3-devel \
@@ -79,7 +79,7 @@ You can use [deadsnakes](https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa) 
 
 ///
 
-/// tab | X11
+/// tab | X11 (System)
 
 ```console
 (venv) $ sudo dnf install git python3-devel \
@@ -93,9 +93,7 @@ You can use [deadsnakes](https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa) 
 
 ///
 
-### Fedora 41+ (without system integration)
-
-/// tab | Wayland
+/// tab | Wayland (Standalone)
 
 ```console
 (venv) $ sudo dnf install git python3-devel \
@@ -106,7 +104,7 @@ You can use [deadsnakes](https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa) 
 
 ///
 
-/// tab | X11
+/// tab | X11 (Standalone)
 
 ```console
 (venv) $ sudo dnf install git python3-devel \

--- a/qt/pyproject.toml
+++ b/qt/pyproject.toml
@@ -117,6 +117,9 @@ pyside6-essentials = [
 pyside6 = [
     "PySide6 == 6.11.1",
 ]
+system = [
+    "system-pyside6 == 0.1.0",
+]
 
 [tool.coverage.run]
 parallel = true

--- a/testbed/pyproject.toml
+++ b/testbed/pyproject.toml
@@ -154,9 +154,6 @@ test_sources = [
 
 requires = [
     "../qt[pyside6]",
-]
-
-test_requires = [
     # psutil would ideally be top-level test dependency. However, for Python < 3.13,
     # Android identifies as Linux, and psutil isn't available for Android.
     "psutil==7.2.2 ; python_version < '3.13'",

--- a/testbed/pyproject.toml
+++ b/testbed/pyproject.toml
@@ -154,6 +154,9 @@ test_sources = [
 
 requires = [
     "../qt[pyside6]",
+]
+
+test_requires = [
     # psutil would ideally be top-level test dependency. However, for Python < 3.13,
     # Android identifies as Linux, and psutil isn't available for Android.
     "psutil==7.2.2 ; python_version < '3.13'",


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

Adds system-pyside6 integration for Qt system themes, including documentation, dependencies, and a TOML optional.

Fixes #3995.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
<!-- update or delete the next line to reflect your usage -->
Assisted-by: <!--name of tool; e.g., Claude Opus 4.5-->
