### PR TITLE
Update pypa/gh-action-pypi-publish pin comment to v1.14.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,4 +51,4 @@ jobs:
           mv packages/${{ matrix.package }}-[0-9]* dist
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247  # v1.14.0
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247  # v1.14.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,6 +103,6 @@ jobs:
           mv staging_dist/${{ matrix.package }}-[0-9]* dist
 
       - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247  # v1.14.0
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247  # v1.14.1
         with:
           repository-url: https://test.pypi.org/legacy/

--- a/changes/4634.misc.md
+++ b/changes/4634.misc.md
@@ -1,0 +1,1 @@
+Updated the pinned reference for pypa/gh-action-pypi-publish to correctly reference v1.14.1.


### PR DESCRIPTION
The `pypa/gh-action-pypi-publish` action is pinned to commit `ba38be9e461d3875417946c167d0b5f3d385a247`, which corresponds to tag `v1.14.1`. The trailing comment incorrectly referenced an older version; this corrects it.

## PR Checklist:
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
Assisted-by: Claude Sonnet 5
