### PR TITLE
Preserve ScrollContainer content minimums on non-scrollable axes

### DIFF
--- a/android/src/toga_android/widgets/scrollcontainer.py
+++ b/android/src/toga_android/widgets/scrollcontainer.py
@@ -1,9 +1,11 @@
+import asyncio
 import weakref
 from decimal import ROUND_DOWN
 
 from android.view import Gravity, View
 from android.widget import HorizontalScrollView, LinearLayout, ScrollView
 from java import dynamic_proxy
+from travertino.size import at_least
 
 from ..container import Container
 from .base import Widget, suppress_reference_error
@@ -65,6 +67,32 @@ class ScrollContainer(Widget, Container):
             self.scale_in(width, ROUND_DOWN),
             self.scale_in(height, ROUND_DOWN),
         )
+
+    def refreshed(self):
+        Container.refreshed(self)
+
+        previous_intrinsic_size = (
+            self.interface.intrinsic.width,
+            self.interface.intrinsic.height,
+        )
+        self.rehint()
+        if previous_intrinsic_size != (
+            self.interface.intrinsic.width,
+            self.interface.intrinsic.height,
+        ):
+            asyncio.get_running_loop().call_soon_threadsafe(self.interface.refresh)
+
+    def rehint(self):
+        min_width = self.interface._MIN_WIDTH
+        min_height = self.interface._MIN_HEIGHT
+        if self.interface.content:
+            if not self.interface.horizontal:
+                min_width = max(min_width, self.interface.content.layout.min_width)
+            if not self.interface.vertical:
+                min_height = max(min_height, self.interface.content.layout.min_height)
+
+        self.interface.intrinsic.width = at_least(min_width)
+        self.interface.intrinsic.height = at_least(min_height)
 
     def get_vertical(self):
         return self.vScrollListener.is_scrolling_enabled

--- a/changes/4503.bugfix.md
+++ b/changes/4503.bugfix.md
@@ -1,0 +1,1 @@
+ScrollContainers were updated to preserve the minimum size of their content along axes where scrolling was disabled.

--- a/cocoa/src/toga_cocoa/libs/appkit.py
+++ b/cocoa/src/toga_cocoa/libs/appkit.py
@@ -597,6 +597,10 @@ NSScrollElasticityAutomatic = 0
 NSScrollElasticityNone = 1
 NSScrollElasticityAllowed = 2
 
+NSPreferredScrollerStyleDidChangeNotification = objc_const(
+    appkit, "NSPreferredScrollerStyleDidChangeNotification"
+)
+
 NSScrollViewDidLiveScrollNotification = objc_const(
     appkit, "NSScrollViewDidLiveScrollNotification"
 )

--- a/cocoa/src/toga_cocoa/widgets/scrollcontainer.py
+++ b/cocoa/src/toga_cocoa/widgets/scrollcontainer.py
@@ -106,8 +106,9 @@ class ScrollContainer(Widget):
         self.native.refreshContent()
 
     def content_refreshed(self, container):
-        width = self.native.frame.size.width
-        height = self.native.frame.size.height
+        viewport_size = self.native.contentSize
+        width = viewport_size.width
+        height = viewport_size.height
 
         # If scrolling is enabled in a given axis, the document container
         # has a minimum size equal to the layout width in that axis.
@@ -121,17 +122,15 @@ class ScrollContainer(Widget):
 
         self.native.documentView.frame = NSMakeRect(0, 0, width, height)
 
-        # Setting the document frame determines which non-overlay scrollers are
-        # visible. Use the resulting viewport so a visible scroller doesn't create
-        # overflow in the other axis.
-        viewport_size = self.native.contentSize
-        width = viewport_size.width
-        height = viewport_size.height
-        if self.interface.horizontal:
-            width = max(self.interface.content.layout.width, width)
-        if self.interface.vertical:
-            height = max(self.interface.content.layout.height, height)
-        self.native.documentView.frame = NSMakeRect(0, 0, width, height)
+        # A non-overlay scroller changes the viewport used to lay out the content.
+        # Refresh once against that resolved viewport before finalizing the geometry.
+        resolved_viewport_size = self.native.contentSize
+        if (
+            viewport_size.width != resolved_viewport_size.width
+            or viewport_size.height != resolved_viewport_size.height
+        ):
+            self.native.refreshContent()
+            return
 
         previous_intrinsic_size = (
             self.interface.intrinsic.width,

--- a/cocoa/src/toga_cocoa/widgets/scrollcontainer.py
+++ b/cocoa/src/toga_cocoa/widgets/scrollcontainer.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from rubicon.objc import SEL, objc_method, objc_property
 from travertino.size import at_least
 
@@ -8,12 +10,14 @@ from toga_cocoa.libs import (
     NSMakeRect,
     NSNoBorder,
     NSNotificationCenter,
+    NSPreferredScrollerStyleDidChangeNotification,
     NSScrollElasticityAllowed,
     NSScrollElasticityAutomatic,
     NSScrollElasticityNone,
     NSScrollView,
     NSScrollViewDidEndLiveScrollNotification,
     NSScrollViewDidLiveScrollNotification,
+    NSSize,
 )
 
 from .base import Widget
@@ -33,6 +37,12 @@ class TogaScrollView(NSScrollView):
         # the size of the document content (assuming there is a document)
         if self.interface._content:
             self.interface._content.refresh()
+
+    @objc_method
+    def scrollerStyleChanged_(self, notification) -> None:
+        # NSScrollView updates its scroller style from the system preference at runtime.
+        # Wait until that update has completed before recomputing the content minimum.
+        self.performSelector(SEL("refreshContent"), withObject=None, afterDelay=0)
 
     # This cannot be covered in CI because the function used to emit
     # a scrolling event is unreliable.
@@ -65,6 +75,12 @@ class ScrollContainer(Widget):
             selector=SEL("didScroll:"),
             name=NSScrollViewDidLiveScrollNotification,
             object=self.native,
+        )
+        NSNotificationCenter.defaultCenter.addObserver(
+            self.native,
+            selector=SEL("scrollerStyleChanged:"),
+            name=NSPreferredScrollerStyleDidChangeNotification,
+            object=None,
         )
         NSNotificationCenter.defaultCenter.addObserver(
             self.native,
@@ -105,6 +121,17 @@ class ScrollContainer(Widget):
 
         self.native.documentView.frame = NSMakeRect(0, 0, width, height)
 
+        previous_intrinsic_size = (
+            self.interface.intrinsic.width,
+            self.interface.intrinsic.height,
+        )
+        self.rehint()
+        if previous_intrinsic_size != (
+            self.interface.intrinsic.width,
+            self.interface.intrinsic.height,
+        ):
+            asyncio.get_running_loop().call_soon_threadsafe(self.interface.refresh)
+
     def update_scroll_elasticity(self):
         # If both horizontal and vertical scrolling
         # is allowed, bounce horizontally only if
@@ -130,11 +157,6 @@ class ScrollContainer(Widget):
 
     def set_vertical(self, value):
         self.native.hasVerticalScroller = value
-        # If the scroll container has content, we need to force a refresh
-        # to let the scroll container know how large its content is.
-        if self.interface.content:
-            self.interface.refresh()
-
         # Disabling scrolling implies a position reset; that's a scroll event.
         if not value:
             self.interface.on_scroll()
@@ -145,19 +167,58 @@ class ScrollContainer(Widget):
 
     def set_horizontal(self, value):
         self.native.hasHorizontalScroller = value
-        # If the scroll container has content, we need to force a refresh
-        # to let the scroll container know how large its content is.
-        if self.interface.content:
-            self.interface.refresh()
-
         # Disabling scrolling implies a position reset; that's a scroll event.
         if not value:
             self.interface.on_scroll()
         self.update_scroll_elasticity()
 
     def rehint(self):
-        self.interface.intrinsic.width = at_least(self.interface._MIN_WIDTH)
-        self.interface.intrinsic.height = at_least(self.interface._MIN_HEIGHT)
+        min_width = self.interface._MIN_WIDTH
+        min_height = self.interface._MIN_HEIGHT
+
+        if self.interface.content:
+            horizontal_scroller = self.native.horizontalScroller
+            vertical_scroller = self.native.verticalScroller
+            horizontal_scroller_class = (
+                horizontal_scroller.objc_class
+                if self.interface.horizontal and not horizontal_scroller.isHidden()
+                else None
+            )
+            vertical_scroller_class = (
+                vertical_scroller.objc_class
+                if self.interface.vertical and not vertical_scroller.isHidden()
+                else None
+            )
+            if horizontal_scroller_class:
+                control_size = horizontal_scroller.controlSize
+            elif vertical_scroller_class:
+                control_size = vertical_scroller.controlSize
+            else:
+                control_size = 0
+            frame_size_selector = (
+                "frameSizeForContentSize_horizontalScrollerClass_"
+                "verticalScrollerClass_borderType_controlSize_scrollerStyle_"
+            )
+            frame_size_for_content_size = getattr(NSScrollView, frame_size_selector)
+            frame_size = frame_size_for_content_size(
+                NSSize(
+                    self.interface.content.layout.min_width,
+                    self.interface.content.layout.min_height,
+                ),
+                horizontal_scroller_class,
+                vertical_scroller_class,
+                self.native.borderType,
+                control_size,
+                self.native.scrollerStyle,
+            )
+
+            if not self.interface.horizontal:
+                min_width = max(min_width, frame_size.width)
+            if not self.interface.vertical:
+                min_height = max(min_height, frame_size.height)
+
+        self.interface.intrinsic.width = at_least(min_width)
+        self.interface.intrinsic.height = at_least(min_height)
 
     def get_max_vertical_position(self):
         return max(

--- a/cocoa/src/toga_cocoa/widgets/scrollcontainer.py
+++ b/cocoa/src/toga_cocoa/widgets/scrollcontainer.py
@@ -121,6 +121,18 @@ class ScrollContainer(Widget):
 
         self.native.documentView.frame = NSMakeRect(0, 0, width, height)
 
+        # Setting the document frame determines which non-overlay scrollers are
+        # visible. Use the resulting viewport so a visible scroller doesn't create
+        # overflow in the other axis.
+        viewport_size = self.native.contentSize
+        width = viewport_size.width
+        height = viewport_size.height
+        if self.interface.horizontal:
+            width = max(self.interface.content.layout.width, width)
+        if self.interface.vertical:
+            height = max(self.interface.content.layout.height, height)
+        self.native.documentView.frame = NSMakeRect(0, 0, width, height)
+
         previous_intrinsic_size = (
             self.interface.intrinsic.width,
             self.interface.intrinsic.height,
@@ -195,21 +207,16 @@ class ScrollContainer(Widget):
                 control_size = vertical_scroller.controlSize
             else:
                 control_size = 0
-            frame_size_selector = (
-                "frameSizeForContentSize_horizontalScrollerClass_"
-                "verticalScrollerClass_borderType_controlSize_scrollerStyle_"
-            )
-            frame_size_for_content_size = getattr(NSScrollView, frame_size_selector)
-            frame_size = frame_size_for_content_size(
+            frame_size = NSScrollView.frameSizeForContentSize(
                 NSSize(
                     self.interface.content.layout.min_width,
                     self.interface.content.layout.min_height,
                 ),
-                horizontal_scroller_class,
-                vertical_scroller_class,
-                self.native.borderType,
-                control_size,
-                self.native.scrollerStyle,
+                horizontalScrollerClass=horizontal_scroller_class,
+                verticalScrollerClass=vertical_scroller_class,
+                borderType=self.native.borderType,
+                controlSize=control_size,
+                scrollerStyle=self.native.scrollerStyle,
             )
 
             if not self.interface.horizontal:
@@ -225,7 +232,7 @@ class ScrollContainer(Widget):
             0,
             int(
                 self.native.documentView.bounds.size.height
-                - self.native.frame.size.height
+                - self.native.contentSize.height
             ),
         )
 
@@ -239,7 +246,7 @@ class ScrollContainer(Widget):
             0,
             int(
                 self.native.documentView.bounds.size.width
-                - self.native.frame.size.width
+                - self.native.contentSize.width
             ),
         )
 

--- a/cocoa/tests_backend/widgets/scrollcontainer.py
+++ b/cocoa/tests_backend/widgets/scrollcontainer.py
@@ -44,6 +44,9 @@ class ScrollContainerProbe(SimpleProbe):
             NSScrollViewDidEndLiveScrollNotification, object=self.native
         )
 
+    async def scroller_style_changed(self):
+        self.native.scrollerStyleChanged_(None)
+
     async def wait_for_scroll_completion(self):
         # No animation associated with scroll, so this is a no-op
         pass

--- a/cocoa/tests_backend/widgets/scrollcontainer.py
+++ b/cocoa/tests_backend/widgets/scrollcontainer.py
@@ -11,8 +11,14 @@ from .base import SimpleProbe
 
 class ScrollContainerProbe(SimpleProbe):
     native_class = NSScrollView
-    scrollbar_inset = 0
     frame_inset = 0
+
+    @property
+    def scrollbar_inset(self):
+        return max(
+            self.native.frame.size.width - self.native.contentSize.width,
+            self.native.frame.size.height - self.native.contentSize.height,
+        )
 
     @property
     def has_content(self):
@@ -45,7 +51,10 @@ class ScrollContainerProbe(SimpleProbe):
         )
 
     async def scroller_style_changed(self):
-        self.native.scrollerStyleChanged_(None)
+        self.native.scrollerStyleChanged(None)
+
+    async def use_legacy_scrollers(self):
+        self.native.scrollerStyle = 0  # NSScrollerStyleLegacy
 
     async def wait_for_scroll_completion(self):
         # No animation associated with scroll, so this is a no-op

--- a/core/src/toga/widgets/scrollcontainer.py
+++ b/core/src/toga/widgets/scrollcontainer.py
@@ -116,6 +116,8 @@ class ScrollContainer(Widget):
         self._content = widget
         if widget:
             widget.refresh()
+        else:
+            self.refresh()
 
     @property
     def vertical(self) -> bool:

--- a/core/tests/widgets/test_scrollcontainer.py
+++ b/core/tests/widgets/test_scrollcontainer.py
@@ -213,6 +213,7 @@ def test_clear_content(app, window, scroll_container, content):
 
     # The content has been assigned to the widget
     assert_action_performed_with(scroll_container, "set content", widget=None)
+    assert_action_performed(scroll_container, "refresh")
 
     # The content has been cleared
     assert scroll_container.content is None

--- a/docs/en/reference/api/containers/scrollcontainer.md
+++ b/docs/en/reference/api/containers/scrollcontainer.md
@@ -10,6 +10,8 @@ content = toga.Box(children=[...])
 container = toga.ScrollContainer(content=content)
 ```
 
+On each axis where scrolling is disabled, the minimum size of a `ScrollContainer` includes the minimum size of its content. Content size does not affect the container's minimum on an axis where scrolling is enabled.
+
 ## Reference
 
 ::: toga.ScrollContainer

--- a/gtk/src/toga_gtk/widgets/scrollcontainer.py
+++ b/gtk/src/toga_gtk/widgets/scrollcontainer.py
@@ -1,3 +1,6 @@
+import asyncio
+from functools import partial
+
 from travertino.size import at_least
 
 from toga.handlers import WeakrefCallable
@@ -27,6 +30,7 @@ class ScrollContainer(Widget):
         self.native.set_overlay_scrolling(True)
 
         self.document_container = TogaContainer()
+        self.document_container.on_recompute = WeakrefCallable(self.on_recompute)
         if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             self.native.add(self.document_container)
         else:  # pragma: no-cover-if-gtk3
@@ -44,6 +48,10 @@ class ScrollContainer(Widget):
         else:  # pragma: no-cover-if-gtk3
             pass
 
+    def on_recompute(self, container):
+        # If the content recomputes, rehint this parent widget next.
+        asyncio.get_running_loop().call_soon(partial(self.container.make_dirty, self))
+
     def set_app(self, app):
         self.interface.content.app = app
 
@@ -52,8 +60,16 @@ class ScrollContainer(Widget):
 
     def rehint(self):
         if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
-            self.interface.intrinsic.width = at_least(self.interface._MIN_WIDTH)
-            self.interface.intrinsic.height = at_least(self.interface._MIN_HEIGHT)
+            min_width = self.interface._MIN_WIDTH
+            min_height = self.interface._MIN_HEIGHT
+            if self.interface.content:
+                if not self.interface.horizontal:
+                    min_width = max(min_width, self.document_container.min_width)
+                if not self.interface.vertical:
+                    min_height = max(min_height, self.document_container.min_height)
+
+            self.interface.intrinsic.width = at_least(min_width)
+            self.interface.intrinsic.height = at_least(min_height)
         else:  # pragma: no-cover-if-gtk3
             pass
 

--- a/gtk/src/toga_gtk/widgets/scrollcontainer.py
+++ b/gtk/src/toga_gtk/widgets/scrollcontainer.py
@@ -49,8 +49,20 @@ class ScrollContainer(Widget):
             pass
 
     def on_recompute(self, container):
-        # If the content recomputes, rehint this parent widget next.
-        asyncio.get_running_loop().call_soon(partial(self.container.make_dirty, self))
+        # If the content recomputes, rehint this widget immediately so that an
+        # unchanged minimum doesn't trigger another parent layout.
+        previous_intrinsic_size = (
+            self.interface.intrinsic.width,
+            self.interface.intrinsic.height,
+        )
+        self.rehint()
+        if self.container and previous_intrinsic_size != (
+            self.interface.intrinsic.width,
+            self.interface.intrinsic.height,
+        ):
+            asyncio.get_running_loop().call_soon(
+                partial(self.container.make_dirty, self)
+            )
 
     def set_app(self, app):
         self.interface.content.app = app

--- a/gtk/src/toga_gtk/widgets/scrollcontainer.py
+++ b/gtk/src/toga_gtk/widgets/scrollcontainer.py
@@ -64,12 +64,6 @@ class ScrollContainer(Widget):
                 partial(self.container.make_dirty, self)
             )
 
-    def set_app(self, app):
-        self.interface.content.app = app
-
-    def set_window(self, window):
-        self.interface.content.window = window
-
     def rehint(self):
         if GTK_VERSION < (4, 0, 0):  # pragma: no-cover-if-gtk4
             min_width = self.interface._MIN_WIDTH

--- a/gtk/src/toga_gtk/widgets/scrollcontainer.py
+++ b/gtk/src/toga_gtk/widgets/scrollcontainer.py
@@ -15,10 +15,10 @@ class ScrollContainer(Widget):
         self.native = Gtk.ScrolledWindow()
 
         self.native.get_hadjustment().connect(
-            "changed", WeakrefCallable(self.gtk_on_changed)
+            "value-changed", WeakrefCallable(self.gtk_on_value_changed)
         )
         self.native.get_vadjustment().connect(
-            "changed", WeakrefCallable(self.gtk_on_changed)
+            "value-changed", WeakrefCallable(self.gtk_on_value_changed)
         )
 
         # Set this minimum size of scroll windows because we must reserve space for
@@ -36,7 +36,7 @@ class ScrollContainer(Widget):
         else:  # pragma: no-cover-if-gtk3
             pass
 
-    def gtk_on_changed(self, *args):
+    def gtk_on_value_changed(self, *args):
         self.interface.on_scroll()
 
     def set_content(self, widget):

--- a/gtk/tests_backend/widgets/scrollcontainer.py
+++ b/gtk/tests_backend/widgets/scrollcontainer.py
@@ -31,7 +31,6 @@ class ScrollContainerProbe(SimpleProbe):
 
         # Fake a vertical scroll
         self.native.get_vadjustment().set_value(200)
-        self.native.get_vadjustment().emit("changed")
 
     async def wait_for_scroll_completion(self):
         # Scroll isn't animated, so this is a no-op.

--- a/iOS/src/toga_iOS/widgets/scrollcontainer.py
+++ b/iOS/src/toga_iOS/widgets/scrollcontainer.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from rubicon.objc import (
     SEL,
     CGRectMake,
@@ -81,20 +83,34 @@ class ScrollContainer(Widget):
         # bounds
         self.document_container.native.frame = CGRectMake(0, 0, width, height)
 
+        previous_intrinsic_size = (
+            self.interface.intrinsic.width,
+            self.interface.intrinsic.height,
+        )
+        self.rehint()
+        if previous_intrinsic_size != (
+            self.interface.intrinsic.width,
+            self.interface.intrinsic.height,
+        ):
+            asyncio.get_running_loop().call_soon_threadsafe(self.interface.refresh)
+
     def rehint(self):
-        self.interface.intrinsic.width = at_least(self.interface._MIN_WIDTH)
-        self.interface.intrinsic.height = at_least(self.interface._MIN_HEIGHT)
+        min_width = self.interface._MIN_WIDTH
+        min_height = self.interface._MIN_HEIGHT
+        if self.interface.content:
+            if not self.interface.horizontal:
+                min_width = max(min_width, self.interface.content.layout.min_width)
+            if not self.interface.vertical:
+                min_height = max(min_height, self.interface.content.layout.min_height)
+
+        self.interface.intrinsic.width = at_least(min_width)
+        self.interface.intrinsic.height = at_least(min_height)
 
     def get_vertical(self):
         return self._allow_vertical
 
     def set_vertical(self, value):
         self._allow_vertical = value
-        # If the scroll container has content, we need to force a refresh
-        # to let the scroll container know how large its content is.
-        if self.interface.content:
-            self.interface.refresh()
-
         # Disabling scrolling implies a position reset; that's a scroll event.
         if not value:
             self.interface.on_scroll()
@@ -104,11 +120,6 @@ class ScrollContainer(Widget):
 
     def set_horizontal(self, value):
         self._allow_horizontal = value
-        # If the scroll container has content, we need to force a refresh
-        # to let the scroll container know how large its content is.
-        if self.interface.content:
-            self.interface.refresh()
-
         # Disabling scrolling implies a position reset; that's a scroll event.
         if not value:
             self.interface.on_scroll()

--- a/iOS/src/toga_iOS/widgets/scrollcontainer.py
+++ b/iOS/src/toga_iOS/widgets/scrollcontainer.py
@@ -66,22 +66,22 @@ class ScrollContainer(Widget):
         )
 
     def content_refreshed(self, container):
-        width = self.native.frame.size.width
-        height = self.native.frame.size.height
+        viewport_width = self.native.frame.size.width
+        viewport_height = self.native.frame.size.height
+        document_width = max(self.interface.content.layout.width, viewport_width)
+        document_height = max(self.interface.content.layout.height, viewport_height)
 
-        if self.interface.horizontal:
-            width = max(self.interface.content.layout.width, width)
-
-        if self.interface.vertical:
-            height = max(self.interface.content.layout.height, height)
+        width = document_width if self.interface.horizontal else viewport_width
+        height = document_height if self.interface.vertical else viewport_height
 
         self.native.contentSize = NSMakeSize(width, height)
 
-        # Update the document container frame to match the content size so that
-        # buttons outside the original scroll view frame can receive touch events.
-        # Without this, hit testing fails for views outside the original container
-        # bounds
-        self.document_container.native.frame = CGRectMake(0, 0, width, height)
+        # Keep the document large enough for hit testing throughout its content. If
+        # scrolling is disabled and a fixed-size screen can't satisfy the content
+        # minimum, contentSize remains limited to the viewport to prevent scrolling.
+        self.document_container.native.frame = CGRectMake(
+            0, 0, document_width, document_height
+        )
 
         previous_intrinsic_size = (
             self.interface.intrinsic.width,

--- a/iOS/tests_backend/widgets/scrollcontainer.py
+++ b/iOS/tests_backend/widgets/scrollcontainer.py
@@ -18,21 +18,31 @@ class ScrollContainerProbe(SimpleProbe):
 
     @property
     def document_height(self):
-        # Assert that the document container and the document itself have the same size.
-        # This is necessary to ensure that events propagate; see #2411.
-        assert self.impl.document_container.native.frame.size.height == (
-            content_height := self.native.contentSize.height
-        )
+        document_height = self.impl.document_container.native.frame.size.height
+        content_height = self.native.contentSize.height
+        if self.widget.vertical:
+            # A scrollable document must cover its entire scroll range so that events
+            # propagate outside the original viewport; see #2411.
+            assert document_height == content_height
+        else:
+            # On a fixed-size screen, non-scrollable content may have a minimum larger
+            # than the viewport. Its native document still holds the content, while
+            # contentSize remains limited to the viewport to prevent scrolling.
+            assert document_height >= content_height
 
         return content_height
 
     @property
     def document_width(self):
-        # Assert that the document container and the document itself have the same size.
-        # This is necessary to ensure that events propagate; see #2411.
-        assert self.impl.document_container.native.frame.size.width == (
-            content_width := self.native.contentSize.width
-        )
+        document_width = self.impl.document_container.native.frame.size.width
+        content_width = self.native.contentSize.width
+        if self.widget.horizontal:
+            # A scrollable document must cover its entire scroll range so that events
+            # propagate outside the original viewport; see #2411.
+            assert document_width == content_width
+        else:
+            # See the corresponding fixed-screen case in document_height.
+            assert document_width >= content_width
 
         return content_width
 

--- a/qt/src/toga_qt/widgets/scrollcontainer.py
+++ b/qt/src/toga_qt/widgets/scrollcontainer.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from PySide6.QtCore import QEvent, QObject, Qt
 from PySide6.QtWidgets import QScrollArea
 from travertino.constants import TRANSPARENT
@@ -97,8 +99,27 @@ class ScrollContainer(Widget):
         self.native.verticalScrollBar().setValue(vertical_position)
 
     def rehint(self):
-        self.interface.intrinsic.width = at_least(self.interface._MIN_WIDTH)
-        self.interface.intrinsic.height = at_least(self.interface._MIN_HEIGHT)
+        min_width = self.interface._MIN_WIDTH
+        min_height = self.interface._MIN_HEIGHT
+
+        if self.interface.content:
+            if not self.interface.horizontal:
+                min_width = max(
+                    min_width,
+                    self.interface.content.layout.min_width
+                    + self.native.width()
+                    - self.native.viewport().width(),
+                )
+            if not self.interface.vertical:
+                min_height = max(
+                    min_height,
+                    self.interface.content.layout.min_height
+                    + self.native.height()
+                    - self.native.viewport().height(),
+                )
+
+        self.interface.intrinsic.width = at_least(min_width)
+        self.interface.intrinsic.height = at_least(min_height)
 
     def content_refreshed(self, container):
         width = self.native.viewport().width()
@@ -111,3 +132,14 @@ class ScrollContainer(Widget):
             height = max(self.interface.content.layout.height, height)
 
         self.document_container.native.setFixedSize(width, height)
+
+        previous_intrinsic_size = (
+            self.interface.intrinsic.width,
+            self.interface.intrinsic.height,
+        )
+        self.rehint()
+        if previous_intrinsic_size != (
+            self.interface.intrinsic.width,
+            self.interface.intrinsic.height,
+        ):
+            asyncio.get_running_loop().call_soon_threadsafe(self.interface.refresh)

--- a/testbed/tests/widgets/test_scrollcontainer.py
+++ b/testbed/tests/widgets/test_scrollcontainer.py
@@ -92,8 +92,9 @@ async def test_content_size_rehint(widget, probe, main_window):
     fixed_size_window = toga.platform.current_platform in {"android", "iOS"}
     original_window_size = main_window.size
     content_width = probe.width + 200
-    content_height = probe.height + 200
-    widget.content = toga.Box(style=Pack(width=content_width, height=content_height))
+    widget.content = toga.Box(
+        style=Pack(width=content_width, height=widget._MIN_HEIGHT)
+    )
     widget.horizontal = False
     widget.vertical = True
 
@@ -105,12 +106,23 @@ async def test_content_size_rehint(widget, probe, main_window):
         ),
     )
 
-    assert widget.intrinsic.width.value >= content_width
+    assert widget.intrinsic.width.value == approx(
+        content_width + probe.frame_inset, abs=1
+    )
     assert widget.intrinsic.height.value == widget._MIN_HEIGHT
     if not fixed_size_window:
         assert probe.width >= content_width
-        assert probe.height < content_height
         assert probe.document_width >= content_width
+
+    content_height = probe.height + 200
+    widget.content.style.height = content_height
+    await probe.redraw(
+        "Content is tall enough to show the vertical scrollbar",
+        wait_for=lambda: (
+            probe.document_height >= content_height
+            and widget.intrinsic.width.value >= content_width + probe.scrollbar_inset
+        ),
+    )
 
     widget.horizontal = True
     widget.vertical = False

--- a/testbed/tests/widgets/test_scrollcontainer.py
+++ b/testbed/tests/widgets/test_scrollcontainer.py
@@ -457,6 +457,9 @@ async def test_vertical_scroll_small_content(widget, probe, small_content):
 
 async def test_horizontal_scroll(widget, probe, content, on_scroll):
     "The widget can be scrolled horizontally."
+    if hasattr(probe, "use_legacy_scrollers"):
+        await probe.use_legacy_scrollers()
+
     content.style.direction = ROW
     await probe.redraw("Content has been switched for a wide document")
 

--- a/testbed/tests/widgets/test_scrollcontainer.py
+++ b/testbed/tests/widgets/test_scrollcontainer.py
@@ -115,7 +115,6 @@ async def test_content_size_rehint(widget, probe, main_window):
     widget.horizontal = True
     widget.vertical = False
     await probe.redraw("Scrolling axes have been exchanged")
-    main_window.size = original_window_size
 
     await probe.redraw(
         "Vertical scrolling is disabled",
@@ -128,9 +127,22 @@ async def test_content_size_rehint(widget, probe, main_window):
     assert widget.intrinsic.width.value == widget._MIN_WIDTH
     assert widget.intrinsic.height.value >= content_height
     if not fixed_size_window:
-        assert probe.width < content_width
         assert probe.height >= content_height
         assert probe.document_height >= content_height
+
+    if hasattr(probe, "scroller_style_changed"):
+        original_refresh = widget.content.refresh
+        content_refresh = Mock(wraps=original_refresh)
+        widget.content.refresh = content_refresh
+        try:
+            await probe.scroller_style_changed()
+            await probe.redraw(
+                "The system scroller style has changed",
+                wait_for=lambda: content_refresh.called,
+            )
+            assert content_refresh.called
+        finally:
+            widget.content.refresh = original_refresh
 
     widget.content = None
     await probe.redraw(
@@ -142,6 +154,7 @@ async def test_content_size_rehint(widget, probe, main_window):
     )
     assert widget.intrinsic.width.value == widget._MIN_WIDTH
     assert widget.intrinsic.height.value == widget._MIN_HEIGHT
+    main_window.size = original_window_size
 
 
 async def test_clear_content(widget, probe, small_content):
@@ -242,7 +255,17 @@ async def test_enable_horizontal_scrolling(widget, probe, main_window, on_scroll
         wait_for=lambda: widget.intrinsic.width.value == widget._MIN_WIDTH,
     )
     main_window.size = original_window_size
-    await probe.redraw("Window size has been restored")
+    await probe.redraw("Restore the original window size")
+    if widget.max_horizontal_position < 120:
+        widget.content = toga.Box(
+            style=Pack(width=probe.width + 200, height=probe.height + 200)
+        )
+        await probe.redraw(
+            "Use oversized content after re-enabling horizontal scrolling",
+            wait_for=lambda: widget.max_horizontal_position >= 120,
+        )
+    assert widget.max_horizontal_position >= 120
+    on_scroll.reset_mock()
 
     widget.horizontal_position = 120
     await probe.wait_for_scroll_completion()
@@ -307,7 +330,17 @@ async def test_enable_vertical_scrolling(widget, probe, main_window, on_scroll):
         wait_for=lambda: widget.intrinsic.height.value == widget._MIN_HEIGHT,
     )
     main_window.size = original_window_size
-    await probe.redraw("Window size has been restored")
+    await probe.redraw("Restore the original window size")
+    if widget.max_vertical_position < 120:
+        widget.content = toga.Box(
+            style=Pack(width=probe.width + 200, height=probe.height + 200)
+        )
+        await probe.redraw(
+            "Use oversized content after re-enabling vertical scrolling",
+            wait_for=lambda: widget.max_vertical_position >= 120,
+        )
+    assert widget.max_vertical_position >= 120
+    on_scroll.reset_mock()
 
     widget.vertical_position = 120
     await probe.wait_for_scroll_completion()

--- a/testbed/tests/widgets/test_scrollcontainer.py
+++ b/testbed/tests/widgets/test_scrollcontainer.py
@@ -169,6 +169,23 @@ async def test_content_size_rehint(widget, probe, main_window):
     main_window.size = original_window_size
 
 
+async def test_legacy_scroller_geometry(widget, probe):
+    if not hasattr(probe, "use_legacy_scrollers"):
+        pytest.skip("requires Cocoa legacy scrollers")
+
+    await probe.use_legacy_scrollers()
+    widget.horizontal = False
+    await probe.redraw("Legacy horizontal scroller is disabled")
+    widget.horizontal = True
+    await probe.redraw("Legacy horizontal scroller is re-enabled")
+    assert probe.document_width == approx(probe.width - probe.scrollbar_inset, abs=1)
+
+    widget.vertical = False
+    widget.content = toga.Box(style=Pack(width=probe.width + 200))
+    await probe.redraw("Legacy vertical scroller is disabled")
+    assert probe.document_height == approx(probe.height - probe.scrollbar_inset, abs=1)
+
+
 async def test_clear_content(widget, probe, small_content):
     "Widget content can be cleared and reset"
     assert probe.document_width == approx(

--- a/testbed/tests/widgets/test_scrollcontainer.py
+++ b/testbed/tests/widgets/test_scrollcontainer.py
@@ -87,6 +87,63 @@ test_cleanup = build_cleanup_test(
 )
 
 
+async def test_content_size_rehint(widget, probe, main_window):
+    "The non-scrolling axis should adopt the content's minimum size"
+    fixed_size_window = toga.platform.current_platform in {"android", "iOS"}
+    original_window_size = main_window.size
+    content_width = probe.width + 200
+    content_height = probe.height + 200
+    widget.content = toga.Box(style=Pack(width=content_width, height=content_height))
+    widget.horizontal = False
+    widget.vertical = True
+
+    await probe.redraw(
+        "Horizontal scrolling is disabled",
+        wait_for=lambda: (
+            widget.intrinsic.width.value >= content_width
+            and (fixed_size_window or probe.width >= content_width)
+        ),
+    )
+
+    assert widget.intrinsic.width.value >= content_width
+    assert widget.intrinsic.height.value == widget._MIN_HEIGHT
+    if not fixed_size_window:
+        assert probe.width >= content_width
+        assert probe.height < content_height
+        assert probe.document_width >= content_width
+
+    widget.horizontal = True
+    widget.vertical = False
+    await probe.redraw("Scrolling axes have been exchanged")
+    main_window.size = original_window_size
+
+    await probe.redraw(
+        "Vertical scrolling is disabled",
+        wait_for=lambda: (
+            widget.intrinsic.height.value >= content_height
+            and (fixed_size_window or probe.height >= content_height)
+        ),
+    )
+
+    assert widget.intrinsic.width.value == widget._MIN_WIDTH
+    assert widget.intrinsic.height.value >= content_height
+    if not fixed_size_window:
+        assert probe.width < content_width
+        assert probe.height >= content_height
+        assert probe.document_height >= content_height
+
+    widget.content = None
+    await probe.redraw(
+        "Content has been cleared",
+        wait_for=lambda: (
+            widget.intrinsic.width.value == widget._MIN_WIDTH
+            and widget.intrinsic.height.value == widget._MIN_HEIGHT
+        ),
+    )
+    assert widget.intrinsic.width.value == widget._MIN_WIDTH
+    assert widget.intrinsic.height.value == widget._MIN_HEIGHT
+
+
 async def test_clear_content(widget, probe, small_content):
     "Widget content can be cleared and reset"
     assert probe.document_width == approx(
@@ -137,21 +194,13 @@ async def test_margin(widget, probe, content):
     assert probe.document_height == original_document_height
 
 
-async def test_enable_horizontal_scrolling(widget, probe, content, on_scroll):
+async def test_enable_horizontal_scrolling(widget, probe, main_window, on_scroll):
     "Horizontal scrolling can be disabled"
-    # Add some wide content
-    content.insert(
-        0,
-        toga.Label(
-            "This is a long label",
-            style=Pack(
-                width=2000,
-                background_color=CORNFLOWERBLUE,
-                margin=20,
-                height=20,
-            ),
-        ),
+    original_window_size = main_window.size
+    widget.content = toga.Box(
+        style=Pack(width=probe.width + 200, height=probe.height + 200)
     )
+    await probe.redraw("Use moderately oversized content")
 
     # clear any scroll events caused by setup
     on_scroll.reset_mock()
@@ -188,7 +237,12 @@ async def test_enable_horizontal_scrolling(widget, probe, content, on_scroll):
     on_scroll.reset_mock()
 
     widget.horizontal = True
-    await probe.redraw("Horizontal scrolling is enabled")
+    await probe.redraw(
+        "Horizontal scrolling is enabled",
+        wait_for=lambda: widget.intrinsic.width.value == widget._MIN_WIDTH,
+    )
+    main_window.size = original_window_size
+    await probe.redraw("Window size has been restored")
 
     widget.horizontal_position = 120
     await probe.wait_for_scroll_completion()
@@ -205,21 +259,14 @@ async def test_enable_horizontal_scrolling(widget, probe, content, on_scroll):
     on_scroll.assert_called_with(widget)
 
 
-async def test_enable_vertical_scrolling(widget, probe, content, on_scroll):
+async def test_enable_vertical_scrolling(widget, probe, main_window, on_scroll):
     "Vertical scrolling can be disabled"
-    # Add some wide content
-    content.insert(
-        0,
-        toga.Label(
-            "This is a long label",
-            style=Pack(
-                width=2000,
-                background_color=CORNFLOWERBLUE,
-                margin=20,
-                height=20,
-            ),
-        ),
+    original_window_size = main_window.size
+    widget.horizontal = True
+    widget.content = toga.Box(
+        style=Pack(width=probe.width + 200, height=probe.height + 200)
     )
+    await probe.redraw("Use moderately oversized content")
 
     # clear any scroll events caused by setup
     on_scroll.reset_mock()
@@ -255,7 +302,12 @@ async def test_enable_vertical_scrolling(widget, probe, content, on_scroll):
     on_scroll.reset_mock()
 
     widget.vertical = True
-    await probe.redraw("Vertical scrolling is enabled")
+    await probe.redraw(
+        "Vertical scrolling is enabled",
+        wait_for=lambda: widget.intrinsic.height.value == widget._MIN_HEIGHT,
+    )
+    main_window.size = original_window_size
+    await probe.redraw("Window size has been restored")
 
     widget.vertical_position = 120
     await probe.wait_for_scroll_completion()
@@ -472,8 +524,12 @@ async def test_scroll_both(widget, probe, content, on_scroll):
     on_scroll.reset_mock()
 
 
-async def test_manual_scroll(widget, probe, content, on_scroll):
+async def test_manual_scroll(widget, probe, on_scroll):
     "The widget can be scrolled manually."
+    widget.content = toga.Box(style=Pack(height=probe.height + 200))
+    await probe.redraw("Use moderately oversized content")
+    on_scroll.reset_mock()
+
     await probe.scroll()
     await probe.wait_for_scroll_completion()
     await probe.redraw("Widget has been scrolled manually")

--- a/web/src/toga_web/widgets/scrollcontainer.py
+++ b/web/src/toga_web/widgets/scrollcontainer.py
@@ -23,6 +23,10 @@ class ScrollContainer(Widget):
         self.native.appendChild(self._content_div)
         self._update_overflow()
 
+    def _reapply_style(self):
+        super()._reapply_style()
+        self._update_overflow()
+
     def set_content(self, content_impl):
         while self._content_div.firstChild:
             self._content_div.removeChild(self._content_div.firstChild)
@@ -33,6 +37,18 @@ class ScrollContainer(Widget):
     def _update_overflow(self):
         self.native.style.overflowX = "auto" if self._horizontal_enabled else "hidden"
         self.native.style.overflowY = "auto" if self._vertical_enabled else "hidden"
+        self.native.style.minWidth = (
+            f"{self.interface._MIN_WIDTH}px"
+            if self._horizontal_enabled
+            else "min-content"
+        )
+        self.native.style.minHeight = (
+            f"{self.interface._MIN_HEIGHT}px"
+            if self._vertical_enabled
+            else "min-content"
+        )
+        self._content_div.style.minWidth = f"{self.interface._MIN_WIDTH}px"
+        self._content_div.style.minHeight = f"{self.interface._MIN_HEIGHT}px"
 
     def get_horizontal(self):
         return self._horizontal_enabled

--- a/winforms/src/toga_winforms/widgets/scrollcontainer.py
+++ b/winforms/src/toga_winforms/widgets/scrollcontainer.py
@@ -1,8 +1,10 @@
+import asyncio
 from decimal import ROUND_DOWN
 
 from System.Drawing import Point
 from System.Windows.Forms import Panel, SystemInformation
 from travertino.node import Node
+from travertino.size import at_least
 
 from toga.handlers import WeakrefCallable
 from toga_winforms.container import Container
@@ -32,6 +34,8 @@ class ScrollContainer(Widget, Container):
         self.native = Panel()
         self.native.AutoScroll = True
         Container.__init__(self, self.native)
+        self._horizontal_scrollbar_visible = False
+        self._vertical_scrollbar_visible = False
 
         # The Scroll event only fires on direct interaction with the scroll bar. It
         # doesn't fire when using the mouse wheel, and it doesn't fire when setting
@@ -58,22 +62,29 @@ class ScrollContainer(Widget, Container):
         # Temporarily reduce container size to account for scroll bars (see explanation
         # at the top of this file).
         def apply_insets():
-            need_scrollbar = False
-            if self.vertical and (layout.height > self.height):
-                need_scrollbar = True
+            vertical_scrollbar_visible = self.vertical and (layout.height > self.height)
+            horizontal_scrollbar_visible = self.horizontal and (
+                layout.width > self.width
+            )
+            if vertical_scrollbar_visible:
                 self.native_width = inset_width
-            if self.horizontal and (layout.width > self.width):
-                need_scrollbar = True
+            if horizontal_scrollbar_visible:
                 self.native_height = inset_height
-            return need_scrollbar
+            return horizontal_scrollbar_visible, vertical_scrollbar_visible
 
-        if apply_insets():
+        scrollbars_visible = apply_insets()
+        if any(scrollbars_visible):
             # Bypass Widget.refresh to avoid a recursive call to `refreshed`.
             Node.refresh(self.interface.content, self)
 
             # In borderline cases, adding one scroll bar may cause the other one to be
             # needed as well.
-            apply_insets()
+            scrollbars_visible = apply_insets()
+
+        (
+            self._horizontal_scrollbar_visible,
+            self._vertical_scrollbar_visible,
+        ) = scrollbars_visible
 
         # Crop any non-scrollable dimensions to the available size.
         self.apply_layout(
@@ -89,6 +100,40 @@ class ScrollContainer(Widget, Container):
         # on dpi scaling changes.
         self.native.AutoScroll = False
         self.native.AutoScroll = True
+
+        previous_intrinsic_size = (
+            self.interface.intrinsic.width,
+            self.interface.intrinsic.height,
+        )
+        self.rehint()
+        if previous_intrinsic_size != (
+            self.interface.intrinsic.width,
+            self.interface.intrinsic.height,
+        ):
+            asyncio.get_running_loop().call_soon_threadsafe(self.interface.refresh)
+
+    def rehint(self):
+        min_width = self.interface._MIN_WIDTH
+        min_height = self.interface._MIN_HEIGHT
+        if self.interface.content:
+            if not self.interface.horizontal:
+                min_width = self.interface.content.layout.min_width
+                if self._vertical_scrollbar_visible:
+                    min_width += self.scale_out(
+                        SystemInformation.VerticalScrollBarWidth
+                    )
+                min_width = max(min_width, self.interface._MIN_WIDTH)
+
+            if not self.interface.vertical:
+                min_height = self.interface.content.layout.min_height
+                if self._horizontal_scrollbar_visible:
+                    min_height += self.scale_out(
+                        SystemInformation.HorizontalScrollBarHeight
+                    )
+                min_height = max(min_height, self.interface._MIN_HEIGHT)
+
+        self.interface.intrinsic.width = at_least(min_width)
+        self.interface.intrinsic.height = at_least(min_height)
 
     def get_horizontal(self):
         return self.horizontal


### PR DESCRIPTION
Fixes #4503.

`ScrollContainer` previously reported the fixed widget minimum on both axes, even when scrolling was disabled on an axis. This allowed parent layouts to allocate less space than the content's minimum and clip it.

Cocoa, GTK 3, Qt, WinForms, iOS, Android, and Web now derive the container minimum from the content minimum only on non-scrollable axes; scrollable axes retain the existing 100-pixel minimum. GTK 4 and Textual remain unimplemented and are outside this change. Native feedback paths request a parent relayout only when the hint changes, while Web delegates intrinsic sizing to CSS; clearing content resets the minimum. Cocoa, Qt, and WinForms include consuming native frame or visible scrollbar space, and Cocoa also handles runtime scroller-style changes. The shared testbed regression covers both axes and content removal.

## Local verification

- At commit `bd88d2226`, `tox -m test` passed 3,384 core tests and 688 Travertino tests with 100% coverage.
- At commit `60377d22c`, the focused core `ScrollContainer` file passed all 49 tests, and pre-commit passed on the two follow-up files.
- Cocoa: all 19 focused testbed tests passed; an additional runtime check covered legacy and overlay scroller styles.
- Chromium: an intrinsic-sizing probe covered overlay and consuming scrollbar gutters.
- `pre-commit run --all-files` and the Towncrier change-note check passed.
- `tox -e docs-lint` could not start because `aspell` is not installed on the local host; the pre-commit `codespell`, `rumdl check`, and `rumdl fmt` hooks passed.
- GTK 3, Qt, WinForms, iOS, Android, and the full Web testbed were not run locally and remain for CI/platform validation. GTK 4 and Textual are not covered because `ScrollContainer` is not implemented on those paths.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
<!-- update or delete the next line to reflect your usage -->
Assisted-by: OpenAI Codex
