### PR TITLE
Modify textual probe to better match Textual's own Pilot test mechanism.

### DIFF
--- a/changes/4568.misc.md
+++ b/changes/4568.misc.md
@@ -1,0 +1,1 @@
+Some failure modes in the textual test probe have been resolved.

--- a/testbed/tests/conftest.py
+++ b/testbed/tests/conftest.py
@@ -199,7 +199,24 @@ class ProxyEventLoop(asyncio.AbstractEventLoop):
             coro = future.coro
         else:
             raise TypeError(f"Future type {type(future)} is not currently supported")
-        return asyncio.run_coroutine_threadsafe(coro, toga.App.app._impl.loop).result()
+
+        # A backend may need to establish a context on the app's event loop
+        # before test code runs. If the probe defines a `test_context`
+        # classmethod, the test is run in that context.
+        backend_module = import_module("tests_backend.app")
+        try:
+            test_context = backend_module.AppProbe.test_context
+
+            async def coro_in_context():
+                with test_context():
+                    return await coro
+
+            test_coro = coro_in_context()
+        except AttributeError:
+            test_coro = coro
+
+        loop = toga.App.app._impl.loop
+        return asyncio.run_coroutine_threadsafe(test_coro, loop).result()
 
     async def shutdown_asyncgens(self):
         # The proxy event loop doesn't need to shut anything down; the

--- a/textual/tests_backend/app.py
+++ b/textual/tests_backend/app.py
@@ -4,6 +4,8 @@ from pathlib import Path
 import pytest
 from textual.app import App as TextualApp
 
+import toga
+
 from .probe import BaseProbe
 
 APP_ID = "org.beeware.toga.testbed-textual"
@@ -20,6 +22,13 @@ class AppProbe(BaseProbe):
     edit_menu_noop_enabled = False
     supports_psutil = True
     beep_delay = 0.1
+
+    @classmethod
+    def test_context(cls):
+        """Establish the context required to safely run test code on the app's event
+        loop.
+        """
+        return toga.App.app._impl.native._context()
 
     def __init__(self, app):
         super().__init__()

--- a/textual/tests_backend/probe.py
+++ b/textual/tests_backend/probe.py
@@ -1,6 +1,8 @@
 import asyncio
 
 import pytest
+from textual._wait import wait_for_idle
+from textual.app import ScreenStackError
 
 import toga
 
@@ -15,22 +17,64 @@ class BaseProbe:
     def approx_height(self, height):
         return pytest.approx(height, abs=self.VERTICAL_SCALE // 2)
 
-    async def wait_for_refresh(self):
-        app = toga.App.app._impl.native
-        loop = asyncio.get_running_loop()
-        refreshed = loop.create_future()
+    async def _wait_for_screen(self, timeout=5.0):
+        """Wait until the screen and all its child widgets have processed the
+        messages currently in their queues.
 
-        if app.call_after_refresh(refreshed.set_result, None):
-            app.refresh(layout=True)
-            await refreshed
+        This duplicates the approach used by Textual's own `Pilot._wait_for_screen`.
+        """
+        native = self.app._impl.native
+        try:
+            screen = native.screen
+        except ScreenStackError:
+            return
+
+        children = [native, *screen.walk_children(with_self=True)]
+        count = 0
+        count_zero_event = asyncio.Event()
+
+        def decrement_counter():
+            """Decrement internal counter, and set an event if it reaches zero."""
+            nonlocal count
+            count -= 1
+            if count == 0:
+                # When count is zero, all messages queued at the start of the
+                # method have been processed.
+                count_zero_event.set()
+
+        for child in children:
+            if child.call_later(decrement_counter):
+                count += 1
+
+        if count:
+            # Wait for the count to return to zero, or a timeout, or an exception
+            wait_for = [
+                asyncio.ensure_future(count_zero_event.wait()),
+                asyncio.ensure_future(native._exception_event.wait()),
+            ]
+            _, pending = await asyncio.wait(
+                wait_for,
+                timeout=timeout,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            for task in pending:
+                task.cancel()
+
+            timed_out = len(wait_for) == len(pending)
+            if timed_out:
+                pytest.fail(
+                    "Timed out while waiting for widgets to process pending messages."
+                )
 
     async def redraw(self, message=None, delay=0, wait_for=None):
+        # This implementation is strongly inspired by Textual's Pilot.pause(),
+        # but adding `wait_for` handling.
         if toga.App.app.run_slow or wait_for:
             delay = max(1, delay)
 
-        await asyncio.sleep(0)
-
         print("Waiting for redraw" if message is None else message)
+        await self._wait_for_screen()
+        await wait_for_idle(0)
         if delay or wait_for:
             if toga.App.app.run_slow or wait_for is None:
                 await asyncio.sleep(delay)
@@ -41,7 +85,7 @@ class BaseProbe:
                     await asyncio.sleep(delta)
                     interval += delta
 
-        await self.wait_for_refresh()
+        self.app._impl.native.screen._on_timer_update()
 
     def assert_image_size(self, image_size, size, screen, window=None):
         pytest.skip("Image size assertions are not implemented on Textual.")

--- a/textual/tests_backend/probe.py
+++ b/textual/tests_backend/probe.py
@@ -2,7 +2,6 @@ import asyncio
 
 import pytest
 from textual._wait import wait_for_idle
-from textual.app import ScreenStackError
 
 import toga
 
@@ -26,8 +25,8 @@ class BaseProbe:
         native = self.app._impl.native
         try:
             screen = native.screen
-        except ScreenStackError:
-            return
+        except Exception:
+            return False
 
         children = [native, *screen.walk_children(with_self=True)]
         count = 0
@@ -65,6 +64,13 @@ class BaseProbe:
                 pytest.fail(
                     "Timed out while waiting for widgets to process pending messages."
                 )
+
+            # We've either timed out, encountered an exception, or we've finished
+            # decrementing all the counters (all events processed in children).
+            if count > 0:
+                return False
+
+        return True
 
     async def redraw(self, message=None, delay=0, wait_for=None):
         # This implementation is strongly inspired by Textual's Pilot.pause(),


### PR DESCRIPTION
We've been seeing intermittent errors on the Textual tests. Investigation revealed 2 sources of error:

1. The "redraw()" implementation wasn't reliably waiting for all redraws. Textual doesn't provide a good *public* API to do this - but it does have a `Pilot` test implementation that provides a `pause()` method. We're able to borrow that implementation.
2. There are some intermittent errors caused when Texual messages can't identify a running message queue. The message queue is established by the app itself; but the way asyncio is used in Toga's testbed suite means it's possible for the "active app" to be lost because events are created outside the normal "app" context. We can fix that by ensuring all test tasks are run in an explicit app context.

Longer term, it may be worth investigating if we can use Pilot directly, instead of duplicating the implementation; but that's a much bigger change, and might fit better into a wider "remote control" based testing approach.

Fixes #4568.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
Assisted-by: Claude Opus 4.8
