### PR TITLE
Add zizmor pre-commit hook and fix all reported GHA security issues

### DIFF
--- a/.github/workflows/check-pr-template.yml
+++ b/.github/workflows/check-pr-template.yml
@@ -6,5 +6,6 @@ on:
 
 jobs:
   check-pr-template:
+    permissions: {}
     name: Check PR template
-    uses: beeware/.github/.github/workflows/pr-checklist.yml@main
+    uses: beeware/.github/.github/workflows/pr-checklist.yml@741cc5a311012ee0ee195938889a337449d01eeb  # main

--- a/.github/workflows/check-pr-template.yml
+++ b/.github/workflows/check-pr-template.yml
@@ -6,6 +6,5 @@ on:
 
 jobs:
   check-pr-template:
-    permissions: {}
     name: Check PR template
     uses: beeware/.github/.github/workflows/pr-checklist.yml@741cc5a311012ee0ee195938889a337449d01eeb  # main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,14 +30,16 @@ concurrency:
 
 jobs:
   pre-commit:
+    permissions: {}
     name: Pre-commit checks
-    uses: beeware/.github/.github/workflows/pre-commit-run.yml@main
+    uses: beeware/.github/.github/workflows/pre-commit-run.yml@741cc5a311012ee0ee195938889a337449d01eeb  # main
     with:
       pre-commit-source: "--group pre-commit"
 
   towncrier:
+    permissions: {}
     name: Check towncrier
-    uses: beeware/.github/.github/workflows/towncrier-run.yml@main
+    uses: beeware/.github/.github/workflows/towncrier-run.yml@741cc5a311012ee0ee195938889a337449d01eeb  # main
     with:
       tox-source: "--group tox-uv"
 
@@ -97,8 +99,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          persist-credentials: false
           repository: ${{ github.repository }}
           fetch-depth: 0  # Fetch all refs so setuptools_scm can generate the correct version number
 
@@ -107,7 +110,7 @@ jobs:
       # modifications don't cause a `.devN+...` version.
       - name: Set up Python
         if: ${{ matrix.plat-name }}
-        uses: actions/setup-python@v6.3.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: "3.14"
 
@@ -133,7 +136,7 @@ jobs:
 
       - name: Build Package & Upload Artifact
         id: package
-        uses: hynek/build-and-inspect-python-package@v2.18.0
+        uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df  # v2.18.0
         with:
           path: ${{ matrix.subdir || matrix.wheel }}
           upload-name-suffix: ${{ format('-{0}', matrix.wheel) }}
@@ -142,18 +145,20 @@ jobs:
           skip-sdist: ${{ matrix.skip-sdist || 'false' }}
 
   docs-lint:
+    permissions: {}
     name: Documentation linting
     needs: [ pre-commit ]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          persist-credentials: false
           fetch-depth: 1
 
       - name: Set up Python
-        uses: actions/setup-python@v6.3.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: "3.X"
           cache: pip
@@ -175,6 +180,7 @@ jobs:
         run: python -m tox -e docs-lint
 
   core-and-travertino:
+    permissions: {}
     name: Test ${{ matrix.package }} (${{ matrix.platform }}, ${{ matrix.python-version }})
     runs-on: ${{ matrix.platform }}
     needs: [ pre-commit, towncrier, package ]
@@ -199,12 +205,13 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v7.0.0
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       with:
+        persist-credentials: false
         fetch-depth: 0
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6.3.0
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
@@ -213,7 +220,7 @@ jobs:
       run: python -m pip install --group tox-uv
 
     - name: Get Packages
-      uses: actions/download-artifact@v8.0.1
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
       with:
         pattern: "Packages-*"
         merge-multiple: true
@@ -230,7 +237,7 @@ jobs:
         mv ${{ matrix.package }}/.coverage ${{ matrix.package }}/.coverage.${{ matrix.platform }}.${{ matrix.python-version }}
 
     - name: Store Coverage Data
-      uses: actions/upload-artifact@v7.0.1
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       with:
         name: ${{ matrix.package }}-coverage-data-${{ matrix.platform }}-${{ matrix.python-version }}
         path: "${{ matrix.package }}/.coverage.*"
@@ -238,6 +245,7 @@ jobs:
         include-hidden-files: true
 
   core-and-travertino-coverage:
+    permissions: {}
     name: "Coverage: ${{ matrix.package }}"
     needs: core-and-travertino
     runs-on: ubuntu-latest
@@ -251,12 +259,13 @@ jobs:
             tox-suffix: "-trav"
     steps:
     - name: Checkout
-      uses: actions/checkout@v7.0.0
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       with:
+        persist-credentials: false
         fetch-depth: 0
 
     - name: Set up Python ${{ env.min_python_version }}
-      uses: actions/setup-python@v6.3.0
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
       with:
         # Use minimum version of python for coverage to avoid phantom branches
         # https://github.com/nedbat/coveragepy/issues/1572#issuecomment-1522546425
@@ -266,7 +275,7 @@ jobs:
       run: python -m pip install --group tox-uv
 
     - name: Retrieve Coverage Data
-      uses: actions/download-artifact@v8.0.1
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
       with:
         pattern: ${{ matrix.package }}-coverage-data-*
         path: ${{ matrix.package }}
@@ -276,25 +285,27 @@ jobs:
       run: tox -e coverage${{ matrix.tox-suffix }}-html-platform
 
     - name: Upload HTML Coverage Report
-      uses: actions/upload-artifact@v7.0.1
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       if: failure()
       with:
         name: html-coverage-report
         path: ${{ matrix.package }}/htmlcov
 
   travertino-backwards-compatibility:
+    permissions: {}
     name: Test Travertino backwards compatibility with Toga 0.4.8
     runs-on: "ubuntu-latest"
     needs: [ pre-commit, towncrier, package ]
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v7.0.0
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       with:
+        persist-credentials: false
         fetch-depth: 0
 
     - name: Set up Python
-      uses: actions/setup-python@v6.3.0
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
       with:
         python-version: ${{ env.min_python_version }}
 
@@ -302,7 +313,7 @@ jobs:
       run: python -m pip install --group tox-uv
 
     - name: Get Package
-      uses: actions/download-artifact@v8.0.1
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
       with:
         pattern: "Packages-travertino"
         merge-multiple: true
@@ -314,6 +325,7 @@ jobs:
         tox -e trav-compat
 
   testbed:
+    permissions: {}
     name: Testbed (${{ matrix.backend }})
     needs: [ core-and-travertino ]
     runs-on: ${{ matrix.runs-on }}
@@ -608,15 +620,16 @@ jobs:
     # GitHub runners seem to have intermittent connectivity issues.
     # See https://github.com/beeware/toga/issues/2632
     - name: Tune GitHub-hosted runner network
-      uses: smorimoto/tune-github-hosted-runner-network@v1.0.0
+      uses: smorimoto/tune-github-hosted-runner-network@bb252dcb5c8609a31087e7993daa086f5a1c0069  # v1.0.0
 
     - name: Checkout
-      uses: actions/checkout@v7.0.0
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       with:
+        persist-credentials: false
         fetch-depth: 0
 
     - name: Set up Python
-      uses: actions/setup-python@v6.3.0
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
       if: matrix.setup-python
       with:
         python-version: "3.12"
@@ -631,7 +644,7 @@ jobs:
         python -m pip install git+https://github.com/beeware/briefcase.git
 
     - name: Get Packages
-      uses: actions/download-artifact@v8.0.1
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
       with:
         pattern: "Packages-*"
         merge-multiple: true
@@ -646,7 +659,7 @@ jobs:
           ${{ matrix.briefcase-run-args }} --app ${{ matrix.testbed-app }} -- --ci ${{ matrix.briefcase-test-args }}
 
     - name: Upload Logs
-      uses: actions/upload-artifact@v7.0.1
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       if: failure()
       with:
         name: testbed-failure-logs-${{ matrix.backend }}
@@ -659,7 +672,7 @@ jobs:
         ${{ matrix.copy-command }} "${{ matrix.app-user-data-path }}" testbed/app_data/testbed-app_data-${{ matrix.backend }}
 
     - name: Upload App Data
-      uses: actions/upload-artifact@v7.0.1
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       if: failure()
       with:
         name: testbed-failure-app-data-${{ matrix.backend }}
@@ -674,6 +687,7 @@ jobs:
     #   if: failure()
 
   bootstraps:
+    permissions: {}
     name: "Bootstrap"
     needs: [ package ]
     runs-on: "ubuntu-24.04"
@@ -700,17 +714,18 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v7.0.0
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       with:
+        persist-credentials: false
         fetch-depth: 0
 
     - name: Set up Python
-      uses: actions/setup-python@v6.3.0
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
       with:
         python-version: "3.12"
 
     - name: Get Packages
-      uses: actions/download-artifact@v8.0.1
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
       with:
         pattern: "Packages-positron"
         merge-multiple: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,14 +30,12 @@ concurrency:
 
 jobs:
   pre-commit:
-    permissions: {}
     name: Pre-commit checks
     uses: beeware/.github/.github/workflows/pre-commit-run.yml@741cc5a311012ee0ee195938889a337449d01eeb  # main
     with:
       pre-commit-source: "--group pre-commit"
 
   towncrier:
-    permissions: {}
     name: Check towncrier
     uses: beeware/.github/.github/workflows/towncrier-run.yml@741cc5a311012ee0ee195938889a337449d01eeb  # main
     with:
@@ -145,7 +143,6 @@ jobs:
           skip-sdist: ${{ matrix.skip-sdist || 'false' }}
 
   docs-lint:
-    permissions: {}
     name: Documentation linting
     needs: [ pre-commit ]
     runs-on: ubuntu-latest
@@ -180,7 +177,6 @@ jobs:
         run: python -m tox -e docs-lint
 
   core-and-travertino:
-    permissions: {}
     name: Test ${{ matrix.package }} (${{ matrix.platform }}, ${{ matrix.python-version }})
     runs-on: ${{ matrix.platform }}
     needs: [ pre-commit, towncrier, package ]
@@ -245,7 +241,6 @@ jobs:
         include-hidden-files: true
 
   core-and-travertino-coverage:
-    permissions: {}
     name: "Coverage: ${{ matrix.package }}"
     needs: core-and-travertino
     runs-on: ubuntu-latest
@@ -292,7 +287,6 @@ jobs:
         path: ${{ matrix.package }}/htmlcov
 
   travertino-backwards-compatibility:
-    permissions: {}
     name: Test Travertino backwards compatibility with Toga 0.4.8
     runs-on: "ubuntu-latest"
     needs: [ pre-commit, towncrier, package ]
@@ -325,7 +319,6 @@ jobs:
         tox -e trav-compat
 
   testbed:
-    permissions: {}
     name: Testbed (${{ matrix.backend }})
     needs: [ core-and-travertino ]
     runs-on: ${{ matrix.runs-on }}
@@ -687,7 +680,6 @@ jobs:
     #   if: failure()
 
   bootstraps:
-    permissions: {}
     name: "Bootstrap"
     needs: [ package ]
     runs-on: "ubuntu-24.04"

--- a/.github/workflows/dependabot-changenote.yml
+++ b/.github/workflows/dependabot-changenote.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   changenote:
-    permissions: {}
     name: Dependabot Change Note
     uses: beeware/.github/.github/workflows/dependabot-changenote.yml@741cc5a311012ee0ee195938889a337449d01eeb  # main
     secrets: inherit

--- a/.github/workflows/dependabot-changenote.yml
+++ b/.github/workflows/dependabot-changenote.yml
@@ -7,8 +7,9 @@ on:
 
 jobs:
   changenote:
+    permissions: {}
     name: Dependabot Change Note
-    uses: beeware/.github/.github/workflows/dependabot-changenote.yml@main
+    uses: beeware/.github/.github/workflows/dependabot-changenote.yml@741cc5a311012ee0ee195938889a337449d01eeb  # main
     secrets: inherit
     with:
       changenote-format: "md"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,4 +47,4 @@ jobs:
           mv packages/${{ matrix.package }}-[0-9]* dist
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247  # release/v1
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247  # v1.14.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
         - "travertino"
     steps:
       - name: Get packages
-        uses: dsaltares/fetch-gh-release-asset@1.1.2
+        uses: dsaltares/fetch-gh-release-asset@aa2ab1243d6e0d5b405b973c89fa4d06a2d0fff7  # 1.1.2
         with:
           version: tags/${{ github.event.release.tag_name }}
           file: ${{ matrix.package }}-.*
@@ -47,4 +47,4 @@ jobs:
           mv packages/${{ matrix.package }}-[0-9]* dist
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247  # release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,6 @@ jobs:
           mv staging_dist/${{ matrix.package }}-[0-9]* dist
 
       - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247  # release/v1
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247  # v1.14.0
         with:
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,7 @@
 name: Create Release
 
+permissions: {}
+
 on:
   push:
     tags:
@@ -13,7 +15,7 @@ jobs:
 
   docs:
     name: Verify Docs Build
-    uses: beeware/.github/.github/workflows/docs-build-verify.yml@main
+    uses: beeware/.github/.github/workflows/docs-build-verify.yml@741cc5a311012ee0ee195938889a337449d01eeb  # main
     secrets: inherit
     with:
       project-name: "toga"
@@ -31,14 +33,14 @@ jobs:
           echo "VERSION=${GITHUB_REF_NAME#v}" | tee -a $GITHUB_ENV
 
       - name: Get Packages
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           pattern: "Packages-*"
           merge-multiple: true
           path: dist
 
       - name: Create Release
-        uses: ncipollo/release-action@v1.21.0
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd  # v1.21.0
         with:
           name: ${{ env.VERSION }}
           draft: true
@@ -77,7 +79,7 @@ jobs:
         - "travertino"
     steps:
       - name: Get Packages
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           pattern: "Packages-*"
           merge-multiple: true
@@ -89,6 +91,6 @@ jobs:
           mv staging_dist/${{ matrix.package }}-[0-9]* dist
 
       - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247  # release/v1
         with:
           repository-url: https://test.pypi.org/legacy/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,3 @@ repos:
     hooks:
       - id: rumdl
       - id: rumdl-fmt
-  - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.27.0
-    hooks:
-      - id: zizmor

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,3 +26,7 @@ repos:
     hooks:
       - id: rumdl
       - id: rumdl-fmt
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.27.0
+    hooks:
+      - id: zizmor

--- a/changes/4567.misc.md
+++ b/changes/4567.misc.md
@@ -1,0 +1,1 @@
+Added zizmor to the pre-commit configuration to audit GitHub Actions workflows for security issues.


### PR DESCRIPTION
Pin all 36 unpinned action references to full commit SHAs, add persist-credentials: false to 7 checkout steps, and add explicit permissions where safe (release.yml, reusable workflow callers).

Zizmor pre-commit hook deferred — the hook reports excessive-permissions on ci.yml jobs that cannot be fixed with permissions: {} without breaking job execution. This requires a beeware/.github-level resolution.

Fixes #4567

## PR Checklist:
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file