### PR TITLE
Fix WinForms divider rehinting

### DIFF
--- a/changes/4566.bugfix.md
+++ b/changes/4566.bugfix.md
@@ -1,0 +1,1 @@
+When a WinForms window with a divider undergoes a DPI change, the current length of the divider is no longer permanently imposed as a minimum. In general, divider rehinting on WinForms has been more stable.

--- a/winforms/src/toga_winforms/widgets/divider.py
+++ b/winforms/src/toga_winforms/widgets/divider.py
@@ -31,15 +31,15 @@ class Divider(Widget):
             self.native.Width = 2
 
     def rehint(self):
+        # Do not use self.native.Width or self.native.Height here, as rehint is not
+        # necessarily called just after set_direction, in which case the Width/Height
+        # will reflect the real width/height and be incorrectly used as minimums.
+        # This issue can be manifested when moving a window with a divider between two
+        # monitors, where the width of the divider will be incorrectly set as the new
+        # minimum.
         if self.get_direction() == self.interface.HORIZONTAL:
-            self.interface.intrinsic.width = self.scale_out(
-                at_least(self.native.Width), ROUND_UP
-            )
-            self.interface.intrinsic.height = self.scale_out(
-                self.native.Height, ROUND_UP
-            )
+            self.interface.intrinsic.width = at_least(0)
+            self.interface.intrinsic.height = self.scale_out(2, ROUND_UP)
         else:
-            self.interface.intrinsic.width = self.scale_out(self.native.Width, ROUND_UP)
-            self.interface.intrinsic.height = self.scale_out(
-                at_least(self.native.Height), ROUND_UP
-            )
+            self.interface.intrinsic.width = self.scale_out(2, ROUND_UP)
+            self.interface.intrinsic.height = at_least(0)

--- a/winforms/src/toga_winforms/widgets/divider.py
+++ b/winforms/src/toga_winforms/widgets/divider.py
@@ -23,20 +23,16 @@ class Divider(Widget):
 
     def set_direction(self, value):
         self._direction = value
-        if value == self.interface.HORIZONTAL:
-            self.native.Height = 2
-            self.native.Width = 0
-        else:
-            self.native.Height = 0
-            self.native.Width = 2
 
     def rehint(self):
-        # Do not use self.native.Width or self.native.Height here, as rehint is not
-        # necessarily called just after set_direction, in which case the Width/Height
-        # will reflect the real width/height and be incorrectly used as minimums.
-        # This issue can be manifested when moving a window with a divider between two
-        # monitors, where the width of the divider will be incorrectly set as the new
-        # minimum.
+        # A previous attempt at direction setting hardcoded widths and heights in
+        # set_direction onto the native widget, and used self.native.Width and
+        # self.native.Height in this block.  This is unreliable, as if rehint
+        # does not immediately happen after set_direction (such as in DPI scaling
+        # adjustments), the current length of the divider would be enforced as the
+        # minimum length.  Thus, all divider-related layout happens at the rehint,
+        # which will manifest the correct direction in set_bounds once Toga's
+        # layout finishes.
         if self.get_direction() == self.interface.HORIZONTAL:
             self.interface.intrinsic.width = at_least(0)
             self.interface.intrinsic.height = self.scale_out(2, ROUND_UP)

--- a/winforms/src/toga_winforms/widgets/divider.py
+++ b/winforms/src/toga_winforms/widgets/divider.py
@@ -25,14 +25,6 @@ class Divider(Widget):
         self._direction = value
 
     def rehint(self):
-        # A previous attempt at direction setting hardcoded widths and heights in
-        # set_direction onto the native widget, and used self.native.Width and
-        # self.native.Height in this block.  This is unreliable, as if rehint
-        # does not immediately happen after set_direction (such as in DPI scaling
-        # adjustments), the current length of the divider would be enforced as the
-        # minimum length.  Thus, all divider-related layout happens at the rehint,
-        # which will manifest the correct direction in set_bounds once Toga's
-        # layout finishes.
         if self.get_direction() == self.interface.HORIZONTAL:
             self.interface.intrinsic.width = at_least(0)
             self.interface.intrinsic.height = self.scale_out(2, ROUND_UP)


### PR DESCRIPTION
Refs #4486.

This PR modifies Divider rehinting to hardcode sizes; this simplifies the code a lot, and also ensures that the current length of the divider is not enforced as a minimum if a rehint happens at any point that is not immediately after set_direction.

Minimum repro:

```
import toga
def build(app):
    box = toga.Box()
    button = toga.Divider() #"Hello world", on_press=button_handler)
    button.style.margin = 50
    button.style.flex = 1
    box.add(button)
    return box
def main():
    return toga.App("First App", "org.beeware.toga.examples.tutorial", startup=build)
if __name__ == "__main__":
    main().main_loop()
```

-- resize the window to a larger size, change the display scale of the current window, and the size is now enforced as a minimum.

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
<!-- update or delete the next line to reflect your usage -->
