### PR TITLE
Fix `__eq__` for `Icon` on the GTK backend

### DIFF
--- a/changes/4602.bugfix.md
+++ b/changes/4602.bugfix.md
@@ -1,0 +1,1 @@
+The equality operator now works with the GTK implementation of Icon.

--- a/gtk/src/toga_gtk/icons.py
+++ b/gtk/src/toga_gtk/icons.py
@@ -24,14 +24,16 @@ class Icon:
                 if (hicolor / f"{size}x{size}/apps/{toga.App.app.app_id}.png").is_file()
             }
 
-        self.paths = path
+        # Here self.paths might be a more accurate name, but self.path is used for
+        # compatibility with the core interface.
+        self.path = path
 
         if not path:
             raise FileNotFoundError("No icon variants found")
 
         # Preload all the required icon sizes
         try:
-            for size, path in self.paths.items():
+            for size, path in self.path.items():
                 if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
                     native = GdkPixbuf.Pixbuf.new_from_file(str(path)).scale_simple(
                         size, size, GdkPixbuf.InterpType.BILINEAR

--- a/gtk/src/toga_gtk/statusicons.py
+++ b/gtk/src/toga_gtk/statusicons.py
@@ -12,7 +12,7 @@ class StatusIcon:
     def set_icon(self, icon):
         if self.native:
             path = str(
-                icon._impl.paths[32] if icon else toga.App.app.icon._impl.paths[32]
+                icon._impl.path[32] if icon else toga.App.app.icon._impl.path[32]
             )
             self.native.set_icon_name(path)
 

--- a/gtk/tests_backend/icons.py
+++ b/gtk/tests_backend/icons.py
@@ -34,7 +34,7 @@ class IconProbe(BaseProbe):
     def assert_icon_content(self, path):
         if path == "resources/icons/green":
             # Three icons given with size; others sizes match the generic name
-            assert self.icon._impl.paths == {
+            assert self.icon._impl.path == {
                 16: self.app.paths.app / "resources/icons/green-16.png",
                 32: self.app.paths.app / "resources/icons/green-32.png",
                 64: self.app.paths.app / "resources/icons/green.png",
@@ -45,7 +45,7 @@ class IconProbe(BaseProbe):
             }
         elif path == "resources/icons/orange":
             # All icons match the single size .ico
-            assert self.icon._impl.paths == dict.fromkeys(
+            assert self.icon._impl.path == dict.fromkeys(
                 [16, 32, 64, 72, 128, 256, 512],
                 self.app.paths.app / "resources/icons/orange.ico",
             )
@@ -53,14 +53,14 @@ class IconProbe(BaseProbe):
             pytest.fail("Unknown icon resource")
 
     def assert_default_icon_content(self):
-        assert self.icon._impl.paths == {
+        assert self.icon._impl.path == {
             size: Path(toga_gtk.__file__).parent / "resources/toga.png"
             for size in [16, 32, 64, 72, 128, 256, 512]
         }
 
     def assert_platform_icon_content(self):
         # Only 32 and 72 pixel forms are available
-        assert self.icon._impl.paths == {
+        assert self.icon._impl.path == {
             32: self.app.paths.app / "resources/logo-linux-32.png",
             72: self.app.paths.app / "resources/logo-linux-72.png",
         }
@@ -70,7 +70,7 @@ class IconProbe(BaseProbe):
             # When running in dev mode, the icon will fall back to the app default.
             assert self.icon._impl == toga.Icon.DEFAULT_ICON._impl
         else:
-            assert self.icon._impl.paths == {
+            assert self.icon._impl.path == {
                 16: (
                     Path(sys.executable).parent.parent
                     / "share/icons/hicolor/16x16/apps/org.beeware.toga.testbed.png"

--- a/testbed/tests/test_statusicons.py
+++ b/testbed/tests/test_statusicons.py
@@ -128,6 +128,21 @@ async def test_unknown_status_icon(app, app_probe):
         app.status_icons.commands.remove(bad_cmd)
 
 
+async def test_change_icon(app, app_probe):
+    """The icon of a status icon can be changed."""
+    status_icon = app_probe.app.status_icons["button"]
+    old_icon = status_icon.icon
+    new_icon = toga.Icon("resources/alt-icon")
+
+    status_icon.icon = new_icon
+    await app_probe.redraw("Status icon changed to a snake icon.")
+    assert status_icon.icon == new_icon
+
+    status_icon.icon = old_icon
+    await app_probe.redraw("Status icon restored to blue disk.")
+    assert status_icon.icon == old_icon
+
+
 async def test_activate_button_icon(app, app_probe):
     """A button status icon can be activated."""
     app_probe.activate_status_icon_button("button")


### PR DESCRIPTION
Renamed `Icon.paths` to `Icon.path` in the GTK implementation of `Icon`. Added a test which failed previously but should now pass.

Draft - since not tested yet.

Fixes #4602 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
<!-- update or delete the next line to reflect your usage -->
Assisted-by: <!--name of tool; e.g., Claude Opus 4.5-->
