### PR TITLE
Drop Python 3.10; add 3.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ on:
         value: ${{ jobs.package.outputs.artifact-basename }}
 
 env:
-  min_python_version: "3.10"
+  min_python_version: "3.11"
   FORCE_COLOR: "1"
 
 defaults:
@@ -79,7 +79,7 @@ jobs:
   docs-lint:
     name: Documentation linting
     needs: [ pre-commit ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
       - name: Checkout
@@ -118,14 +118,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ "macos-15", "ubuntu-latest", "windows-latest" ]
-        python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
+        platform: [ "macos-26", "ubuntu-24.04", "windows-2025" ]
+        python-version: [ "3.11", "3.12", "3.13", "3.14", "3.15" ]
         package: ["core", "travertino"]
         exclude:
         - package: travertino
-          platform: macos-15
+          platform: macos-26
         - package: travertino
-          platform: windows-latest
+          platform: windows-2025
         include:
         - experimental: false
         - package: "core"
@@ -177,7 +177,7 @@ jobs:
   core-and-travertino-coverage:
     name: "Coverage: ${{ matrix.package }}"
     needs: core-and-travertino
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         package: ["core", "travertino"]
@@ -222,7 +222,7 @@ jobs:
 
   travertino-backwards-compatibility:
     name: Test Travertino backwards compatibility with Toga 0.4.8
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-24.04"
     needs: [ pre-commit, towncrier, package ]
 
     steps:
@@ -484,7 +484,7 @@ jobs:
 
         - backend: "textual-linux"
           platform: "linux"
-          runs-on: "ubuntu-latest"
+          runs-on: "ubuntu-24.04"
           setup-python: false  # Use the system Python packages
           testbed-app: "testbed-textual"
           app-user-data-path: "$HOME/.local/share/testbed-textual"
@@ -499,19 +499,19 @@ jobs:
 
         - backend: "textual-windows"
           platform: "windows"
-          runs-on: "windows-latest"
+          runs-on: "windows-2025"
           testbed-app: "testbed-textual"
           app-user-data-path: '$HOME\AppData\Local\Tiberius Yak\Toga Testbed (Textual)\Data'
 
         - backend: "windows-netfx-x86_64"
           platform: "windows"
-          runs-on: "windows-latest"
+          runs-on: "windows-2025"
           app-user-data-path: '$HOME\AppData\Local\Tiberius Yak\Toga Testbed\Data'
           briefcase-run-prefix: TOGA_WINFORMS_USE_NETFX=1
 
         - backend: "windows-netcore-x86_64"
           platform: "windows"
-          runs-on: "windows-latest"
+          runs-on: "windows-2025"
           app-user-data-path: '$HOME\AppData\Local\Tiberius Yak\Toga Testbed\Data'
 
         - backend: "windows-netcore-arm64"
@@ -527,7 +527,7 @@ jobs:
 
         - backend: "android"
           platform: "android"
-          runs-on: "ubuntu-latest"
+          runs-on: "ubuntu-24.04"
           briefcase-run-prefix: JAVA_HOME=${JAVA_HOME_17_X64}
           briefcase-run-args: >-
             --device '{"avd":"beePhone","device_type":"pixel"}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,13 @@ jobs:
         run: |
           echo "VERSION=${GITHUB_REF_NAME#v}" | tee -a $GITHUB_ENV
 
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          fetch-tags: true
+
       - name: Get Packages
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ Any PR failing one of these is rejected, not waived.
 
 ## Toolchain
 
-- **Python**: 3.10–3.14 (see `core/pyproject.toml` classifiers).
+- **Python**: 3.11–3.15 (see `core/pyproject.toml` classifiers).
 - **Task runner**: `tox` (with `tox-uv`). Install the dev tooling via `uv pip install --group dev` at the repo root, or let `tox` bootstrap.
 - **Lint/format**: `ruff` (check + format), `codespell`, `rumdl` (Markdown), configured in root `pyproject.toml`.
 - **Pre-commit**: `pre-commit run --all-files` — MUST pass before PR.

--- a/android/pyproject.toml
+++ b/android/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = ["version", "dependencies"]
 name = "toga-android"
 description = "An Android backend for the Toga widget toolkit."
 readme = "README.md"
-requires-python = ">= 3.10"
+requires-python = ">= 3.11"
 license = "BSD-3-Clause"
 license-files = [
     "LICENSE",
@@ -35,11 +35,11 @@ classifiers = [
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development",
     "Topic :: Software Development :: User Interfaces",

--- a/changes/4683.feature.md
+++ b/changes/4683.feature.md
@@ -1,0 +1,1 @@
+Support for Python 3.15 was added.

--- a/changes/4683.removal.md
+++ b/changes/4683.removal.md
@@ -1,0 +1,1 @@
+Python 3.10 is no longer supported.

--- a/cocoa/pyproject.toml
+++ b/cocoa/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = ["version", "dependencies"]
 name = "toga-cocoa"
 description = "A Cocoa (macOS) backend for the Toga widget toolkit."
 readme = "README.md"
-requires-python = ">= 3.10"
+requires-python = ">= 3.11"
 license = "BSD-3-Clause"
 license-files = [
     "LICENSE",
@@ -36,11 +36,11 @@ classifiers = [
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development",
     "Topic :: Software Development :: User Interfaces",

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = ["version", "dependencies"]
 name = "toga-core"
 description = "A Python native, OS native GUI toolkit."
 readme = "README.md"
-requires-python = ">= 3.10"
+requires-python = ">= 3.11"
 license = "BSD-3-Clause"
 license-files = [
     "LICENSE",
@@ -47,11 +47,11 @@ classifiers = [
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development",
     "Topic :: Software Development :: User Interfaces",

--- a/core/src/toga/widgets/canvas/canvas.py
+++ b/core/src/toga/widgets/canvas/canvas.py
@@ -103,8 +103,6 @@ class drawing_context_property:
                     if (value := getattr(action, self.name)) is not None:
                         # This is a state we're currently in, and it sets the attribute.
                         return value
-                    else:  # no-cover-if-lt-py311
-                        pass
                 case self.ActionClass() if restores <= 0:
                     return getattr(action, self.name)
 

--- a/core/src/toga/widgets/splitcontainer.py
+++ b/core/src/toga/widgets/splitcontainer.py
@@ -118,7 +118,7 @@ class SplitContainer(Widget):
                 case toga.Widget() | None as widget:
                     flex_value = 1
                 case toga.Widget() | None as widget, int() as flex_value:
-                    if flex_value <= 0:  # no-cover-if-lt-py311
+                    if flex_value <= 0:
                         raise ValueError(
                             "The flex value for an item in a SplitContainer must be >0"
                         )

--- a/demo/pyproject.toml
+++ b/demo/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = ["version", "dependencies"]
 name = "toga-demo"
 description = "A demonstration of the capabilities of the Toga widget toolkit."
 readme = "README.md"
-requires-python = ">= 3.10"
+requires-python = ">= 3.11"
 license = "BSD-3-Clause"
 license-files = [
     "LICENSE",
@@ -42,11 +42,11 @@ classifiers = [
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development",
     "Topic :: Software Development :: User Interfaces",

--- a/docs/config.yml
+++ b/docs/config.yml
@@ -12,9 +12,9 @@ extra:
   project_name: toga
   package_name: toga-core
   formal_name: Toga
-  min_python_version: "3.10"  # The oldest supported Python version
-  min_python_version_tag: "310"  # The tag version of the minimum python version
-  recent_python_version: "3.13"  # The newest Python version known to work on all platforms
+  min_python_version: "3.11"  # The oldest supported Python version
+  min_python_version_tag: "311"  # The tag version of the minimum python version
+  recent_python_version: "3.14"  # The newest Python version known to work on all platforms
   docs_python_version: "3.13"  # The version of Python required to build the documentation
   contribution_guide_root: how-to/contribute
   social:

--- a/docs/en/reference/platforms/linux/gtk.md
+++ b/docs/en/reference/platforms/linux/gtk.md
@@ -22,7 +22,7 @@ Although GTK *can* be installed on Windows and macOS, and the `toga-gtk` backend
 
 ## Prerequisites { #gtk-prerequisites }
 
-`toga-gtk` requires Python 3.10+, and GTK 3.22 or newer. It also requires `libgirepository 2.0`; older Linux distributions (including Debian 12 and Ubuntu 22.04) do not provide this library.
+`toga-gtk` requires Python {{ min_python_version }}+, and GTK 3.22 or newer. It also requires `libgirepository 2.0`; older Linux distributions (including Debian 12 and Ubuntu 22.04) do not provide this library.
 
 Most testing occurs with GTK 3.24 as this is the version that has shipped with Ubuntu 24.04.
 

--- a/docs/en/reference/platforms/linux/qt.md
+++ b/docs/en/reference/platforms/linux/qt.md
@@ -2,7 +2,7 @@
 
 The Toga backend for Linux (and other Unix-like operating systems) running KDE is [`toga-qt`](https://github.com/beeware/toga/tree/main/qt).
 
-`toga-qt` requires Python 3.10+, and Qt 6.8 or newer.
+`toga-qt` requires Python {{ min_python_version }}++, and Qt 6.8 or newer.
 
 /// admonition | Qt on Windows and macOS
 

--- a/dummy/pyproject.toml
+++ b/dummy/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = ["version", "dependencies"]
 name = "toga-dummy"
 description = "A dummy testing backend for the Toga widget toolkit."
 readme = "README.md"
-requires-python = ">= 3.10"
+requires-python = ">= 3.11"
 license = "BSD-3-Clause"
 license-files = [
     "LICENSE",
@@ -34,11 +34,11 @@ classifiers = [
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development",
     "Topic :: Software Development :: User Interfaces",

--- a/gtk/pyproject.toml
+++ b/gtk/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = ["version", "dependencies"]
 name = "toga-gtk"
 description = "A GTK backend for the Toga widget toolkit."
 readme = "README.md"
-requires-python = ">= 3.10"
+requires-python = ">= 3.11"
 license = "BSD-3-Clause"
 license-files = [
     "LICENSE",
@@ -37,11 +37,11 @@ classifiers = [
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development",
     "Topic :: Software Development :: User Interfaces",

--- a/iOS/pyproject.toml
+++ b/iOS/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = ["version", "dependencies"]
 name = "toga-iOS"
 description = "An iOS backend for the Toga widget toolkit."
 readme = "README.md"
-requires-python = ">= 3.10"
+requires-python = ">= 3.11"
 license = "BSD-3-Clause"
 license-files = [
     "LICENSE",
@@ -35,11 +35,11 @@ classifiers = [
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development",
     "Topic :: Software Development :: User Interfaces",

--- a/positron/pyproject.toml
+++ b/positron/pyproject.toml
@@ -11,6 +11,7 @@ build-backend = "setuptools.build_meta"
 name = "toga-positron"
 description = "A Briefcase plugin for generating Positron apps."
 readme = "README.md"
+requires-python = ">= 3.11"
 license = "BSD-3-Clause"
 license-files = [
     "LICENSE",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,6 @@ no-cover-if-missing-PIL = "not is_installed('PIL')"
 no-cover-if-PIL-installed = "is_installed('PIL')"
 no-cover-if-lt-py312 = "sys_version_info < (3, 12) and os_environ.get('COVERAGE_EXCLUDE_PYTHON_VERSION') != 'disable'"
 no-cover-if-gte-py312 = "sys_version_info > (3, 12) and os_environ.get('COVERAGE_EXCLUDE_PYTHON_VERSION') != 'disable'"
-no-cover-if-lt-py311 = "sys_version_info < (3, 11) and os_environ.get('COVERAGE_EXCLUDE_PYTHON_VERSION') != 'disable'"
-no-cover-if-gte-py311 = "sys_version_info > (3, 11) and os_environ.get('COVERAGE_EXCLUDE_PYTHON_VERSION') != 'disable'"
 
 [tool.ruff]
 exclude = [

--- a/qt/pyproject.toml
+++ b/qt/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = ["version", "dependencies"]
 name = "toga-qt"
 description = "An Qt (KDE) backend for the Toga widget toolkit."
 readme = "README.md"
-requires-python = ">= 3.10"
+requires-python = ">= 3.11"
 license = "BSD-3-Clause"
 license-files = [
     "LICENSE",
@@ -35,11 +35,11 @@ classifiers = [
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development",
     "Topic :: Software Development :: User Interfaces",

--- a/textual/pyproject.toml
+++ b/textual/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = ["version", "dependencies"]
 name = "toga-textual"
 description = "A Textual backend for the Toga widget toolkit."
 readme = "README.md"
-requires-python = ">= 3.10"
+requires-python = ">= 3.11"
 license = "BSD-3-Clause"
 license-files = [
     "LICENSE",
@@ -36,11 +36,11 @@ classifiers = [
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development",
     "Topic :: Software Development :: User Interfaces",

--- a/toga/pyproject.toml
+++ b/toga/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = ["version", "dependencies"]
 name = "toga"
 description = "A Python native, OS native GUI toolkit."
 readme = "README.md"
-requires-python = ">= 3.10"
+requires-python = ">= 3.11"
 license = "BSD-3-Clause"
 license-files = [
     "LICENSE",
@@ -47,11 +47,11 @@ classifiers = [
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development",
     "Topic :: Software Development :: User Interfaces",

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,16 @@
 [tox]
-envlist = towncrier-check,docs-lint,pre-commit,py3{10-14}-cov{,-trav},coverage{,-trav}-platform,trav-compat
+envlist = towncrier-check,docs-lint,pre-commit,py3{11-15}-cov{,-trav},coverage{,-trav}-platform,trav-compat
 labels =
     test = py-cov{,-trav},coverage{,-trav}
     test-core = py-cov,coverage
     test-trav = py-cov-trav,coverage-trav
-    test310 = py310-cov{,-trav},coverage310{,-trav}
     test311 = py311-cov{,-trav},coverage311{,-trav}
     test312 = py312-cov{,-trav},coverage312{,-trav}
     test313 = py313-cov{,-trav},coverage313{,-trav}
     test314 = py314-cov{,-trav},coverage314{,-trav}
-    test-fast = py3{10-14}-fast
-    test-platform = py3{10-14}-cov{,-trav},coverage{,-trav}-platform
+    test315 = py315-cov{,-trav},coverage315{,-trav}
+    test-fast = py3{10-15}-fast
+    test-platform = py3{10-15}-cov{,-trav},coverage{,-trav}-platform
 skip_missing_interpreters = True
 
 [testenv:pre-commit]
@@ -21,7 +21,7 @@ dependency_groups = pre-commit
 commands = pre-commit run --all-files --show-diff-on-failure --color=always
 
 # The leading comma generates the "py" environment
-[testenv:py{,310,311,312,313,314}{,-fast,-cov}{,-trav}]
+[testenv:py{,311,312,313,314,315}{,-fast,-cov}{,-trav}]
 depends = pre-commit
 changedir =
     !trav: core
@@ -38,10 +38,10 @@ commands =
     cov  : python -X warn_default_encoding -m coverage run -m pytest {posargs:-vv --color yes}
     fast : python -X warn_default_encoding -m pytest {posargs:-vv --color yes -n auto}
 
-[testenv:coverage{,310,311,312,313,314}{,-trav}{,-html}{,-keep}{,-platform}]
+[testenv:coverage{,311,312,313,314,315}{,-trav}{,-html}{,-keep}{,-platform}]
 depends =
-    !trav: pre-commit,py3{10-14}{,-cov}
-    trav: pre-commit,py3{10-14}{,-trav}{,-cov}
+    !trav: pre-commit,py3{10-15}{,-cov}
+    trav: pre-commit,py3{10-15}{,-trav}{,-cov}
 changedir =
     !trav: core
     trav: travertino
@@ -49,12 +49,12 @@ skip_install = True
 # by default, coverage should run on oldest supported Python for testing platform coverage.
 # however, coverage for a particular Python version should match the version used for pytest.
 base_python =
-    coverage310{,-trav}{,-html}{,-keep}{,-platform}: py310
     coverage311{,-trav}{,-html}{,-keep}{,-platform}: py311
     coverage312{,-trav}{,-html}{,-keep}{,-platform}: py312
     coverage313{,-trav}{,-html}{,-keep}{,-platform}: py313
     coverage314{,-trav}{,-html}{,-keep}{,-platform}: py314
-    coverage{,-trav}{,-html}{,-keep}{,-platform}: py310
+    coverage315{,-trav}{,-html}{,-keep}{,-platform}: py315
+    coverage{,-trav}{,-html}{,-keep}{,-platform}: py311
 setenv =
     keep: COMBINE_KEEP = --keep
     !trav: PACKAGE_RCFILE = --rcfile {tox_root}{/}core{/}pyproject.toml

--- a/travertino/pyproject.toml
+++ b/travertino/pyproject.toml
@@ -10,7 +10,7 @@ dynamic = ["version"]
 name = "travertino"
 description = "A set of constants and base classes for describing user interface layouts."
 readme = "README.md"
-requires-python = ">= 3.10"
+requires-python = ">= 3.11"
 license = "BSD-3-Clause"
 license-files = [
     "LICENSE",
@@ -31,11 +31,11 @@ classifiers = [
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development",
     "Topic :: Software Development :: User Interfaces",

--- a/web/pyproject.toml
+++ b/web/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = ["version", "dependencies"]
 name = "toga-web"
 description = "A Web backend for the Toga widget toolkit."
 readme = "README.md"
-requires-python = ">= 3.10"
+requires-python = ">= 3.11"
 license = "BSD-3-Clause"
 license-files = [
     "LICENSE",
@@ -37,11 +37,11 @@ classifiers = [
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development",
     "Topic :: Software Development :: User Interfaces",

--- a/winforms/pyproject.toml
+++ b/winforms/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = ["version", "dependencies"]
 name = "toga-winforms"
 description = "A Windows backend for the Toga widget toolkit using the WinForms API."
 readme = "README.md"
-requires-python = ">= 3.10"
+requires-python = ">= 3.11"
 license = "BSD-3-Clause"
 license-files = [
     "LICENSE",
@@ -38,11 +38,11 @@ classifiers = [
     "Intended Audience :: Developers",
     "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development",
     "Topic :: Software Development :: User Interfaces",


### PR DESCRIPTION
Drop support for Python 3.10; add Python 3.15

This is almost entirely documentation and configuration; there are only 2 code changes, and they were to cover edge cases in coverage due to performance of Python 3.10.

Also includes an addition to the release workflow that was identified in the process of releasing support packages. This change was made as part of the zizmor changes, but wasn't tested (because release workflows can't be tested until we do a release).

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
