### PR TITLE
Correct macOS toolbar handling

### DIFF
--- a/android/tests_backend/window.py
+++ b/android/tests_backend/window.py
@@ -106,7 +106,7 @@ class WindowProbe(BaseProbe, DialogsMixin):
     def assert_is_toolbar_separator(self, index, section=False):
         assert self._toolbar_items()[index] is None
 
-    def assert_toolbar_item(self, index, label, tooltip, has_icon, enabled):
+    def assert_toolbar_item(self, index, separators, label, tooltip, has_icon, enabled):
         item = self._toolbar_items()[index]
         assert item.getTitle() == label
         # Tooltips are not implemented

--- a/changes/3786.bugfix.1.md
+++ b/changes/3786.bugfix.1.md
@@ -1,0 +1,1 @@
+On macOS Tahoe, toolbar icons are now correctly sized.

--- a/changes/3786.bugfix.2.md
+++ b/changes/3786.bugfix.2.md
@@ -1,0 +1,1 @@
+On macOS space is no longer allocated for separators, matching recent style changes in macOS.

--- a/cocoa/src/toga_cocoa/window.py
+++ b/cocoa/src/toga_cocoa/window.py
@@ -145,7 +145,7 @@ class TogaWindow(NSWindow):
         prev_group = None
         for item in self.interface.toolbar:
             # If there's been a group change, and this item isn't a separator,
-            # add a separator between groups.
+            # add an item to act as a separator between groups.
             if (
                 prev_group is not None
                 and item.group != prev_group
@@ -165,22 +165,22 @@ class TogaWindow(NSWindow):
         insert: bool,
     ):
         """Create the requested toolbar button."""
-        native = NSToolbarItem.alloc().initWithItemIdentifier_(identifier)
         try:
             item = self.impl._toolbar_items[str(identifier)]
+            native = NSToolbarItem.alloc().initWithItemIdentifier_(identifier)
             native.setLabel(item.text)
             native.setPaletteLabel(item.text)
             if item.tooltip:
                 native.setToolTip(item.tooltip)
             if item.icon:
-                native.setImage(item.icon._impl.native)
+                native.setImage(item.icon._impl._as_size(32))
 
             item._impl.native.add(native)
 
             native.setTarget_(self)
             native.setAction_(SEL("onToolbarButtonPress:"))
-        except KeyError:  # Separator items
-            pass
+        except KeyError:  # No toolbar item for the identifier
+            native = None
 
         return native
 

--- a/cocoa/tests_backend/window.py
+++ b/cocoa/tests_backend/window.py
@@ -127,13 +127,11 @@ class WindowProbe(BaseProbe, DialogsMixin):
         return self.native.toolbar is not None
 
     def assert_is_toolbar_separator(self, index, section=False):
-        item = self.native.toolbar.items[index]
-        assert str(item.itemIdentifier).startswith(
-            f"Toolbar-{'Separator' if section else 'Group'}"
-        )
+        # macOS doesn't display separators, so there's nothing to assert.
+        pass
 
-    def assert_toolbar_item(self, index, label, tooltip, has_icon, enabled):
-        item = self.native.toolbar.items[index]
+    def assert_toolbar_item(self, index, separators, label, tooltip, has_icon, enabled):
+        item = self.native.toolbar.items[index - separators]
 
         assert str(item.label) == label
         assert (None if item.toolTip is None else str(item.toolTip)) == tooltip

--- a/gtk/tests_backend/window.py
+++ b/gtk/tests_backend/window.py
@@ -149,7 +149,7 @@ class WindowProbe(BaseProbe, DialogsMixin):
         assert isinstance(item, Gtk.SeparatorToolItem)
         assert item.get_draw() == (not section)
 
-    def assert_toolbar_item(self, index, label, tooltip, has_icon, enabled):
+    def assert_toolbar_item(self, index, separators, label, tooltip, has_icon, enabled):
         item = self.impl.native_toolbar.get_nth_item(index)
         assert item.get_label() == label
         # FIXME: get_tooltip_text() doesn't work. The tooltip can be set, but the

--- a/qt/tests_backend/window.py
+++ b/qt/tests_backend/window.py
@@ -107,7 +107,7 @@ class WindowProbe(BaseProbe):
     def assert_is_toolbar_separator(self, index, section=False):
         assert self.window._impl.toolbar_native.actions()[index].isSeparator()
 
-    def assert_toolbar_item(self, index, label, tooltip, has_icon, enabled):
+    def assert_toolbar_item(self, index, separators, label, tooltip, has_icon, enabled):
         action = self.window._impl.toolbar_native.actions()[index]
         assert action.text() == label
         if tooltip is None:

--- a/testbed/tests/app/test_app.py
+++ b/testbed/tests/app/test_app.py
@@ -37,14 +37,18 @@ async def test_main_window_toolbar(app, main_window, main_window_probe):
     # Ordering is lexicographical for cmd 2 and 3.
     main_window_probe.assert_toolbar_item(
         0,
+        separators=0,
         label="Full command",
         tooltip="A full command definition",
         has_icon=True,
         enabled=True,
     )
+
     main_window_probe.assert_is_toolbar_separator(1)
+
     main_window_probe.assert_toolbar_item(
         2,
+        separators=1,
         label="No Icon",
         tooltip="A command with no icon",
         has_icon=False,
@@ -52,14 +56,18 @@ async def test_main_window_toolbar(app, main_window, main_window_probe):
     )
     main_window_probe.assert_toolbar_item(
         3,
+        separators=1,
         label="No Tooltip",
         tooltip=None,
         has_icon=True,
         enabled=True,
     )
+
     main_window_probe.assert_is_toolbar_separator(4, section=True)
+
     main_window_probe.assert_toolbar_item(
         5,
+        separators=2,
         label="Sectioned",
         tooltip="I'm in another section",
         has_icon=True,
@@ -77,6 +85,7 @@ async def test_main_window_toolbar(app, main_window, main_window_probe):
     await main_window_probe.redraw("Command 1 disabled")
     main_window_probe.assert_toolbar_item(
         0,
+        separators=0,
         label="Full command",
         tooltip="A full command definition",
         has_icon=True,
@@ -88,6 +97,7 @@ async def test_main_window_toolbar(app, main_window, main_window_probe):
     await main_window_probe.redraw("Command 1 re-enabled")
     main_window_probe.assert_toolbar_item(
         0,
+        separators=0,
         label="Full command",
         tooltip="A full command definition",
         has_icon=True,

--- a/textual/tests_backend/window.py
+++ b/textual/tests_backend/window.py
@@ -73,7 +73,7 @@ class WindowProbe(BaseProbe):
     def assert_is_toolbar_separator(self, index, section=False):
         pytest.skip("Toolbars are not implemented on Textual.")
 
-    def assert_toolbar_item(self, index, label, tooltip, has_icon, enabled):
+    def assert_toolbar_item(self, index, separators, label, tooltip, has_icon, enabled):
         pytest.skip("Toolbars are not implemented on Textual.")
 
     def press_toolbar_button(self, index):

--- a/winforms/tests_backend/window.py
+++ b/winforms/tests_backend/window.py
@@ -138,7 +138,7 @@ class WindowProbe(BaseProbe, DialogsMixin):
     def assert_is_toolbar_separator(self, index, section=False):
         assert isinstance(self._native_toolbar_item(index), ToolStripSeparator)
 
-    def assert_toolbar_item(self, index, label, tooltip, has_icon, enabled):
+    def assert_toolbar_item(self, index, separators, label, tooltip, has_icon, enabled):
         item = self._native_toolbar_item(index)
         assert item.Text == label
         assert item.ToolTipText == tooltip


### PR DESCRIPTION
macOS Tahoe changes how icons are handled in toolbars, and no longer selects an appropriate size from an .icns file. This PR modifies icon use to ensure that an appropriately sized icon is used.

There's also been some style changes over the last couple of macOS releases regarding how separators are displayed. Prior to Big Sur (released in 2020), the toolbar was displayed as a standalone "in window" bar, and a separator would be displayed between items if `None` was returns as the display item. In Big Sur, the toolbar was merged into the window titlebar, and separators were replaced with a spacer, but no visual bar. In Liquid Glass changes, those items are now displayed as an empty button, and there doesn't appear to be a way to separate individual toolbar items. 

To that end, this PR removes any attempt to use separator items in macOS toolbars.

Tutorial 2 demonstrates both these problems:

Without this PR:
<img width="865" height="90" alt="Screenshot 2026-08-07 at 12 43 54 pm" src="https://github.com/user-attachments/assets/ffb719b4-8609-4076-bbb8-5adf98d957ba" />

With the icon size fix:
<img width="655" height="84" alt="Screenshot 2026-08-07 at 12 43 35 pm" src="https://github.com/user-attachments/assets/dbd64d67-08ae-454b-b888-820249f36674" />

With separator removal:
<img width="656" height="79" alt="Screenshot 2026-08-07 at 12 42 59 pm" src="https://github.com/user-attachments/assets/a9eebbf4-d287-4598-8b93-8c004df3a9cb" />


Fixes #3786.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
