### PR TITLE
Fix intermittent test_window_state_change failure on macOS x86-64

### DIFF
--- a/changes/3897.misc.md
+++ b/changes/3897.misc.md
@@ -1,0 +1,1 @@
+The Cocoa testbed's window state probe now waits for a window's reported size to stabilize (not just its state flag) before considering a state transition complete, fixing an intermittent failure in `test_window_state_change` on macOS x86-64 CI runners.

--- a/cocoa/tests_backend/window.py
+++ b/cocoa/tests_backend/window.py
@@ -39,19 +39,42 @@ class WindowProbe(BaseProbe, DialogsMixin):
         if state:
             timeout = 5
             polling_interval = 0.1
+            # Number of consecutive polls the window's size must be unchanged for
+            # before considering the state transition fully settled.
+            required_stable_polls = 2
             exception = None
+            stable_polls = 0
+            last_size = None
             loop = asyncio.get_running_loop()
             start_time = loop.time()
             while (loop.time() - start_time) < timeout:
                 try:
                     assert self.instantaneous_state == state
                     assert self.window._impl._pending_state_transition is None
-                    return
+                    # AppKit can report a window as having completed a state
+                    # transition (e.g. via windowDidEnterFullScreen:) slightly
+                    # before its on-screen frame has finished animating to the
+                    # final size, especially on slower CI runners. Waiting for
+                    # the reported size to be stable across a couple of polls
+                    # avoids capturing a transient, not-yet-settled size (#3897).
+                    current_size = self.window.size
+                    if current_size == last_size:
+                        stable_polls += 1
+                        if stable_polls >= required_stable_polls:
+                            return
+                    else:
+                        stable_polls = 0
+                    last_size = current_size
                 except AssertionError as e:
                     exception = e
-                    await asyncio.sleep(polling_interval)
-                    continue
+                    stable_polls = 0
+                    last_size = None
+                await asyncio.sleep(polling_interval)
+            if exception:
                 raise exception
+            raise AssertionError(
+                f"Window size did not stabilize in {state} state within {timeout}s"
+            )
 
     async def cleanup(self):
         # Store the pre closing window state as determination of window state after

--- a/cocoa/tests_backend/window.py
+++ b/cocoa/tests_backend/window.py
@@ -40,7 +40,7 @@ class WindowProbe(BaseProbe, DialogsMixin):
             timeout = 5
             polling_interval = 0.1
             # Number of consecutive polls the window's size must be unchanged for
-            # before considering the state transition fully settled.
+            # before considering the state transition fully settled. See #3897.
             required_stable_polls = 2
             exception = None
             stable_polls = 0
@@ -51,12 +51,6 @@ class WindowProbe(BaseProbe, DialogsMixin):
                 try:
                     assert self.instantaneous_state == state
                     assert self.window._impl._pending_state_transition is None
-                    # AppKit can report a window as having completed a state
-                    # transition (e.g. via windowDidEnterFullScreen:) slightly
-                    # before its on-screen frame has finished animating to the
-                    # final size, especially on slower CI runners. Waiting for
-                    # the reported size to be stable across a couple of polls
-                    # avoids capturing a transient, not-yet-settled size (#3897).
                     current_size = self.window.size
                     if current_size == last_size:
                         stable_polls += 1


### PR DESCRIPTION
Fixes #3897.

## Summary

Fix an intermittent macOS x86-64 failure in `test_window_state_change` by waiting for the window size to stabilize before considering a state transition complete.

Also fix the timeout path in `WindowProbe.wait_for_window()` so it correctly raises on timeout.

This change only affects the Cocoa test probe and does not modify the production window-state implementation.

## PR Checklist:
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool

