### PR TITLE
Declare toga-dummy runtime dependencies

### DIFF
--- a/changes/4675.bugfix.md
+++ b/changes/4675.bugfix.md
@@ -1,1 +1,1 @@
-The Dummy backend declared its Pillow and pytest runtime dependencies.
+The Dummy backend now correctly declares all dependencies it requires for operation, instead of relying on testing dependencies from Toga's core library.

--- a/changes/4675.bugfix.md
+++ b/changes/4675.bugfix.md
@@ -1,0 +1,1 @@
+The Dummy backend declared its Pillow and pytest runtime dependencies.

--- a/core/tests/test_import.py
+++ b/core/tests/test_import.py
@@ -1,18 +1,6 @@
-import re
 import sys
-from importlib.metadata import requires
 
 import pytest
-
-
-def test_dummy_runtime_dependencies():
-    """The dummy backend declares the packages it imports at runtime."""
-    dependency_names = {
-        re.match(r"^[A-Za-z0-9._-]+", dependency).group().lower()
-        for dependency in requires("toga-dummy")
-    }
-
-    assert {"pillow", "pytest"} <= dependency_names
 
 
 def test_lazy_succeed(monkeypatch):

--- a/core/tests/test_import.py
+++ b/core/tests/test_import.py
@@ -1,6 +1,18 @@
+import re
 import sys
+from importlib.metadata import requires
 
 import pytest
+
+
+def test_dummy_runtime_dependencies():
+    """The dummy backend declares the packages it imports at runtime."""
+    dependency_names = {
+        re.match(r"^[A-Za-z0-9._-]+", dependency).group().lower()
+        for dependency in requires("toga-dummy")
+    }
+
+    assert {"pillow", "pytest"} <= dependency_names
 
 
 def test_lazy_succeed(monkeypatch):

--- a/dummy/pyproject.toml
+++ b/dummy/pyproject.toml
@@ -123,7 +123,7 @@ root = ".."
 
 [tool.setuptools_dynamic_dependencies]
 dependencies = [
-    "pillow >= 10.0.0",
-    "pytest",
+    "pillow >= 9.2.0",
+    "pytest >= 7.2.0",
     "toga-core == {version}",
 ]

--- a/dummy/pyproject.toml
+++ b/dummy/pyproject.toml
@@ -123,5 +123,7 @@ root = ".."
 
 [tool.setuptools_dynamic_dependencies]
 dependencies = [
+    "pillow >= 10.0.0",
+    "pytest",
     "toga-core == {version}",
 ]


### PR DESCRIPTION
`toga-dummy` imports Pillow for its image and screen implementations, and pytest for its assertion helpers, but only declared `toga-core` as a runtime dependency. As a result, a clean installation could not import the backend.

This declares both imported packages and adds a regression test for the distribution metadata.

I also built local wheels and installed `toga-dummy` into an empty Python 3.13 environment. Pillow and pytest were resolved automatically, and `import toga_dummy.app` succeeded.

Fixes #4675

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
Assisted-by: OpenAI Codex (GPT-5)
