### PR TITLE
Use renamed WebView2 package.

### DIFF
--- a/changes/4582.feature.md
+++ b/changes/4582.feature.md
@@ -1,1 +1,1 @@
-The binary DLLs needed to support WebView2 usage on Windows have been split into a standalone PyPI package (`WebView2.runtime`).
+The binary DLLs needed to support WebView2 usage on Windows have been split into a standalone PyPI package (`dotnet-WebView2.WinForms`).

--- a/winforms/pyproject.toml
+++ b/winforms/pyproject.toml
@@ -118,7 +118,7 @@ dependencies = [
     "pythonnet >= 3.0.0",
     "toga-core == {version}",
     "pillow >= 10.0.0",
-    "WebView2.runtime >= 1.0.3912.50",
+    "dotnet-WebView2.WinForms >= 1.0.4078.44",
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
Following the rename of `WebView2.runtime` to `dotnet-WebView2.WinForms`, update the Toga dependency name.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
