### PR TITLE
Formally deprecate older Linux distros

### DIFF
--- a/changes/4533.removal.md
+++ b/changes/4533.removal.md
@@ -1,0 +1,1 @@
+Toga's GTK backend now requires the use of PyGObject 3.55.1. This means support for Debian 12 and Ubuntu 22.04 has been dropped.

--- a/docs/en/reference/api/widgets/mapview.md
+++ b/docs/en/reference/api/widgets/mapview.md
@@ -50,8 +50,7 @@ Pins can respond to being pressed. When a pin is pressed, the map generates an `
 - Using MapView on Windows 10 requires that your users have installed the [Edge WebView2 Evergreen Runtime](https://developer.microsoft.com/en-us/microsoft-edge/webview2/#download). This is installed by default on Windows 11.
 
 - Using MapView on Linux requires that the user has installed the system packages for WebKit2, plus the GObject Introspection bindings for WebKit2. The name of the system package required is distribution dependent:
-    - Ubuntu 20.04; Debian 11: `gir1.2-webkit2-4.0`
-    - Ubuntu 22.04+; Debian 12+: `gir1.2-webkit2-4.1`
+    - Ubuntu, Debian: `gir1.2-webkit2-4.1`
     - Fedora: `webkit2gtk4.1`
     - Arch/Manjaro: `webkit2gtk-4.1`
     - OpenSUSE Tumbleweed: `libwebkit2gtk3 typelib(WebKit2)`

--- a/docs/en/reference/api/widgets/webview.md
+++ b/docs/en/reference/api/widgets/webview.md
@@ -22,8 +22,7 @@ webview.set_content("https://example.com", "<html>...</html>")
 - Using WebView on Windows 10 requires that your users have installed the [Edge WebView2 Evergreen Runtime](https://developer.microsoft.com/en-us/microsoft-edge/webview2/#download). This is installed by default on Windows 11.
 
 - Using WebView on Linux requires that the user has installed the system packages for WebKit2, plus the GObject Introspection bindings for WebKit2. The name of the system package required is distribution dependent:
-    - Ubuntu 20.04; Debian 11: `gir1.2-webkit2-4.0`
-    - Ubuntu 22.04+; Debian 12+: `gir1.2-webkit2-4.1`
+    - Ubuntu, Debian: `gir1.2-webkit2-4.1`
     - Fedora: `webkit2gtk4.1`
     - Arch/Manjaro: `webkit2gtk-4.1`
     - OpenSUSE Tumbleweed: `libwebkit2gtk3 typelib(WebKit2)`

--- a/docs/en/reference/platforms/linux/gtk.md
+++ b/docs/en/reference/platforms/linux/gtk.md
@@ -22,15 +22,13 @@ Although GTK *can* be installed on Windows and macOS, and the `toga-gtk` backend
 
 ## Prerequisites { #gtk-prerequisites }
 
-`toga-gtk` requires Python 3.10+, and GTK 3.22 or newer.
+`toga-gtk` requires Python 3.10+, and GTK 3.22 or newer. It also requires `libgirepository 2.0`; older Linux distributions (including Debian 12 and Ubuntu 22.04) do not provide this library.
 
-Most testing occurs with GTK 3.24 as this is the version that has shipped with all versions of Ubuntu since Ubuntu 20.04, and all versions of Fedora since Fedora 32.
+Most testing occurs with GTK 3.24 as this is the version that has shipped with Ubuntu 24.04.
 
 The system packages that provide GTK must be installed manually:
 
 -8<- "snippets/gtk-prerequisites.md"
-
-Toga has experimental support for GTK 4. GTK 4 support requires a Linux distribution that provides `libgirepository 2.0`. This means it is not possible to use the GTK 4 backend on Debian 11, Debian 12, Ubuntu 22.04, or any other older Debian-based distribution.
 
 ## Installation
 
@@ -42,7 +40,7 @@ $ python -m pip install toga-gtk
 
 ### GTK 4 support (experimental)
 
-The experimental GTK 4 backend requires the use of GTK 4.10 or newer. This requirement is met by Debian 13, Ubuntu 24.04, and Fedora 41. Most testing occurs with GTK 4.14, as this is the version that ships with Ubuntu 24.04.
+Toga also has experimental support for GTK 4, which requires the use of GTK 4.10 or newer. This requirement is met by Debian 13, Ubuntu 24.04, and Fedora 41. Most testing occurs with GTK 4.14, as this is the version that ships with Ubuntu 24.04.
 
 If you want to use the experimental GTK 4 backend, run:
 

--- a/docs/en/snippets/gtk-prerequisites.md
+++ b/docs/en/snippets/gtk-prerequisites.md
@@ -11,17 +11,6 @@ These instructions are different on almost every version of Linux and Unix; here
 
 You can use [deadsnakes](https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa) (or a similar third-party source) to install a Python version other than the system default by replacing `python3-dev` with the `-dev` package matching the desired Python version. For example, to use Python 3.12, replace `python3-dev` with `python3.12-dev`.
 
-### Ubuntu 22.04 / Debian 11, 12
-
-```console
-(venv) $ sudo apt update
-(venv) $ sudo apt install git build-essential pkg-config python3-dev libgirepository1.0-dev libcairo2-dev gir1.2-gtk-3.0 libcanberra-gtk3-module
-```
-
-You'll also need to add a pin for `PyGObject < 3.52.1` to your Python dependencies. Later versions of PyGObject require the `libgirepository-2.0-dev` library, which isn't available on older Debian-based distributions.
-
-You can use [deadsnakes](https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa) (or a similar third-party source) to install a Python version other than the system default by replacing `python3-dev` with the `-dev` package matching the desired Python version. For example, to use Python 3.12, replace `python3-dev` with `python3.12-dev`.
-
 ### Fedora 41+
 
 ```console

--- a/gtk/pyproject.toml
+++ b/gtk/pyproject.toml
@@ -119,21 +119,10 @@ dependencies = [
     # It is needed to moderate PyGObject version requirements.
     "packaging",
     "pycairo >= 1.17.0",
-    # PyGObject 3.50.0 is the first version with native GTK asyncio integration.
-    #
-    # A version < 3.52.1 is required to support Debian 12 and other distributions that
-    # don't provide libgirepository 2.0.
-    #
-    # However, GTK4 requires the use of a virtual function implementation that is only
-    # available on 3.52.1 and higher. The GTK4 requirement is satisfied with an optional
-    # dependency.
-    "pygobject >= 3.50.0",
+    # PyGObject 3.55.1 is the first version to include support for asyncio event loops
+    # without the use of an EventLoopPolicy. It requires libgirepository 2.0.
+    "pygobject >= 3.55.1",
     "toga-core == {version}",
-]
-
-[project.optional-dependencies]
-gtk4 = [
-    "pygobject >= 3.52.1",
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
#4438 introduced an implicit dependency on PyGObject 3.55.1. This version is required to support Python 3.15; but it also breaks the compromise introduced to support #3143.

At the time we introduced that compromise (March 2025), Debian 12 was the current stable release, and Ubuntu 22.04 was the "most recent but one" stable LTS for Ubuntu. Today, Debian 12 loses security support status and enters LTS mode in a week (July 11 2026); Ubuntu 22.04 maintenance support ends in 9 months (April 2027). Debian 13 is the stable Debian release, and Ubuntu 26.04 and 24.04 both exist.

Since there is now a viable upgrade path for older Linux distributions, this PR adds a pin for pygobject, and formally drops support for older Linux distros.

Fixes #4533.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
