### PR TITLE
Release stale native menu command items on rebuild

### DIFF
--- a/android/tests_backend/app.py
+++ b/android/tests_backend/app.py
@@ -12,6 +12,8 @@ from .window import WindowProbe
 
 
 class AppProbe(BaseProbe, DialogsMixin):
+    supports_application_menu_command_native_items = False
+    supports_status_icon_command_native_items = False
     supports_key = False
     supports_dark_mode = True
     edit_menu_noop_enabled = False

--- a/changes/4580.bugfix.md
+++ b/changes/4580.bugfix.md
@@ -1,0 +1,1 @@
+Native menu and toolbar command instances are now released when their containers are rebuilt or closed.

--- a/cocoa/src/toga_cocoa/window.py
+++ b/cocoa/src/toga_cocoa/window.py
@@ -176,6 +176,7 @@ class TogaWindow(NSWindow):
                 native.setImage(item.icon._impl._as_size(32))
 
             item._impl.native.add(native)
+            self.impl.toolbar_items[native] = item
 
             native.setTarget_(self)
             native.setAction_(SEL("onToolbarButtonPress:"))
@@ -544,10 +545,15 @@ class MainWindow(Window):
 
         # By default, no toolbar
         self._toolbar_items = {}
+        self.toolbar_items = {}
         self.native_toolbar = None
 
     def __del__(self):
         self.purge_toolbar()
+
+    def close(self):
+        self.purge_toolbar()
+        super().close()
 
     def create_menus(self):
         # macOS doesn't have window-level menus
@@ -577,20 +583,7 @@ class MainWindow(Window):
             self.interface.content.refresh()
 
     def purge_toolbar(self):
-        while self._toolbar_items:
-            dead_items = []
-            _, cmd = self._toolbar_items.popitem()
-            # The command might have toolbar representations on multiple window
-            # toolbars, and may have other representations (at the very least, a menu
-            # item). Only clean up the representation pointing at *this* window. Do this
-            # in 2 passes so that we're not modifying the set of native objects while
-            # iterating over it.
-            for item_native in cmd._impl.native:
-                if (
-                    isinstance(item_native, NSToolbarItem)
-                    and item_native.target == self.native
-                ):
-                    dead_items.append(item_native)
-
-            for item_native in dead_items:
-                cmd._impl.native.remove(item_native)
+        for item_native, cmd in self.toolbar_items.items():
+            cmd._impl.native.remove(item_native)
+        self.toolbar_items = {}
+        self._toolbar_items = {}

--- a/cocoa/tests_backend/app.py
+++ b/cocoa/tests_backend/app.py
@@ -20,6 +20,8 @@ NSDate = ObjCClass("NSDate")
 
 
 class AppProbe(BaseProbe, DialogsMixin):
+    supports_application_menu_command_native_items = True
+    supports_status_icon_command_native_items = True
     supports_key = True
     supports_key_mod3 = True
     supports_current_window_assignment = True

--- a/cocoa/tests_backend/window.py
+++ b/cocoa/tests_backend/window.py
@@ -10,6 +10,7 @@ from .probe import BaseProbe
 
 
 class WindowProbe(BaseProbe, DialogsMixin):
+    supports_command_items = True
     supports_closable = True
     supports_minimizable = True
     supports_move_while_hidden = True
@@ -125,6 +126,13 @@ class WindowProbe(BaseProbe, DialogsMixin):
 
     def has_toolbar(self):
         return self.native.toolbar is not None
+
+    def command_items(self, command):
+        return {
+            item
+            for item, item_command in self.impl.toolbar_items.items()
+            if item_command is command
+        }
 
     def assert_is_toolbar_separator(self, index, section=False):
         # macOS doesn't display separators, so there's nothing to assert.

--- a/gtk/src/toga_gtk/app.py
+++ b/gtk/src/toga_gtk/app.py
@@ -53,6 +53,7 @@ class App:
                 flags=Gio.ApplicationFlags.DEFAULT_FLAGS,
             )
         self.native_about_dialog = None
+        self._menu_items = {}
 
         # Connect the GTK signal that will cause app startup to occur
         self.native.connect("startup", self.gtk_startup)
@@ -121,7 +122,10 @@ class App:
         # application level, and are automatically added to any ApplicationWindow.
         # (or to the top of the screen if the GTK theme requires)
 
-        # Only create the menu if the menu item index has been created.
+        for action, cmd in self._menu_items.items():
+            self.native.remove_action(action.get_name())
+            cmd._impl.native.remove(action)
+
         self._menu_items = {}
         self._menu_groups = {}
 
@@ -138,7 +142,7 @@ class App:
                 action = Gio.SimpleAction.new(cmd_id, None)
                 action.connect("activate", cmd._impl.gtk_activate)
 
-                cmd._impl.native.append(action)
+                cmd._impl.native.add(action)
                 cmd._impl.set_enabled(cmd.enabled)
                 self._menu_items[action] = cmd
                 self.native.add_action(action)

--- a/gtk/src/toga_gtk/command.py
+++ b/gtk/src/toga_gtk/command.py
@@ -4,7 +4,7 @@ from toga import Command as StandardCommand, Group, Key
 
 
 class Command:
-    """Command `native` property is a list of native widgets associated with the
+    """Command `native` property is a set of native widgets associated with the
     command.
 
     Native widgets can be both Gtk.ToolButton and Gio.SimpleAction.
@@ -12,7 +12,7 @@ class Command:
 
     def __init__(self, interface):
         self.interface = interface
-        self.native = []
+        self.native = set()
 
     @classmethod
     def standard(self, app, id):

--- a/gtk/src/toga_gtk/window.py
+++ b/gtk/src/toga_gtk/window.py
@@ -516,24 +516,32 @@ class MainWindow(Window):
         # GTK menus are handled at the app level
         pass
 
+    def purge_toolbar(self):
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+            for item_impl, cmd in self.toolbar_items.items():
+                self.native_toolbar.remove(item_impl)
+                cmd._impl.native.remove(item_impl)
+
+            for sep in self.toolbar_separators:
+                self.native_toolbar.remove(sep)
+
+            self.toolbar_items = {}
+            self.toolbar_separators = set()
+
+    def close(self):
+        self.purge_toolbar()
+        super().close()
+
     def create_toolbar(self):
         if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             # If there's an existing toolbar, hide it until we know we need it.
             self.layout.remove(self.native_toolbar)
 
             # Deregister any toolbar buttons from their commands, and remove them
-            # from the toolbar
-            for cmd, item_impl in self.toolbar_items.items():
-                self.native_toolbar.remove(item_impl)
-                cmd._impl.native.remove(item_impl)
-
-            # Remove any toolbar separators
-            for sep in self.toolbar_separators:
-                self.native_toolbar.remove(sep)
+            # from the toolbar.
+            self.purge_toolbar()
 
             # Create the new toolbar items
-            self.toolbar_items = {}
-            self.toolbar_separators = set()
             prev_group = None
             for cmd in self.interface.toolbar:
                 if isinstance(cmd, Separator):
@@ -561,8 +569,8 @@ class MainWindow(Window):
                     if cmd.tooltip:
                         item_impl.set_tooltip_text(cmd.tooltip)
                     item_impl.connect("clicked", cmd._impl.gtk_clicked)
-                    cmd._impl.native.append(item_impl)
-                    self.toolbar_items[cmd] = item_impl
+                    cmd._impl.native.add(item_impl)
+                    self.toolbar_items[item_impl] = cmd
 
                 self.native_toolbar.insert(item_impl, -1)
 

--- a/gtk/src/toga_gtk/window.py
+++ b/gtk/src/toga_gtk/window.py
@@ -517,7 +517,7 @@ class MainWindow(Window):
         pass
 
     def purge_toolbar(self):
-        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
+        if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4  # pragma: no branch
             for item_impl, cmd in self.toolbar_items.items():
                 self.native_toolbar.remove(item_impl)
                 cmd._impl.native.remove(item_impl)

--- a/gtk/tests_backend/app.py
+++ b/gtk/tests_backend/app.py
@@ -13,6 +13,8 @@ from .probe import BaseProbe
 
 
 class AppProbe(BaseProbe, DialogsMixin):
+    supports_application_menu_command_native_items = True
+    supports_status_icon_command_native_items = False
     supports_key = True
     supports_key_mod3 = True
     # Gtk 3.24.41 ships with Ubuntu 24.04 where present() works on Wayland

--- a/gtk/tests_backend/window.py
+++ b/gtk/tests_backend/window.py
@@ -11,6 +11,7 @@ from .probe import BaseProbe
 
 
 class WindowProbe(BaseProbe, DialogsMixin):
+    supports_command_items = GTK_VERSION < (4, 0)
     # GTK defers a lot of window behavior to the window manager, which means some
     # features either don't exist, or we can't guarantee they behave the way Toga would
     # like.
@@ -143,6 +144,13 @@ class WindowProbe(BaseProbe, DialogsMixin):
         if GTK_VERSION < (4, 0, 0):
             return self.impl.native_toolbar.get_n_items() > 0
         pytest.skip("Toolbars not implemented on GTK4")
+
+    def command_items(self, command):
+        return {
+            item
+            for item, item_command in self.impl.toolbar_items.items()
+            if item_command is command
+        }
 
     def assert_is_toolbar_separator(self, index, section=False):
         item = self.impl.native_toolbar.get_nth_item(index)

--- a/iOS/tests_backend/app.py
+++ b/iOS/tests_backend/app.py
@@ -14,6 +14,8 @@ from .probe import BaseProbe
 
 
 class AppProbe(BaseProbe, DialogsMixin):
+    supports_application_menu_command_native_items = False
+    supports_status_icon_command_native_items = False
     supports_key = False
     supports_dark_mode = True
     edit_menu_noop_enabled = False

--- a/qt/src/toga_qt/command.py
+++ b/qt/src/toga_qt/command.py
@@ -36,14 +36,14 @@ class EditOperation:
 
 class Command:
     """
-    Command `native` property is a list of native widgets associated with the command.
+    Command `native` property is a set of native widgets associated with the command.
 
     Native widgets is of type QAction
     """
 
     def __init__(self, interface):
         self.interface = interface
-        self.native = []
+        self.native = set()
 
     @classmethod
     def standard(self, app, id):
@@ -138,6 +138,6 @@ class Command:
 
         item.setEnabled(self.interface.enabled)
 
-        self.native.append(item)
+        self.native.add(item)
 
         return item

--- a/qt/src/toga_qt/statusicons.py
+++ b/qt/src/toga_qt/statusicons.py
@@ -55,6 +55,7 @@ class MenuStatusIcon(StatusIcon):
 class StatusIconSet:
     def __init__(self, interface):
         self.interface = interface
+        self._menu_items = {}
 
     def _submenu(self, group, group_cache):
         try:
@@ -74,6 +75,9 @@ class StatusIconSet:
         This gets called on App creation, and then on any changes to the status icon
         command set.
         """
+        for menu_item, cmd in self._menu_items.items():
+            cmd._impl.native.remove(menu_item)
+
         # Menu status icons are the only icons that have extra construction needs.
         # Clear existing menu items
         for item in self.interface._menu_status_icons:
@@ -93,6 +97,7 @@ class StatusIconSet:
         }
         # Map the COMMANDS group to the primary status icon's menu.
         group_cache[Group.COMMANDS] = primary_group._impl.native.contextMenu()
+        self._menu_items = {}
 
         for cmd in self.interface.commands:
             try:
@@ -106,4 +111,6 @@ class StatusIconSet:
                 if isinstance(cmd, Separator):
                     submenu.addSeparator()
                 else:
-                    submenu.addAction(cmd._impl.create_menu_item())
+                    menu_item = cmd._impl.create_menu_item()
+                    submenu.addAction(menu_item)
+                    self._menu_items[menu_item] = cmd

--- a/qt/src/toga_qt/window.py
+++ b/qt/src/toga_qt/window.py
@@ -354,6 +354,26 @@ class Window:
 
 
 class MainWindow(Window):
+    def create(self):
+        super().create()
+        self.menu_items = {}
+        self.toolbar_items = {}
+
+    def purge_menu_items(self):
+        for item, cmd in self.menu_items.items():
+            cmd._impl.native.remove(item)
+        self.menu_items = {}
+
+    def purge_toolbar_items(self):
+        for item, cmd in self.toolbar_items.items():
+            cmd._impl.native.remove(item)
+        self.toolbar_items = {}
+
+    def close(self):
+        self.purge_menu_items()
+        self.purge_toolbar_items()
+        super().close()
+
     def _submenu(self, group, group_cache):
         try:
             return group_cache[group]
@@ -366,6 +386,8 @@ class MainWindow(Window):
         return submenu
 
     def create_menus(self):
+        self.purge_menu_items()
+
         menubar = self.native.menuBar()
         menubar.clear()
 
@@ -376,9 +398,13 @@ class MainWindow(Window):
             if isinstance(cmd, Separator):
                 submenu.addSeparator()
             else:
-                submenu.addAction(cmd._impl.create_menu_item())
+                item = cmd._impl.create_menu_item()
+                submenu.addAction(item)
+                self.menu_items[item] = cmd
 
     def create_toolbar(self):
+        self.purge_toolbar_items()
+
         if self.interface.toolbar:
             if self.toolbar_native:
                 self.toolbar_native.clear()
@@ -414,7 +440,8 @@ class MainWindow(Window):
 
                 action.triggered.connect(cmd.action)
 
-                cmd._impl.native.append(action)
+                cmd._impl.native.add(action)
+                self.toolbar_items[action] = cmd
 
                 self.toolbar_native.addAction(action)
 
@@ -422,3 +449,4 @@ class MainWindow(Window):
             self.native.removeToolBar(self.toolbar_native)
             self.toolbar_native.deleteLater()
             self.toolbar_native = None
+            self.toolbar_items = {}

--- a/qt/tests_backend/app.py
+++ b/qt/tests_backend/app.py
@@ -15,6 +15,8 @@ from .probe import BaseProbe
 
 class AppProbe(BaseProbe):
     formal_name = "Toga Testbed (Qt)"
+    supports_application_menu_command_native_items = True
+    supports_status_icon_command_native_items = True
     supports_key = True
     supports_key_mod3 = True
     supports_current_window_assignment = True

--- a/qt/tests_backend/window.py
+++ b/qt/tests_backend/window.py
@@ -9,6 +9,7 @@ from .probe import BaseProbe
 
 
 class WindowProbe(BaseProbe):
+    supports_command_items = True
     # There *is* a close button hint but it doesn't seem to work
     # under KDE so we take similar handling as winforms here: disable
     # the action of the close button.
@@ -103,6 +104,14 @@ class WindowProbe(BaseProbe):
 
     def has_toolbar(self):
         return self.window._impl.toolbar_native is not None
+
+    def command_items(self, command):
+        return {
+            item
+            for items in (self.window._impl.menu_items, self.window._impl.toolbar_items)
+            for item, item_command in items.items()
+            if item_command is command
+        }
 
     def assert_is_toolbar_separator(self, index, section=False):
         assert self.window._impl.toolbar_native.actions()[index].isSeparator()

--- a/testbed/tests/app/test_app.py
+++ b/testbed/tests/app/test_app.py
@@ -115,6 +115,24 @@ async def test_main_window_toolbar(app, main_window, main_window_probe):
     assert not main_window_probe.has_toolbar()
 
 
+async def test_command_rebuild_replaces_native_items(app, app_probe):
+    """Rebuilding menus must release obsolete native command items."""
+    command = app.cmd1
+    old_items = set(command._impl.native)
+    assert old_items
+
+    app.commands.add(
+        toga.Command(
+            action=None,
+            text="Rebuild command",
+            group=toga.Group.FILE,
+        )
+    )
+    await app_probe.redraw("Application menus rebuilt")
+
+    assert old_items.isdisjoint(command._impl.native)
+
+
 async def test_system_menus(app_probe):
     """System-specific menus behave as expected"""
     # Check that the system menus (which can be platform specific) exist.

--- a/testbed/tests/app/test_app.py
+++ b/testbed/tests/app/test_app.py
@@ -117,6 +117,9 @@ async def test_main_window_toolbar(app, main_window, main_window_probe):
 
 async def test_command_rebuild_replaces_native_items(app, app_probe):
     """Rebuilding menus must release obsolete native command items."""
+    if not app_probe.supports_application_menu_command_native_items:
+        pytest.skip("Application menu commands don't expose native items.")
+
     command = app.cmd1
     old_items = set(command._impl.native)
     assert old_items

--- a/testbed/tests/test_statusicons.py
+++ b/testbed/tests/test_statusicons.py
@@ -62,8 +62,9 @@ async def test_add_remove(app, app_probe):
     assert app_probe.status_menu_items(new_status_icon) == [
         "New Action 1",
     ]
-    first_native_items = set(new_cmd1._impl.native)
-    assert first_native_items
+    if app_probe.supports_status_icon_command_native_items:
+        first_native_items = set(new_cmd1._impl.native)
+        assert first_native_items
 
     # A second command
     new_cmd2 = toga.Command(
@@ -80,8 +81,9 @@ async def test_add_remove(app, app_probe):
         "New Action 2",
         "New Action 1",
     ]
-    assert first_native_items.isdisjoint(new_cmd1._impl.native)
-    assert new_cmd1._impl.native
+    if app_probe.supports_status_icon_command_native_items:
+        assert first_native_items.isdisjoint(new_cmd1._impl.native)
+        assert new_cmd1._impl.native
 
     # Remove the first command
     app.status_icons.commands.remove(new_cmd1)
@@ -90,7 +92,8 @@ async def test_add_remove(app, app_probe):
     assert app_probe.status_menu_items(new_status_icon) == [
         "New Action 2",
     ]
-    assert not new_cmd1._impl.native
+    if app_probe.supports_status_icon_command_native_items:
+        assert not new_cmd1._impl.native
 
     # Remove the second command
     app.status_icons.commands.remove(new_cmd2)

--- a/testbed/tests/test_statusicons.py
+++ b/testbed/tests/test_statusicons.py
@@ -62,6 +62,8 @@ async def test_add_remove(app, app_probe):
     assert app_probe.status_menu_items(new_status_icon) == [
         "New Action 1",
     ]
+    first_native_items = set(new_cmd1._impl.native)
+    assert first_native_items
 
     # A second command
     new_cmd2 = toga.Command(
@@ -78,6 +80,8 @@ async def test_add_remove(app, app_probe):
         "New Action 2",
         "New Action 1",
     ]
+    assert first_native_items.isdisjoint(new_cmd1._impl.native)
+    assert new_cmd1._impl.native
 
     # Remove the first command
     app.status_icons.commands.remove(new_cmd1)
@@ -86,6 +90,7 @@ async def test_add_remove(app, app_probe):
     assert app_probe.status_menu_items(new_status_icon) == [
         "New Action 2",
     ]
+    assert not new_cmd1._impl.native
 
     # Remove the second command
     app.status_icons.commands.remove(new_cmd2)

--- a/testbed/tests/window/test_window.py
+++ b/testbed/tests/window/test_window.py
@@ -489,6 +489,34 @@ else:
 
     @pytest.mark.parametrize(
         "second_window_class, second_window_kwargs",
+        [(toga.MainWindow, {"title": "Temporary window"})],
+    )
+    async def test_closed_window_releases_native_command_items(
+        app, second_window, second_window_probe
+    ):
+        """Closing a window releases its native command menu and toolbar items."""
+        if not second_window_probe.supports_command_items:
+            skip_on_backends(
+                toga.backend,
+                reason="Window command items are not implemented on this backend.",
+            )
+
+        command = app.cmd1
+        second_window.toolbar.add(command)
+        second_window.show()
+        await second_window_probe.wait_for_window("Temporary window created")
+
+        window_items = second_window_probe.command_items(command)
+        assert window_items
+        assert window_items <= command._impl.native
+
+        second_window.close()
+        await second_window_probe.wait_for_window("Temporary window closed")
+
+        assert window_items.isdisjoint(command._impl.native)
+
+    @pytest.mark.parametrize(
+        "second_window_class, second_window_kwargs",
         [
             (
                 toga.Window,

--- a/textual/tests_backend/app.py
+++ b/textual/tests_backend/app.py
@@ -15,6 +15,8 @@ FORMAL_NAME = "Toga Testbed (Textual)"
 
 
 class AppProbe(BaseProbe):
+    supports_application_menu_command_native_items = False
+    supports_status_icon_command_native_items = False
     supports_key = False
     supports_key_mod3 = False
     supports_current_window_assignment = True

--- a/winforms/src/toga_winforms/command.py
+++ b/winforms/src/toga_winforms/command.py
@@ -10,7 +10,7 @@ from toga_winforms.keys import toga_to_winforms_key, toga_to_winforms_shortcut
 class Command:
     def __init__(self, interface):
         self.interface = interface
-        self.native = []
+        self.native = set()
 
     @classmethod
     def standard(self, app, id):
@@ -117,6 +117,6 @@ class Command:
 
         item.Enabled = self.interface.enabled
 
-        self.native.append(item)
+        self.native.add(item)
 
         return item

--- a/winforms/src/toga_winforms/statusicons.py
+++ b/winforms/src/toga_winforms/statusicons.py
@@ -76,6 +76,9 @@ class StatusIconSet:
         return submenu
 
     def create(self):
+        for menu_item, cmd in self._menu_items.items():
+            cmd._impl.native.remove(menu_item)
+
         # Menu status icons are the only icons that have extra construction needs.
         # Clear existing menus
         for item in self.interface._menu_status_icons:
@@ -114,6 +117,7 @@ class StatusIconSet:
                     menu_item = "-"
                 else:
                     menu_item = cmd._impl.create_menu_item(ToolStripMenuItem)
+                    self._menu_items[menu_item] = cmd
 
                 attr = MENU_ATTR if cmd.group.parent is None else SUBMENU_ATTR
                 getattr(submenu, attr).Add(menu_item)

--- a/winforms/src/toga_winforms/window.py
+++ b/winforms/src/toga_winforms/window.py
@@ -514,6 +514,23 @@ class MainWindow(Window):
     def create(self):
         super().create()
         self.toolbar_native = None
+        self.menu_items = {}
+        self.toolbar_items = {}
+
+    def purge_menu_items(self):
+        for item, cmd in self.menu_items.items():
+            cmd._impl.native.remove(item)
+        self.menu_items = {}
+
+    def purge_toolbar_items(self):
+        for item, cmd in self.toolbar_items.items():
+            cmd._impl.native.remove(item)
+        self.toolbar_items = {}
+
+    def close(self):
+        self.purge_menu_items()
+        self.purge_toolbar_items()
+        super().close()
 
     def update_fonts(self):
         # Update all the native fonts and determine the new preferred sizes.
@@ -549,6 +566,8 @@ class MainWindow(Window):
         return submenu
 
     def create_menus(self):
+        self.purge_menu_items()
+
         menubar = self.native.MainMenuStrip
         if menubar:
             menubar.Items.Clear()
@@ -570,12 +589,15 @@ class MainWindow(Window):
                 item = "-"
             else:
                 item = cmd._impl.create_menu_item(WinForms.ToolStripMenuItem)
+                self.menu_items[item] = cmd
 
             submenu.DropDownItems.Add(item)
 
         self.resize_content()
 
     def create_toolbar(self):
+        self.purge_toolbar_items()
+
         if self.interface.toolbar:
             if self.toolbar_native:
                 self.toolbar_native.Items.Clear()
@@ -608,11 +630,13 @@ class MainWindow(Window):
                         item.Image = cmd.icon._impl.native.ToBitmap()
                     item.Enabled = cmd.enabled
                     item.Click += WeakrefCallable(cmd._impl.winforms_Click)
-                    cmd._impl.native.append(item)
+                    cmd._impl.native.add(item)
+                    self.toolbar_items[item] = cmd
                 self.toolbar_native.Items.Add(item)
 
         elif self.toolbar_native:
             self.native.Controls.Remove(self.toolbar_native)
             self.toolbar_native = None
+            self.toolbar_items = {}
 
         self.resize_content()

--- a/winforms/tests_backend/app.py
+++ b/winforms/tests_backend/app.py
@@ -21,6 +21,8 @@ from .probe import BaseProbe
 
 
 class AppProbe(BaseProbe, DialogsMixin):
+    supports_application_menu_command_native_items = True
+    supports_status_icon_command_native_items = True
     supports_key = True
     supports_key_mod3 = False
     supports_current_window_assignment = True

--- a/winforms/tests_backend/window.py
+++ b/winforms/tests_backend/window.py
@@ -18,6 +18,7 @@ from .probe import BaseProbe
 
 
 class WindowProbe(BaseProbe, DialogsMixin):
+    supports_command_items = True
     # Disabling the close button requires overriding a protected method
     # (https://stackoverflow.com/a/7301828), which Python.NET doesn't support
     # (https://github.com/pythonnet/pythonnet/issues/2192).
@@ -131,6 +132,14 @@ class WindowProbe(BaseProbe, DialogsMixin):
 
     def has_toolbar(self):
         return self._native_toolbar() is not None
+
+    def command_items(self, command):
+        return {
+            item
+            for items in (self.impl.menu_items, self.impl.toolbar_items)
+            for item, item_command in items.items()
+            if item_command is command
+        }
 
     def _native_toolbar_item(self, index):
         return self._native_toolbar().Items[index]


### PR DESCRIPTION
Fixes #4580

Rebuilding application menus, window menus and toolbars, and status-icon menus now deregisters obsolete native command items on Cocoa, GTK, Qt, and WinForms.

The desktop backends use the same ownership model:

- `Command.native` is a set of active native representations.
- Menu and toolbar owners track native-item-to-command mappings.
- Rebuild and close paths purge only the items owned by that container.
- No proxy removal API is added; cleanup directly removes the tracked native item.

The testbed covers application-menu rebuilds, status-icon menu rebuilds, and closing a temporary MainWindow with command items. Backend-specific discovery remains in WindowProbe implementations.

## PR Checklist:
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool

Assisted-by: OpenAI Codex