### PR TITLE
Fix typo in `Row` docstring

### DIFF
--- a/changes/4644.misc.md
+++ b/changes/4644.misc.md
@@ -1,0 +1,1 @@
+Fix typo in Row docstring

--- a/core/src/toga/widgets/box.py
+++ b/core/src/toga/widgets/box.py
@@ -55,7 +55,7 @@ class Box(Widget):
 
 def Row(*args, **kwargs):
     """Shorthand for [`Box`][toga.Box] with its
-    [text-direction][toga.style.pack.Pack.text_direction] set to "row".
+    [direction][toga.style.pack.Pack.direction] set to "row".
     """
     return Box(*args, direction="row", **kwargs)
 


### PR DESCRIPTION
It linked to `text-direction` where it should have been `direction`.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
<!-- update or delete the next line to reflect your usage -->
Assisted-by: <!--name of tool; e.g., Claude Opus 4.5-->
