### PR TITLE
Fix iOS Selection picker dismissal on focus loss

### DIFF
--- a/changes/4563.bugfix.md
+++ b/changes/4563.bugfix.md
@@ -1,0 +1,1 @@
+Fixed iOS Selection pickers remaining open after a tap outside the widget.

--- a/iOS/src/toga_iOS/widgets/selection.py
+++ b/iOS/src/toga_iOS/widgets/selection.py
@@ -1,4 +1,13 @@
-from rubicon.objc import CGSize, objc_method, objc_property
+from ctypes import c_void_p
+
+from rubicon.objc import (
+    SEL,
+    CGPoint,
+    CGSize,
+    objc_method,
+    objc_property,
+    send_super,
+)
 from travertino.size import at_least
 
 from toga_iOS.colors import native_color
@@ -15,6 +24,25 @@ from toga_iOS.widgets.base import Widget
 class TogaBaseTextField(UITextField):
     interface = objc_property(object, weak=True)
     impl = objc_property(object, weak=True)
+
+    @objc_method
+    def pointInside_withEvent_(self, point: CGPoint, event) -> bool:  # pragma: no cover
+        # Schedule dismissal after the touch event so UIKit animates the picker away.
+        point_inside = send_super(
+            __class__,
+            self,
+            "pointInside:withEvent:",
+            point,
+            event,
+            argtypes=[CGPoint, c_void_p],
+        )
+        if not bool(point_inside):
+            self.performSelector(
+                SEL("resignFirstResponder"),
+                withObject=None,
+                afterDelay=0.0,
+            )
+        return point_inside
 
 
 class TogaPickerView(UIPickerView):


### PR DESCRIPTION
Fixes #4563.

Selection now uses the same delayed `resignFirstResponder` path as the existing iOS text inputs when UIKit detects a touch outside the field. Scheduling the resignation after the touch event allows the picker dismissal to animate.

Validation:
- `pre-commit run --files iOS/src/toga_iOS/widgets/selection.py changes/4563.bugfix.md`
- `ruff check` and `ruff format --check` for the changed iOS widget
- `python -m py_compile iOS/src/toga_iOS/widgets/selection.py`
- `briefcase build iOS --app testbed`

The outside-touch animation cannot be driven by the automated iOS testbed; the matching text-input implementation documents the same UIKit limitation.

## PR Checklist:

- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool

Assisted-by: Codex 