### PR TITLE
docs: document Pack properties directly on widgets (#4353)

### DIFF
--- a/changes/4353.doc.md
+++ b/changes/4353.doc.md
@@ -1,0 +1,1 @@
+The [Widget reference documentation](/reference/api/widgets/widget.md) now states explicitly that every widget exposes the [Pack style properties](/reference/api/style/pack.md) directly on the widget itself, and links the `PackMixin` base of `Widget` to the Pack style page.

--- a/core/src/toga/widgets/base.py
+++ b/core/src/toga/widgets/base.py
@@ -44,6 +44,20 @@ DEBUG_BACKGROUND_PALETTE = [
 
 
 class Widget(Node, PackMixin, ABC):
+    """An abstract base class for all Toga widgets.
+
+    A widget is a graphical element that can be added to a window or a
+    container. This class exists only for other widgets to inherit from;
+    it should never be instantiated directly.
+
+    Because [PackMixin][toga.widgets.base.PackMixin] is a base of this
+    class, every widget exposes the [Pack][pack-style] style properties
+    (such as `color`, `font_size` and `padding`) directly as attributes -
+    for example, `widget.color` is equivalent to
+    `widget.style.color`. See the [Pack reference][pack-style] for the
+    full list of available properties.
+    """
+
     _MIN_WIDTH = 100
     _MIN_HEIGHT = 100
 

--- a/docs/en/reference/api/widgets/widget.md
+++ b/docs/en/reference/api/widgets/widget.md
@@ -4,6 +4,8 @@
 
 This class exists only for actual widgets to inherit from; it should not be be instantiated directly.
 
+Because every widget inherits from `PackMixin`, all widgets support the [Pack style properties](/reference/api/style/pack.md) directly on the widget itself — for example, `widget.color` instead of `widget.style.color`. See the [Pack reference](/reference/api/style/pack.md) for the full list of properties that can be set this way.
+
 ## Reference
 
 <!-- REMOVE WHEN RESOLVED -->


### PR DESCRIPTION
﻿Closes #4353

The Widget reference page showed `PackMixin` in the class bases but gave users no way to learn what that mixin provides. This change makes the Pack-on-widget behavior discoverable in three places:

- Added a class docstring to `toga.Widget` that states every widget exposes the Pack style properties directly as attributes (e.g. `widget.color` instead of `widget.style.color`) and links to the Pack reference.
- Extended the "Usage" section of the Widget reference page with the same note and direct links to the Pack style page.
- Added the towncrier fragment `changes/4353.doc.md`.

Verification: docs-only change â€” no runtime code paths touched. The generated `PackMixin` docstring (via `style_mixin`) was already present; the gap was that nothing on the Widget page surfaced it. `docs-lint` / `pre-commit` and the test suite are not expected to be affected by a docstring and a markdown paragraph, but CI will confirm.
