### PR TITLE
Fix AsyncResult.__bool__ signature and SplitContainer content setter orphaned widgets

### DIFF
--- a/core/src/toga/handlers.py
+++ b/core/src/toga/handlers.py
@@ -247,18 +247,21 @@ class AsyncResult(ABC):
         return self.future.__await__()
 
     # All the comparison dunder methods are disabled
-    def __bool__(self, other: object) -> NoReturn:
+    def _raise_unwrapable(self, *args: object) -> NoReturn:
         raise RuntimeError(
             f"Can't check {self.RESULT_TYPE} result directly; "
             "use await or an on_result handler"
         )
 
-    __lt__ = __bool__
-    __le__ = __bool__
-    __eq__ = __bool__
-    __ne__ = __bool__
-    __gt__ = __bool__
-    __ge__ = __bool__
+    def __bool__(self) -> NoReturn:
+        return self._raise_unwrapable()
+
+    __lt__ = _raise_unwrapable
+    __le__ = _raise_unwrapable
+    __eq__ = _raise_unwrapable
+    __ne__ = _raise_unwrapable
+    __gt__ = _raise_unwrapable
+    __ge__ = _raise_unwrapable
 
 
 class PermissionResult(AsyncResult):

--- a/core/src/toga/widgets/splitcontainer.py
+++ b/core/src/toga/widgets/splitcontainer.py
@@ -97,11 +97,6 @@ class SplitContainer(Widget):
 
     @content.setter
     def content(self, content: Sequence[SplitContainerContentT]) -> None:
-        for old_content in self._content:
-            if old_content is not None:
-                old_content.app = None
-                old_content.window = None
-
         try:
             if len(content) != 2:
                 raise TypeError()
@@ -131,6 +126,14 @@ class SplitContainer(Widget):
             _content.append(widget)
             flex.append(flex_value)
 
+        # Only detach the old content once the new content is fully validated,
+        # so a failed assignment doesn't orphan the widgets currently shown.
+        for old_content in self._content:
+            if old_content is not None:
+                old_content.app = None
+                old_content.window = None
+
+        for widget in _content:
             if widget:
                 widget.app = self.app
                 widget.window = self.window

--- a/core/tests/test_handlers.py
+++ b/core/tests/test_handlers.py
@@ -538,6 +538,14 @@ async def test_async_result_non_comparable():
     ):
         _ = result != 42
 
+    # Truthiness must raise the same helpful error (regression:
+    # __bool__ carried an extra parameter, so bool() raised TypeError).
+    with pytest.raises(
+        RuntimeError,
+        match=r"Can't check Test result directly; use await or an on_result handler",
+    ):
+        _ = bool(result)
+
 
 async def test_async_result():
     """An async result can be set."""

--- a/core/tests/widgets/test_splitcontainer.py
+++ b/core/tests/widgets/test_splitcontainer.py
@@ -412,6 +412,24 @@ def test_set_content_invalid(splitcontainer, content, message):
         splitcontainer.content = content
 
 
+def test_set_content_invalid_keeps_previous_content(content1, content2):
+    """A failed content assignment must not orphan the widgets currently shown
+    (regression: the old content was detached before validation)."""
+    app = toga.App("Test App", "org.beeware.toga.splitcontainer-test")
+    window = toga.Window()
+    splitcontainer = toga.SplitContainer(content=[content1, content2])
+    window.content = splitcontainer
+
+    assert content1.id in app.widgets
+
+    with pytest.raises(ValueError):
+        splitcontainer.content = [content1]
+
+    # The previous content is still attached and intact
+    assert content1.id in app.widgets
+    assert splitcontainer.content == [content1, content2]
+
+
 def test_direction(splitcontainer):
     """The direction of the splitcontainer can be changed."""
 


### PR DESCRIPTION
## Summary
Two fixes:

1. **handlers.AsyncResult.__bool__** — had a stray \other\ parameter, so \ool(result)\ raised \TypeError: __bool__() takes 2 positional arguments but 1 was given\. Refactored to \_raise_unwrapable(self, *args)\ and aliased \__bool__\ and comparisons to it.
2. **SplitContainer.content setter** — detached old content before validating the new value, so a failed assignment left previously displayed widgets orphaned (app/window = None). Now validates first, then detaches, then attaches.

## Tests
Extended \	est_async_result_non_comparable\ with a \ool(result)\ check; added \	est_set_content_invalid_keeps_previous_content\.
Full core suite: 3344 passed (16 pre-existing env-only errors unrelated to these changes).