### PR TITLE
Fix AsyncResult.__bool__ signature so truthiness raises the helpful message

### DIFF
--- a/changes/4630.bugfix.md
+++ b/changes/4630.bugfix.md
@@ -1,0 +1,1 @@
+Bool checks on an async result now raise the same helpful error as comparisons, instead of a confusing ``TypeError``.

--- a/changes/4630.bugfix.md
+++ b/changes/4630.bugfix.md
@@ -1,1 +1,1 @@
-Bool checks on an async result now raise the same helpful error as comparisons, instead of a confusing ``TypeError``.
+Boolean checks on an `AsyncResult` now raise the same helpful error as comparisons, instead of a confusing `TypeError`.

--- a/core/src/toga/handlers.py
+++ b/core/src/toga/handlers.py
@@ -247,18 +247,21 @@ class AsyncResult(ABC):
         return self.future.__await__()
 
     # All the comparison dunder methods are disabled
-    def __bool__(self, other: object) -> NoReturn:
+    def _raise_unwrapable(self, *args: object) -> NoReturn:
         raise RuntimeError(
             f"Can't check {self.RESULT_TYPE} result directly; "
             "use await or an on_result handler"
         )
 
-    __lt__ = __bool__
-    __le__ = __bool__
-    __eq__ = __bool__
-    __ne__ = __bool__
-    __gt__ = __bool__
-    __ge__ = __bool__
+    def __bool__(self) -> NoReturn:
+        return self._raise_unwrapable()
+
+    __lt__ = _raise_unwrapable
+    __le__ = _raise_unwrapable
+    __eq__ = _raise_unwrapable
+    __ne__ = _raise_unwrapable
+    __gt__ = _raise_unwrapable
+    __ge__ = _raise_unwrapable
 
 
 class PermissionResult(AsyncResult):

--- a/core/tests/test_handlers.py
+++ b/core/tests/test_handlers.py
@@ -538,6 +538,14 @@ async def test_async_result_non_comparable():
     ):
         _ = result != 42
 
+    # Truthiness must raise the same helpful error (regression:
+    # __bool__ carried an extra parameter, so bool() raised TypeError).
+    with pytest.raises(
+        RuntimeError,
+        match=r"Can't check Test result directly; use await or an on_result handler",
+    ):
+        _ = bool(result)
+
 
 async def test_async_result():
     """An async result can be set."""


### PR DESCRIPTION
`AsyncResult.__bool__` was declared with a bogus extra `other` parameter:

```python
def __bool__(self, other: object) -> NoReturn:
```

`bool()` calls `__bool__` with only `self`, so the signature mismatch surfaces as a confusing `TypeError` instead of the designed, helpful `RuntimeError` ("Can't check ... result directly; use await or an on_result handler"). Comparisons (`==`, `!=`, ...) already alias the shared helper correctly; truthiness did not.

This PR:
- gives `__bool__` the correct `self`-only signature;
- routes it (and the comparison dunders) through a shared `_raise_unwrapable(*args)` helper so all uses raise the same message;
- adds a regression test: `bool(result)` must raise the same `RuntimeError` as `result == 42`.

Fixes #4630

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
<!-- update or delete the next line to reflect your usage -->
Assisted-by: Claude Opus 4.5