### PR TITLE
Add cooldown to Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "20:00"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pre-commit"
     directory: "/"
@@ -15,6 +17,8 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "20:00"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pip"
     directory: "/"
@@ -23,6 +27,8 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "20:00"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pip"
     directory: "/toga"
@@ -31,6 +37,8 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "20:00"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pip"
     directory: "/demo"
@@ -39,6 +47,8 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "20:00"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pip"
     directory: "/core"
@@ -47,6 +57,8 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "20:00"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pip"
     directory: "/android"
@@ -55,6 +67,8 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "20:00"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pip"
     directory: "/cocoa"
@@ -63,6 +77,8 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "20:00"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pip"
     directory: "/dummy"
@@ -71,6 +87,8 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "20:00"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pip"
     directory: "/gtk"
@@ -79,6 +97,8 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "20:00"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pip"
     directory: "/iOS"
@@ -87,6 +107,8 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "20:00"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pip"
     directory: "/positron"
@@ -95,6 +117,8 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "20:00"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pip"
     directory: "/qt"
@@ -103,6 +127,8 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "20:00"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pip"
     directory: "/testbed"
@@ -114,6 +140,8 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "20:00"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pip"
     directory: "/textual"
@@ -122,6 +150,8 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "20:00"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pip"
     directory: "/travertino"
@@ -130,6 +160,8 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "20:00"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pip"
     directory: "/web"
@@ -138,6 +170,8 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "20:00"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pip"
     directory: "/winforms"
@@ -146,3 +180,5 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "20:00"
+    cooldown:
+      default-days: 7

--- a/changes/4564.misc.md
+++ b/changes/4564.misc.md
@@ -1,0 +1,1 @@
+Dependency updates now wait seven days after a release before Dependabot proposes them.


### PR DESCRIPTION
Adds an explicit seven-day cooldown to every Dependabot update configuration, matching the BeeWare organization configuration. This gives newly released dependency versions time to be identified as problematic before Dependabot proposes them.

Fixes #4564

## PR Checklist:
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool

Assisted-by: Hermes Agent (GPT-5.6)
